### PR TITLE
feat: real login flow, role-based UI and admin user management

### DIFF
--- a/frontend/src/__tests__/composables/useUsers.test.js
+++ b/frontend/src/__tests__/composables/useUsers.test.js
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock useApi before importing useUsers
+const mockGet = vi.fn()
+const mockPost = vi.fn()
+const mockPut = vi.fn()
+vi.mock('@/composables/useApi.js', () => ({
+  useApi: () => ({ get: mockGet, post: mockPost, put: mockPut }),
+}))
+
+const { useUsers } = await import('@/composables/useUsers.js')
+
+describe('useUsers', () => {
+  beforeEach(() => {
+    mockGet.mockReset()
+    mockPost.mockReset()
+    mockPut.mockReset()
+  })
+
+  describe('fetchList', () => {
+    it('calls API with default params', async () => {
+      mockGet.mockResolvedValue({ success: true, data: [], pagination: { total: 0 } })
+
+      const { fetchList } = useUsers()
+      await fetchList()
+
+      expect(mockGet).toHaveBeenCalledTimes(1)
+      const url = mockGet.mock.calls[0][0]
+      expect(url).toContain('/users?')
+      expect(url).toContain('limit=20')
+      expect(url).toContain('offset=0')
+    })
+
+    it('encodes Thai search param in URL', async () => {
+      mockGet.mockResolvedValue({ success: true, data: [], pagination: { total: 0 } })
+
+      const { fetchList } = useUsers()
+      await fetchList({ search: 'สมชาย', limit: 10, offset: 20 })
+
+      const url = mockGet.mock.calls[0][0]
+      expect(url).toContain('search=%E0%B8%AA%E0%B8%A1%E0%B8%8A%E0%B8%B2%E0%B8%A2')
+      expect(url).toContain('limit=10')
+      expect(url).toContain('offset=20')
+    })
+
+    it('maps snake_case rows to camelCase with boolean coercion', async () => {
+      mockGet.mockResolvedValue({
+        success: true,
+        data: [{
+          user_id: 5,
+          username: 'somchai.j',
+          full_name: 'สมชาย ใจดี',
+          email: null,
+          role: 'operator',
+          is_active: '1',
+          must_change_password: '0',
+          last_login_at: '2026-06-11 10:00:00',
+          created_at: '2026-06-01 09:00:00',
+        }],
+        pagination: { total: 1, limit: 20, offset: 0, has_more: false },
+      })
+
+      const { fetchList } = useUsers()
+      const result = await fetchList()
+
+      expect(result.data).toHaveLength(1)
+      const row = result.data[0]
+      expect(row.userId).toBe(5)
+      expect(row.username).toBe('somchai.j')
+      expect(row.fullName).toBe('สมชาย ใจดี')
+      expect(row.isActive).toBe(true)
+      expect(row.mustChangePassword).toBe(false)
+      expect(row.lastLoginAt).toBe('2026-06-11 10:00:00')
+    })
+
+    it('coerces is_active "0" to false', async () => {
+      mockGet.mockResolvedValue({
+        success: true,
+        data: [{ user_id: 2, username: 'x', full_name: 'y', role: 'admin', is_active: '0', must_change_password: '1' }],
+        pagination: { total: 1 },
+      })
+
+      const { fetchList } = useUsers()
+      const result = await fetchList()
+
+      expect(result.data[0].isActive).toBe(false)
+      expect(result.data[0].mustChangePassword).toBe(true)
+    })
+  })
+
+  describe('create', () => {
+    it('posts full payload in snake_case', async () => {
+      mockPost.mockResolvedValue({ success: true, user_id: 9 })
+
+      const { create } = useUsers()
+      await create({
+        username: 'somying',
+        password: 'secret123',
+        fullName: 'สมหญิง ขยัน',
+        email: 'somying@example.go.th',
+        role: 'operator',
+      })
+
+      expect(mockPost).toHaveBeenCalledWith('/users', {
+        username: 'somying',
+        password: 'secret123',
+        full_name: 'สมหญิง ขยัน',
+        email: 'somying@example.go.th',
+        role: 'operator',
+      })
+    })
+
+    it('sends null email when omitted', async () => {
+      mockPost.mockResolvedValue({ success: true, user_id: 10 })
+
+      const { create } = useUsers()
+      await create({ username: 'a', password: 'secret123', fullName: 'ก', role: 'admin' })
+
+      expect(mockPost.mock.calls[0][1].email).toBeNull()
+    })
+  })
+
+  describe('update', () => {
+    it('puts only provided fields', async () => {
+      mockPut.mockResolvedValue({ success: true })
+
+      const { update } = useUsers()
+      await update(5, { password: 'newsecret1' })
+
+      expect(mockPut).toHaveBeenCalledWith('/users/5', { password: 'newsecret1' })
+    })
+
+    it('converts isActive boolean to 0/1', async () => {
+      mockPut.mockResolvedValue({ success: true })
+
+      const { update } = useUsers()
+      await update(7, { isActive: false })
+
+      expect(mockPut).toHaveBeenCalledWith('/users/7', { is_active: 0 })
+    })
+
+    it('maps fullName/email/role to snake_case', async () => {
+      mockPut.mockResolvedValue({ success: true })
+
+      const { update } = useUsers()
+      await update(3, { fullName: 'ใหม่', email: null, role: 'admin' })
+
+      expect(mockPut).toHaveBeenCalledWith('/users/3', {
+        full_name: 'ใหม่',
+        email: null,
+        role: 'admin',
+      })
+    })
+
+    it('does not send empty password', async () => {
+      mockPut.mockResolvedValue({ success: true })
+
+      const { update } = useUsers()
+      await update(4, { fullName: 'x', password: '' })
+
+      expect(mockPut).toHaveBeenCalledWith('/users/4', { full_name: 'x' })
+    })
+  })
+})

--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -79,10 +79,12 @@
           </div>
           <div class="flex-1 min-w-0">
             <div class="flex items-center gap-1.5">
-              <p class="text-white text-sm font-medium truncate">{{ auth.user?.name || 'ผู้ดูแลระบบ' }}</p>
-              <span class="text-[10px] px-1.5 py-0.5 bg-blue-500/20 text-blue-300 rounded font-medium shrink-0">Admin</span>
+              <p class="text-white text-sm font-medium truncate">{{ auth.user?.name || 'ผู้ใช้' }}</p>
+              <span class="text-[10px] px-1.5 py-0.5 bg-blue-500/20 text-blue-300 rounded font-medium shrink-0">
+                {{ auth.user?.role === 'admin' ? 'Admin' : 'Operator' }}
+              </span>
             </div>
-            <p class="text-gray-400 text-xs truncate mt-0.5">{{ auth.user?.email || 'admin@smartport.com' }}</p>
+            <p class="text-gray-400 text-xs truncate mt-0.5">{{ auth.user?.email || auth.user?.username || '' }}</p>
           </div>
         </div>
       </div>
@@ -91,13 +93,13 @@
 </template>
 
 <script setup>
-import { reactive } from 'vue'
+import { reactive, computed } from 'vue'
 import { useRoute } from 'vue-router'
 import { RouterLink } from 'vue-router'
 import { useAuthStore } from '@/stores/auth.js'
 import {
   X, BookOpen, LayoutDashboard, UserCheck, Users, Clock, Award, UserMinus,
-  Briefcase, FileText, Trophy, ChevronRight,
+  Briefcase, FileText, Trophy, ChevronRight, UserCog,
 } from 'lucide-vue-next'
 
 defineProps({ open: Boolean })
@@ -107,7 +109,7 @@ const route = useRoute()
 const auth = useAuthStore()
 const openSubmenus = reactive(new Set())
 
-const menuItems = [
+const menuItems = computed(() => [
   { id: 'dashboard', label: 'Dashboard', icon: LayoutDashboard, to: '/dashboard' },
   { id: 'probation-end', label: 'พ้นทดลองปฏิบัติราชการ', icon: UserCheck, to: '/probation-end' },
   {
@@ -130,10 +132,14 @@ const menuItems = [
   },
   { id: 'royal-decorations', label: 'เครื่องราชอิสริยาภรณ์', icon: Award, to: '/royal-decorations' },
   { id: 'retirement-report', label: 'รายงานผู้เกษียณ', icon: UserMinus, to: '/retirement-report' },
+  // เมนูจัดการผู้ใช้ — admin เท่านั้น
+  ...(auth.user?.role === 'admin'
+    ? [{ id: 'user-management', label: 'จัดการผู้ใช้', icon: UserCog, to: '/users' }]
+    : []),
   { id: 'work-management', label: 'การจัดการงาน', icon: Briefcase, to: '/admin' },
   { id: 'work-results', label: 'ผลงานและข้อเสนอ', icon: FileText, to: '/analytics' },
   { id: 'awards', label: 'รางวัล/ความดีความชอบ', icon: Trophy, to: '/analytics' },
-]
+])
 
 function toggleSubmenu(id) {
   if (openSubmenus.has(id)) {
@@ -146,4 +152,5 @@ function toggleSubmenu(id) {
 function isParentActive(item) {
   return item.children?.some((c) => route.path === c.to)
 }
+
 </script>

--- a/frontend/src/components/AppTopbar.vue
+++ b/frontend/src/components/AppTopbar.vue
@@ -37,8 +37,8 @@
         >
           <!-- User info header -->
           <div class="px-4 py-3 border-b border-gray-100">
-            <p class="text-sm font-medium text-gray-900">{{ auth.user?.name || 'ผู้ดูแลระบบ' }}</p>
-            <p class="text-xs text-gray-500 mt-0.5">{{ auth.user?.email || 'admin@smartport.gov.th' }}</p>
+            <p class="text-sm font-medium text-gray-900">{{ auth.user?.name || 'ผู้ใช้' }}</p>
+            <p class="text-xs text-gray-500 mt-0.5">{{ auth.user?.email || auth.user?.username || '' }}</p>
           </div>
 
           <!-- Menu items -->
@@ -93,6 +93,7 @@ const pageTitles = {
   '/dashboard': 'Dashboard',
   '/probation-end': 'พ้นทดลองปฏิบัติราชการ',
   '/candidates': 'Candidate Lists',
+  '/users': 'จัดการผู้ใช้',
   '/analytics': 'การวิเคราะห์ข้อมูล',
   '/admin': 'การจัดการระบบ',
   '/time-counting': 'การนับเวลาเกื้อกูล',

--- a/frontend/src/composables/useUsers.js
+++ b/frontend/src/composables/useUsers.js
@@ -1,0 +1,55 @@
+import { useApi } from '@/composables/useApi.js'
+
+export function useUsers() {
+  const api = useApi()
+
+  async function fetchList({ search = '', limit = 20, offset = 0 } = {}) {
+    const params = new URLSearchParams()
+    if (search) params.set('search', search)
+    params.set('limit', limit)
+    params.set('offset', offset)
+
+    const result = await api.get(`/users?${params}`)
+    return {
+      success: result.success,
+      data: (result.data || []).map(mapRow),
+      pagination: result.pagination,
+    }
+  }
+
+  async function create(data) {
+    return api.post('/users', {
+      username: data.username,
+      password: data.password,
+      full_name: data.fullName,
+      email: data.email || null,
+      role: data.role,
+    })
+  }
+
+  async function update(id, data) {
+    const payload = {}
+    if (data.fullName !== undefined) payload.full_name = data.fullName
+    if (data.email !== undefined) payload.email = data.email
+    if (data.role !== undefined) payload.role = data.role
+    if (data.isActive !== undefined) payload.is_active = data.isActive ? 1 : 0
+    if (data.password !== undefined && data.password !== '') payload.password = data.password
+    return api.put(`/users/${id}`, payload)
+  }
+
+  function mapRow(row) {
+    return {
+      userId: row.user_id,
+      username: row.username,
+      fullName: row.full_name,
+      email: row.email,
+      role: row.role,
+      isActive: Boolean(Number(row.is_active)),
+      mustChangePassword: Boolean(Number(row.must_change_password)),
+      lastLoginAt: row.last_login_at,
+      createdAt: row.created_at,
+    }
+  }
+
+  return { fetchList, create, update }
+}

--- a/frontend/src/pages/EquivalencePage.vue
+++ b/frontend/src/pages/EquivalencePage.vue
@@ -137,10 +137,11 @@
                     <button @click="openEdit(row)" class="p-1 text-gray-400 hover:text-blue-600 transition-colors" title="แก้ไข">
                       <Pencil class="w-4 h-4" />
                     </button>
-                    <button @click="openApprove(row)" class="p-1 text-gray-400 hover:text-green-600 transition-colors" title="อนุมัติ">
+                    <!-- อนุมัติ/ไม่อนุมัติ — admin เท่านั้น (backend เช็ค role ซ้ำอีกชั้น) -->
+                    <button v-if="auth.isAdmin" @click="openApprove(row)" class="p-1 text-gray-400 hover:text-green-600 transition-colors" title="อนุมัติ">
                       <Check class="w-4 h-4" />
                     </button>
-                    <button @click="confirmReject(row.equivalenceId)" class="p-1 text-gray-400 hover:text-red-600 transition-colors" title="ไม่อนุมัติ">
+                    <button v-if="auth.isAdmin" @click="confirmReject(row.equivalenceId)" class="p-1 text-gray-400 hover:text-red-600 transition-colors" title="ไม่อนุมัติ">
                       <X class="w-4 h-4" />
                     </button>
                   </template>
@@ -468,6 +469,7 @@ import { ref, computed, onMounted } from 'vue'
 import { useEquivalence } from '@/composables/useEquivalence.js'
 import { useApi } from '@/composables/useApi.js'
 import { useUiStore } from '@/stores/ui.js'
+import { useAuthStore } from '@/stores/auth.js'
 import StatCard from '@/components/StatCard.vue'
 import StatusBadge from '@/components/StatusBadge.vue'
 import SkeletonLoader from '@/components/SkeletonLoader.vue'
@@ -481,6 +483,7 @@ import {
 const { fetchList, create, update, approve, reject } = useEquivalence()
 const api = useApi()
 const ui = useUiStore()
+const auth = useAuthStore()
 
 // Data state
 const loading = ref(false)

--- a/frontend/src/pages/LoginPage.vue
+++ b/frontend/src/pages/LoginPage.vue
@@ -29,17 +29,17 @@
         <!-- Login Form -->
         <form @submit.prevent="handleLogin" class="space-y-5">
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-2">อีเมล</label>
+            <label class="block text-sm font-medium text-gray-700 mb-2">ชื่อผู้ใช้</label>
             <div class="relative">
               <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                <AtSign class="h-5 w-5 text-gray-400" />
+                <User class="h-5 w-5 text-gray-400" />
               </div>
               <!-- #1: Input focus animation -->
               <input
-                v-model="form.email"
-                type="email"
+                v-model="form.username"
+                type="text"
                 class="block w-full pl-10 pr-3 py-3 border border-gray-300 rounded-xl bg-white text-gray-900 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent focus:shadow-lg focus:shadow-blue-500/10 focus:-translate-y-px"
-                placeholder="กรุณาใส่อีเมลของคุณ"
+                placeholder="กรุณาใส่ชื่อผู้ใช้ของคุณ"
                 autocomplete="username"
               />
             </div>
@@ -87,23 +87,6 @@
             {{ loading ? 'กำลังเข้าสู่ระบบ...' : 'เข้าสู่ระบบ' }}
           </button>
         </form>
-
-        <!-- #7: Compact demo section -->
-        <div class="mt-5 pt-4 border-t border-gray-200">
-          <div class="flex items-center gap-3 mb-3 px-1">
-            <div class="flex-1">
-              <p class="text-[11px] text-gray-400">ทดสอบ: <span class="text-gray-500">admin@smartport.gov.th</span> / <span class="text-gray-500">admin123</span></p>
-            </div>
-          </div>
-          <div class="flex gap-2">
-            <button @click="fillDemo" class="flex-1 py-2 text-xs font-medium border border-gray-200 text-gray-500 hover:bg-gray-50 hover:border-gray-300 rounded-lg transition-all cursor-pointer">
-              กรอกข้อมูลตัวอย่าง
-            </button>
-            <button @click="skipLogin" class="flex-1 py-2 text-xs font-medium text-gray-400 hover:bg-gray-50 hover:text-gray-600 rounded-lg transition-all cursor-pointer">
-              ข้ามการเข้าสู่ระบบ
-            </button>
-          </div>
-        </div>
       </div>
     </div>
   </div>
@@ -113,12 +96,12 @@
 import { ref, reactive } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth.js'
-import { Shield, AtSign, Lock, Eye, EyeOff, Loader2, AlertCircle } from 'lucide-vue-next'
+import { Shield, User, Lock, Eye, EyeOff, Loader2, AlertCircle } from 'lucide-vue-next'
 
 const router = useRouter()
 const auth = useAuthStore()
 
-const form = reactive({ email: '', password: '' })
+const form = reactive({ username: '', password: '' })
 const showPassword = ref(false)
 const loading = ref(false)
 const errorMsg = ref('')
@@ -128,26 +111,7 @@ async function handleLogin() {
   errorMsg.value = ''
   loading.value = true
   try {
-    await auth.login({ email: form.email, password: form.password })
-    router.push('/dashboard')
-  } catch (e) {
-    errorMsg.value = e.message || 'เข้าสู่ระบบไม่สำเร็จ กรุณาลองใหม่'
-  } finally {
-    loading.value = false
-  }
-}
-
-function fillDemo() {
-  form.email = 'admin@smartport.gov.th'
-  form.password = 'admin123'
-}
-
-async function skipLogin() {
-  loading.value = true
-  errorMsg.value = ''
-  try {
-    auth.logout()
-    await auth.demoLogin()
+    await auth.login({ username: form.username, password: form.password })
     router.push('/dashboard')
   } catch (e) {
     errorMsg.value = e.message || 'เข้าสู่ระบบไม่สำเร็จ กรุณาลองใหม่'

--- a/frontend/src/pages/UserManagementPage.vue
+++ b/frontend/src/pages/UserManagementPage.vue
@@ -1,0 +1,542 @@
+<template>
+  <div class="p-6 space-y-6">
+    <!-- Header -->
+    <div class="flex items-center justify-between">
+      <div>
+        <h1 class="text-2xl font-bold text-gray-900">จัดการผู้ใช้</h1>
+        <p class="text-sm text-gray-500 mt-1">เพิ่ม แก้ไข และจัดการบัญชีผู้ใช้งานระบบ (เฉพาะผู้ดูแลระบบ)</p>
+      </div>
+      <button
+        @click="openCreate"
+        class="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition-colors cursor-pointer"
+      >
+        <Plus class="w-4 h-4" />
+        เพิ่มผู้ใช้
+      </button>
+    </div>
+
+    <!-- Search -->
+    <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-4">
+      <div class="relative max-w-md">
+        <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+          <Search class="h-4 w-4 text-gray-400" />
+        </div>
+        <input
+          v-model="searchQuery"
+          type="text"
+          placeholder="ค้นหาชื่อผู้ใช้หรือชื่อ-สกุล..."
+          class="block w-full pl-9 pr-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          @input="onSearchInput"
+          @compositionstart="isComposing = true"
+          @compositionend="onCompositionEnd"
+        />
+      </div>
+    </div>
+
+    <!-- Table -->
+    <div class="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
+      <div v-if="loading" class="py-12 text-center text-sm text-gray-500">กำลังโหลดข้อมูล...</div>
+
+      <div v-else-if="error" class="py-12 text-center">
+        <p class="text-sm text-red-600 mb-3">{{ error }}</p>
+        <button @click="fetchData" class="px-4 py-2 bg-blue-500 text-white rounded-lg text-sm hover:bg-blue-600 transition-colors cursor-pointer">
+          ลองใหม่
+        </button>
+      </div>
+
+      <EmptyState
+        v-else-if="rows.length === 0"
+        :icon="Users"
+        title="ไม่พบผู้ใช้"
+        :description="searchQuery ? 'ไม่พบผู้ใช้ที่ตรงกับคำค้นหา' : 'ยังไม่มีผู้ใช้ในระบบ'"
+      />
+
+      <div v-else class="overflow-x-auto">
+        <table class="min-w-full divide-y divide-gray-200">
+          <thead class="bg-gray-50">
+            <tr>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ชื่อผู้ใช้</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ชื่อ-สกุล</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">อีเมล</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">สิทธิ์</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">สถานะ</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">เข้าใช้ล่าสุด</th>
+              <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">จัดการ</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-200">
+            <tr v-for="row in rows" :key="row.userId" class="hover:bg-gray-50 transition-colors">
+              <td class="px-6 py-4 whitespace-nowrap">
+                <div class="text-sm font-medium text-gray-900">{{ row.username }}</div>
+                <div v-if="row.mustChangePassword" class="flex items-center gap-1 text-xs text-amber-600 mt-0.5">
+                  <KeyRound class="w-3 h-3" />
+                  ยังไม่เปลี่ยนรหัสผ่าน
+                </div>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{{ row.fullName }}</td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ row.email || '-' }}</td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <span
+                  class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full"
+                  :class="row.role === 'admin' ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 text-gray-600'"
+                >
+                  {{ row.role === 'admin' ? 'Admin' : 'Operator' }}
+                </span>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <span
+                  class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full"
+                  :class="row.isActive ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'"
+                >
+                  {{ row.isActive ? 'ใช้งาน' : 'ปิดใช้งาน' }}
+                </span>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ formatDateTime(row.lastLoginAt) }}</td>
+              <td class="px-6 py-4 whitespace-nowrap text-right">
+                <div class="flex items-center justify-end gap-1">
+                  <button @click="openEdit(row)" class="p-1 text-gray-400 hover:text-blue-600 transition-colors cursor-pointer" title="แก้ไข">
+                    <Pencil class="w-4 h-4" />
+                  </button>
+                  <button @click="openResetPassword(row)" class="p-1 text-gray-400 hover:text-amber-600 transition-colors cursor-pointer" title="รีเซ็ตรหัสผ่าน">
+                    <KeyRound class="w-4 h-4" />
+                  </button>
+                  <!-- Self-guard: ไม่แสดงปุ่มปิดบัญชีของตัวเอง -->
+                  <button
+                    v-if="row.userId !== auth.user?.id"
+                    @click="openToggleActive(row)"
+                    class="p-1 text-gray-400 transition-colors cursor-pointer"
+                    :class="row.isActive ? 'hover:text-red-600' : 'hover:text-green-600'"
+                    :title="row.isActive ? 'ปิดบัญชี' : 'เปิดใช้งานบัญชี'"
+                  >
+                    <component :is="row.isActive ? Ban : CheckCircle" class="w-4 h-4" />
+                  </button>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div v-if="!loading && !error && pagination.total > 0" class="px-6 pb-4">
+        <PaginationBar
+          :total="pagination.total"
+          :limit="pagination.limit"
+          :offset="pagination.offset"
+          @update:offset="onPageChange"
+        />
+      </div>
+    </div>
+
+    <!-- Create / Edit Modal -->
+    <div v-if="showFormModal" class="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div class="absolute inset-0 bg-black/40" @click="closeFormModal"></div>
+      <div class="relative bg-white rounded-2xl shadow-xl w-full max-w-md p-6 space-y-4">
+        <h2 class="text-lg font-semibold text-gray-900">{{ editingUser ? 'แก้ไขผู้ใช้' : 'เพิ่มผู้ใช้ใหม่' }}</h2>
+
+        <div class="space-y-3">
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1">ชื่อผู้ใช้ <span v-if="!editingUser" class="text-red-500">*</span></label>
+            <input
+              v-model="formData.username"
+              type="text"
+              :disabled="!!editingUser"
+              class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-gray-100 disabled:text-gray-500"
+              placeholder="เช่น somchai.j"
+            />
+            <p v-if="editingUser" class="text-xs text-gray-400 mt-1">ชื่อผู้ใช้แก้ไขไม่ได้</p>
+          </div>
+
+          <template v-if="!editingUser">
+            <div>
+              <label class="block text-sm font-medium text-gray-700 mb-1">รหัสผ่าน <span class="text-red-500">*</span></label>
+              <input
+                v-model="formData.password"
+                type="password"
+                autocomplete="new-password"
+                class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                placeholder="อย่างน้อย 8 ตัวอักษร"
+              />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700 mb-1">ยืนยันรหัสผ่าน <span class="text-red-500">*</span></label>
+              <input
+                v-model="formData.passwordConfirm"
+                type="password"
+                autocomplete="new-password"
+                class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+          </template>
+
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1">ชื่อ-สกุล <span class="text-red-500">*</span></label>
+            <input
+              v-model="formData.fullName"
+              type="text"
+              class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="เช่น สมชาย ใจดี"
+            />
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1">อีเมล</label>
+            <input
+              v-model="formData.email"
+              type="email"
+              class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="(ไม่บังคับ)"
+            />
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1">สิทธิ์ <span class="text-red-500">*</span></label>
+            <select
+              v-model="formData.role"
+              :disabled="isSelfEditing"
+              class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-gray-100 disabled:text-gray-500"
+            >
+              <option value="operator">Operator — บันทึกข้อมูล</option>
+              <option value="admin">Admin — อนุมัติ + จัดการผู้ใช้</option>
+            </select>
+            <p v-if="isSelfEditing" class="text-xs text-gray-400 mt-1">ไม่สามารถแก้ไขสิทธิ์ของตนเองได้</p>
+          </div>
+        </div>
+
+        <div class="flex justify-end gap-2 pt-2">
+          <button @click="closeFormModal" class="px-4 py-2 text-sm text-gray-600 hover:bg-gray-100 rounded-lg transition-colors cursor-pointer">
+            ยกเลิก
+          </button>
+          <button
+            @click="submitForm"
+            :disabled="saving"
+            class="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors cursor-pointer"
+          >
+            {{ saving ? 'กำลังบันทึก...' : (editingUser ? 'บันทึก' : 'สร้างผู้ใช้') }}
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Reset Password Modal -->
+    <div v-if="showResetModal" class="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div class="absolute inset-0 bg-black/40" @click="closeResetModal"></div>
+      <div class="relative bg-white rounded-2xl shadow-xl w-full max-w-md p-6 space-y-4">
+        <h2 class="text-lg font-semibold text-gray-900">รีเซ็ตรหัสผ่าน</h2>
+        <p class="text-sm text-gray-600">
+          กำหนดรหัสผ่านใหม่ให้ <span class="font-medium text-gray-900">{{ resettingUser?.username }}</span>
+          — ผู้ใช้จะต้องเปลี่ยนรหัสผ่านเมื่อเข้าสู่ระบบครั้งถัดไป
+        </p>
+
+        <div class="space-y-3">
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1">รหัสผ่านใหม่ <span class="text-red-500">*</span></label>
+            <input
+              v-model="resetForm.password"
+              type="password"
+              autocomplete="new-password"
+              class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="อย่างน้อย 8 ตัวอักษร"
+            />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1">ยืนยันรหัสผ่านใหม่ <span class="text-red-500">*</span></label>
+            <input
+              v-model="resetForm.passwordConfirm"
+              type="password"
+              autocomplete="new-password"
+              class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+        </div>
+
+        <div class="flex justify-end gap-2 pt-2">
+          <button @click="closeResetModal" class="px-4 py-2 text-sm text-gray-600 hover:bg-gray-100 rounded-lg transition-colors cursor-pointer">
+            ยกเลิก
+          </button>
+          <button
+            @click="submitResetPassword"
+            :disabled="saving"
+            class="px-4 py-2 bg-amber-600 text-white text-sm font-medium rounded-lg hover:bg-amber-700 disabled:opacity-50 transition-colors cursor-pointer"
+          >
+            {{ saving ? 'กำลังดำเนินการ...' : 'รีเซ็ตรหัสผ่าน' }}
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Toggle Active Confirm Modal -->
+    <div v-if="showToggleConfirm" class="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div class="absolute inset-0 bg-black/40" @click="showToggleConfirm = false"></div>
+      <div class="relative bg-white rounded-2xl shadow-xl w-full max-w-sm p-6 space-y-4">
+        <h2 class="text-lg font-semibold text-gray-900">
+          {{ togglingUser?.isActive ? 'ยืนยันการปิดบัญชี' : 'ยืนยันการเปิดใช้งานบัญชี' }}
+        </h2>
+        <p class="text-sm text-gray-600">
+          คุณต้องการ{{ togglingUser?.isActive ? 'ปิด' : 'เปิดใช้งาน' }}บัญชี
+          <span class="font-medium text-gray-900">{{ togglingUser?.username }}</span> หรือไม่?
+          <template v-if="togglingUser?.isActive">ผู้ใช้นี้จะไม่สามารถเข้าสู่ระบบได้จนกว่าจะเปิดใช้งานอีกครั้ง</template>
+        </p>
+        <div class="flex justify-end gap-2 pt-2">
+          <button @click="showToggleConfirm = false" class="px-4 py-2 text-sm text-gray-600 hover:bg-gray-100 rounded-lg transition-colors cursor-pointer">
+            ยกเลิก
+          </button>
+          <button
+            @click="submitToggleActive"
+            :disabled="saving"
+            class="px-4 py-2 text-white text-sm font-medium rounded-lg disabled:opacity-50 transition-colors cursor-pointer"
+            :class="togglingUser?.isActive ? 'bg-red-600 hover:bg-red-700' : 'bg-green-600 hover:bg-green-700'"
+          >
+            {{ saving ? 'กำลังดำเนินการ...' : (togglingUser?.isActive ? 'ปิดบัญชี' : 'เปิดใช้งาน') }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { useUsers } from '@/composables/useUsers.js'
+import { useAuthStore } from '@/stores/auth.js'
+import { useUiStore } from '@/stores/ui.js'
+import PaginationBar from '@/components/PaginationBar.vue'
+import EmptyState from '@/components/EmptyState.vue'
+import { Plus, Search, Pencil, KeyRound, Ban, CheckCircle, Users } from 'lucide-vue-next'
+
+const PASSWORD_MIN_LENGTH = 8
+
+const { fetchList, create, update } = useUsers()
+const auth = useAuthStore()
+const ui = useUiStore()
+
+// Data state
+const loading = ref(false)
+const error = ref(null)
+const rows = ref([])
+const pagination = ref({ total: 0, limit: 20, offset: 0, has_more: false })
+
+// Search state with IME guard
+const searchQuery = ref('')
+const isComposing = ref(false)
+let searchTimeout = null
+
+// Create/Edit modal state
+const showFormModal = ref(false)
+const editingUser = ref(null)
+const saving = ref(false)
+
+const defaultFormData = () => ({
+  username: '',
+  password: '',
+  passwordConfirm: '',
+  fullName: '',
+  email: '',
+  role: 'operator',
+})
+const formData = ref(defaultFormData())
+
+const isSelfEditing = computed(() => editingUser.value?.userId === auth.user?.id)
+
+// Reset password modal state
+const showResetModal = ref(false)
+const resettingUser = ref(null)
+const resetForm = ref({ password: '', passwordConfirm: '' })
+
+// Toggle active confirm state
+const showToggleConfirm = ref(false)
+const togglingUser = ref(null)
+
+// ==================== Data fetching ====================
+
+async function fetchData() {
+  loading.value = true
+  error.value = null
+  try {
+    const result = await fetchList({
+      search: searchQuery.value,
+      limit: pagination.value.limit,
+      offset: pagination.value.offset,
+    })
+    rows.value = result.data
+    pagination.value = result.pagination
+  } catch (err) {
+    error.value = err.message || 'ไม่สามารถโหลดข้อมูลได้ กรุณาลองใหม่อีกครั้ง'
+  } finally {
+    loading.value = false
+  }
+}
+
+function onPageChange(offset) {
+  pagination.value.offset = offset
+  fetchData()
+}
+
+// ==================== Search ====================
+
+function onCompositionEnd() {
+  isComposing.value = false
+  onSearchInput()
+}
+
+function onSearchInput() {
+  if (isComposing.value) return
+  clearTimeout(searchTimeout)
+  searchTimeout = setTimeout(() => {
+    pagination.value.offset = 0
+    fetchData()
+  }, 300)
+}
+
+// ==================== Create / Edit ====================
+
+function openCreate() {
+  editingUser.value = null
+  formData.value = defaultFormData()
+  showFormModal.value = true
+}
+
+function openEdit(row) {
+  editingUser.value = row
+  formData.value = {
+    username: row.username,
+    password: '',
+    passwordConfirm: '',
+    fullName: row.fullName,
+    email: row.email || '',
+    role: row.role,
+  }
+  showFormModal.value = true
+}
+
+function closeFormModal() {
+  showFormModal.value = false
+  editingUser.value = null
+}
+
+function validateForm() {
+  if (!editingUser.value) {
+    if (!formData.value.username.trim()) {
+      ui.showToast('กรุณาระบุชื่อผู้ใช้', 'error')
+      return false
+    }
+    if (formData.value.password.length < PASSWORD_MIN_LENGTH) {
+      ui.showToast(`รหัสผ่านต้องมีความยาวอย่างน้อย ${PASSWORD_MIN_LENGTH} ตัวอักษร`, 'error')
+      return false
+    }
+    if (formData.value.password !== formData.value.passwordConfirm) {
+      ui.showToast('รหัสผ่านและการยืนยันรหัสผ่านไม่ตรงกัน', 'error')
+      return false
+    }
+  }
+  if (!formData.value.fullName.trim()) {
+    ui.showToast('กรุณาระบุชื่อ-สกุล', 'error')
+    return false
+  }
+  return true
+}
+
+async function submitForm() {
+  if (!validateForm()) return
+  saving.value = true
+  try {
+    if (editingUser.value) {
+      await update(editingUser.value.userId, {
+        fullName: formData.value.fullName,
+        email: formData.value.email || null,
+        role: formData.value.role,
+      })
+      ui.showToast('บันทึกข้อมูลผู้ใช้สำเร็จ', 'success')
+    } else {
+      await create({
+        username: formData.value.username.trim(),
+        password: formData.value.password,
+        fullName: formData.value.fullName,
+        email: formData.value.email || null,
+        role: formData.value.role,
+      })
+      ui.showToast('สร้างผู้ใช้สำเร็จ', 'success')
+    }
+    closeFormModal()
+    fetchData()
+  } catch (e) {
+    ui.showToast(e.message || 'เกิดข้อผิดพลาด กรุณาลองใหม่', 'error')
+  } finally {
+    saving.value = false
+  }
+}
+
+// ==================== Reset password ====================
+
+function openResetPassword(row) {
+  resettingUser.value = row
+  resetForm.value = { password: '', passwordConfirm: '' }
+  showResetModal.value = true
+}
+
+function closeResetModal() {
+  showResetModal.value = false
+  resettingUser.value = null
+}
+
+async function submitResetPassword() {
+  if (resetForm.value.password.length < PASSWORD_MIN_LENGTH) {
+    ui.showToast(`รหัสผ่านต้องมีความยาวอย่างน้อย ${PASSWORD_MIN_LENGTH} ตัวอักษร`, 'error')
+    return
+  }
+  if (resetForm.value.password !== resetForm.value.passwordConfirm) {
+    ui.showToast('รหัสผ่านและการยืนยันรหัสผ่านไม่ตรงกัน', 'error')
+    return
+  }
+  saving.value = true
+  try {
+    await update(resettingUser.value.userId, { password: resetForm.value.password })
+    ui.showToast('รีเซ็ตรหัสผ่านสำเร็จ — ผู้ใช้ต้องเปลี่ยนรหัสผ่านเมื่อเข้าสู่ระบบครั้งถัดไป', 'success')
+    closeResetModal()
+    fetchData()
+  } catch (e) {
+    ui.showToast(e.message || 'เกิดข้อผิดพลาด กรุณาลองใหม่', 'error')
+  } finally {
+    saving.value = false
+  }
+}
+
+// ==================== Toggle active ====================
+
+function openToggleActive(row) {
+  togglingUser.value = row
+  showToggleConfirm.value = true
+}
+
+async function submitToggleActive() {
+  saving.value = true
+  try {
+    const activating = !togglingUser.value.isActive
+    await update(togglingUser.value.userId, { isActive: activating })
+    ui.showToast(activating ? 'เปิดใช้งานบัญชีสำเร็จ' : 'ปิดบัญชีสำเร็จ', 'success')
+    showToggleConfirm.value = false
+    togglingUser.value = null
+    fetchData()
+  } catch (e) {
+    ui.showToast(e.message || 'เกิดข้อผิดพลาด กรุณาลองใหม่', 'error')
+  } finally {
+    saving.value = false
+  }
+}
+
+// ==================== Helpers ====================
+
+function formatDateTime(value) {
+  if (!value) return '-'
+  const date = new Date(value.replace(' ', 'T'))
+  if (isNaN(date.getTime())) return '-'
+  return date.toLocaleString('th-TH', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+onMounted(fetchData)
+</script>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -52,6 +52,12 @@ const routes = [
         props: { title: 'การจัดการระบบ', description: 'การจัดการระบบ - กำลังพัฒนา' },
       },
       {
+        path: 'users',
+        name: 'users',
+        component: () => import('@/pages/UserManagementPage.vue'),
+        meta: { requiresAdmin: true },
+      },
+      {
         path: 'time-counting',
         name: 'time-counting',
         component: () => import('@/pages/SupportivePage.vue'),
@@ -100,6 +106,11 @@ router.beforeEach(async (to) => {
   }
 
   if (to.path === '/login' && auth.isAuthenticated) {
+    return '/dashboard'
+  }
+
+  // หน้า admin only — operator เด้งกลับ dashboard
+  if (to.meta.requiresAdmin && auth.user?.role !== 'admin') {
     return '/dashboard'
   }
 })

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -33,10 +33,10 @@ export const useAuthStore = defineStore('auth', () => {
   const user = ref(readStoredJson('user'))
 
   const isAuthenticated = computed(() => !!token.value && isTokenValid())
+  const isAdmin = computed(() => user.value?.role === 'admin')
 
   function isTokenValid() {
     if (!token.value) return false
-    if (token.value.startsWith('demo-token-')) return true
     try {
       const payload = JSON.parse(atob(token.value.split('.')[1]))
       return payload.exp * 1000 > Date.now()
@@ -66,10 +66,6 @@ export const useAuthStore = defineStore('auth', () => {
     return data
   }
 
-  async function demoLogin() {
-    await login({ email: 'admin', password: 'admin123' })
-  }
-
   function logout() {
     token.value = ''
     refreshToken.value = ''
@@ -81,5 +77,5 @@ export const useAuthStore = defineStore('auth', () => {
     localStorage.removeItem('user')
   }
 
-  return { token, user, isAuthenticated, isTokenValid, setAuth, login, demoLogin, logout }
+  return { token, user, isAuthenticated, isAdmin, isTokenValid, setAuth, login, logout }
 })


### PR DESCRIPTION
## Summary

Phase 4 (Auth frontend) ของ production-readiness release — เชื่อม frontend เข้ากับ auth backend จริง (PR #5):

- **LoginPage**: ลบ demo credentials / ปุ่มข้ามการเข้าสู่ระบบทั้งหมด; เปลี่ยน input จากอีเมล (`type=email`) เป็นชื่อผู้ใช้ (`type=text` — type=email บล็อกค่า `admin` ด้วย HTML5 validation)
- **Auth store**: ลบ `demoLogin()` + demo-token bypass; เพิ่ม `isAdmin` computed
- **หน้าจัดการผู้ใช้ `/users`** (admin เท่านั้น): list + ค้นหา + pagination, สร้างผู้ใช้, แก้ไขข้อมูล, reset password (บังคับเปลี่ยนครั้งถัดไป), ปิด/เปิดบัญชี พร้อม self-guard ฝั่ง UI
- **Role-based UI**: เมนู จัดการผู้ใช้ + route guard `requiresAdmin` (operator โดน redirect), badge Admin/Operator ตาม role จริง, ซ่อนปุ่มอนุมัติ/ไม่อนุมัติใน EquivalencePage จาก operator (backend เช็ค 403 อยู่แล้ว — นี่คือชั้น UX)

## Test plan

- [x] Unit tests 56/56 ผ่าน (vitest ใน Docker node:20-slim) — เพิ่ม `useUsers.test.js` 10 tests
- [x] `vite build` ผ่าน
- [x] grep `demoLogin|demo-token|admin123|skipLogin|fillDemo` = 0 matches ใน frontend/src
- [ ] CI green (Frontend + Docker)
- [ ] Manual หลัง deploy: login admin จริง, สร้าง operator แล้ว login ได้, operator ไม่เห็นปุ่มอนุมัติ/เมนูจัดการผู้ใช้

## Notes

- ไม่แตะไฟล์ backend — contract จาก Phase 3 (deploy แล้ว) ทั้งหมด
- ไม่มี migration gate รอบนี้ (frontend อย่างเดียว) — merge แล้ว Render auto-deploy ได้เลย
- หลัง deploy: รหัส `admin123` ยังเป็นค่าชั่วคราว — เปลี่ยนผ่านหน้า /users ใหม่ได้ทันที (งาน Phase 6)