### PR TITLE
feat: backend summary fixes (PRD Phase 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,8 @@ uploads/*
 !uploads/.gitkeep
 backend/uploads/*
 !backend/uploads/.gitkeep
+database/export-*.sql
+database/reimport-data.sql
 
 # Test coverage
 coverage/

--- a/backend/QualificationEngine.php
+++ b/backend/QualificationEngine.php
@@ -14,23 +14,30 @@ class QualificationEngine
 {
     private PDO $pdo;
 
+    /** ระดับเป้าหมายทั้งหมดที่แสดงในภาพรวม แยกตามประเภทตำแหน่ง */
+    private const OVERVIEW_LEVELS = [
+        'general' => ['O2', 'O3'],
+        'academic' => ['K2', 'K3', 'K4'],
+    ];
+
+    /** เกณฑ์ "ใกล้ถึงเกณฑ์" — เหลือ 1-90 วัน (ตรงกับ NEAR_THRESHOLD_DAYS ฝั่ง frontend) */
+    private const NEAR_THRESHOLD_DAYS = 90;
+
     public function __construct(PDO $pdo)
     {
         $this->pdo = $pdo;
     }
 
     /**
-     * คำนวณคุณสมบัติเลื่อนระดับสำหรับบุคลากรทั้งหมดที่อยู่ในระดับต้นทาง
+     * สร้าง base SELECT query + parameters สำหรับ target level ที่กำหนด
+     * แชร์ระหว่าง computeForLevel และ computeOverview เพื่อไม่ให้ SQL ซ้ำสองก๊อปปี้
      *
      * @param string $targetLevel รหัสระดับเป้าหมาย (e.g. K2, K3, O2)
-     * @param string|null $search คำค้นหา (ชื่อ, นามสกุล, ตำแหน่ง)
-     * @param int $limit จำนวนรายการต่อหน้า
-     * @param int $offset เริ่มต้นจากรายการที่
-     * @return array ผลลัพธ์พร้อม data, summary, pagination
+     * @return array|null ['sql' => baseSelect, 'params' => params] หรือ null ถ้าไม่มี source levels
      */
-    public function computeForLevel(string $targetLevel, ?string $search, int $limit, int $offset): array
+    private function buildBaseQuery(string $targetLevel): ?array
     {
-        // Step 1: ดึง source level codes สำหรับ target level นี้
+        // ดึง source level codes สำหรับ target level นี้
         $stmt = $this->pdo->prepare(
             'SELECT DISTINCT source_level_code FROM promotion_criteria WHERE target_level_code = ? AND is_active = 1'
         );
@@ -38,15 +45,9 @@ class QualificationEngine
         $sourceLevels = $stmt->fetchAll(PDO::FETCH_COLUMN);
 
         if (empty($sourceLevels)) {
-            return [
-                'success' => true,
-                'data' => [],
-                'summary' => ['total' => 0, 'qualified' => 0, 'not_yet' => 0, 'check_data' => 0],
-                'pagination' => ['total' => 0, 'limit' => $limit, 'offset' => $offset, 'has_more' => false]
-            ];
+            return null;
         }
 
-        // Step 2: Build main query
         $placeholders = implode(',', array_fill(0, count($sourceLevels), '?'));
 
         $baseSelect = "
@@ -120,8 +121,36 @@ class QualificationEngine
         ";
 
         // Build params: targetLevel for JOIN, then source levels for IN clause
-        $params = [$targetLevel];
-        $params = array_merge($params, $sourceLevels);
+        $params = array_merge([$targetLevel], $sourceLevels);
+
+        return ['sql' => $baseSelect, 'params' => $params];
+    }
+
+    /**
+     * คำนวณคุณสมบัติเลื่อนระดับสำหรับบุคลากรทั้งหมดที่อยู่ในระดับต้นทาง
+     *
+     * @param string $targetLevel รหัสระดับเป้าหมาย (e.g. K2, K3, O2)
+     * @param string|null $search คำค้นหา (ชื่อ, นามสกุล, ตำแหน่ง)
+     * @param int $limit จำนวนรายการต่อหน้า
+     * @param int $offset เริ่มต้นจากรายการที่
+     * @return array ผลลัพธ์พร้อม data, summary, pagination
+     */
+    public function computeForLevel(string $targetLevel, ?string $search, int $limit, int $offset): array
+    {
+        // Step 1-2: สร้าง base query (แชร์ logic กับ computeOverview)
+        $base = $this->buildBaseQuery($targetLevel);
+
+        if ($base === null) {
+            return [
+                'success' => true,
+                'data' => [],
+                'summary' => ['total' => 0, 'qualified' => 0, 'not_yet' => 0, 'check_data' => 0],
+                'pagination' => ['total' => 0, 'limit' => $limit, 'offset' => $offset, 'has_more' => false]
+            ];
+        }
+
+        $baseSelect = $base['sql'];
+        $params = $base['params'];
 
         // Step 3: Apply search filter
         $searchClause = '';
@@ -189,6 +218,110 @@ class QualificationEngine
                 'offset' => $offset,
                 'has_more' => ($offset + $limit) < $total,
             ]
+        ];
+    }
+
+    /**
+     * สรุปภาพรวมบัญชีรายชื่อทุกระดับ (ทั่วไป + วิชาการ) จาก full dataset
+     * แทนการให้ frontend ยิงรายระดับแล้วรวมเลขเอง (ผิดเมื่อข้อมูลเกิน limit ต่อหน้า)
+     *
+     * @return array summary รวมทุกระดับ, by_level รายระดับ, top5 ใกล้ครบเกณฑ์ที่สุดข้ามระดับ
+     */
+    public function computeOverview(): array
+    {
+        $summary = [
+            'general_total' => 0,
+            'academic_total' => 0,
+            'qualified_total' => 0,
+            'near_qualified_total' => 0,
+            'not_yet_total' => 0,
+            'check_data_total' => 0,
+        ];
+        $byLevel = [];
+        $top5Pool = [];
+
+        foreach (self::OVERVIEW_LEVELS as $category => $levels) {
+            foreach ($levels as $level) {
+                $base = $this->buildBaseQuery($level);
+
+                // ระดับที่ไม่มีเกณฑ์ active — ใส่ค่าศูนย์ทั้งแถว ห้าม error
+                if ($base === null) {
+                    $byLevel[$level] = ['total' => 0, 'qualified' => 0, 'not_yet' => 0, 'check_data' => 0, 'near_qualified' => 0];
+                    continue;
+                }
+
+                // Summary ต่อระดับจาก full dataset (BETWEEN 1 AND 90 — NULL ไม่ถูกนับโดยธรรมชาติ)
+                $summarySql = "
+                    SELECT
+                        COUNT(*) AS total,
+                        SUM(CASE WHEN sub.status = 'qualified' THEN 1 ELSE 0 END) AS qualified,
+                        SUM(CASE WHEN sub.status = 'not_yet' THEN 1 ELSE 0 END) AS not_yet,
+                        SUM(CASE WHEN sub.status = 'check_data' THEN 1 ELSE 0 END) AS check_data,
+                        SUM(CASE WHEN sub.remaining_days BETWEEN 1 AND " . self::NEAR_THRESHOLD_DAYS . " THEN 1 ELSE 0 END) AS near_qualified
+                    FROM ({$base['sql']}) AS sub
+                ";
+                $stmt = $this->pdo->prepare($summarySql);
+                $stmt->execute($base['params']);
+                $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+                $levelSummary = [
+                    'total' => (int) ($row['total'] ?? 0),
+                    'qualified' => (int) ($row['qualified'] ?? 0),
+                    'not_yet' => (int) ($row['not_yet'] ?? 0),
+                    'check_data' => (int) ($row['check_data'] ?? 0),
+                    'near_qualified' => (int) ($row['near_qualified'] ?? 0),
+                ];
+                $byLevel[$level] = $levelSummary;
+
+                $summary[$category === 'general' ? 'general_total' : 'academic_total'] += $levelSummary['total'];
+                $summary['qualified_total'] += $levelSummary['qualified'];
+                $summary['near_qualified_total'] += $levelSummary['near_qualified'];
+                $summary['not_yet_total'] += $levelSummary['not_yet'];
+                $summary['check_data_total'] += $levelSummary['check_data'];
+
+                // Top 5 ของระดับนี้ — NULL remaining_days ไปท้ายสุด (ตรง logic ฝั่ง frontend เดิม)
+                $dataSql = "{$base['sql']} ORDER BY (remaining_days IS NULL), remaining_days ASC LIMIT 5";
+                $dataStmt = $this->pdo->prepare($dataSql);
+                $dataStmt->execute($base['params']);
+                $rows = $dataStmt->fetchAll(PDO::FETCH_ASSOC);
+
+                // Format fields ให้ตรงกับ data row ของ computeForLevel + ระบุระดับเป้าหมาย
+                foreach ($rows as &$r) {
+                    $r['target_level'] = $level;
+                    $r['qualification_date_thai'] = formatThaiDate($r['qualification_date']);
+                    $r['level_start_date_thai'] = formatThaiDate($r['current_level_start_date']);
+                    $r['current_level_name'] = getLevelName($r['current_level_code'] ?? '');
+                    $r['remaining_days'] = $r['remaining_days'] !== null ? (int) $r['remaining_days'] : null;
+                    $r['min_years'] = $r['min_years'] !== null ? (float) $r['min_years'] : null;
+                    $r['supportive_days'] = (int) $r['supportive_days'];
+                    $r['equivalence_days'] = (int) $r['equivalence_days'];
+                    $r['diverse_diff_count'] = (int) $r['diverse_diff_count'];
+                }
+                unset($r);
+
+                $top5Pool = array_merge($top5Pool, $rows);
+            }
+        }
+
+        // รวมทุกระดับ → เรียง remaining_days น้อยสุดก่อน (NULL ท้ายสุด) → ตัด 5 อันดับแรก
+        usort($top5Pool, function (array $a, array $b): int {
+            if ($a['remaining_days'] === null && $b['remaining_days'] === null) {
+                return 0;
+            }
+            if ($a['remaining_days'] === null) {
+                return 1;
+            }
+            if ($b['remaining_days'] === null) {
+                return -1;
+            }
+            return $a['remaining_days'] <=> $b['remaining_days'];
+        });
+
+        return [
+            'success' => true,
+            'summary' => $summary,
+            'by_level' => $byLevel,
+            'top5' => array_slice($top5Pool, 0, 5),
         ];
     }
 

--- a/backend/routes/candidates.php
+++ b/backend/routes/candidates.php
@@ -5,6 +5,7 @@
 // จัดการเส้นทาง API สำหรับบัญชีรายชื่อผู้มีคุณสมบัติเลื่อนระดับ
 //
 // Endpoints:
+//   GET /candidates/overview                 — สรุปภาพรวมทุกระดับ (ทั่วไป + วิชาการ) จาก full dataset
 //   GET /candidates/{targetLevel}            — รายชื่อบุคลากรพร้อมสถานะคุณสมบัติ
 //   GET /candidates/{targetLevel}/{id}       — รายละเอียดคุณสมบัติรายบุคคล
 // ============================================================================
@@ -25,6 +26,13 @@ function handleCandidates(PDO $pdo, string $method, array $path): void
     if ($method !== 'GET') {
         http_response_code(405);
         echo json_encode(['error' => 'Method not allowed']);
+        return;
+    }
+
+    // GET /candidates/overview — สรุปภาพรวมทุกระดับ (ต้องเช็คก่อน treat path[1] เป็น targetLevel)
+    if (strtolower($path[1] ?? '') === 'overview') {
+        $engine = new QualificationEngine($pdo);
+        echo json_encode($engine->computeOverview());
         return;
     }
 

--- a/backend/routes/equivalence.php
+++ b/backend/routes/equivalence.php
@@ -107,10 +107,14 @@ function getEquivalenceList(PDO $pdo): void
     }
     unset($row);
 
-    // Summary จาก full dataset
+    // Summary จาก full dataset — แยกนับตามสถานะอนุมัติ
+    // distinct_personnel นับเฉพาะคนที่มีรายการ APPROVED จริง (ไม่นับ PENDING/REJECTED)
     $summaryStmt = $pdo->query("
-        SELECT COUNT(DISTINCT personnel_id) AS distinct_personnel,
-               SUM(CASE WHEN approval_status = 'APPROVED' THEN approved_total_days ELSE 0 END) AS total_approved_days
+        SELECT COUNT(DISTINCT CASE WHEN approval_status = 'APPROVED' THEN personnel_id END) AS distinct_personnel,
+               SUM(CASE WHEN approval_status = 'APPROVED' THEN approved_total_days ELSE 0 END) AS total_approved_days,
+               SUM(CASE WHEN approval_status = 'PENDING' THEN 1 ELSE 0 END) AS pending_count,
+               SUM(CASE WHEN approval_status = 'APPROVED' THEN 1 ELSE 0 END) AS approved_count,
+               SUM(CASE WHEN approval_status = 'REJECTED' THEN 1 ELSE 0 END) AS rejected_count
         FROM position_equivalence
     ");
     $summaryRow = $summaryStmt->fetch(PDO::FETCH_ASSOC);
@@ -122,6 +126,9 @@ function getEquivalenceList(PDO $pdo): void
             'total' => $total,
             'distinct_personnel' => (int) ($summaryRow['distinct_personnel'] ?? 0),
             'total_approved_days' => (float) ($summaryRow['total_approved_days'] ?? 0),
+            'pending_count' => (int) ($summaryRow['pending_count'] ?? 0),
+            'approved_count' => (int) ($summaryRow['approved_count'] ?? 0),
+            'rejected_count' => (int) ($summaryRow['rejected_count'] ?? 0),
         ],
         'pagination' => [
             'total' => $total,

--- a/docs/render-tidb-production.md
+++ b/docs/render-tidb-production.md
@@ -59,6 +59,25 @@ Before testing production data pages, import the schema into TiDB Cloud:
 2. Run [database/tidb-init.sql](D:/hrProject/smart-port/database/tidb-init.sql) against that database.
 3. If you have production seed data, import it after the schema load.
 
+Important for Thai text and other UTF-8 data:
+
+- Always specify `utf8mb4` explicitly on both export and import when moving data between MySQL/TiDB instances.
+- If you skip the charset flag during import, UTF-8 bytes can be double-encoded and Thai text may appear as mojibake on production.
+
+Recommended commands:
+
+```bash
+# Export
+mysqldump --default-character-set=utf8mb4 --set-charset ...
+
+# Import
+mysql --default-character-set=utf8mb4 ...
+```
+
+Operational note:
+
+- Files like `database/reimport-data.sql` are generated repair/import artifacts for a specific environment and should not be committed as normal source files.
+
 ## 5. Manual Render dashboard checklist
 
 If you are updating the existing services instead of recreating them from the Blueprint:

--- a/project-log-md/codeX/2026-03-24_11-51-55_codex-gpt5_session-summary.md
+++ b/project-log-md/codeX/2026-03-24_11-51-55_codex-gpt5_session-summary.md
@@ -1,0 +1,173 @@
+# Smart Port Session Summary
+
+- Agent model: Codex (GPT-5)
+- Timestamp: 2026-03-24 11:51:55 Asia/Bangkok
+- Repository: `d:\hrProject\smart-port`
+- Branch: `main`
+
+## Executive Summary
+
+Session นี้เริ่มจากการตรวจเช็กต่อว่าปัญหา production ที่วิเคราะห์ไว้ก่อนหน้า ได้แก่ `ล็อกอินช้ามาก` และ `ข้อมูลแสดงไม่เหมือน local` ได้ถูกแก้แล้วครบหรือยัง จากการตรวจโค้ดบน `main` และ git history พบว่าแกนของปัญหาหลักถูกแก้ไปแล้วในหลาย commit ก่อนหน้า โดยเฉพาะ lazy DB connection, dashboard aggregation, fallback สำหรับ `vw_probation_dashboard`, และการแก้ `servant_id` vs `personnel_id`
+
+หลังจากนั้นมีการยืนยันจากการตรวจสอบล่าสุดบน production ว่า `ล็อกอินเร็วแล้ว` และ `จำนวนข้อมูลตรงกับ local แล้ว` แต่ยังพบปัญหาใหม่คือ `ข้อความภาษาไทยแสดงเป็นภาษาต่างดาว` จึงตรวจต่อด้าน encoding/charset และแก้ที่ชั้นการตอบ response และ web server config ทั้ง frontend และ backend
+
+สุดท้ายมีการ commit และ push การแก้ UTF-8/charset ขึ้น `origin/main` เรียบร้อยแล้วใน commit `994aab3` และสรุปว่าต้อง redeploy ทั้ง `frontend` และ `backend` บน Render เพื่อให้การแก้นี้มีผลจริงบน production
+
+## What Was Verified
+
+### 1. Verification of previously analyzed production issues
+
+ตรวจสอบแล้วว่า fix สำคัญจากรอบก่อนหน้าอยู่ในโค้ดปัจจุบัน:
+
+- `32ea2b5` `fix: lazy DB connection + dashboard/probation view fallback for TiDB`
+- `4d516fd` `fix: personnel ID mismatch + summary from full dataset`
+- `7d2f75f` `perf: aggregate candidate totals in dashboard endpoint`
+
+สิ่งที่ยืนยันได้จากโค้ด:
+
+- login route ไม่บังคับ connect DB ก่อนแล้ว
+- dashboard จากเดิมหลาย request ลดเหลือ request เดียว
+- probation/dashboard มี fallback เมื่อ `vw_probation_dashboard` ใช้งานบน TiDB ไม่ได้
+- supportive/diverse/equivalence เปลี่ยนไปใช้ `/personnel` และ `personnel_id` แล้ว
+
+ข้อสรุป ณ จุดนั้น:
+
+- ปัญหา `login ช้า` ถูกแก้ที่ชั้นโค้ดแล้ว
+- ปัญหา `ข้อมูลไม่ตรง local` ถูกแก้ไปมากแล้ว
+- ยังมีจุดค้างบางส่วน เช่น summary ในหน้า equivalence และความเสี่ยงเรื่อง deploy/schema จริงบน production
+
+### 2. Production status update from latest user verification
+
+ผู้ใช้ยืนยันล่าสุดว่า:
+
+- production login เร็วแล้ว
+- จำนวนข้อมูลที่แสดงเท่ากับ local แล้ว
+- ปัญหาที่เหลือคือภาษาไทยแสดงผิด encoding
+
+## UTF-8 / Encoding Investigation
+
+### Findings
+
+ตรวจพบว่า source file หลักหลายไฟล์ใน frontend ยังเก็บข้อความภาษาไทยเป็น UTF-8 ปกติ เช่น:
+
+- `frontend/index.html`
+- `frontend/src/pages/LoginPage.vue`
+- `frontend/src/pages/DashboardPage.vue`
+- `frontend/src/components/AppSidebar.vue`
+
+จึงตีความได้ว่าปัญหาที่ production ไม่ได้มาจาก source code ภาษาไทยเสียทั้งระบบ แต่มีแนวโน้มสูงว่าเกิดจากการเสิร์ฟ response โดยไม่ประกาศ charset ให้ชัดเจนในบางชั้นของ stack
+
+### Fixes applied in this session
+
+แก้ไขเพื่อบังคับ UTF-8 ชัดเจนใน production ดังนี้:
+
+- `frontend/nginx.conf`
+  - เพิ่ม `charset utf-8;`
+  - เพิ่ม `charset_types` สำหรับ HTML/CSS/JS/JSON/XML/SVG
+- `backend/api.php`
+  - เปลี่ยน header เป็น `Content-Type: application/json; charset=UTF-8`
+- `backend/config.php`
+  - เปลี่ยน header เป็น `Content-Type: application/json; charset=UTF-8`
+- `backend/index.php`
+  - เปลี่ยน header เป็น `Content-Type: application/json; charset=UTF-8`
+- `backend/Dockerfile`
+  - เพิ่ม Apache `AddDefaultCharset UTF-8`
+  - เพิ่ม PHP `default_charset = "UTF-8"`
+
+## Validation Performed
+
+### Successful validation
+
+- รัน `npm run build` ใน `frontend/` ผ่านเรียบร้อยหลังแก้ config
+
+### Validation limitation
+
+- ไม่สามารถรัน `php -l` ได้จากเครื่องนี้ เพราะไม่มี `php` CLI ใน environment ปัจจุบัน
+- ยังไม่ได้ตรวจ live response headers จาก Render production โดยตรงใน session นี้
+
+## Git Actions Completed
+
+- Commit created:
+  - `994aab3` `fix: enforce utf-8 charset for production responses`
+- Push completed:
+  - `origin/main`
+
+ไฟล์ที่รวมอยู่ใน commit นี้:
+
+- `frontend/nginx.conf`
+- `backend/api.php`
+- `backend/config.php`
+- `backend/index.php`
+- `backend/Dockerfile`
+
+หมายเหตุ:
+
+- มีไฟล์ untracked จำนวนมากใน workspace แต่ไม่ได้ถูกนำเข้า commit นี้
+- commit นี้จำกัดเฉพาะการแก้เรื่อง UTF-8/charset เท่านั้น
+
+## Deployment Impact
+
+การแก้นี้จะยังไม่ส่งผลบน production จนกว่าจะ redeploy ใหม่ทั้งสอง service:
+
+- `frontend`
+  - เพราะแก้ `frontend/nginx.conf`
+- `backend`
+  - เพราะแก้ทั้ง PHP headers และ `backend/Dockerfile`
+
+ข้อสรุป deployment:
+
+- ต้อง redeploy ทั้ง `frontend` และ `backend` บน Render
+
+## Current Status
+
+สถานะล่าสุดของปัญหา production หลัง session นี้:
+
+- `Login slow on production`: แก้แล้ว
+- `Production counts differ from local`: แก้แล้วตามผลตรวจล่าสุดของผู้ใช้
+- `Thai text rendered as mojibake`: แก้ในโค้ดแล้ว แต่ยังต้อง redeploy เพื่อยืนยันผล
+
+## Remaining Risks / Next Checks
+
+ถ้าหลัง redeploy แล้วภาษาไทยยังเพี้ยนอยู่ ให้ตรวจต่อในลำดับนี้:
+
+1. ตรวจ response headers จริงจาก Render ว่า frontend/backend ส่ง `charset=UTF-8` แล้วหรือไม่
+2. ตรวจข้อความภาษาไทยที่มาจากฐานข้อมูล TiDB ว่าถูก import แบบ encoding ผิดหรือไม่
+3. ตรวจเฉพาะ field ที่มาจาก DB ว่าเพี้ยนตั้งแต่ data layer หรือเพี้ยนเฉพาะ static UI
+
+อีกจุดค้างจากการตรวจรอบก่อนหน้า:
+
+- หน้า `Equivalence` ยังมีโอกาสคำนวณ stat cards จาก current page rows แทน full dataset ซึ่งเป็นคนละประเด็นกับ encoding และยังไม่ได้แก้ใน session นี้
+
+## Recommended Immediate Next Step
+
+1. Redeploy `smartport-frontend`
+2. Redeploy `smartport-backend`
+3. เปิด production แล้วตรวจภาษาไทยในหน้า login, dashboard, sidebar, และข้อความที่มาจาก API
+4. ถ้ายังเพี้ยน ให้ trace ต่อว่ามาจาก static bundle หรือจากข้อมูลใน TiDB
+
+## Post-Session Addendum
+
+หลังจากสรุป session นี้ มีการอ่านรายงานเพิ่มจาก Claude ที่ไฟล์ `project-log-md/claude-code/2026-03-24_12-30_claude-opus-4.6_tidb-encoding-fix.md` และพบว่าต้นตอของภาษาไทยเพี้ยนบน production ถูกระบุชัดเจนแล้วว่าอยู่ที่ `data ใน TiDB ถูก double-encode ตอน import` ไม่ใช่ที่ response headers เพียงอย่างเดียว
+
+สาระสำคัญของ addendum นี้:
+
+- static UI text และ response headers ของ frontend/backend ถูกต้องแล้ว
+- ข้อความภาษาไทยที่เพี้ยนมาจากข้อมูลใน TiDB โดยตรง
+- root cause คือขั้นตอน import ก่อนหน้าไม่ได้ระบุ `--default-character-set=utf8mb4`
+- การแก้จริงบน production ทำโดย re-export และ re-import ข้อมูลด้วย `utf8mb4`
+- ไม่มี code change เพิ่มจากรายงานนั้น
+
+ผลต่อข้อสรุปเดิม:
+
+- commit `994aab3` ยังคงมีประโยชน์ในฐานะ hardening เรื่อง charset ของ response
+- แต่ root cause ของ `Thai text rendered as mojibake` ตัวจริงคือ data import workflow ของ TiDB
+- สถานะล่าสุดควรถือว่า:
+  - `Login slow on production`: แก้แล้ว
+  - `Production counts differ from local`: แก้แล้ว
+  - `Thai text rendered as mojibake`: แก้แล้วเชิงปฏิบัติการผ่านการ re-import data ด้วย `utf8mb4`
+
+Decision on `database/reimport-data.sql`:
+
+- ไม่ควร commit ไฟล์นี้เป็น source-of-truth
+- ควรถือเป็น generated repair artifact สำหรับงาน operational ราย environment
+- ได้เพิ่ม rule ใน `.gitignore` และเพิ่มหมายเหตุใน `docs/render-tidb-production.md` แล้ว


### PR DESCRIPTION
## Summary
- `/equivalence` summary now includes `pending_count` / `approved_count` / `rejected_count`, and `distinct_personnel` counts only personnel with APPROVED records (was inflated by PENDING/REJECTED)
- New endpoint `GET /candidates/overview` — aggregates all 5 levels (general O2,O3 + academic K2,K3,K4) server-side from the full dataset, replacing the frontend pattern of firing 5 requests with limit=100 and summing client-side
- Refactored `QualificationEngine`: extracted shared `buildBaseQuery()`; added `computeOverview()` with per-level summary, near-qualified count (1-90 days), and cross-level top-5
- Includes pending docs commit `2bdb8f9` (TiDB encoding import guidance)

Backward compatible: existing summary fields unchanged; `/candidates/{level}` response shape untouched.

## Test plan
- [x] `php -l` clean on all 3 changed files
- [x] Contract tests vs local Docker MySQL: `/equivalence`, `/candidates/overview`, `/candidates/K2` (regression), `/dashboard`
- [x] API summary verified against direct SQL (pending 1 / approved 2 / rejected 1, distinct APPROVED = 1, K2 total = 3, personnel = 7)
- [x] Frontend unit tests (vitest) pass locally
- [ ] CI green (frontend build & test, docker build check)
- [ ] Verify on TiDB after deploy (Phase 6 of PRD)