### PR TITLE
fix: dashboard live data, auth fixes, status display for probation & candidates

### DIFF
--- a/backend/.htaccess
+++ b/backend/.htaccess
@@ -1,4 +1,9 @@
 RewriteEngine On
+
+# Pass Authorization header through to PHP
+RewriteCond %{HTTP:Authorization} .
+RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule ^(.*)$ api.php [QSA,L]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -17,14 +17,11 @@ FROM php:8.3-apache
 # เปิดใช้งาน mod_rewrite สำหรับ routing (เช่น .htaccess)
 RUN a2enmod rewrite
 
-# --- FIX for PostgreSQL ---
-# ติดตั้ง client library ของ PostgreSQL (libpq-dev)
-# และติดตั้ง PHP extension สำหรับ PostgreSQL (pdo_pgsql) แทน pdo_mysql
+# ติดตั้ง PHP extensions สำหรับ MySQL
 RUN apt-get update && apt-get install -y \
-    libpq-dev \
     libzip-dev \
     unzip \
-    && docker-php-ext-install pdo_pgsql zip opcache \
+    && docker-php-ext-install pdo_mysql zip opcache \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # เปิดใช้งาน OPcache สำหรับ production

--- a/backend/api.php
+++ b/backend/api.php
@@ -187,40 +187,44 @@ switch ($path[0]) {
 
     case 'dashboard':
         if ($method == 'GET') {
-            // Dashboard analytics and statistics
-            $stats = [];
+            // จำนวนบุคลากรทั้งหมด (จาก personnel table)
+            $stmt = $pdo->query("SELECT COUNT(*) as total FROM personnel WHERE is_active = 1");
+            $totalPersonnel = (int) $stmt->fetch(PDO::FETCH_ASSOC)['total'];
 
-            // Total civil servants
-            $stmt = $pdo->query("SELECT COUNT(*) as total FROM civil_servants WHERE is_active = 1");
-            $stats['total_servants'] = $stmt->fetch(PDO::FETCH_ASSOC)['total'];
+            // สรุปพ้นทดลอง
+            $stmt = $pdo->query("SELECT COUNT(*) as total FROM probation_enrollment");
+            $probationTotal = (int) $stmt->fetch(PDO::FETCH_ASSOC)['total'];
 
-            // Upcoming retirements (next 2 years)
-            $stmt = $pdo->query("
-                SELECT COUNT(*) as count 
-                FROM civil_servants 
-                WHERE retirement_date BETWEEN CURDATE() AND DATE_ADD(CURDATE(), INTERVAL 2 YEAR)
-                AND is_active = 1
-            ");
-            $stats['upcoming_retirements'] = $stmt->fetch(PDO::FETCH_ASSOC)['count'];
+            $stmt = $pdo->query("SELECT COUNT(*) as c FROM vw_probation_dashboard WHERE remaining_days BETWEEN 1 AND 30");
+            $probationNear = (int) $stmt->fetch(PDO::FETCH_ASSOC)['c'];
 
-            // Pending notifications
-            $stmt = $pdo->query("SELECT COUNT(*) as count FROM advance_notifications WHERE status = 'pending'");
-            $stats['pending_notifications'] = $stmt->fetch(PDO::FETCH_ASSOC)['count'];
+            $stmt = $pdo->query("SELECT COUNT(*) as c FROM vw_probation_dashboard WHERE remaining_days < 0");
+            $probationOverdue = (int) $stmt->fetch(PDO::FETCH_ASSOC)['c'];
 
-            // Recent performance proposals
-            $stmt = $pdo->query("
-                SELECT COUNT(*) as count 
-                FROM performance_proposals 
-                WHERE submission_date >= DATE_SUB(CURDATE(), INTERVAL 30 DAY)
-            ");
-            $stats['recent_proposals'] = $stmt->fetch(PDO::FETCH_ASSOC)['count'];
+            // จำนวนการนับเวลาเพิ่มเติม
+            $stmt = $pdo->query("SELECT COUNT(*) as c FROM supportive_experience");
+            $supportiveCount = (int) $stmt->fetch(PDO::FETCH_ASSOC)['c'];
+
+            $stmt = $pdo->query("SELECT COUNT(*) as c FROM diverse_experience");
+            $diverseCount = (int) $stmt->fetch(PDO::FETCH_ASSOC)['c'];
+
+            $stmt = $pdo->query("SELECT COUNT(*) as c FROM position_equivalence");
+            $equivalenceCount = (int) $stmt->fetch(PDO::FETCH_ASSOC)['c'];
 
             echo json_encode([
                 'success' => true,
-                'total_civil_servants' => $stats['total_servants'],
-                'upcoming_retirements' => $stats['upcoming_retirements'],
-                'pending_notifications' => $stats['pending_notifications'],
-                'recent_proposals' => $stats['recent_proposals']
+                'total_personnel' => $totalPersonnel,
+                'probation' => [
+                    'total' => $probationTotal,
+                    'near_deadline' => $probationNear,
+                    'overdue' => $probationOverdue,
+                ],
+                'time_counting' => [
+                    'supportive' => $supportiveCount,
+                    'diverse' => $diverseCount,
+                    'equivalence' => $equivalenceCount,
+                    'total' => $supportiveCount + $diverseCount + $equivalenceCount,
+                ],
             ]);
         }
         break;

--- a/backend/api.php
+++ b/backend/api.php
@@ -15,7 +15,8 @@ include 'config.php';
 include 'auth.php';
 
 $method = $_SERVER['REQUEST_METHOD'];
-$path = explode('/', trim($_SERVER['REQUEST_URI'], '/'));
+$uri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+$path = explode('/', trim($uri, '/'));
 
 // Remove 'api' from path if present
 if ($path[0] === 'api') {

--- a/backend/auth.php
+++ b/backend/auth.php
@@ -61,14 +61,19 @@ function getAuthHeader() {
     if (isset($_SERVER['HTTP_AUTHORIZATION'])) {
         return str_replace('Bearer ', '', $_SERVER['HTTP_AUTHORIZATION']);
     }
-    
+
+    // Apache rewrite sets REDIRECT_HTTP_AUTHORIZATION
+    if (isset($_SERVER['REDIRECT_HTTP_AUTHORIZATION'])) {
+        return str_replace('Bearer ', '', $_SERVER['REDIRECT_HTTP_AUTHORIZATION']);
+    }
+
     if (function_exists('apache_request_headers')) {
         $headers = apache_request_headers();
         if (isset($headers['Authorization'])) {
             return str_replace('Bearer ', '', $headers['Authorization']);
         }
     }
-    
+
     return null;
 }
 ?>

--- a/frontend/src/__tests__/components/StatusBadge.test.js
+++ b/frontend/src/__tests__/components/StatusBadge.test.js
@@ -4,16 +4,16 @@ import StatusBadge from '@/components/StatusBadge.vue'
 
 describe('StatusBadge', () => {
   // Candidate statuses
-  it('renders "ครบกำหนด" for qualified status', () => {
+  it('renders "ถึงเกณฑ์" for qualified status', () => {
     const wrapper = mount(StatusBadge, { props: { status: 'qualified' } })
-    expect(wrapper.text()).toBe('ครบกำหนด')
+    expect(wrapper.text()).toBe('ถึงเกณฑ์')
     expect(wrapper.classes()).toContain('bg-green-50')
   })
 
-  it('renders "รอดำเนินการ" for not_yet status', () => {
+  it('renders "ยังไม่ถึงเกณฑ์" for not_yet status', () => {
     const wrapper = mount(StatusBadge, { props: { status: 'not_yet' } })
-    expect(wrapper.text()).toBe('รอดำเนินการ')
-    expect(wrapper.classes()).toContain('bg-amber-50')
+    expect(wrapper.text()).toBe('ยังไม่ถึงเกณฑ์')
+    expect(wrapper.classes()).toContain('bg-yellow-50')
   })
 
   it('renders "ตรวจสอบข้อมูล" for check_data status', () => {

--- a/frontend/src/__tests__/composables/useCandidates.test.js
+++ b/frontend/src/__tests__/composables/useCandidates.test.js
@@ -84,7 +84,7 @@ describe('useCandidates', () => {
       levelStartDate: '1 ม.ค. 2567',
       qualificationDate: '1 ม.ค. 2568',
       remainingDays: 45,
-      status: 'qualified',
+      status: 'NOT_MET',
       department: 'กองบริหาร',
     })
   })

--- a/frontend/src/__tests__/composables/useProbation.test.js
+++ b/frontend/src/__tests__/composables/useProbation.test.js
@@ -84,7 +84,7 @@ describe('useProbation', () => {
       startDate: '1 เม.ย. 2567',
       endDate: '1 ต.ค. 2567',
       remainingDays: 120,
-      status: 'IN_PROGRESS',
+      status: 'NOT_DUE',
       totalTasks: 5,
       completedTasks: 2,
     })

--- a/frontend/src/__tests__/composables/useRemainingDays.test.js
+++ b/frontend/src/__tests__/composables/useRemainingDays.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
-import { getRemainingDaysClass, formatRemainingDays } from '@/composables/useRemainingDays.js'
+import { getRemainingDaysClass, getCandidateRemainingDaysClass, formatRemainingDays } from '@/composables/useRemainingDays.js'
 
-describe('getRemainingDaysClass', () => {
+describe('getRemainingDaysClass (probation)', () => {
   it('returns red for days < 0 (overdue)', () => {
     expect(getRemainingDaysClass(-1)).toBe('text-red-600 font-medium')
     expect(getRemainingDaysClass(-30)).toBe('text-red-600 font-medium')
@@ -13,18 +13,40 @@ describe('getRemainingDaysClass', () => {
 
   it('returns orange for days 1-30 (near deadline)', () => {
     expect(getRemainingDaysClass(1)).toBe('text-orange-600 font-medium')
-    expect(getRemainingDaysClass(15)).toBe('text-orange-600 font-medium')
     expect(getRemainingDaysClass(30)).toBe('text-orange-600 font-medium')
   })
 
   it('returns yellow for days > 30 (not due)', () => {
     expect(getRemainingDaysClass(31)).toBe('text-yellow-600')
-    expect(getRemainingDaysClass(100)).toBe('text-yellow-600')
   })
 
   it('returns gray for null/undefined', () => {
     expect(getRemainingDaysClass(null)).toBe('text-gray-400')
     expect(getRemainingDaysClass(undefined)).toBe('text-gray-400')
+  })
+})
+
+describe('getCandidateRemainingDaysClass', () => {
+  it('returns normal text for days < 0 (already met criteria)', () => {
+    expect(getCandidateRemainingDaysClass(-1)).toBe('text-gray-700')
+    expect(getCandidateRemainingDaysClass(-100)).toBe('text-gray-700')
+  })
+
+  it('returns green for days === 0 (met today)', () => {
+    expect(getCandidateRemainingDaysClass(0)).toBe('text-green-600 font-medium')
+  })
+
+  it('returns orange for days 1-30 (near criteria)', () => {
+    expect(getCandidateRemainingDaysClass(1)).toBe('text-orange-600 font-medium')
+    expect(getCandidateRemainingDaysClass(30)).toBe('text-orange-600 font-medium')
+  })
+
+  it('returns yellow for days > 30 (not met)', () => {
+    expect(getCandidateRemainingDaysClass(31)).toBe('text-yellow-600')
+  })
+
+  it('returns gray for null/undefined', () => {
+    expect(getCandidateRemainingDaysClass(null)).toBe('text-gray-400')
   })
 })
 
@@ -39,7 +61,6 @@ describe('formatRemainingDays', () => {
 
   it('formats negative days as overdue in Thai', () => {
     expect(formatRemainingDays(-5)).toBe('เกิน 5 วัน')
-    expect(formatRemainingDays(-30)).toBe('เกิน 30 วัน')
   })
 
   it('returns dash for null/undefined', () => {

--- a/frontend/src/__tests__/composables/useRemainingDays.test.js
+++ b/frontend/src/__tests__/composables/useRemainingDays.test.js
@@ -2,25 +2,24 @@ import { describe, it, expect } from 'vitest'
 import { getRemainingDaysClass, formatRemainingDays } from '@/composables/useRemainingDays.js'
 
 describe('getRemainingDaysClass', () => {
-  it('returns red for days < 7', () => {
+  it('returns red for days < 0 (overdue)', () => {
     expect(getRemainingDaysClass(-1)).toBe('text-red-600 font-medium')
-    expect(getRemainingDaysClass(0)).toBe('text-red-600 font-medium')
-    expect(getRemainingDaysClass(6)).toBe('text-red-600 font-medium')
+    expect(getRemainingDaysClass(-30)).toBe('text-red-600 font-medium')
   })
 
-  it('returns orange for days 7-14', () => {
-    expect(getRemainingDaysClass(7)).toBe('text-orange-600')
-    expect(getRemainingDaysClass(14)).toBe('text-orange-600')
+  it('returns green for days === 0 (due today)', () => {
+    expect(getRemainingDaysClass(0)).toBe('text-green-600 font-medium')
   })
 
-  it('returns yellow for days 15-30', () => {
-    expect(getRemainingDaysClass(15)).toBe('text-yellow-600')
-    expect(getRemainingDaysClass(30)).toBe('text-yellow-600')
+  it('returns orange for days 1-30 (near deadline)', () => {
+    expect(getRemainingDaysClass(1)).toBe('text-orange-600 font-medium')
+    expect(getRemainingDaysClass(15)).toBe('text-orange-600 font-medium')
+    expect(getRemainingDaysClass(30)).toBe('text-orange-600 font-medium')
   })
 
-  it('returns green for days > 30', () => {
-    expect(getRemainingDaysClass(31)).toBe('text-green-600')
-    expect(getRemainingDaysClass(100)).toBe('text-green-600')
+  it('returns yellow for days > 30 (not due)', () => {
+    expect(getRemainingDaysClass(31)).toBe('text-yellow-600')
+    expect(getRemainingDaysClass(100)).toBe('text-yellow-600')
   })
 
   it('returns gray for null/undefined', () => {
@@ -32,7 +31,10 @@ describe('getRemainingDaysClass', () => {
 describe('formatRemainingDays', () => {
   it('formats positive days in Thai', () => {
     expect(formatRemainingDays(45)).toBe('45 วัน')
-    expect(formatRemainingDays(0)).toBe('0 วัน')
+  })
+
+  it('formats zero as due today', () => {
+    expect(formatRemainingDays(0)).toBe('ครบกำหนดวันนี้')
   })
 
   it('formats negative days as overdue in Thai', () => {

--- a/frontend/src/components/StatusBadge.vue
+++ b/frontend/src/components/StatusBadge.vue
@@ -22,9 +22,15 @@ const statusMap = {
   completed: { label: 'เสร็จสิ้น', class: 'bg-gray-100 text-gray-600' },
   ready: { label: 'พร้อมดำเนินการ', class: 'bg-green-50 text-green-700' },
   active: { label: 'ใช้งานอยู่', class: 'bg-blue-50 text-blue-700' },
-  // Candidate statuses (lowercase from backend)
-  qualified: { label: 'ครบกำหนด', class: 'bg-green-50 text-green-700' },
-  not_yet: { label: 'รอดำเนินการ', class: 'bg-amber-50 text-amber-700' },
+  // Candidate display statuses (computed by useCandidates composable)
+  NOT_MET: { label: 'ยังไม่ถึงเกณฑ์', class: 'bg-yellow-50 text-yellow-700' },
+  NEAR_MET: { label: 'ใกล้ถึงเกณฑ์', class: 'bg-orange-50 text-orange-700' },
+  MET: { label: 'ครบเกณฑ์', class: 'bg-green-50 text-green-700' },
+  EXCEEDED: { label: 'ถึงเกณฑ์', class: 'bg-green-50 text-green-700' },
+  PROMOTING: { label: 'กำลังดำเนินการ', class: 'bg-blue-50 text-blue-700' },
+  // Candidate backend statuses (fallback)
+  qualified: { label: 'ถึงเกณฑ์', class: 'bg-green-50 text-green-700' },
+  not_yet: { label: 'ยังไม่ถึงเกณฑ์', class: 'bg-yellow-50 text-yellow-700' },
   check_data: { label: 'ตรวจสอบข้อมูล', class: 'bg-orange-50 text-orange-700' },
   // Probation display statuses (computed by useProbation composable)
   NOT_DUE: { label: 'ยังไม่ครบกำหนด', class: 'bg-yellow-50 text-yellow-700' },

--- a/frontend/src/components/StatusBadge.vue
+++ b/frontend/src/components/StatusBadge.vue
@@ -26,7 +26,13 @@ const statusMap = {
   qualified: { label: 'ครบกำหนด', class: 'bg-green-50 text-green-700' },
   not_yet: { label: 'รอดำเนินการ', class: 'bg-amber-50 text-amber-700' },
   check_data: { label: 'ตรวจสอบข้อมูล', class: 'bg-orange-50 text-orange-700' },
-  // Probation statuses (UPPER_CASE from backend -- case-sensitive)
+  // Probation display statuses (computed by useProbation composable)
+  NOT_DUE: { label: 'ยังไม่ครบกำหนด', class: 'bg-yellow-50 text-yellow-700' },
+  NEAR_DEADLINE: { label: 'ใกล้ครบกำหนด', class: 'bg-orange-50 text-orange-700' },
+  READY: { label: 'พร้อมพ้นทดลอง', class: 'bg-green-50 text-green-700' },
+  OVERDUE: { label: 'เกินกำหนด', class: 'bg-red-50 text-red-700' },
+  IN_REVIEW: { label: 'กำลังดำเนินการ', class: 'bg-blue-50 text-blue-700' },
+  // Probation backend statuses
   IN_PROGRESS: { label: 'กำลังดำเนินการ', class: 'bg-blue-50 text-blue-700' },
   COMPLETED: { label: 'ผ่านทดลอง', class: 'bg-green-50 text-green-700' },
   FAILED: { label: 'ไม่ผ่าน', class: 'bg-red-50 text-red-700' },

--- a/frontend/src/composables/useCandidates.js
+++ b/frontend/src/composables/useCandidates.js
@@ -18,6 +18,29 @@ export function useCandidates() {
     }
   }
 
+  // คำนวณสถานะแสดงผลจาก remaining_days และ backend status
+  function computeDisplayStatus(backendStatus, remainingDays) {
+    const days = remainingDays !== null ? parseInt(remainingDays) : null
+
+    // ถ้า backend บอกว่า qualified + มีข้อมูลว่ากำลังเลื่อนตำแหน่ง
+    // (สำหรับ v2: ตรวจสอบจาก promotion_evaluation table)
+    // ตอนนี้ใช้ backendStatus ที่ไม่ใช่ qualified/not_yet เป็นสัญญาณ
+    if (backendStatus === 'promoting') {
+      return 'PROMOTING' // กำลังดำเนินการเลื่อนตำแหน่ง (สีน้ำเงิน)
+    }
+
+    if (backendStatus === 'check_data') {
+      return 'check_data' // ตรวจสอบข้อมูล (สีส้ม)
+    }
+
+    // คำนวณจาก remaining_days
+    if (days === null) return 'NOT_MET'
+    if (days > 30) return 'NOT_MET'           // > 30 วัน = ยังไม่ถึงเกณฑ์ (สีเหลือง)
+    if (days >= 1) return 'NEAR_MET'          // 1-30 วัน = ใกล้ถึงเกณฑ์ (สีส้ม)
+    if (days === 0) return 'MET'              // ครบเกณฑ์วันนี้ (สีเขียว)
+    return 'EXCEEDED'                         // เกินเกณฑ์แล้ว = ถึงเกณฑ์ (สีเขียว)
+  }
+
   function mapCandidateRow(row) {
     return {
       personnelId: row.personnel_id,
@@ -28,11 +51,11 @@ export function useCandidates() {
       levelStartDate: row.level_start_date_thai,
       qualificationDate: row.qualification_date_thai,
       remainingDays: row.remaining_days,
-      status: row.status,
+      status: computeDisplayStatus(row.status, row.remaining_days),
       department: row.department,
       supportiveDays: row.supportive_days,
       equivalenceDays: row.equivalence_days,
-      diverseStatus: row.diverse_status,  // 'DIFF_PASS', 'DIFF_NOT_YET', or null
+      diverseStatus: row.diverse_status,
     }
   }
 

--- a/frontend/src/composables/useCandidates.js
+++ b/frontend/src/composables/useCandidates.js
@@ -20,7 +20,7 @@ export function useCandidates() {
 
   // คำนวณสถานะแสดงผลจาก remaining_days และ backend status
   function computeDisplayStatus(backendStatus, remainingDays) {
-    const days = remainingDays !== null ? parseInt(remainingDays) : null
+    const days = (remainingDays !== null && remainingDays !== undefined) ? parseInt(remainingDays, 10) : null
 
     // ถ้า backend บอกว่า qualified + มีข้อมูลว่ากำลังเลื่อนตำแหน่ง
     // (สำหรับ v2: ตรวจสอบจาก promotion_evaluation table)
@@ -34,7 +34,7 @@ export function useCandidates() {
     }
 
     // คำนวณจาก remaining_days
-    if (days === null) return 'NOT_MET'
+    if (days === null || isNaN(days)) return 'NOT_MET'
     if (days > 30) return 'NOT_MET'           // > 30 วัน = ยังไม่ถึงเกณฑ์ (สีเหลือง)
     if (days >= 1) return 'NEAR_MET'          // 1-30 วัน = ใกล้ถึงเกณฑ์ (สีส้ม)
     if (days === 0) return 'MET'              // ครบเกณฑ์วันนี้ (สีเขียว)

--- a/frontend/src/composables/useProbation.js
+++ b/frontend/src/composables/useProbation.js
@@ -18,6 +18,24 @@ export function useProbation() {
     }
   }
 
+  // คำนวณสถานะแสดงผลจาก remaining_days และ backend status
+  function computeDisplayStatus(backendStatus, remainingDays) {
+    const days = remainingDays !== null ? parseInt(remainingDays) : null
+
+    // ถ้า backend บอกว่าไม่ใช่ IN_PROGRESS (เช่น COMPLETED, EXTENDED, FAILED)
+    // แสดงว่าอยู่ระหว่างทำประเมิน
+    if (backendStatus !== 'IN_PROGRESS') {
+      return 'IN_REVIEW' // กำลังดำเนินการประเมิน (สีน้ำเงิน)
+    }
+
+    // คำนวณจาก remaining_days
+    if (days === null) return 'NOT_DUE'
+    if (days > 30) return 'NOT_DUE'           // > 30 วัน = ยังไม่ครบกำหนด (สีเหลือง)
+    if (days >= 1) return 'NEAR_DEADLINE'     // 1-30 วัน = ใกล้ครบกำหนด (สีส้ม)
+    if (days === 0) return 'READY'            // ครบกำหนดวันนี้ = พร้อมพ้นทดลอง (สีเขียว)
+    return 'OVERDUE'                          // < 0 วัน = เกินกำหนด (สีแดง)
+  }
+
   function mapProbationRow(row) {
     return {
       enrollmentId: row.enrollment_id,
@@ -28,7 +46,7 @@ export function useProbation() {
       startDate: row.start_date_thai,
       endDate: row.end_date_thai,
       remainingDays: row.remaining_days,
-      status: row.status,
+      status: computeDisplayStatus(row.status, row.remaining_days),
       totalTasks: row.total_tasks,
       completedTasks: row.completed_tasks,
     }

--- a/frontend/src/composables/useProbation.js
+++ b/frontend/src/composables/useProbation.js
@@ -20,16 +20,15 @@ export function useProbation() {
 
   // คำนวณสถานะแสดงผลจาก remaining_days และ backend status
   function computeDisplayStatus(backendStatus, remainingDays) {
-    const days = remainingDays !== null ? parseInt(remainingDays) : null
+    const days = (remainingDays !== null && remainingDays !== undefined) ? parseInt(remainingDays, 10) : null
 
-    // ถ้า backend บอกว่าไม่ใช่ IN_PROGRESS (เช่น COMPLETED, EXTENDED, FAILED)
-    // แสดงว่าอยู่ระหว่างทำประเมิน
-    if (backendStatus !== 'IN_PROGRESS') {
-      return 'IN_REVIEW' // กำลังดำเนินการประเมิน (สีน้ำเงิน)
-    }
+    // สถานะจาก backend ที่ไม่ใช่ IN_PROGRESS — ส่งผ่านตรงๆ ให้ StatusBadge แสดง
+    if (backendStatus === 'COMPLETED') return 'COMPLETED'   // ผ่านทดลอง (สีเขียว)
+    if (backendStatus === 'FAILED') return 'FAILED'         // ไม่ผ่าน (สีแดง)
+    if (backendStatus === 'EXTENDED') return 'EXTENDED'     // ขยายเวลา (สีส้ม)
 
-    // คำนวณจาก remaining_days
-    if (days === null) return 'NOT_DUE'
+    // ถ้ายังเป็น IN_PROGRESS — คำนวณสถานะแสดงผลจาก remaining_days
+    if (days === null || isNaN(days)) return 'NOT_DUE'
     if (days > 30) return 'NOT_DUE'           // > 30 วัน = ยังไม่ครบกำหนด (สีเหลือง)
     if (days >= 1) return 'NEAR_DEADLINE'     // 1-30 วัน = ใกล้ครบกำหนด (สีส้ม)
     if (days === 0) return 'READY'            // ครบกำหนดวันนี้ = พร้อมพ้นทดลอง (สีเขียว)

--- a/frontend/src/composables/useRemainingDays.js
+++ b/frontend/src/composables/useRemainingDays.js
@@ -1,9 +1,19 @@
+// สำหรับหน้าพ้นทดลอง — เกินกำหนดเป็นเรื่องเร่งด่วน (สีแดง)
 export function getRemainingDaysClass(days) {
   if (days === null || days === undefined) return 'text-gray-400'
-  if (days < 0) return 'text-red-600 font-medium'        // เกินกำหนด — แดง
-  if (days === 0) return 'text-green-600 font-medium'     // ครบกำหนดวันนี้ — เขียว
-  if (days <= 30) return 'text-orange-600 font-medium'    // ใกล้ครบกำหนด — ส้ม
-  return 'text-yellow-600'                                // ยังไม่ครบกำหนด — เหลือง
+  if (days < 0) return 'text-red-600 font-medium'
+  if (days === 0) return 'text-green-600 font-medium'
+  if (days <= 30) return 'text-orange-600 font-medium'
+  return 'text-yellow-600'
+}
+
+// สำหรับหน้า candidate list — เกินเกณฑ์เป็นเรื่องดี (สีปกติ)
+export function getCandidateRemainingDaysClass(days) {
+  if (days === null || days === undefined) return 'text-gray-400'
+  if (days < 0) return 'text-gray-700'                         // ถึงเกณฑ์แล้ว — สีปกติ
+  if (days === 0) return 'text-green-600 font-medium'          // ครบเกณฑ์วันนี้ — เขียว
+  if (days <= 30) return 'text-orange-600 font-medium'         // ใกล้ถึงเกณฑ์ — ส้ม
+  return 'text-yellow-600'                                     // ยังไม่ถึงเกณฑ์ — เหลือง
 }
 
 export function formatRemainingDays(days) {

--- a/frontend/src/composables/useRemainingDays.js
+++ b/frontend/src/composables/useRemainingDays.js
@@ -1,13 +1,14 @@
 export function getRemainingDaysClass(days) {
   if (days === null || days === undefined) return 'text-gray-400'
-  if (days < 7) return 'text-red-600 font-medium'
-  if (days <= 14) return 'text-orange-600'
-  if (days <= 30) return 'text-yellow-600'
-  return 'text-green-600'
+  if (days < 0) return 'text-red-600 font-medium'        // เกินกำหนด — แดง
+  if (days === 0) return 'text-green-600 font-medium'     // ครบกำหนดวันนี้ — เขียว
+  if (days <= 30) return 'text-orange-600 font-medium'    // ใกล้ครบกำหนด — ส้ม
+  return 'text-yellow-600'                                // ยังไม่ครบกำหนด — เหลือง
 }
 
 export function formatRemainingDays(days) {
   if (days === null || days === undefined) return '-'
   if (days < 0) return `เกิน ${Math.abs(days)} วัน`
+  if (days === 0) return 'ครบกำหนดวันนี้'
   return `${days} วัน`
 }

--- a/frontend/src/pages/CandidateListsPage.vue
+++ b/frontend/src/pages/CandidateListsPage.vue
@@ -95,18 +95,18 @@
         <!-- Row 2: 3 stat cards -->
         <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
           <StatCard
-            label="ครบกำหนด"
+            label="ถึงเกณฑ์"
             :value="overviewData.qualifiedTotal"
             :icon="UserCheck"
             icon-bg-class="bg-green-50"
             icon-class="text-green-600"
           />
           <StatCard
-            label="รอดำเนินการ"
+            label="ยังไม่ถึงเกณฑ์"
             :value="overviewData.notYetTotal"
             :icon="Clock"
-            icon-bg-class="bg-amber-50"
-            icon-class="text-amber-600"
+            icon-bg-class="bg-yellow-50"
+            icon-class="text-yellow-600"
           />
           <StatCard
             label="ตรวจสอบข้อมูล"
@@ -145,7 +145,7 @@
                 <td class="px-6 py-3 text-gray-600">{{ row.currentPosition }}</td>
                 <td class="px-6 py-3 text-gray-600">{{ row.currentLevelName }}</td>
                 <td class="px-6 py-3 text-gray-500">{{ row.qualificationDate }}</td>
-                <td class="px-6 py-3" :class="getRemainingDaysClass(row.remainingDays)">
+                <td class="px-6 py-3" :class="getCandidateRemainingDaysClass(row.remainingDays)">
                   {{ formatRemainingDays(row.remainingDays) }}
                 </td>
                 <td class="px-6 py-3">
@@ -263,7 +263,7 @@
                 <td class="px-6 py-3 text-gray-500">
                   {{ row.equivalenceDays > 0 ? `${row.equivalenceDays} วัน` : '-' }}
                 </td>
-                <td class="px-6 py-3" :class="getRemainingDaysClass(row.remainingDays)">
+                <td class="px-6 py-3" :class="getCandidateRemainingDaysClass(row.remainingDays)">
                   {{ formatRemainingDays(row.remainingDays) }}
                 </td>
                 <td class="px-6 py-3">
@@ -310,7 +310,7 @@
 <script setup>
 import { ref, computed, watch, onMounted } from 'vue'
 import { useCandidates } from '@/composables/useCandidates.js'
-import { getRemainingDaysClass, formatRemainingDays } from '@/composables/useRemainingDays.js'
+import { getCandidateRemainingDaysClass, formatRemainingDays } from '@/composables/useRemainingDays.js'
 import StatCard from '@/components/StatCard.vue'
 import StatusBadge from '@/components/StatusBadge.vue'
 import SkeletonLoader from '@/components/SkeletonLoader.vue'

--- a/frontend/src/pages/DashboardPage.vue
+++ b/frontend/src/pages/DashboardPage.vue
@@ -130,13 +130,12 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, onMounted } from 'vue'
 import { RouterLink } from 'vue-router'
 import StatCard from '@/components/StatCard.vue'
 import SkeletonLoader from '@/components/SkeletonLoader.vue'
 import { useApi } from '@/composables/useApi.js'
 import { useCandidates } from '@/composables/useCandidates.js'
-import { useProbation } from '@/composables/useProbation.js'
 import {
   Users, UserCheck, TrendingUp, Clock,
   RefreshCw, AlertCircle, Zap,
@@ -144,7 +143,6 @@ import {
 
 const api = useApi()
 const { fetchByLevel } = useCandidates()
-const { fetchList: fetchProbation } = useProbation()
 
 const loading = ref(false)
 const error = ref('')
@@ -175,55 +173,39 @@ async function fetchDashboard() {
   error.value = ''
 
   try {
-    const [dashboardRes, probationRes, ...candidateResults] = await Promise.allSettled([
+    // ดึงข้อมูลสรุปจาก /dashboard endpoint เดียว + จำนวน candidates
+    const [dashboardRes, ...candidateResults] = await Promise.allSettled([
       api.get('/dashboard'),
-      fetchProbation({ limit: 100 }),
-      fetchByLevel('K2', { limit: 100 }),
-      fetchByLevel('K3', { limit: 100 }),
-      fetchByLevel('K4', { limit: 100 }),
-      fetchByLevel('O2', { limit: 100 }),
-      fetchByLevel('O3', { limit: 100 }),
+      fetchByLevel('K2', { limit: 1 }),
+      fetchByLevel('K3', { limit: 1 }),
+      fetchByLevel('K4', { limit: 1 }),
+      fetchByLevel('O2', { limit: 1 }),
+      fetchByLevel('O3', { limit: 1 }),
     ])
 
-    // Dashboard basic stats
+    // สถิติจาก /dashboard
     if (dashboardRes.status === 'fulfilled' && dashboardRes.value) {
-      stats.value.totalPersonnel = dashboardRes.value.total_civil_servants || 0
-    }
-
-    // Probation summary
-    if (probationRes.status === 'fulfilled' && probationRes.value) {
-      const prob = probationRes.value
-      stats.value.probationTotal = prob.summary?.total || prob.data?.length || 0
+      const d = dashboardRes.value
+      stats.value.totalPersonnel = d.total_personnel || 0
+      stats.value.probationTotal = d.probation?.total || 0
+      stats.value.timeCountTotal = d.time_counting?.total || 0
       probationSummary.value = {
-        inProgress: prob.summary?.in_progress || 0,
-        nearDeadline: prob.summary?.near_deadline || 0,
-        overdue: prob.summary?.overdue || 0,
+        inProgress: Math.max(0, (d.probation?.total || 0) - (d.probation?.near_deadline || 0) - (d.probation?.overdue || 0)),
+        nearDeadline: d.probation?.near_deadline || 0,
+        overdue: d.probation?.overdue || 0,
       }
     }
 
-    // Candidate totals across all levels
+    // จำนวน candidates รวมทุกระดับ (ใช้ pagination.total แทน data.length)
     let totalCandidates = 0
     for (const result of candidateResults) {
       if (result.status === 'fulfilled' && result.value) {
-        totalCandidates += result.value.data?.length || 0
+        totalCandidates += result.value.pagination?.total || result.value.data?.length || 0
       }
     }
     stats.value.candidateTotal = totalCandidates
 
-    // Time counting totals
-    const [supportiveRes, diverseRes, equivalenceRes] = await Promise.allSettled([
-      api.get('/supportive?limit=1'),
-      api.get('/diverse?limit=1'),
-      api.get('/equivalence?limit=1'),
-    ])
-
-    let timeTotal = 0
-    if (supportiveRes.status === 'fulfilled') timeTotal += supportiveRes.value?.pagination?.total || 0
-    if (diverseRes.status === 'fulfilled') timeTotal += diverseRes.value?.pagination?.total || 0
-    if (equivalenceRes.status === 'fulfilled') timeTotal += equivalenceRes.value?.pagination?.total || 0
-    stats.value.timeCountTotal = timeTotal
-
-    // Build priority tasks from real data
+    // สร้างรายการงานสำคัญจากข้อมูลจริง
     const tasks = []
     if (probationSummary.value.nearDeadline > 0 || probationSummary.value.overdue > 0) {
       tasks.push({

--- a/frontend/src/pages/DashboardPage.vue
+++ b/frontend/src/pages/DashboardPage.vue
@@ -7,23 +7,24 @@
         <p class="text-gray-600 mt-1">สรุปข้อมูลสำคัญและกิจกรรมล่าสุดของระบบการจัดการข้าราชการ</p>
       </div>
       <div class="flex items-center space-x-3">
-        <button class="flex items-center space-x-2 px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors text-sm">
-          <Download class="w-4 h-4" />
-          <span>ส่งออกรายงาน</span>
-        </button>
-        <button class="flex items-center space-x-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors text-sm">
-          <RefreshCw class="w-4 h-4" />
+        <button @click="fetchDashboard" class="flex items-center space-x-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors text-sm">
+          <RefreshCw class="w-4 h-4" :class="{ 'animate-spin': loading }" />
           <span>รีเฟรช</span>
         </button>
       </div>
     </div>
 
+    <!-- Loading State -->
+    <div v-if="loading && !stats.totalPersonnel" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+      <SkeletonLoader v-for="i in 4" :key="i" height="h-28" />
+    </div>
+
     <!-- Statistics Cards -->
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-      <StatCard label="จำนวนข้าราชการทั้งหมด" value="2,847" change="+12%" :icon="Users" icon-bg-class="bg-blue-50" icon-class="text-blue-600" sparkline sparkline-color="bg-blue-200" />
-      <StatCard label="ผู้พ้นทดลองปีนี้" value="156" change="+8%" :icon="UserCheck" icon-bg-class="bg-green-50" icon-class="text-green-600" sparkline sparkline-color="bg-green-200" />
-      <StatCard label="Candidate Lists" value="89" change="+3%" :icon="Users" icon-bg-class="bg-orange-50" icon-class="text-orange-600" sparkline sparkline-color="bg-orange-200" />
-      <StatCard label="ผู้เกษียณปีนี้" value="24" change="+15%" :icon="UserMinus" icon-bg-class="bg-purple-50" icon-class="text-purple-600" sparkline sparkline-color="bg-purple-200" />
+    <div v-else class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+      <StatCard label="จำนวนข้าราชการทั้งหมด" :value="stats.totalPersonnel.toLocaleString()" :icon="Users" icon-bg-class="bg-blue-50" icon-class="text-blue-600" />
+      <StatCard label="ติดตามพ้นทดลอง" :value="stats.probationTotal.toLocaleString()" :icon="UserCheck" icon-bg-class="bg-green-50" icon-class="text-green-600" />
+      <StatCard label="ผู้มีคุณสมบัติเลื่อนระดับ" :value="stats.candidateTotal.toLocaleString()" :icon="TrendingUp" icon-bg-class="bg-orange-50" icon-class="text-orange-600" />
+      <StatCard label="การนับเวลาเพิ่มเติม" :value="stats.timeCountTotal.toLocaleString()" :icon="Clock" icon-bg-class="bg-purple-50" icon-class="text-purple-600" />
     </div>
 
     <!-- Main Content Grid -->
@@ -54,7 +55,7 @@
                     <span class="text-sm font-medium text-gray-900">{{ task.title }}</span>
                   </div>
                 </td>
-                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{{ task.count }}</td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{{ task.count }} คน</td>
                 <td class="px-6 py-4 whitespace-nowrap">
                   <span class="inline-flex px-2 py-1 text-xs font-semibold rounded-full" :class="task.priorityColor">
                     {{ task.priority }}
@@ -74,7 +75,7 @@
         </div>
       </div>
 
-      <!-- Right Column: Quick Actions + Recent Activity -->
+      <!-- Right Column: Quick Actions + Summary -->
       <div class="space-y-6">
         <!-- Quick Actions -->
         <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
@@ -97,79 +98,164 @@
           </div>
         </div>
 
-        <!-- Recent Activity -->
+        <!-- Probation Summary -->
         <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
           <div class="flex items-center justify-between mb-4">
-            <h3 class="text-lg font-semibold text-gray-900">กิจกรรมล่าสุด</h3>
-            <Activity class="w-5 h-5 text-blue-500" />
+            <h3 class="text-lg font-semibold text-gray-900">สรุปพ้นทดลอง</h3>
+            <UserCheck class="w-5 h-5 text-blue-500" />
           </div>
           <div class="space-y-3">
-            <div v-for="(act, i) in recentActivities" :key="i" class="flex items-start space-x-3 p-3 rounded-lg hover:bg-gray-50 transition-colors">
-              <div class="w-2 h-2 rounded-full mt-2" :class="act.dotColor"></div>
-              <div class="flex-1 min-w-0">
-                <p class="text-sm font-medium text-gray-900">{{ act.action }}</p>
-                <p class="text-xs text-gray-500 mt-1">{{ act.time }}</p>
-              </div>
+            <div class="flex justify-between items-center p-2 rounded-lg bg-blue-50">
+              <span class="text-sm text-blue-700">กำลังดำเนินการ</span>
+              <span class="text-sm font-bold text-blue-700">{{ probationSummary.inProgress }}</span>
+            </div>
+            <div class="flex justify-between items-center p-2 rounded-lg bg-orange-50">
+              <span class="text-sm text-orange-700">ใกล้ครบกำหนด</span>
+              <span class="text-sm font-bold text-orange-700">{{ probationSummary.nearDeadline }}</span>
+            </div>
+            <div class="flex justify-between items-center p-2 rounded-lg bg-red-50">
+              <span class="text-sm text-red-700">เกินกำหนด</span>
+              <span class="text-sm font-bold text-red-700">{{ probationSummary.overdue }}</span>
             </div>
           </div>
         </div>
       </div>
     </div>
 
-    <!-- System Status -->
-    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-      <div class="flex items-center justify-between mb-4">
-        <h2 class="text-lg font-semibold text-gray-900">สถานะระบบ</h2>
-        <div class="flex items-center space-x-2">
-          <div class="w-2 h-2 bg-green-500 rounded-full"></div>
-          <span class="text-sm text-gray-600">ปกติ</span>
-        </div>
-      </div>
-      <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <div v-for="status in systemStatus" :key="status.label" class="text-center p-4 rounded-lg" :class="status.bgColor">
-          <component :is="status.icon" class="w-6 h-6 mx-auto mb-2" :class="status.color" />
-          <p class="text-sm font-medium" :class="status.textColor">{{ status.label }}</p>
-          <p class="text-xs opacity-75" :class="status.textColor">{{ status.value }}</p>
-        </div>
-      </div>
+    <!-- Error Message -->
+    <div v-if="error" class="bg-red-50 border border-red-200 rounded-lg p-4">
+      <p class="text-red-700 text-sm">{{ error }}</p>
     </div>
   </div>
 </template>
 
 <script setup>
+import { ref, computed, onMounted } from 'vue'
 import { RouterLink } from 'vue-router'
 import StatCard from '@/components/StatCard.vue'
+import SkeletonLoader from '@/components/SkeletonLoader.vue'
+import { useApi } from '@/composables/useApi.js'
+import { useCandidates } from '@/composables/useCandidates.js'
+import { useProbation } from '@/composables/useProbation.js'
 import {
-  Users, UserCheck, UserMinus, Award, Clock, TrendingUp,
-  Download, RefreshCw, AlertCircle, Zap, Activity,
-  Database, ShieldCheck,
+  Users, UserCheck, TrendingUp, Clock,
+  RefreshCw, AlertCircle, Zap,
 } from 'lucide-vue-next'
 
-const priorityTasks = [
-  { title: 'ข้าราชการครบกำหนดพ้นทดลอง', count: '12 คน', priority: 'เร่งด่วน', priorityColor: 'bg-red-100 text-red-800', icon: UserCheck, iconColor: 'text-red-500', route: '/probation-end' },
-  { title: 'รายชื่อผู้มีสิทธิ์เลื่อนตำแหน่ง', count: '28 คน', priority: 'สำคัญ', priorityColor: 'bg-orange-100 text-orange-800', icon: TrendingUp, iconColor: 'text-orange-500', route: '/candidates/general' },
-  { title: 'ข้าราชการใกล้เกษียณ (6 เดือน)', count: '15 คน', priority: 'ปกติ', priorityColor: 'bg-blue-100 text-blue-800', icon: UserMinus, iconColor: 'text-blue-500', route: '/retirement-report' },
-  { title: 'เครื่องราชอิสริยาภรณ์รอดำเนินการ', count: '7 คน', priority: 'ปกติ', priorityColor: 'bg-green-100 text-green-800', icon: Award, iconColor: 'text-green-500', route: '/royal-decorations' },
-]
+const api = useApi()
+const { fetchByLevel } = useCandidates()
+const { fetchList: fetchProbation } = useProbation()
+
+const loading = ref(false)
+const error = ref('')
+
+const stats = ref({
+  totalPersonnel: 0,
+  probationTotal: 0,
+  candidateTotal: 0,
+  timeCountTotal: 0,
+})
+
+const probationSummary = ref({
+  inProgress: 0,
+  nearDeadline: 0,
+  overdue: 0,
+})
+
+const priorityTasks = ref([])
 
 const quickActions = [
   { title: 'พ้นทดลองปฏิบัติราชการ', icon: UserCheck, color: 'bg-blue-500', route: '/probation-end' },
   { title: 'เลื่อนระดับตำแหน่ง', icon: TrendingUp, color: 'bg-green-500', route: '/candidates/general' },
-  { title: 'รายงานผู้เกษียณ', icon: UserMinus, color: 'bg-purple-500', route: '/retirement-report' },
-  { title: 'เครื่องราชอิสริยาภรณ์', icon: Award, color: 'bg-orange-500', route: '/royal-decorations' },
+  { title: 'การนับเวลาเกื้อกูล', icon: Clock, color: 'bg-purple-500', route: '/supportive' },
 ]
 
-const recentActivities = [
-  { action: 'มีผู้สมัครพ้นทดลองปฏิบัติราชการ', time: '2 นาทีที่แล้ว', dotColor: 'bg-green-500' },
-  { action: 'อัพเดตข้อมูลเครื่องราชอิสริยาภรณ์', time: '1 ชั่วโมงที่แล้ว', dotColor: 'bg-blue-500' },
-  { action: 'รายงานผู้เกษียณรอการตรวจสอบ', time: '3 ชั่วโมงที่แล้ว', dotColor: 'bg-orange-500' },
-  { action: 'สร้างรายงานการนับเวลาเกื้อกูล', time: '1 วันที่แล้ว', dotColor: 'bg-green-500' },
-]
+async function fetchDashboard() {
+  loading.value = true
+  error.value = ''
 
-const systemStatus = [
-  { label: 'ฐานข้อมูล', value: 'ออนไลน์', icon: Database, color: 'text-green-600', bgColor: 'bg-green-50', textColor: 'text-green-700' },
-  { label: 'ระบบสำรอง', value: 'พร้อมใช้งาน', icon: ShieldCheck, color: 'text-blue-600', bgColor: 'bg-blue-50', textColor: 'text-blue-700' },
-  { label: 'ผู้ใช้ออนไลน์', value: '23 คน', icon: Users, color: 'text-purple-600', bgColor: 'bg-purple-50', textColor: 'text-purple-700' },
-  { label: 'อัพเดทล่าสุด', value: '2 ชม. ที่แล้ว', icon: Clock, color: 'text-gray-600', bgColor: 'bg-gray-50', textColor: 'text-gray-700' },
-]
+  try {
+    const [dashboardRes, probationRes, ...candidateResults] = await Promise.allSettled([
+      api.get('/dashboard'),
+      fetchProbation({ limit: 100 }),
+      fetchByLevel('K2', { limit: 100 }),
+      fetchByLevel('K3', { limit: 100 }),
+      fetchByLevel('K4', { limit: 100 }),
+      fetchByLevel('O2', { limit: 100 }),
+      fetchByLevel('O3', { limit: 100 }),
+    ])
+
+    // Dashboard basic stats
+    if (dashboardRes.status === 'fulfilled' && dashboardRes.value) {
+      stats.value.totalPersonnel = dashboardRes.value.total_civil_servants || 0
+    }
+
+    // Probation summary
+    if (probationRes.status === 'fulfilled' && probationRes.value) {
+      const prob = probationRes.value
+      stats.value.probationTotal = prob.summary?.total || prob.data?.length || 0
+      probationSummary.value = {
+        inProgress: prob.summary?.in_progress || 0,
+        nearDeadline: prob.summary?.near_deadline || 0,
+        overdue: prob.summary?.overdue || 0,
+      }
+    }
+
+    // Candidate totals across all levels
+    let totalCandidates = 0
+    for (const result of candidateResults) {
+      if (result.status === 'fulfilled' && result.value) {
+        totalCandidates += result.value.data?.length || 0
+      }
+    }
+    stats.value.candidateTotal = totalCandidates
+
+    // Time counting totals
+    const [supportiveRes, diverseRes, equivalenceRes] = await Promise.allSettled([
+      api.get('/supportive?limit=1'),
+      api.get('/diverse?limit=1'),
+      api.get('/equivalence?limit=1'),
+    ])
+
+    let timeTotal = 0
+    if (supportiveRes.status === 'fulfilled') timeTotal += supportiveRes.value?.summary?.total || 0
+    if (diverseRes.status === 'fulfilled') timeTotal += diverseRes.value?.summary?.total || 0
+    if (equivalenceRes.status === 'fulfilled') timeTotal += equivalenceRes.value?.summary?.total || 0
+    stats.value.timeCountTotal = timeTotal
+
+    // Build priority tasks from real data
+    const tasks = []
+    if (probationSummary.value.nearDeadline > 0 || probationSummary.value.overdue > 0) {
+      tasks.push({
+        title: 'ข้าราชการใกล้ครบ/เกินกำหนดพ้นทดลอง',
+        count: probationSummary.value.nearDeadline + probationSummary.value.overdue,
+        priority: probationSummary.value.overdue > 0 ? 'เร่งด่วน' : 'สำคัญ',
+        priorityColor: probationSummary.value.overdue > 0 ? 'bg-red-100 text-red-800' : 'bg-orange-100 text-orange-800',
+        icon: UserCheck,
+        iconColor: probationSummary.value.overdue > 0 ? 'text-red-500' : 'text-orange-500',
+        route: '/probation-end',
+      })
+    }
+    if (totalCandidates > 0) {
+      tasks.push({
+        title: 'รายชื่อผู้มีคุณสมบัติเลื่อนระดับ',
+        count: totalCandidates,
+        priority: 'สำคัญ',
+        priorityColor: 'bg-orange-100 text-orange-800',
+        icon: TrendingUp,
+        iconColor: 'text-orange-500',
+        route: '/candidates/general',
+      })
+    }
+    priorityTasks.value = tasks
+
+  } catch (err) {
+    error.value = 'ไม่สามารถโหลดข้อมูลได้ กรุณาลองใหม่อีกครั้ง'
+    console.error('Dashboard fetch error:', err)
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(fetchDashboard)
 </script>

--- a/frontend/src/pages/DashboardPage.vue
+++ b/frontend/src/pages/DashboardPage.vue
@@ -218,9 +218,9 @@ async function fetchDashboard() {
     ])
 
     let timeTotal = 0
-    if (supportiveRes.status === 'fulfilled') timeTotal += supportiveRes.value?.summary?.total || 0
-    if (diverseRes.status === 'fulfilled') timeTotal += diverseRes.value?.summary?.total || 0
-    if (equivalenceRes.status === 'fulfilled') timeTotal += equivalenceRes.value?.summary?.total || 0
+    if (supportiveRes.status === 'fulfilled') timeTotal += supportiveRes.value?.pagination?.total || 0
+    if (diverseRes.status === 'fulfilled') timeTotal += diverseRes.value?.pagination?.total || 0
+    if (equivalenceRes.status === 'fulfilled') timeTotal += equivalenceRes.value?.pagination?.total || 0
     stats.value.timeCountTotal = timeTotal
 
     // Build priority tasks from real data

--- a/frontend/src/pages/LoginPage.vue
+++ b/frontend/src/pages/LoginPage.vue
@@ -143,8 +143,17 @@ function fillDemo() {
 }
 
 async function skipLogin() {
-  await auth.demoLogin()
-  router.push('/dashboard')
+  loading.value = true
+  errorMsg.value = ''
+  try {
+    auth.logout()
+    await auth.demoLogin()
+    router.push('/dashboard')
+  } catch (e) {
+    errorMsg.value = e.message || 'เข้าสู่ระบบไม่สำเร็จ กรุณาลองใหม่'
+  } finally {
+    loading.value = false
+  }
 }
 </script>
 

--- a/frontend/src/pages/LoginPage.vue
+++ b/frontend/src/pages/LoginPage.vue
@@ -110,7 +110,7 @@
 </template>
 
 <script setup>
-import { ref, reactive, nextTick } from 'vue'
+import { ref, reactive } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth.js'
 import { Shield, AtSign, Lock, Eye, EyeOff, Loader2, AlertCircle } from 'lucide-vue-next'

--- a/frontend/src/pages/LoginPage.vue
+++ b/frontend/src/pages/LoginPage.vue
@@ -110,7 +110,7 @@
 </template>
 
 <script setup>
-import { ref, reactive } from 'vue'
+import { ref, reactive, nextTick } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth.js'
 import { Shield, AtSign, Lock, Eye, EyeOff, Loader2, AlertCircle } from 'lucide-vue-next'

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -37,11 +37,7 @@ export const useAuthStore = defineStore('auth', () => {
   }
 
   async function demoLogin() {
-    const demoToken = `demo-token-${Date.now()}`
-    setAuth({
-      token: demoToken,
-      user: { id: 1, email: 'admin@smartport.gov.th', name: 'Administrator' },
-    })
+    await login({ email: 'admin', password: 'admin123' })
   }
 
   function logout() {


### PR DESCRIPTION
## Summary

- Dashboard ดึงข้อมูลจริงจาก API แทน hardcoded values
- แก้ปัญหา login ไม่ได้ (Apache strip Authorization header, fake demo token, query string routing)
- Probation status คำนวณจาก remaining_days พร้อม color-coded display
- Candidate list status เปลี่ยนเป็น ถึงเกณฑ์/ยังไม่ถึงเกณฑ์/ใกล้ถึงเกณฑ์
- Backend Dockerfile แก้จาก pdo_pgsql เป็น pdo_mysql

## Changes (10 commits)

### Dashboard
- `DashboardPage.vue` — ดึงข้อมูลจริงจาก `/dashboard`, `/candidates/{level}`
- `api.php` — `/dashboard` endpoint อ่านจาก `personnel` table (ไม่ใช่ `civil_servants`)

### Auth & Routing
- `.htaccess` — เพิ่ม RewriteRule ส่ง Authorization header ผ่านไป PHP
- `auth.php` — เพิ่ม `REDIRECT_HTTP_AUTHORIZATION` fallback
- `api.php` — ใช้ `parse_url()` ตัด query string ก่อน path routing
- `auth.js` — `demoLogin()` เรียก API จริงแทน fake token
- `LoginPage.vue` — skipLogin ลบ token เก่า + error handling

### Status Display
- `useProbation.js` — `computeDisplayStatus()`: NOT_DUE/NEAR_DEADLINE/READY/OVERDUE/IN_REVIEW
- `useCandidates.js` — `computeDisplayStatus()`: NOT_MET/NEAR_MET/MET/EXCEEDED/PROMOTING
- `useRemainingDays.js` — เพิ่ม `getCandidateRemainingDaysClass()` (negative = ปกติ, ไม่ใช่แดง)
- `StatusBadge.vue` — เพิ่ม status ใหม่ทั้ง probation + candidate
- `CandidateListsPage.vue` — stat cards ใช้ label ใหม่ (ถึงเกณฑ์/ยังไม่ถึงเกณฑ์)

### Infrastructure
- `Dockerfile` — แก้ `pdo_pgsql` เป็น `pdo_mysql`

## Test plan

- [x] All 38 tests pass (vitest)
- [x] API endpoints verified via curl (direct + Vite proxy)
- [x] Browser verification via agent-browser (login → dashboard → probation)
- [x] Stat cards show real data
- [x] Probation table shows 3 rows with color-coded status
- [x] Candidate list shows correct status labels

🤖 Generated with [Claude Code](https://claude.ai/code)