### PR TITLE
feat: use backend summaries on stat cards and fix dead UI buttons

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
 
       - name: Install dependencies
-        run: rm -f package-lock.json && npm install
+        run: npm ci
 
       - name: Run tests
         run: npm test

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -12,13 +12,13 @@ ARG VITE_API_URL=http://localhost:8000
 # กำหนด working directory ภายใน container
 WORKDIR /app
 
-# คัดลอกเฉพาะ package.json เท่านั้น เพื่อบังคับให้ npm install
-# สร้าง dependency tree ใหม่ที่เหมาะสมกับ Linux
-COPY package.json ./
+# คัดลอก package.json พร้อม lockfile — npm ci เลือก optional deps
+# ตาม platform ของ container เอง (lockfile ใช้ข้ามแพลตฟอร์มได้)
+# การ resolve ใหม่โดยไม่มี lockfile เสี่ยง registry breakage เช่น workspace:* protocol
+COPY package.json package-lock.json ./
 
-# ติดตั้ง dependencies ใหม่สำหรับ Linux platform
-# ไม่ copy lockfile เพราะสร้างจาก Windows — ให้ npm resolve ใหม่
-RUN npm install
+# ติดตั้งตาม lockfile แบบ deterministic
+RUN npm ci
 
 # คัดลอกไฟล์ source code ทั้งหมดเข้ามาใน image
 # (ไฟล์ที่ไม่จำเป็นจะถูกกรองออกโดย .dockerignore)

--- a/frontend/src/__tests__/components/EmptyState.test.js
+++ b/frontend/src/__tests__/components/EmptyState.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import EmptyState from '@/components/EmptyState.vue'
+
+describe('EmptyState', () => {
+  it('renders title and description', () => {
+    const wrapper = mount(EmptyState, {
+      props: { title: 'ไม่พบข้อมูล', description: 'ยังไม่มีข้อมูลในขณะนี้' },
+    })
+    expect(wrapper.text()).toContain('ไม่พบข้อมูล')
+    expect(wrapper.text()).toContain('ยังไม่มีข้อมูลในขณะนี้')
+  })
+
+  it('does not render action button when actionLabel is not provided', () => {
+    const wrapper = mount(EmptyState)
+    expect(wrapper.find('button').exists()).toBe(false)
+  })
+
+  it('renders action button with label when actionLabel is provided', () => {
+    const wrapper = mount(EmptyState, {
+      props: { actionLabel: 'ลองใหม่อีกครั้ง' },
+    })
+    const button = wrapper.find('button')
+    expect(button.exists()).toBe(true)
+    expect(button.text()).toBe('ลองใหม่อีกครั้ง')
+  })
+
+  it('emits action when the button is clicked', async () => {
+    const wrapper = mount(EmptyState, {
+      props: { actionLabel: 'ลองใหม่อีกครั้ง' },
+    })
+    await wrapper.find('button').trigger('click')
+    expect(wrapper.emitted('action')).toBeTruthy()
+    expect(wrapper.emitted('action')).toHaveLength(1)
+  })
+
+  it('still renders default slot content (backward compat)', () => {
+    const wrapper = mount(EmptyState, {
+      slots: { default: '<button class="slot-btn">retry</button>' },
+    })
+    expect(wrapper.find('.slot-btn').exists()).toBe(true)
+  })
+})

--- a/frontend/src/__tests__/composables/useCandidates.test.js
+++ b/frontend/src/__tests__/composables/useCandidates.test.js
@@ -53,6 +53,73 @@ describe('useCandidates', () => {
     expect(url).toContain('offset=20')
   })
 
+  it('fetchOverview calls the overview endpoint', async () => {
+    mockGet.mockResolvedValue({ success: true, summary: {}, by_level: {}, top5: [] })
+
+    const { fetchOverview } = useCandidates()
+    await fetchOverview()
+
+    expect(mockGet).toHaveBeenCalledTimes(1)
+    expect(mockGet.mock.calls[0][0]).toBe('/candidates/overview')
+  })
+
+  it('fetchOverview passes summary through and maps top5 rows', async () => {
+    mockGet.mockResolvedValue({
+      success: true,
+      summary: {
+        general_total: 2,
+        academic_total: 5,
+        qualified_total: 6,
+        near_qualified_total: 0,
+        not_yet_total: 1,
+        check_data_total: 0,
+      },
+      by_level: { K2: { total: 3 } },
+      top5: [{
+        personnel_id: 7,
+        full_name: 'สมหญิง ขยัน',
+        current_position: 'เจ้าพนักงานธุรการ',
+        current_level_code: 'O1',
+        current_level_name: 'ปฏิบัติงาน',
+        level_start_date_thai: '1 ม.ค. 2566',
+        qualification_date_thai: '1 ม.ค. 2569',
+        remaining_days: 10,
+        status: 'not_yet',
+        department: 'กองกลาง',
+        supportive_days: 15,
+        equivalence_days: 30,
+        diverse_status: 'DIFF_PASS',
+        target_level: 'O2',
+      }],
+    })
+
+    const { fetchOverview } = useCandidates()
+    const result = await fetchOverview()
+
+    expect(result.summary.general_total).toBe(2)
+    expect(result.summary.qualified_total).toBe(6)
+    expect(result.byLevel.K2.total).toBe(3)
+    expect(result.top5).toHaveLength(1)
+    expect(result.top5[0].name).toBe('สมหญิง ขยัน')
+    expect(result.top5[0].currentLevelName).toBe('ปฏิบัติงาน')
+    expect(result.top5[0].remainingDays).toBe(10)
+    expect(result.top5[0].status).toBe('NEAR_MET')
+    expect(result.top5[0].supportiveDays).toBe(15)
+    expect(result.top5[0].equivalenceDays).toBe(30)
+    expect(result.top5[0].diverseStatus).toBe('DIFF_PASS')
+  })
+
+  it('fetchOverview tolerates missing fields in response', async () => {
+    mockGet.mockResolvedValue({ success: true })
+
+    const { fetchOverview } = useCandidates()
+    const result = await fetchOverview()
+
+    expect(result.summary).toEqual({})
+    expect(result.byLevel).toEqual({})
+    expect(result.top5).toEqual([])
+  })
+
   it('maps snake_case API response to camelCase', async () => {
     mockGet.mockResolvedValue({
       success: true,

--- a/frontend/src/components/EmptyState.vue
+++ b/frontend/src/components/EmptyState.vue
@@ -6,6 +6,13 @@
     <h3 class="text-base font-medium text-gray-900 mb-1">{{ title }}</h3>
     <p class="text-sm text-gray-500 text-center max-w-sm">{{ description }}</p>
     <slot />
+    <button
+      v-if="actionLabel"
+      class="mt-4 px-4 py-2 bg-blue-500 text-white rounded-lg text-sm hover:bg-blue-600 transition-colors"
+      @click="emit('action')"
+    >
+      {{ actionLabel }}
+    </button>
   </div>
 </template>
 
@@ -13,8 +20,11 @@
 import { Inbox } from 'lucide-vue-next'
 
 defineProps({
-  icon: { type: Object, default: () => Inbox },
+  icon: { type: [Object, Function], default: () => Inbox },
   title: { type: String, default: 'ไม่พบข้อมูล' },
   description: { type: String, default: 'ยังไม่มีข้อมูลในขณะนี้' },
+  actionLabel: { type: String, default: '' },
 })
+
+const emit = defineEmits(['action'])
 </script>

--- a/frontend/src/composables/useCandidates.js
+++ b/frontend/src/composables/useCandidates.js
@@ -18,6 +18,17 @@ export function useCandidates() {
     }
   }
 
+  // ภาพรวมทุกระดับจาก aggregate ฝั่ง backend (แทนการยิง 5 requests แล้วรวมเลขฝั่ง client)
+  async function fetchOverview() {
+    const result = await api.get('/candidates/overview')
+    return {
+      success: result.success,
+      summary: result.summary || {},
+      byLevel: result.by_level || {},
+      top5: (result.top5 || []).map(mapCandidateRow),
+    }
+  }
+
   // คำนวณสถานะแสดงผลจาก remaining_days และ backend status
   function computeDisplayStatus(backendStatus, remainingDays) {
     const days = (remainingDays !== null && remainingDays !== undefined) ? parseInt(remainingDays, 10) : null
@@ -59,5 +70,5 @@ export function useCandidates() {
     }
   }
 
-  return { fetchByLevel }
+  return { fetchByLevel, fetchOverview }
 }

--- a/frontend/src/pages/CandidateListsPage.vue
+++ b/frontend/src/pages/CandidateListsPage.vue
@@ -13,17 +13,6 @@
         <h1 class="text-2xl font-bold text-gray-900">{{ currentConfig.title }}</h1>
         <p class="text-sm text-gray-500 mt-1">{{ currentConfig.subtitle }}</p>
       </div>
-      <div v-if="hasSubTabs" class="flex gap-2">
-        <button class="flex items-center gap-1.5 px-4 py-2 bg-green-500 hover:bg-green-600 text-white text-sm rounded-lg">
-          <Download class="w-4 h-4" /> ส่งออก
-        </button>
-        <button class="flex items-center gap-1.5 px-4 py-2 bg-green-500 hover:bg-green-600 text-white text-sm rounded-lg">
-          <Upload class="w-4 h-4" /> นำเข้า
-        </button>
-        <button class="flex items-center gap-1.5 px-4 py-2 bg-blue-500 hover:bg-blue-600 text-white text-sm rounded-lg">
-          <Plus class="w-4 h-4" /> เพิ่มรายชื่อ
-        </button>
-      </div>
     </div>
 
     <!-- ==================== OVERVIEW SECTION ==================== -->
@@ -205,9 +194,6 @@
             @input="onSearchInput"
           />
         </div>
-        <button class="flex items-center gap-1.5 px-4 py-2 bg-white text-gray-700 text-sm border border-gray-300 rounded-lg hover:bg-gray-50">
-          ตัวกรอง
-        </button>
       </div>
 
       <!-- Loading state -->
@@ -277,17 +263,13 @@
                   <StatusBadge :status="row.status" />
                 </td>
                 <td class="px-6 py-3">
-                  <div class="flex items-center gap-2">
-                    <button class="p-1 text-blue-500 hover:text-blue-700 hover:bg-blue-50 rounded" title="ดูรายละเอียด">
-                      <Eye class="w-4 h-4" />
-                    </button>
-                    <button class="p-1 text-amber-500 hover:text-amber-700 hover:bg-amber-50 rounded" title="แก้ไข">
-                      <Pencil class="w-4 h-4" />
-                    </button>
-                    <button class="p-1 text-red-500 hover:text-red-700 hover:bg-red-50 rounded" title="ลบ">
-                      <Trash2 class="w-4 h-4" />
-                    </button>
-                  </div>
+                  <button
+                    @click="openView(row)"
+                    class="p-1 text-blue-500 hover:text-blue-700 hover:bg-blue-50 rounded"
+                    title="ดูรายละเอียด"
+                  >
+                    <Eye class="w-4 h-4" />
+                  </button>
                 </td>
               </tr>
               <tr v-if="rows.length === 0">
@@ -311,6 +293,77 @@
         />
       </template>
     </template>
+
+    <!-- ==================== View Modal ==================== -->
+    <Teleport to="body">
+      <div v-if="showViewModal" class="fixed inset-0 z-50 flex items-center justify-center">
+        <div class="absolute inset-0 bg-black/50" @click="showViewModal = false"></div>
+        <div class="relative bg-white rounded-lg shadow-xl w-full max-w-lg mx-4 max-h-[90vh] overflow-y-auto">
+          <div class="px-6 py-4 border-b border-gray-200">
+            <h2 class="text-lg font-semibold text-gray-900">รายละเอียดผู้มีคุณสมบัติ</h2>
+          </div>
+          <div class="px-6 py-4 space-y-3">
+            <div class="grid grid-cols-2 gap-4">
+              <div>
+                <p class="text-xs text-gray-500">ชื่อ-สกุล</p>
+                <p class="text-sm font-medium text-gray-900">{{ viewingRow?.name }}</p>
+              </div>
+              <div>
+                <p class="text-xs text-gray-500">สถานะ</p>
+                <StatusBadge v-if="viewingRow" :status="viewingRow.status" />
+              </div>
+              <div>
+                <p class="text-xs text-gray-500">ตำแหน่งปัจจุบัน</p>
+                <p class="text-sm text-gray-900">{{ viewingRow?.currentPosition || '-' }}</p>
+              </div>
+              <div>
+                <p class="text-xs text-gray-500">ระดับตำแหน่ง</p>
+                <p class="text-sm text-gray-900">{{ viewingRow?.currentLevelName || '-' }}</p>
+              </div>
+              <div>
+                <p class="text-xs text-gray-500">สังกัด</p>
+                <p class="text-sm text-gray-900">{{ viewingRow?.department || '-' }}</p>
+              </div>
+              <div>
+                <p class="text-xs text-gray-500">วันเข้าสู่ระดับปัจจุบัน</p>
+                <p class="text-sm text-gray-900">{{ viewingRow?.levelStartDate || '-' }}</p>
+              </div>
+              <div>
+                <p class="text-xs text-gray-500">วันที่ครบกำหนด</p>
+                <p class="text-sm text-gray-900">{{ viewingRow?.qualificationDate || '-' }}</p>
+              </div>
+              <div>
+                <p class="text-xs text-gray-500">วันคงเหลือ</p>
+                <p class="text-sm" :class="getCandidateRemainingDaysClass(viewingRow?.remainingDays)">
+                  {{ formatRemainingDays(viewingRow?.remainingDays) }}
+                </p>
+              </div>
+              <div>
+                <p class="text-xs text-gray-500">วันเกื้อกูล</p>
+                <p class="text-sm text-gray-900">{{ viewingRow?.supportiveDays > 0 ? `${viewingRow.supportiveDays} วัน` : '-' }}</p>
+              </div>
+              <div>
+                <p class="text-xs text-gray-500">วันเทียบ ตน.</p>
+                <p class="text-sm text-gray-900">{{ viewingRow?.equivalenceDays > 0 ? `${viewingRow.equivalenceDays} วัน` : '-' }}</p>
+              </div>
+              <div>
+                <p class="text-xs text-gray-500">สถานะ 3 ต่าง</p>
+                <StatusBadge v-if="viewingRow?.diverseStatus" :status="viewingRow.diverseStatus" />
+                <p v-else class="text-sm text-gray-400">-</p>
+              </div>
+            </div>
+          </div>
+          <div class="px-6 py-4 border-t border-gray-200 flex justify-end">
+            <button
+              @click="showViewModal = false"
+              class="px-4 py-2 text-sm text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+            >
+              ปิด
+            </button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
   </div>
 </template>
 
@@ -325,15 +378,14 @@ import EmptyState from '@/components/EmptyState.vue'
 import PaginationBar from '@/components/PaginationBar.vue'
 import {
   Users, UserCheck, AlertCircle, Clock, Timer, Loader, Home,
-  Download, Upload, Plus, Eye, Pencil, Trash2,
-  Construction
+  Eye, Construction
 } from 'lucide-vue-next'
 
 const props = defineProps({
   section: { type: String, default: 'overview' },
 })
 
-const { fetchByLevel } = useCandidates()
+const { fetchByLevel, fetchOverview } = useCandidates()
 
 // Sub-tab state (reactive, not router per D-04)
 const activeSubTab = ref(null)
@@ -349,10 +401,19 @@ const pagination = ref({ total: 0, limit: 20, offset: 0, has_more: false })
 const searchQuery = ref('')
 let searchTimeout = null
 
-// Overview state (separate because it merges multiple API calls)
+// Overview state
 const overviewLoading = ref(false)
 const overviewError = ref(null)
 const overviewData = ref(null)
+
+// View modal state
+const showViewModal = ref(false)
+const viewingRow = ref(null)
+
+function openView(row) {
+  viewingRow.value = row
+  showViewModal.value = true
+}
 
 // Configuration maps
 const subTabConfig = {
@@ -423,57 +484,21 @@ async function fetchData() {
   }
 }
 
-// Fetch overview data (Promise.allSettled for all 5 levels per D-08)
+// Fetch overview data — aggregate จาก backend ครั้งเดียว (เลขถูกต้องทั้ง dataset เสมอ)
 async function fetchOverviewData() {
   overviewLoading.value = true
   overviewError.value = null
   try {
-    const levels = ['O2', 'O3', 'K2', 'K3', 'K4']
-    const results = await Promise.allSettled(
-      levels.map(level => fetchByLevel(level, { limit: 100, offset: 0 }))
-    )
-
-    // Extract fulfilled results mapped by level
-    const dataByLevel = {}
-    levels.forEach((level, i) => {
-      if (results[i].status === 'fulfilled') {
-        dataByLevel[level] = results[i].value
-      } else {
-        dataByLevel[level] = { data: [], summary: { total: 0, qualified: 0, not_yet: 0, check_data: 0 } }
-      }
-    })
-
-    const generalTotal = (dataByLevel.O2.summary?.total || 0) + (dataByLevel.O3.summary?.total || 0)
-    const academicTotal = (dataByLevel.K2.summary?.total || 0) + (dataByLevel.K3.summary?.total || 0) + (dataByLevel.K4.summary?.total || 0)
-
-    const allSummaries = Object.values(dataByLevel).map(d => d.summary || {})
-    const qualifiedTotal = allSummaries.reduce((sum, s) => sum + (s.qualified || 0), 0)
-    const notYetTotal = allSummaries.reduce((sum, s) => sum + (s.not_yet || 0), 0)
-    const checkDataTotal = allSummaries.reduce((sum, s) => sum + (s.check_data || 0), 0)
-
-    // Top 5 nearest deadline: concatenate all data, sort by remainingDays asc (null last), take 5
-    const allRows = Object.values(dataByLevel).flatMap(d => d.data || [])
-    allRows.sort((a, b) => {
-      if (a.remainingDays === null || a.remainingDays === undefined) return 1
-      if (b.remainingDays === null || b.remainingDays === undefined) return -1
-      return a.remainingDays - b.remainingDays
-    })
-    const top5 = allRows.slice(0, 5)
-
-    // ใกล้ถึงเกณฑ์: เหลือ 1-90 วัน (ยังไม่ถึงแต่ใกล้แล้ว)
-    const NEAR_THRESHOLD_DAYS = 90
-    const nearQualifiedTotal = allRows.filter(r =>
-      r.remainingDays != null && r.remainingDays > 0 && r.remainingDays <= NEAR_THRESHOLD_DAYS
-    ).length
-
+    const result = await fetchOverview()
+    const s = result.summary
     overviewData.value = {
-      generalTotal,
-      academicTotal,
-      qualifiedTotal,
-      nearQualifiedTotal,
-      notYetTotal,
-      checkDataTotal,
-      top5,
+      generalTotal: s.general_total || 0,
+      academicTotal: s.academic_total || 0,
+      qualifiedTotal: s.qualified_total || 0,
+      nearQualifiedTotal: s.near_qualified_total || 0,
+      notYetTotal: s.not_yet_total || 0,
+      checkDataTotal: s.check_data_total || 0,
+      top5: result.top5,
     }
   } catch (err) {
     overviewError.value = err.message || 'ไม่สามารถโหลดข้อมูลภาพรวมได้'

--- a/frontend/src/pages/EquivalencePage.vue
+++ b/frontend/src/pages/EquivalencePage.vue
@@ -26,7 +26,7 @@
     <div v-else class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
       <StatCard
         label="คำขอทั้งหมด"
-        :value="pagination.total"
+        :value="totalCount"
         :icon="FileText"
         icon-bg-class="bg-blue-50"
         icon-class="text-blue-600"
@@ -529,13 +529,23 @@ const rejectingId = ref(null)
 const showViewModal = ref(false)
 const viewingRecord = ref(null)
 
-// Computed status counts from current rows
+// Status counts — ใช้ summary จาก backend (full dataset) ถ้ามี, fallback นับจาก rows หน้าปัจจุบัน
 const statusCounts = computed(() => {
+  if (summary.value?.pending_count != null) {
+    return {
+      pending: summary.value.pending_count ?? 0,
+      approved: summary.value.approved_count ?? 0,
+      rejected: summary.value.rejected_count ?? 0,
+    }
+  }
   const pending = rows.value.filter(r => r.approvalStatus === 'PENDING').length
   const approved = rows.value.filter(r => r.approvalStatus === 'APPROVED').length
   const rejected = rows.value.filter(r => r.approvalStatus === 'REJECTED').length
   return { pending, approved, rejected }
 })
+
+// คำขอทั้งหมด — full dataset จาก summary เพื่อให้สอดคล้องกับ 3 cards ข้างบนเมื่อมี search
+const totalCount = computed(() => summary.value?.total ?? pagination.value.total)
 
 // ==================== Data fetching ====================
 

--- a/frontend/src/pages/ProbationEndPage.vue
+++ b/frontend/src/pages/ProbationEndPage.vue
@@ -118,17 +118,13 @@
                 <StatusBadge :status="row.status" />
               </td>
               <td class="px-6 py-3 text-sm">
-                <div class="flex items-center gap-2">
-                  <button class="p-1 text-gray-400 hover:text-blue-600 transition-colors" title="ดูรายละเอียด">
-                    <Eye class="w-4 h-4" />
-                  </button>
-                  <button class="p-1 text-gray-400 hover:text-yellow-600 transition-colors" title="แก้ไข">
-                    <Pencil class="w-4 h-4" />
-                  </button>
-                  <button class="p-1 text-gray-400 hover:text-red-600 transition-colors" title="ลบ">
-                    <Trash2 class="w-4 h-4" />
-                  </button>
-                </div>
+                <button
+                  @click="openView(row)"
+                  class="p-1 text-gray-400 hover:text-blue-600 transition-colors"
+                  title="ดูรายละเอียด"
+                >
+                  <Eye class="w-4 h-4" />
+                </button>
               </td>
             </tr>
             <tr v-if="rows.length === 0 && !loading">
@@ -152,6 +148,66 @@
       :offset="pagination.offset"
       @update:offset="val => { pagination.offset = val; fetchData() }"
     />
+
+    <!-- ==================== View Modal ==================== -->
+    <Teleport to="body">
+      <div v-if="showViewModal" class="fixed inset-0 z-50 flex items-center justify-center">
+        <div class="absolute inset-0 bg-black/50" @click="showViewModal = false"></div>
+        <div class="relative bg-white rounded-lg shadow-xl w-full max-w-lg mx-4 max-h-[90vh] overflow-y-auto">
+          <div class="px-6 py-4 border-b border-gray-200">
+            <h2 class="text-lg font-semibold text-gray-900">รายละเอียดการทดลองปฏิบัติราชการ</h2>
+          </div>
+          <div class="px-6 py-4 space-y-3">
+            <div class="grid grid-cols-2 gap-4">
+              <div>
+                <p class="text-xs text-gray-500">ชื่อ-สกุล</p>
+                <p class="text-sm font-medium text-gray-900">{{ viewingRow?.name }}</p>
+              </div>
+              <div>
+                <p class="text-xs text-gray-500">สถานะ</p>
+                <StatusBadge v-if="viewingRow" :status="viewingRow.status" />
+              </div>
+              <div>
+                <p class="text-xs text-gray-500">ตำแหน่ง</p>
+                <p class="text-sm text-gray-900">{{ viewingRow?.position || '-' }}</p>
+              </div>
+              <div>
+                <p class="text-xs text-gray-500">หน่วยงาน</p>
+                <p class="text-sm text-gray-900">{{ viewingRow?.department || '-' }}</p>
+              </div>
+              <div>
+                <p class="text-xs text-gray-500">วันเริ่มทดลอง</p>
+                <p class="text-sm text-gray-900">{{ viewingRow?.startDate || '-' }}</p>
+              </div>
+              <div>
+                <p class="text-xs text-gray-500">วันครบกำหนด</p>
+                <p class="text-sm text-gray-900">{{ viewingRow?.endDate || '-' }}</p>
+              </div>
+              <div>
+                <p class="text-xs text-gray-500">วันคงเหลือ</p>
+                <p class="text-sm" :class="getRemainingDaysClass(viewingRow?.remainingDays)">
+                  {{ formatRemainingDays(viewingRow?.remainingDays) }}
+                </p>
+              </div>
+              <div>
+                <p class="text-xs text-gray-500">ภารกิจ</p>
+                <p class="text-sm text-gray-900">
+                  {{ viewingRow?.totalTasks != null ? `${viewingRow.completedTasks ?? 0}/${viewingRow.totalTasks} ภารกิจ` : '-' }}
+                </p>
+              </div>
+            </div>
+          </div>
+          <div class="px-6 py-4 border-t border-gray-200 flex justify-end">
+            <button
+              @click="showViewModal = false"
+              class="px-4 py-2 text-sm text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+            >
+              ปิด
+            </button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
   </div>
 </template>
 
@@ -164,7 +220,7 @@ import StatusBadge from '@/components/StatusBadge.vue'
 import SkeletonLoader from '@/components/SkeletonLoader.vue'
 import EmptyState from '@/components/EmptyState.vue'
 import PaginationBar from '@/components/PaginationBar.vue'
-import { Users, UserCheck, Clock, AlertTriangle, AlertCircle, Home, Eye, Pencil, Trash2, Search } from 'lucide-vue-next'
+import { Users, UserCheck, Clock, AlertTriangle, AlertCircle, Home, Eye, Search } from 'lucide-vue-next'
 
 const { fetchList } = useProbation()
 
@@ -177,6 +233,15 @@ const pagination = ref({ total: 0, limit: 20, offset: 0, has_more: false })
 // Search with 300ms debounce
 const searchQuery = ref('')
 let searchTimeout = null
+
+// View modal state
+const showViewModal = ref(false)
+const viewingRow = ref(null)
+
+function openView(row) {
+  viewingRow.value = row
+  showViewModal.value = true
+}
 
 async function fetchData() {
   loading.value = true


### PR DESCRIPTION
## Summary

Phase 2 ของ Production Readiness Release — frontend ใช้ summary จาก backend (full dataset) และกำจัด dead UI ทั้งหมด

- **EquivalencePage**: stat cards ใช้ `summary.pending_count/approved_count/rejected_count` จาก backend (fallback นับจาก rows) — เลขไม่เพี้ยนเมื่อข้อมูลเกิน 1 หน้า pagination
- **CandidateListsPage overview**: เปลี่ยนจากยิง 5 requests limit=100 แล้วรวมเลขฝั่ง client → เรียก `GET /candidates/overview` ครั้งเดียว (endpoint จาก PR #3)
- **Dead UI**: ลบปุ่ม ส่งออก/นำเข้า/เพิ่มรายชื่อ/ตัวกรอง/แก้ไข/ลบ ที่ไม่มี handler; ปุ่มดูรายละเอียดเปิด View modal จริง (Candidate + Probation)
- **EmptyState**: เพิ่ม `actionLabel` prop + `action` emit — ปุ่ม retry ของ DiversePage กลับมาทำงาน (เดิม prop ตกหล่นเงียบ ๆ ปุ่มไม่ render)
- แก้ prop `icon` เป็น `[Object, Function]` กัน Vue warn จาก lucide functional components

## Test plan

- [x] Unit tests 46/46 ผ่าน (เพิ่มใหม่ 8: EmptyState 5 + fetchOverview 3) — รันใน Docker node:20-slim เพราะ vitest worker มีปัญหาบนเครื่อง dev Windows; CI ubuntu เป็น authoritative
- [x] `npm run build` ผ่าน
- [x] Code review (code-reviewer agent): APPROVE — 0 CRITICAL/HIGH, MEDIUM 2 ข้อแก้แล้ว
- [ ] CI: Frontend Build & Test + Docker Build Check
- [ ] Manual: ตรวจเลข stat cards กับ API จริงหลัง deploy (Phase 6 checklist)

อ้างอิง: `.claude/PRPs/plans/completed/frontend-summary-dead-ui.plan.md`, report + review ใน `.claude/PRPs/`