### PR TITLE
feat: multi-user auth with roles, rate limiting and user management

### DIFF
--- a/backend/api.php
+++ b/backend/api.php
@@ -32,8 +32,8 @@ if ($path[0] === 'api') {
 
 $token = getAuthHeader();
 
-// Skip authentication for login and options
-if (!in_array($path[0], ['login', 'auth']) && $method !== 'OPTIONS') {
+// Skip authentication for auth endpoints and options
+if ($path[0] !== 'auth' && $method !== 'OPTIONS') {
     if (!$token || !validateJWT($token)) {
         http_response_code(401);
         echo json_encode(['error' => 'Unauthorized']);
@@ -43,55 +43,15 @@ if (!in_array($path[0], ['login', 'auth']) && $method !== 'OPTIONS') {
 
 switch ($path[0]) {
     case 'auth':
-        if ($path[1] === 'login' && $method == 'POST') {
-            $data = json_decode(file_get_contents('php://input'), true);
-
-            // รองรับทั้ง email/password และ username/password
-            $email = $data['email'] ?? $data['username'] ?? '';
-            $password = $data['password'] ?? '';
-
-            // Simple validation (ควรเช็คกับ database จริง)
-            if (($email == 'admin@smartport.gov.th' || $email == 'admin') && $password == 'admin123') {
-                $token = generateJWT(1); // user_id = 1
-                echo json_encode([
-                    'token' => $token,
-                    'user' => [
-                        'id' => 1,
-                        'email' => 'admin@smartport.gov.th',
-                        'name' => 'Administrator'
-                    ]
-                ]);
-            } else {
-                http_response_code(401);
-                echo json_encode(['error' => 'Invalid credentials']);
-            }
-        }
+        $pdo = getDB();
+        include __DIR__ . '/routes/auth.php';
+        handleAuth($pdo, $method, $path);
         break;
 
-    case 'login':
-        if ($method == 'POST') {
-            $data = json_decode(file_get_contents('php://input'), true);
-
-            // รองรับทั้ง email/password และ username/password
-            $email = $data['email'] ?? $data['username'] ?? '';
-            $password = $data['password'] ?? '';
-
-            // Simple validation (ควรเช็คกับ database จริง)
-            if (($email == 'admin@smartport.gov.th' || $email == 'admin') && $password == 'admin123') {
-                $token = generateJWT(1); // user_id = 1
-                echo json_encode([
-                    'token' => $token,
-                    'user' => [
-                        'id' => 1,
-                        'email' => 'admin@smartport.gov.th',
-                        'name' => 'Administrator'
-                    ]
-                ]);
-            } else {
-                http_response_code(401);
-                echo json_encode(['error' => 'Invalid credentials']);
-            }
-        }
+    case 'users':
+        $pdo = getDB();
+        include __DIR__ . '/routes/users.php';
+        handleUsers($pdo, $method, $path);
         break;
 
     case 'profile':

--- a/backend/auth.php
+++ b/backend/auth.php
@@ -8,12 +8,12 @@ function base64url_decode($data) {
     return base64_decode(str_pad(strtr($data, '-_', '+/'), strlen($data) % 4, '=', STR_PAD_RIGHT));
 }
 
-function generateJWT($user_id) {
+function generateJWT($user_id, $role = 'operator') {
     $header = json_encode(['typ' => 'JWT', 'alg' => 'HS256']);
     $payload = json_encode([
         'iat' => time(),
         'exp' => time() + 3600, // หมดอายุ 1 ชม.
-        'data' => ['user_id' => $user_id]
+        'data' => ['user_id' => $user_id, 'role' => $role]
     ]);
     
     $headerEncoded = base64url_encode($header);
@@ -56,24 +56,49 @@ function validateJWT($token) {
     return $payload['data'];
 }
 
+// แยก token จากค่า header "Bearer <token>" — รองรับ prefix ทุกตัวพิมพ์ (Bearer/bearer)
+function extractBearerToken(string $headerValue): ?string {
+    if (stripos($headerValue, 'Bearer ') === 0) {
+        return substr($headerValue, 7);
+    }
+    return null;
+}
+
 function getAuthHeader() {
     // Check for Authorization header in different ways
     if (isset($_SERVER['HTTP_AUTHORIZATION'])) {
-        return str_replace('Bearer ', '', $_SERVER['HTTP_AUTHORIZATION']);
+        return extractBearerToken($_SERVER['HTTP_AUTHORIZATION']);
     }
 
     // Apache rewrite sets REDIRECT_HTTP_AUTHORIZATION
     if (isset($_SERVER['REDIRECT_HTTP_AUTHORIZATION'])) {
-        return str_replace('Bearer ', '', $_SERVER['REDIRECT_HTTP_AUTHORIZATION']);
+        return extractBearerToken($_SERVER['REDIRECT_HTTP_AUTHORIZATION']);
     }
 
     if (function_exists('apache_request_headers')) {
         $headers = apache_request_headers();
         if (isset($headers['Authorization'])) {
-            return str_replace('Bearer ', '', $headers['Authorization']);
+            return extractBearerToken($headers['Authorization']);
         }
     }
 
     return null;
+}
+
+// ดึงข้อมูล user จาก JWT ของ request ปัจจุบัน — คืน ['user_id'=>.., 'role'=>..] หรือ null
+function currentUser(): ?array {
+    $payload = validateJWT(getAuthHeader());
+    return is_array($payload) ? $payload : null;
+}
+
+// บังคับ role admin — ส่ง 403 แล้วจบ request ถ้าไม่ใช่
+function requireAdmin(): array {
+    $user = currentUser();
+    if (!$user || ($user['role'] ?? '') !== 'admin') {
+        http_response_code(403);
+        echo json_encode(['error' => 'ต้องเป็นผู้ดูแลระบบเท่านั้น']);
+        exit;
+    }
+    return $user;
 }
 ?>

--- a/backend/config.php
+++ b/backend/config.php
@@ -11,14 +11,21 @@ function env($key, $default = '') {
 
 header('Content-Type: application/json; charset=UTF-8');
 
-// JWT Secret — อ่านจาก env var ก่อน ถ้าไม่มีใช้ค่า default (dev only)
-define('JWT_SECRET', env('JWT_SECRET', 'your_secret_key_here'));
+// JWT Secret — ต้องมาจาก env var เท่านั้น
+// ห้ามมี default: ค่า fallback ใน source สาธารณะ = ใครก็ forge token ได้
+$jwtSecret = env('JWT_SECRET', '');
+if ($jwtSecret === '') {
+    http_response_code(500);
+    echo json_encode(['error' => 'Server configuration error']);
+    exit;
+}
+define('JWT_SECRET', $jwtSecret);
 define('UPLOAD_DIR', __DIR__ . '/uploads/');
 
 // ============================================================================
 // Lazy PDO Connection
 // สร้าง connection เฉพาะเมื่อ route ต้องใช้ DB จริงๆ
-// ช่วยให้ login (hardcoded) เร็วขึ้นมากเพราะไม่ต้องรอ TiDB SSL handshake
+// (OPTIONS preflight และ error responses ไม่ต้องรอ TiDB SSL handshake)
 // ============================================================================
 $pdo = null;
 

--- a/backend/routes/auth.php
+++ b/backend/routes/auth.php
@@ -1,0 +1,117 @@
+<?php
+// ============================================================================
+// routes/auth.php
+// Authentication Route Handler — เข้าสู่ระบบจากตาราง users จริง
+//
+// Endpoints:
+//   POST /auth/login — ตรวจ username/password กับ DB + rate limit
+//
+// Rate limiting (ตาราง login_attempts):
+//   ผิดติดต่อกัน 5 ครั้งภายใน 15 นาที (นับต่อ username) -> 429
+// ============================================================================
+
+include_once __DIR__ . '/../helpers.php';
+
+const MAX_LOGIN_ATTEMPTS = 5;
+const LOCKOUT_WINDOW_MINUTES = 15;
+
+/**
+ * จัดการ request สำหรับ auth endpoints
+ *
+ * @param PDO $pdo Database connection
+ * @param string $method HTTP method
+ * @param array $path URL path segments
+ */
+function handleAuth(PDO $pdo, string $method, array $path): void
+{
+    if (($path[1] ?? '') === 'login' && $method === 'POST') {
+        loginUser($pdo);
+        return;
+    }
+
+    http_response_code(404);
+    echo json_encode(['error' => 'Not found']);
+}
+
+/**
+ * POST /auth/login — ตรวจสอบ credentials กับตาราง users
+ *
+ * ข้อความ error 401 เหมือนกันทุกกรณี (user ไม่มี / รหัสผิด / ถูกปิดใช้งาน)
+ * เพื่อไม่เปิดเผยว่า username ใดมีอยู่ในระบบ
+ */
+function loginUser(PDO $pdo): void
+{
+    $data = json_decode(file_get_contents('php://input'), true);
+
+    // รองรับทั้ง username/password และ email/password (frontend เดิมส่งได้ทั้งสอง key)
+    $username = trim((string) ($data['username'] ?? $data['email'] ?? ''));
+    $password = (string) ($data['password'] ?? '');
+
+    if ($username === '' || $password === '') {
+        http_response_code(400);
+        echo json_encode(['error' => 'กรุณาระบุชื่อผู้ใช้และรหัสผ่าน']);
+        return;
+    }
+
+    // ลบ log เก่าเกิน 1 วัน — กันตาราง login_attempts โตไม่จำกัด
+    $pdo->exec("DELETE FROM login_attempts WHERE attempted_at < NOW() - INTERVAL 1 DAY");
+
+    // Rate limit: นับครั้งที่ผิดใน 15 นาทีล่าสุดของ username นี้
+    $stmt = $pdo->prepare(
+        "SELECT COUNT(*) AS fails FROM login_attempts
+         WHERE username = ? AND is_success = 0
+           AND attempted_at > NOW() - INTERVAL " . LOCKOUT_WINDOW_MINUTES . " MINUTE"
+    );
+    $stmt->execute([$username]);
+    $fails = (int) $stmt->fetch(PDO::FETCH_ASSOC)['fails'];
+
+    if ($fails >= MAX_LOGIN_ATTEMPTS) {
+        http_response_code(429);
+        echo json_encode(['error' => 'พยายามเข้าสู่ระบบผิดเกินกำหนด กรุณารอ ' . LOCKOUT_WINDOW_MINUTES . ' นาที']);
+        return;
+    }
+
+    $stmt = $pdo->prepare(
+        "SELECT user_id, username, password_hash, full_name, role, is_active, must_change_password
+         FROM users WHERE username = ?"
+    );
+    $stmt->execute([$username]);
+    $user = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    // password_verify รันเสมอแม้ไม่พบ user — กัน timing attack แยกแยะ username
+    $dummyHash = '$2y$10$usesomesillystringfore7hnbRJHxXVLeakoG8K30oukPsA.ztMG';
+    $hash = $user['password_hash'] ?? $dummyHash;
+    $isValid = password_verify($password, $hash)
+        && $user !== false
+        && $user['password_hash'] !== null
+        && (int) $user['is_active'] === 1;
+
+    $ip = $_SERVER['REMOTE_ADDR'] ?? null;
+    $logStmt = $pdo->prepare(
+        "INSERT INTO login_attempts (username, ip_address, is_success) VALUES (?, ?, ?)"
+    );
+
+    if (!$isValid) {
+        $logStmt->execute([$username, $ip, 0]);
+        http_response_code(401);
+        echo json_encode(['error' => 'ชื่อผู้ใช้หรือรหัสผ่านไม่ถูกต้อง']);
+        return;
+    }
+
+    $logStmt->execute([$username, $ip, 1]);
+    $pdo->prepare("UPDATE users SET last_login_at = NOW() WHERE user_id = ?")
+        ->execute([$user['user_id']]);
+
+    $token = generateJWT((int) $user['user_id'], $user['role']);
+
+    echo json_encode([
+        'token' => $token,
+        'user' => [
+            'id' => (int) $user['user_id'],
+            'username' => $user['username'],
+            'name' => $user['full_name'],
+            'role' => $user['role'],
+            'must_change_password' => (bool) $user['must_change_password'],
+        ],
+    ]);
+}

--- a/backend/routes/equivalence.php
+++ b/backend/routes/equivalence.php
@@ -66,8 +66,9 @@ function handleEquivalence(PDO $pdo, string $method, array $path): void
 function getEquivalenceList(PDO $pdo): void
 {
     $personnelId = $_GET['personnel_id'] ?? null;
-    $limit = intval($_GET['limit'] ?? 20);
-    $offset = intval($_GET['offset'] ?? 0);
+    // clamp กัน limit มหาศาล / offset ติดลบ
+    $limit = max(1, min(intval($_GET['limit'] ?? 20), 200));
+    $offset = max(0, intval($_GET['offset'] ?? 0));
 
     $baseQuery = "SELECT pe.*,
                          CONCAT(p.first_name, ' ', p.last_name) AS full_name,
@@ -193,8 +194,14 @@ function createEquivalence(PDO $pdo): void
     // คำนวณ request_total_days จากวันที่เริ่มต้นและสิ้นสุด (DATEDIFF+1)
     $requestTotalDays = null;
     if (!empty($data['request_start_date']) && !empty($data['request_end_date'])) {
-        $startDate = new DateTime($data['request_start_date']);
-        $endDate = new DateTime($data['request_end_date']);
+        try {
+            $startDate = new DateTime($data['request_start_date']);
+            $endDate = new DateTime($data['request_end_date']);
+        } catch (Exception $e) {
+            http_response_code(400);
+            echo json_encode(['error' => 'รูปแบบวันที่ไม่ถูกต้อง']);
+            return;
+        }
         $requestTotalDays = $endDate->diff($startDate)->days + 1;
     }
 
@@ -249,6 +256,9 @@ function updateEquivalence(PDO $pdo, int $id): void
     $newStatus = $data['approval_status'] ?? null;
 
     if ($newStatus !== null) {
+        // อนุมัติ/ปฏิเสธ — สงวนสิทธิ์ admin เท่านั้น (operator แก้ field ปกติได้)
+        $approver = requireAdmin();
+
         // ตรวจสอบ transition ที่อนุญาต
         $validTransitions = ['PENDING' => ['APPROVED', 'REJECTED']];
         $currentStatus = $current['approval_status'];
@@ -268,14 +278,18 @@ function updateEquivalence(PDO $pdo, int $id): void
             }
 
             // คำนวณ approved_total_days (DATEDIFF+1)
-            $approvedStart = new DateTime($data['approved_start_date']);
-            $approvedEnd = new DateTime($data['approved_end_date']);
+            try {
+                $approvedStart = new DateTime($data['approved_start_date']);
+                $approvedEnd = new DateTime($data['approved_end_date']);
+            } catch (Exception $e) {
+                http_response_code(400);
+                echo json_encode(['error' => 'รูปแบบวันที่ไม่ถูกต้อง']);
+                return;
+            }
             $approvedTotalDays = $approvedEnd->diff($approvedStart)->days + 1;
 
-            // ดึง user_id จาก JWT สำหรับ approved_by
-            $token = getAuthHeader();
-            $payload = validateJWT($token);
-            $userId = $payload['user_id'] ?? null;
+            // ผู้อนุมัติจาก JWT (ผ่าน requireAdmin แล้ว) สำหรับ approved_by
+            $userId = $approver['user_id'] ?? null;
 
             $sql = "UPDATE position_equivalence
                     SET approval_status = 'APPROVED',
@@ -323,8 +337,14 @@ function updateEquivalence(PDO $pdo, int $id): void
     $startDate = $data['request_start_date'] ?? $current['request_start_date'];
     $endDate = $data['request_end_date'] ?? $current['request_end_date'];
     if ((isset($data['request_start_date']) || isset($data['request_end_date'])) && !empty($startDate) && !empty($endDate)) {
-        $start = new DateTime($startDate);
-        $end = new DateTime($endDate);
+        try {
+            $start = new DateTime($startDate);
+            $end = new DateTime($endDate);
+        } catch (Exception $e) {
+            http_response_code(400);
+            echo json_encode(['error' => 'รูปแบบวันที่ไม่ถูกต้อง']);
+            return;
+        }
         $requestTotalDays = $end->diff($start)->days + 1;
         $sets[] = "request_total_days = ?";
         $params[] = $requestTotalDays;

--- a/backend/routes/users.php
+++ b/backend/routes/users.php
@@ -1,0 +1,229 @@
+<?php
+// ============================================================================
+// routes/users.php
+// User Management Route Handler — จัดการบัญชีผู้ใช้ (admin เท่านั้น)
+//
+// Endpoints:
+//   GET  /users          — รายชื่อผู้ใช้ (pagination + search)
+//   POST /users          — สร้างผู้ใช้ใหม่
+//   PUT  /users/{id}     — แก้ไขข้อมูล / reset password / ปิดบัญชี (is_active=0)
+//
+// ไม่มี DELETE — ปิดบัญชีด้วย is_active=0 เพื่อรักษา FK approved_by และ audit trail
+// ============================================================================
+
+include_once __DIR__ . '/../helpers.php';
+
+const PASSWORD_MIN_LENGTH = 8;
+const VALID_ROLES = ['admin', 'operator'];
+
+// คอลัมน์ที่ส่งออกได้ — ห้ามมี password_hash เด็ดขาด
+const USER_PUBLIC_COLUMNS = 'user_id, username, full_name, email, role, is_active, must_change_password, last_login_at, created_at';
+
+/**
+ * จัดการ request สำหรับ user management endpoints (ทุก method ต้องเป็น admin)
+ *
+ * @param PDO $pdo Database connection
+ * @param string $method HTTP method
+ * @param array $path URL path segments
+ */
+function handleUsers(PDO $pdo, string $method, array $path): void
+{
+    $auth = requireAdmin();
+
+    switch ($method) {
+        case 'GET':
+            getUserList($pdo);
+            break;
+
+        case 'POST':
+            createUser($pdo);
+            break;
+
+        case 'PUT':
+            $id = $path[1] ?? null;
+            if ($id === null) {
+                http_response_code(400);
+                echo json_encode(['error' => 'กรุณาระบุ ID ของผู้ใช้']);
+                return;
+            }
+            updateUser($pdo, intval($id), $auth);
+            break;
+
+        default:
+            http_response_code(405);
+            echo json_encode(['error' => 'Method not allowed']);
+    }
+}
+
+/**
+ * GET /users — รายชื่อผู้ใช้ พร้อม pagination และค้นหาจาก username/full_name
+ */
+function getUserList(PDO $pdo): void
+{
+    $search = $_GET['search'] ?? '';
+    // clamp กัน limit มหาศาล / offset ติดลบ
+    $limit = max(1, min(intval($_GET['limit'] ?? 20), 200));
+    $offset = max(0, intval($_GET['offset'] ?? 0));
+
+    $where = '';
+    $params = [];
+
+    if (!empty($search)) {
+        $where = " WHERE (username LIKE ? OR full_name LIKE ?)";
+        $searchTerm = "%{$search}%";
+        $params = [$searchTerm, $searchTerm];
+    }
+
+    $sql = "SELECT " . USER_PUBLIC_COLUMNS . " FROM users"
+        . $where . " ORDER BY user_id LIMIT {$limit} OFFSET {$offset}";
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute($params);
+    $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    $countStmt = $pdo->prepare("SELECT COUNT(*) AS total FROM users" . $where);
+    $countStmt->execute($params);
+    $total = intval($countStmt->fetch(PDO::FETCH_ASSOC)['total']);
+
+    echo json_encode([
+        'success' => true,
+        'data' => $rows,
+        'pagination' => [
+            'total' => $total,
+            'limit' => $limit,
+            'offset' => $offset,
+            'has_more' => ($offset + $limit) < $total
+        ]
+    ]);
+}
+
+/**
+ * POST /users — สร้างผู้ใช้ใหม่ (must_change_password = 1 เสมอ)
+ */
+function createUser(PDO $pdo): void
+{
+    $data = json_decode(file_get_contents('php://input'), true);
+
+    $required = ['username', 'password', 'full_name', 'role'];
+    foreach ($required as $field) {
+        if (!isset($data[$field]) || $data[$field] === '') {
+            http_response_code(400);
+            echo json_encode(['error' => "กรุณาระบุข้อมูล: {$field}"]);
+            return;
+        }
+    }
+
+    if (strlen($data['password']) < PASSWORD_MIN_LENGTH) {
+        http_response_code(400);
+        echo json_encode(['error' => 'รหัสผ่านต้องมีความยาวอย่างน้อย ' . PASSWORD_MIN_LENGTH . ' ตัวอักษร']);
+        return;
+    }
+
+    if (!in_array($data['role'], VALID_ROLES, true)) {
+        http_response_code(400);
+        echo json_encode(['error' => 'role ต้องเป็น admin หรือ operator เท่านั้น']);
+        return;
+    }
+
+    try {
+        $stmt = $pdo->prepare(
+            "INSERT INTO users (username, password_hash, full_name, email, role, is_active, must_change_password)
+             VALUES (?, ?, ?, ?, ?, 1, 1)"
+        );
+        $stmt->execute([
+            trim($data['username']),
+            password_hash($data['password'], PASSWORD_DEFAULT),
+            $data['full_name'],
+            $data['email'] ?? null,
+            $data['role'],
+        ]);
+    } catch (PDOException $e) {
+        // SQLSTATE 23000 = duplicate key (username ซ้ำ)
+        if ($e->getCode() === '23000') {
+            http_response_code(409);
+            echo json_encode(['error' => 'ชื่อผู้ใช้นี้ถูกใช้งานแล้ว']);
+            return;
+        }
+        throw $e;
+    }
+
+    http_response_code(201);
+    echo json_encode(['success' => true, 'user_id' => intval($pdo->lastInsertId())]);
+}
+
+/**
+ * PUT /users/{id} — แก้ไขข้อมูลผู้ใช้บางส่วน
+ *
+ * - field ที่แก้ได้: full_name, email, role, is_active
+ * - ส่ง password มา = reset password (บังคับเปลี่ยนครั้งถัดไป)
+ * - username แก้ไม่ได้ (immutable — ผูกกับ audit trail)
+ * - กัน admin ลดสิทธิ์/ปิดบัญชีตัวเอง (กัน lock-out)
+ */
+function updateUser(PDO $pdo, int $id, array $auth): void
+{
+    $data = json_decode(file_get_contents('php://input'), true);
+
+    $stmt = $pdo->prepare("SELECT user_id FROM users WHERE user_id = ?");
+    $stmt->execute([$id]);
+    if (!$stmt->fetch(PDO::FETCH_ASSOC)) {
+        http_response_code(404);
+        echo json_encode(['error' => 'ไม่พบผู้ใช้']);
+        return;
+    }
+
+    // Self-guard: ห้ามแก้ role ตัวเองเป็น non-admin หรือปิดบัญชีตัวเอง
+    if ($id === intval($auth['user_id'] ?? 0)) {
+        $demotesSelf = isset($data['role']) && $data['role'] !== 'admin';
+        $deactivatesSelf = isset($data['is_active']) && !((int) (bool) $data['is_active']);
+        if ($demotesSelf || $deactivatesSelf) {
+            http_response_code(400);
+            echo json_encode(['error' => 'ไม่สามารถแก้ไขสิทธิ์หรือปิดบัญชีของตนเองได้']);
+            return;
+        }
+    }
+
+    if (isset($data['role']) && !in_array($data['role'], VALID_ROLES, true)) {
+        http_response_code(400);
+        echo json_encode(['error' => 'role ต้องเป็น admin หรือ operator เท่านั้น']);
+        return;
+    }
+
+    $sets = [];
+    $params = [];
+
+    foreach (['full_name', 'email', 'role'] as $field) {
+        if (isset($data[$field])) {
+            $sets[] = "{$field} = ?";
+            $params[] = $data[$field];
+        }
+    }
+
+    if (isset($data['is_active'])) {
+        $sets[] = "is_active = ?";
+        $params[] = (int) (bool) $data['is_active'];
+    }
+
+    // Reset password — hash ใหม่ + บังคับเปลี่ยนครั้งถัดไป
+    if (isset($data['password']) && $data['password'] !== '') {
+        if (strlen($data['password']) < PASSWORD_MIN_LENGTH) {
+            http_response_code(400);
+            echo json_encode(['error' => 'รหัสผ่านต้องมีความยาวอย่างน้อย ' . PASSWORD_MIN_LENGTH . ' ตัวอักษร']);
+            return;
+        }
+        $sets[] = "password_hash = ?";
+        $params[] = password_hash($data['password'], PASSWORD_DEFAULT);
+        $sets[] = "must_change_password = 1";
+    }
+
+    if (empty($sets)) {
+        http_response_code(400);
+        echo json_encode(['error' => 'ไม่มีข้อมูลที่สามารถอัปเดตได้']);
+        return;
+    }
+
+    $params[] = $id;
+    $sql = "UPDATE users SET " . implode(', ', $sets) . " WHERE user_id = ?";
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute($params);
+
+    echo json_encode(['success' => true]);
+}

--- a/database/09-auth-users.sql
+++ b/database/09-auth-users.sql
@@ -1,0 +1,46 @@
+-- ============================================================================
+-- 09-auth-users.sql
+-- Multi-user Authentication — ขยายตาราง users (stub จาก 03-personnel-stubs.sql)
+-- + ตาราง login_attempts สำหรับ rate limiting + seed admin คนแรก
+--
+-- หมายเหตุ TiDB: ไม่ใช้ ENUM / TRIGGER / DEFINER — role เป็น VARCHAR
+-- แล้ว validate ฝั่ง PHP (admin | operator)
+-- ============================================================================
+
+-- ขยายตาราง users (stub เดิมมีแค่ user_id, username, created_at)
+ALTER TABLE users
+    ADD COLUMN password_hash VARCHAR(255) NULL,
+    ADD COLUMN full_name VARCHAR(200) NULL,
+    ADD COLUMN email VARCHAR(200) NULL,
+    ADD COLUMN role VARCHAR(20) NOT NULL DEFAULT 'operator',
+    ADD COLUMN is_active TINYINT(1) NOT NULL DEFAULT 1,
+    ADD COLUMN must_change_password TINYINT(1) NOT NULL DEFAULT 0,
+    ADD COLUMN last_login_at TIMESTAMP NULL DEFAULT NULL,
+    ADD COLUMN updated_at TIMESTAMP NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP;
+
+-- username ต้องไม่ซ้ำ (ตารางยืนยันว่าว่างเปล่า ณ ตอนสร้าง migration นี้)
+ALTER TABLE users ADD UNIQUE KEY uq_users_username (username);
+
+-- บันทึกความพยายาม login สำหรับ rate limiting
+-- (Render free tier ไม่มี Redis และ filesystem ไม่ persist — เก็บใน DB)
+CREATE TABLE login_attempts (
+    attempt_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    username VARCHAR(200) NOT NULL,
+    ip_address VARCHAR(45) NULL,
+    is_success TINYINT(1) NOT NULL DEFAULT 0,
+    attempted_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    KEY idx_login_attempts_user_time (username, attempted_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Seed admin คนแรก (กัน lock-out) — รหัสผ่านชั่วคราว 'admin123'
+-- ต้องเปลี่ยนทันทีหลัง deploy production (must_change_password = 1)
+-- ใช้ upsert เพราะ dump เก่า (export-tidb.sql / reimport-data.sql) seed แถว
+-- (1,'admin') ไว้แล้วทั้งบน local และ TiDB production
+INSERT INTO users (username, password_hash, full_name, role, is_active, must_change_password)
+VALUES ('admin', '$2y$10$Vrl20xAh4dvfwpDt/pWnTOcMuCzjj8353VKy348pb80StKqkENMcm', 'ผู้ดูแลระบบ', 'admin', 1, 1)
+ON DUPLICATE KEY UPDATE
+    password_hash = VALUES(password_hash),
+    full_name = VALUES(full_name),
+    role = VALUES(role),
+    is_active = VALUES(is_active),
+    must_change_password = VALUES(must_change_password);

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -59,6 +59,7 @@ services:
       - ./database/06-seed-data.sql:/docker-entrypoint-initdb.d/06-seed-data.sql
       - ./database/07-add-education-level.sql:/docker-entrypoint-initdb.d/07-add-education-level.sql
       - ./database/08-career-path-v11.sql:/docker-entrypoint-initdb.d/08-career-path-v11.sql
+      - ./database/09-auth-users.sql:/docker-entrypoint-initdb.d/09-auth-users.sql
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "--silent"]
       interval: 10s


### PR DESCRIPTION
## Summary

ระบบ authentication หลายผู้ใช้พร้อม role-based access control (admin/operator) แทนที่ hardcoded admin/admin123 เดิมทั้งหมด

### Changes

**Database (`database/09-auth-users.sql`)**
- ALTER `users`: เพิ่ม `password_hash`, `full_name`, `email`, `role` (VARCHAR — TiDB ไม่รองรับ ENUM), `is_active`, `must_change_password`, `last_login_at`, `updated_at` + UNIQUE KEY on `username`
- CREATE TABLE `login_attempts` สำหรับ rate limiting (Render free tier ไม่มี Redis)
- Seed admin ด้วย bcrypt hash ผ่าน `ON DUPLICATE KEY UPDATE` (รองรับ row `(1,'admin')` ที่มีอยู่แล้วจาก dump เดิมทั้ง local และ TiDB)

**Backend**
- `backend/routes/auth.php` (ใหม่) — login จาก DB ด้วย `password_verify()`, rate limiting 5 ครั้ง/15 นาทีต่อ username → 429, dummy-hash timing guard, generic 401 ทุก failure mode, JWT payload มี `role`
- `backend/routes/users.php` (ใหม่) — user management (admin เท่านั้น): list/create/update, password ≥8 ตัว, role whitelist, self-guard (ห้าม demote/ปิดบัญชีตัวเอง), ไม่คืน `password_hash` เด็ดขาด
- `backend/auth.php` — `generateJWT($user_id, $role)`, `extractBearerToken()` แบบ strict, helper `currentUser()` / `requireAdmin()`
- `backend/api.php` — **ลบ hardcoded admin/admin123 ทั้งหมด** (`grep admin123` = 0), ลบ `case 'login'`, route ใหม่ `auth` + `users`
- `backend/routes/equivalence.php` — approve ต้องเป็น admin (`requireAdmin()`), `approved_by` จาก JWT, DateTime input validation → 400, limit clamp
- `backend/config.php` — JWT_SECRET fail-fast: ไม่มี env → 500 ทันที (ไม่มี default secret อีกต่อไป)

### Security Review
security-reviewer agent: 0 CRITICAL — blocker ทั้งหมดแก้แล้ว (JWT_SECRET fail-fast, strict Bearer parsing, DateTime try-catch, limit clamping). Backlog ที่ไม่ block: IP-based rate limiting, TiDB SSL CA verify, dummy-hash randomization

### Tests
Contract tests 19/19 ผ่านบน local Docker stack:
- admin login → token มี role + must_change_password
- lockout: 401×5 → 429 (username เดิมโดน 429 ตลอด window)
- operator → 403 ทั้ง `/users` และ approve; แต่ update ปกติได้
- admin approve → `approved_by_name` ไม่เป็น NULL ครั้งแรก
- `POST /login` เดิม → 401 (ถูกถอดออก)
- self-deactivate → 400, deactivated user login → 401
- GET /users ไม่มี `password_hash` หลุด

## ⚠️ Deploy Gate — ห้าม merge ก่อนทำข้อนี้

**ต้อง apply `database/09-auth-users.sql` บน TiDB production ก่อน merge**

Merge เข้า main = Render auto-deploy backend ทันที และโค้ดใหม่ login จาก DB เท่านั้น — ถ้า schema บน TiDB ยังไม่มีคอลัมน์ `password_hash`/`role` ระบบ login production จะพังทั้งระบบ

หลัง deploy แล้ว: ตั้ง `JWT_SECRET` ใน Render env (fail-fast — ไม่มีแล้ว backend ตาย), เปลี่ยนรหัส admin จากค่าชั่วคราว, สร้าง user จริง

## Test plan
- [x] Contract tests 19/19 (local Docker)
- [x] Security review — 0 CRITICAL
- [x] Migration ทดสอบบน local MySQL (ON DUPLICATE KEY ผ่านกับ row admin เดิม)
- [ ] CI green (Docker Build Check)
- [ ] Apply 09-auth-users.sql บน TiDB ก่อน merge
- [ ] Smoke test production หลัง deploy (รัน auth-contract-tests.ps1 ชี้ production)