### PR TITLE
feat: ThaiDatePicker — Buddhist-era (พ.ศ.) date input & display

### DIFF
--- a/frontend/src/__tests__/components/ThaiDatePicker.test.js
+++ b/frontend/src/__tests__/components/ThaiDatePicker.test.js
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ThaiDatePicker from '@/components/ThaiDatePicker.vue'
+
+const sel = {
+  day: '[aria-label="วัน"]',
+  month: '[aria-label="เดือน"]',
+  year: '[aria-label="ปี พ.ศ."]',
+  clear: '[aria-label="ล้างวันที่"]',
+  openCal: '[aria-label="เปิดปฏิทินเลือกวันที่"]',
+}
+
+function lastEmit(wrapper) {
+  const events = wrapper.emitted('update:modelValue')
+  return events ? events[events.length - 1][0] : undefined
+}
+
+describe('ThaiDatePicker', () => {
+  it('renders modelValue (Y-m-d) as พ.ศ. parts', () => {
+    const wrapper = mount(ThaiDatePicker, { props: { modelValue: '2026-06-16' } })
+    expect(wrapper.find(sel.day).element.value).toBe('16')
+    expect(wrapper.find(sel.month).element.value).toBe('06')
+    expect(wrapper.find(sel.year).element.value).toBe('2569')
+  })
+
+  it('emits update:modelValue with Y-m-d (ค.ศ.) when a full พ.ศ. date is typed', async () => {
+    const wrapper = mount(ThaiDatePicker, { props: { modelValue: '' } })
+    await wrapper.find(sel.day).setValue('16')
+    await wrapper.find(sel.month).setValue('06')
+    await wrapper.find(sel.year).setValue('2569')
+    expect(lastEmit(wrapper)).toBe('2026-06-16')
+  })
+
+  it('sanitizes non-digit input', async () => {
+    const wrapper = mount(ThaiDatePicker, { props: { modelValue: '' } })
+    await wrapper.find(sel.day).setValue('1a6!')
+    expect(wrapper.find(sel.day).element.value).toBe('16')
+  })
+
+  it('emits empty string when cleared', async () => {
+    const wrapper = mount(ThaiDatePicker, { props: { modelValue: '2026-06-16' } })
+    await wrapper.find(sel.clear).trigger('click')
+    expect(lastEmit(wrapper)).toBe('')
+  })
+
+  it('emits Y-m-d when a calendar day is picked', async () => {
+    const wrapper = mount(ThaiDatePicker, { props: { modelValue: '2026-06-16' } })
+    await wrapper.find(sel.openCal).trigger('click')
+    await wrapper.find('[aria-label="20 มิถุนายน 2569"]').trigger('click')
+    expect(lastEmit(wrapper)).toBe('2026-06-20')
+  })
+
+  it('shows an error and does not emit when a ค.ศ. year is typed', async () => {
+    const wrapper = mount(ThaiDatePicker, { props: { modelValue: '' } })
+    await wrapper.find(sel.day).setValue('16')
+    await wrapper.find(sel.month).setValue('06')
+    await wrapper.find(sel.year).setValue('2026')
+    expect(wrapper.text()).toContain('ปี พ.ศ. ไม่ถูกต้อง')
+    expect(wrapper.emitted('update:modelValue')).toBeFalsy()
+  })
+
+  it('renders the error prop', () => {
+    const wrapper = mount(ThaiDatePicker, {
+      props: { modelValue: '', error: 'กรุณาระบุวันเริ่มต้น' },
+    })
+    expect(wrapper.text()).toContain('กรุณาระบุวันเริ่มต้น')
+  })
+
+  it('switches to the decade (year) grid and picks a พ.ศ. year', async () => {
+    const wrapper = mount(ThaiDatePicker, { props: { modelValue: '2026-06-16' } })
+    await wrapper.find(sel.openCal).trigger('click')
+    await wrapper.find('[aria-label="เลือกปี"]').trigger('click')
+    expect(wrapper.find('[aria-label="พ.ศ. 2569"]').exists()).toBe(true)
+  })
+})

--- a/frontend/src/__tests__/utils/thaiDate.test.js
+++ b/frontend/src/__tests__/utils/thaiDate.test.js
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest'
+import {
+  toBE,
+  toCE,
+  toYMD,
+  ymdToDate,
+  partsFromYMD,
+  formatThaiShort,
+  parseParts,
+  daysInMonth,
+  thaiDow,
+} from '@/utils/thaiDate.js'
+
+describe('thaiDate conversion', () => {
+  it('toBE adds 543 (ค.ศ. → พ.ศ.)', () => {
+    expect(toBE(2026)).toBe(2569)
+  })
+
+  it('toCE subtracts 543 (พ.ศ. → ค.ศ.)', () => {
+    expect(toCE(2569)).toBe(2026)
+  })
+})
+
+describe('toYMD (timezone-safe)', () => {
+  it('formats a local Date to Y-m-d', () => {
+    // มิ.ย. = month index 5
+    expect(toYMD(new Date(2026, 5, 16))).toBe('2026-06-16')
+  })
+
+  it('does not shift across year boundary (1 ม.ค.)', () => {
+    expect(toYMD(new Date(2026, 0, 1))).toBe('2026-01-01')
+  })
+
+  it('does not shift across year boundary (31 ธ.ค.)', () => {
+    expect(toYMD(new Date(2025, 11, 31))).toBe('2025-12-31')
+  })
+
+  it('returns empty string for invalid input', () => {
+    expect(toYMD('nope')).toBe('')
+    expect(toYMD(new Date('invalid'))).toBe('')
+  })
+})
+
+describe('ymdToDate', () => {
+  it('parses a valid Y-m-d to local Date', () => {
+    const d = ymdToDate('2026-06-16')
+    expect(d.getFullYear()).toBe(2026)
+    expect(d.getMonth()).toBe(5)
+    expect(d.getDate()).toBe(16)
+  })
+
+  it('rejects overflow dates (2026-02-31)', () => {
+    expect(ymdToDate('2026-02-31')).toBeNull()
+  })
+
+  it('rejects malformed strings', () => {
+    expect(ymdToDate('2026-6-16')).toBeNull()
+    expect(ymdToDate('')).toBeNull()
+    expect(ymdToDate(null)).toBeNull()
+  })
+})
+
+describe('partsFromYMD', () => {
+  it('splits Y-m-d into zero-padded พ.ศ. parts', () => {
+    expect(partsFromYMD('2026-06-16')).toEqual({ day: '16', month: '06', beYear: '2569' })
+  })
+
+  it('returns empty parts for invalid input', () => {
+    expect(partsFromYMD('')).toEqual({ day: '', month: '', beYear: '' })
+    expect(partsFromYMD('garbage')).toEqual({ day: '', month: '', beYear: '' })
+  })
+})
+
+describe('formatThaiShort', () => {
+  it('renders a Thai short date in พ.ศ.', () => {
+    expect(formatThaiShort('2026-06-16')).toBe('16 มิ.ย. 2569')
+  })
+
+  it('returns empty string for invalid input', () => {
+    expect(formatThaiShort('')).toBe('')
+  })
+})
+
+describe('parseParts', () => {
+  it('produces Y-m-d (ค.ศ.) from valid พ.ศ. parts', () => {
+    const r = parseParts('16', '06', '2569')
+    expect(r.ok).toBe(true)
+    expect(r.ymd).toBe('2026-06-16')
+  })
+
+  it('flags day that does not exist in month (31 ก.พ.)', () => {
+    const r = parseParts('31', '02', '2569')
+    expect(r.ok).toBe(false)
+    expect(r.error).toContain('ไม่มีในเดือน')
+  })
+
+  it('accepts 29 ก.พ. in a leap year (พ.ศ. 2567 = ค.ศ. 2024)', () => {
+    expect(parseParts('29', '02', '2567').ok).toBe(true)
+  })
+
+  it('rejects 29 ก.พ. in a non-leap year (พ.ศ. 2569 = ค.ศ. 2026)', () => {
+    expect(parseParts('29', '02', '2569').ok).toBe(false)
+  })
+
+  it('rejects out-of-range month', () => {
+    expect(parseParts('16', '13', '2569').ok).toBe(false)
+  })
+
+  it('rejects a year that looks like ค.ศ. and surfaces a warning', () => {
+    const r = parseParts('16', '06', '2026')
+    expect(r.ok).toBe(false)
+    expect(r.error).toContain('ปี พ.ศ. ไม่ถูกต้อง')
+    expect(r.warning).toContain('ค.ศ.')
+  })
+
+  it('treats incomplete input as not-yet-error', () => {
+    const r = parseParts('16', '', '')
+    expect(r.ok).toBe(false)
+    expect(r.error).toBe('')
+  })
+})
+
+describe('calendar helpers', () => {
+  it('daysInMonth handles February leap/non-leap', () => {
+    expect(daysInMonth(2024, 2)).toBe(29)
+    expect(daysInMonth(2026, 2)).toBe(28)
+    expect(daysInMonth(2026, 6)).toBe(30)
+  })
+
+  it('thaiDow maps Monday to 0', () => {
+    // 2026-06-15 เป็นวันจันทร์
+    expect(thaiDow(new Date(2026, 5, 15))).toBe(0)
+  })
+})

--- a/frontend/src/components/ThaiDatePicker.vue
+++ b/frontend/src/components/ThaiDatePicker.vue
@@ -1,0 +1,369 @@
+<script setup>
+// ThaiDatePicker — drop-in แทน <input type="date">
+// แสดง/รับวันที่เป็น พ.ศ. (พิมพ์เอง วว/ดด/ปปปป + ปฏิทินไทย + decade grid)
+// v-model in/out = 'Y-m-d' (ค.ศ.) เหมือน native date input ทุกประการ
+import { ref, computed, watch, onMounted, onBeforeUnmount, nextTick } from 'vue'
+import { Calendar, ChevronLeft, ChevronRight, X, Check } from 'lucide-vue-next'
+import {
+  toBE, toCE, daysInMonth, thaiDow, toYMD, ymdToDate,
+  partsFromYMD, formatThaiShort, parseParts,
+  THAI_MONTHS_LONG, THAI_WEEKDAYS_SHORT,
+} from '@/utils/thaiDate.js'
+
+const props = defineProps({
+  modelValue: { type: String, default: '' },
+  error: { type: String, default: '' },
+  disabled: { type: Boolean, default: false },
+})
+const emit = defineEmits(['update:modelValue'])
+
+// --- ช่องพิมพ์ วว/ดด/ปปปป(พ.ศ.) ---
+const day = ref('')
+const month = ref('')
+const year = ref('')
+const localError = ref('')
+const localWarning = ref('')
+const isEditing = ref(false)
+
+const dayRef = ref(null)
+const monthRef = ref(null)
+const yearRef = ref(null)
+const rootRef = ref(null)
+
+function syncFromModel() {
+  const parts = partsFromYMD(props.modelValue)
+  day.value = parts.day
+  month.value = parts.month
+  year.value = parts.beYear
+}
+// sync ช่องจาก modelValue เฉพาะตอนผู้ใช้ไม่ได้กำลังพิมพ์ (กัน loop)
+watch(() => props.modelValue, () => {
+  if (!isEditing.value) syncFromModel()
+}, { immediate: true })
+
+const hasValue = computed(() => !!ymdToDate(props.modelValue))
+const displayError = computed(() => props.error || localError.value)
+
+function focusAndSelect(el) {
+  nextTick(() => { el.value?.focus(); el.value?.select?.() })
+}
+
+// digit-only sanitize + auto-advance + commit เมื่อปีครบ
+function onInput(field, e) {
+  isEditing.value = true
+  if (isOpen.value) isOpen.value = false
+  const max = field === 'year' ? 4 : 2
+  const clean = (e.target.value || '').replace(/\D/g, '').slice(0, max)
+  if (field === 'day') {
+    day.value = clean
+    if (clean.length === 2) focusAndSelect(monthRef)
+  } else if (field === 'month') {
+    month.value = clean
+    if (clean.length === 2) focusAndSelect(yearRef)
+  } else {
+    year.value = clean
+  }
+  if (field === 'year' && clean.length === 4 && day.value && month.value) {
+    commit()
+  }
+}
+
+function commit() {
+  const res = parseParts(day.value, month.value, year.value)
+  localWarning.value = res.warning || ''
+  if (res.ok) {
+    localError.value = ''
+    if (res.ymd !== props.modelValue) emit('update:modelValue', res.ymd)
+    isEditing.value = false
+  } else {
+    localError.value = res.error || ''
+  }
+}
+
+function onBlur() {
+  // commit เมื่อ focus ออกจาก component ทั้งก้อน
+  setTimeout(() => {
+    if (!rootRef.value || rootRef.value.contains(document.activeElement)) return
+    isEditing.value = false
+    const allEmpty = !day.value && !month.value && !year.value
+    if (allEmpty) {
+      localError.value = ''
+      localWarning.value = ''
+      if (props.modelValue) emit('update:modelValue', '')
+    } else {
+      commit()
+    }
+  }, 120)
+}
+
+function clearValue() {
+  day.value = ''
+  month.value = ''
+  year.value = ''
+  localError.value = ''
+  localWarning.value = ''
+  isEditing.value = false
+  emit('update:modelValue', '')
+}
+
+// --- ปฏิทิน popup ---
+const isOpen = ref(false)
+const calendarView = ref('date') // 'date' | 'year'
+const viewMonth = ref(firstOfThisMonth())
+const yearGridStart = ref(0) // พ.ศ.
+
+function firstOfThisMonth() {
+  const n = new Date()
+  return new Date(n.getFullYear(), n.getMonth(), 1)
+}
+
+function openCalendar() {
+  if (props.disabled) return
+  const d = ymdToDate(props.modelValue)
+  viewMonth.value = d ? new Date(d.getFullYear(), d.getMonth(), 1) : firstOfThisMonth()
+  calendarView.value = 'date'
+  isOpen.value = !isOpen.value
+}
+
+const viewMonthLabel = computed(() => THAI_MONTHS_LONG[viewMonth.value.getMonth()])
+const viewYearBE = computed(() => toBE(viewMonth.value.getFullYear()))
+
+function shiftMonth(delta) {
+  const d = new Date(viewMonth.value)
+  d.setMonth(d.getMonth() + delta)
+  viewMonth.value = d
+}
+
+const dayCells = computed(() => {
+  const y = viewMonth.value.getFullYear()
+  const m = viewMonth.value.getMonth()
+  const firstDow = thaiDow(new Date(y, m, 1))
+  const count = daysInMonth(y, m + 1)
+  const selected = ymdToDate(props.modelValue)
+  const today = new Date()
+  const cells = []
+  for (let i = 0; i < firstDow; i++) cells.push({ key: `pad-${i}`, pad: true })
+  for (let d = 1; d <= count; d++) {
+    const isSel = selected && selected.getFullYear() === y && selected.getMonth() === m && selected.getDate() === d
+    const isToday = today.getFullYear() === y && today.getMonth() === m && today.getDate() === d
+    cells.push({ key: `d-${d}`, day: d, isSel, isToday })
+  }
+  return cells
+})
+
+function pickDay(d) {
+  const picked = new Date(viewMonth.value.getFullYear(), viewMonth.value.getMonth(), d)
+  isEditing.value = false
+  localError.value = ''
+  localWarning.value = ''
+  emit('update:modelValue', toYMD(picked))
+  isOpen.value = false
+}
+
+function openYearView() {
+  const beNow = viewYearBE.value
+  yearGridStart.value = beNow - (beNow % 12)
+  calendarView.value = 'year'
+}
+
+function shiftDecade(delta) {
+  yearGridStart.value += delta
+}
+
+const yearCells = computed(() => {
+  const selected = ymdToDate(props.modelValue)
+  const selBE = selected ? toBE(selected.getFullYear()) : null
+  const cells = []
+  for (let i = 0; i < 12; i++) {
+    const be = yearGridStart.value + i
+    cells.push({ be, isSel: selBE === be, isCurrent: viewYearBE.value === be })
+  }
+  return cells
+})
+
+function pickYear(be) {
+  // normalize เป็นวันที่ 1 กัน month overflow (เช่นเปลี่ยนปีตอน viewMonth ชี้วันสิ้นเดือน)
+  viewMonth.value = new Date(toCE(be), viewMonth.value.getMonth(), 1)
+  calendarView.value = 'date'
+}
+
+function pickToday() {
+  const t = new Date()
+  isEditing.value = false
+  localError.value = ''
+  localWarning.value = ''
+  emit('update:modelValue', toYMD(new Date(t.getFullYear(), t.getMonth(), t.getDate())))
+  isOpen.value = false
+}
+
+const todayLabel = computed(() => formatThaiShort(toYMD(new Date())))
+
+function closePopup() {
+  isOpen.value = false
+  calendarView.value = 'date'
+}
+function onDocPointer(e) {
+  if (isOpen.value && rootRef.value && !rootRef.value.contains(e.target)) closePopup()
+}
+function onDocKeydown(e) {
+  if (e.key === 'Escape' && isOpen.value) closePopup()
+}
+onMounted(() => {
+  document.addEventListener('mousedown', onDocPointer)
+  document.addEventListener('keydown', onDocKeydown)
+})
+onBeforeUnmount(() => {
+  document.removeEventListener('mousedown', onDocPointer)
+  document.removeEventListener('keydown', onDocKeydown)
+})
+</script>
+
+<template>
+  <div ref="rootRef" class="relative w-full">
+    <div
+      class="flex items-center gap-1 w-full px-2 py-2 border rounded-lg text-sm bg-white transition-colors focus-within:ring-2 focus-within:ring-blue-500 focus-within:border-blue-500"
+      :class="displayError ? 'border-red-300' : 'border-gray-300'"
+    >
+      <input
+        ref="dayRef" :value="day" type="text" inputmode="numeric" maxlength="2"
+        placeholder="วว" aria-label="วัน" :disabled="disabled"
+        class="w-9 text-center bg-transparent outline-none placeholder:text-gray-300 disabled:opacity-50"
+        @input="onInput('day', $event)" @blur="onBlur" @focus="isEditing = true"
+      />
+      <span class="text-gray-300 select-none" aria-hidden="true">/</span>
+      <input
+        ref="monthRef" :value="month" type="text" inputmode="numeric" maxlength="2"
+        placeholder="ดด" aria-label="เดือน" :disabled="disabled"
+        class="w-9 text-center bg-transparent outline-none placeholder:text-gray-300 disabled:opacity-50"
+        @input="onInput('month', $event)" @blur="onBlur" @focus="isEditing = true"
+      />
+      <span class="text-gray-300 select-none" aria-hidden="true">/</span>
+      <input
+        ref="yearRef" :value="year" type="text" inputmode="numeric" maxlength="4"
+        placeholder="ปปปป" aria-label="ปี พ.ศ." :disabled="disabled"
+        class="flex-1 min-w-[3rem] text-center bg-transparent outline-none placeholder:text-gray-300 disabled:opacity-50"
+        @input="onInput('year', $event)" @blur="onBlur" @focus="isEditing = true"
+      />
+      <div class="flex items-center gap-0.5 shrink-0">
+        <Check v-if="hasValue && !isEditing && !localError" class="w-4 h-4 text-emerald-500" aria-hidden="true" />
+        <button
+          v-if="hasValue" type="button" :disabled="disabled" aria-label="ล้างวันที่"
+          class="p-1 rounded text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors disabled:opacity-50"
+          @click="clearValue"
+        >
+          <X class="w-4 h-4" />
+        </button>
+        <button
+          type="button" :disabled="disabled" aria-haspopup="dialog" :aria-expanded="isOpen"
+          aria-label="เปิดปฏิทินเลือกวันที่"
+          class="p-1 rounded transition-colors disabled:opacity-50"
+          :class="isOpen ? 'bg-blue-500 text-white' : 'text-gray-400 hover:text-gray-600 hover:bg-gray-100'"
+          @click="openCalendar"
+        >
+          <Calendar class="w-[18px] h-[18px]" />
+        </button>
+      </div>
+    </div>
+
+    <p v-if="localWarning && !displayError" class="text-xs text-amber-600 mt-1">{{ localWarning }}</p>
+    <p v-if="displayError" class="text-xs text-red-500 mt-1">{{ displayError }}</p>
+
+    <Transition name="tdp-pop">
+      <div
+        v-if="isOpen" role="dialog" aria-modal="true" aria-label="ปฏิทิน พ.ศ."
+        class="absolute z-50 mt-2 right-0 w-[320px] max-w-[calc(100vw-2rem)] bg-white rounded-xl border border-gray-200 shadow-lg p-3"
+      >
+        <div class="flex items-center justify-between mb-3">
+          <button
+            type="button" class="p-1.5 rounded-lg hover:bg-gray-100 transition-colors"
+            :aria-label="calendarView === 'date' ? 'เดือนก่อนหน้า' : 'ช่วงปีก่อนหน้า'"
+            @click="calendarView === 'date' ? shiftMonth(-1) : shiftDecade(-12)"
+          >
+            <ChevronLeft class="w-[18px] h-[18px] text-gray-600" />
+          </button>
+          <button
+            v-if="calendarView === 'date'" type="button" aria-label="เลือกปี"
+            class="flex-1 mx-1 px-2 py-1.5 rounded-lg hover:bg-gray-100 transition-colors font-semibold text-gray-900"
+            @click="openYearView"
+          >
+            {{ viewMonthLabel }} <span class="text-blue-600">{{ viewYearBE }}</span>
+          </button>
+          <button
+            v-else type="button" aria-label="กลับมุมมองวัน"
+            class="flex-1 mx-1 px-2 py-1.5 rounded-lg hover:bg-gray-100 transition-colors font-semibold text-gray-900"
+            @click="calendarView = 'date'"
+          >
+            {{ yearGridStart }} – {{ yearGridStart + 11 }}
+          </button>
+          <button
+            type="button" class="p-1.5 rounded-lg hover:bg-gray-100 transition-colors"
+            :aria-label="calendarView === 'date' ? 'เดือนถัดไป' : 'ช่วงปีถัดไป'"
+            @click="calendarView === 'date' ? shiftMonth(1) : shiftDecade(12)"
+          >
+            <ChevronRight class="w-[18px] h-[18px] text-gray-600" />
+          </button>
+        </div>
+
+        <template v-if="calendarView === 'date'">
+          <div class="grid grid-cols-7 gap-1 mb-1">
+            <div
+              v-for="(w, i) in THAI_WEEKDAYS_SHORT" :key="w"
+              class="text-center text-xs font-medium py-1"
+              :class="i >= 5 ? 'text-red-400' : 'text-gray-400'"
+            >{{ w }}</div>
+          </div>
+          <div class="grid grid-cols-7 gap-1">
+            <template v-for="cell in dayCells" :key="cell.key">
+              <div v-if="cell.pad" />
+              <button
+                v-else type="button"
+                class="h-9 w-9 rounded-lg text-sm font-medium transition-colors"
+                :class="cell.isSel
+                  ? 'bg-blue-600 text-white'
+                  : cell.isToday
+                    ? 'bg-blue-50 text-blue-600 ring-1 ring-blue-200'
+                    : 'text-gray-700 hover:bg-gray-100'"
+                :aria-label="`${cell.day} ${viewMonthLabel} ${viewYearBE}`"
+                :aria-current="cell.isToday ? 'date' : undefined"
+                @click="pickDay(cell.day)"
+              >{{ cell.day }}</button>
+            </template>
+          </div>
+        </template>
+        <div v-else class="grid grid-cols-4 gap-2 py-1">
+          <button
+            v-for="yc in yearCells" :key="yc.be" type="button"
+            class="h-11 rounded-lg text-sm font-medium transition-colors"
+            :class="yc.isSel
+              ? 'bg-blue-600 text-white'
+              : yc.isCurrent
+                ? 'bg-blue-50 text-blue-600 ring-1 ring-blue-200'
+                : 'text-gray-700 hover:bg-gray-100'"
+            :aria-label="`พ.ศ. ${yc.be}`"
+            @click="pickYear(yc.be)"
+          >{{ yc.be }}</button>
+        </div>
+
+        <div class="mt-3 pt-2 border-t border-gray-100 flex justify-center">
+          <button
+            type="button"
+            class="px-3 py-1.5 text-sm font-medium text-blue-600 hover:bg-blue-50 rounded-lg transition-colors"
+            @click="pickToday"
+          >วันนี้ ({{ todayLabel }})</button>
+        </div>
+      </div>
+    </Transition>
+  </div>
+</template>
+
+<style scoped>
+.tdp-pop-enter-active,
+.tdp-pop-leave-active {
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+.tdp-pop-enter-from,
+.tdp-pop-leave-to {
+  opacity: 0;
+  transform: translateY(-4px) scale(0.98);
+}
+</style>

--- a/frontend/src/pages/DiversePage.vue
+++ b/frontend/src/pages/DiversePage.vue
@@ -231,23 +231,17 @@
               </div>
               <div>
                 <label class="block text-sm font-medium text-gray-700 mb-1">วันเริ่มต้น <span class="text-red-500">*</span></label>
-                <input
+                <ThaiDatePicker
                   v-model="formData.from_start_date"
-                  type="date"
-                  class="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                  :class="{ 'border-red-500': validationErrors.from_start_date }"
+                  :error="validationErrors.from_start_date || ''"
                 />
-                <p v-if="validationErrors.from_start_date" class="text-red-500 text-xs mt-1">{{ validationErrors.from_start_date }}</p>
               </div>
               <div>
                 <label class="block text-sm font-medium text-gray-700 mb-1">วันสิ้นสุด <span class="text-red-500">*</span></label>
-                <input
+                <ThaiDatePicker
                   v-model="formData.from_end_date"
-                  type="date"
-                  class="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                  :class="{ 'border-red-500': validationErrors.from_end_date }"
+                  :error="validationErrors.from_end_date || ''"
                 />
-                <p v-if="validationErrors.from_end_date" class="text-red-500 text-xs mt-1">{{ validationErrors.from_end_date }}</p>
               </div>
             </div>
 
@@ -278,23 +272,17 @@
               </div>
               <div>
                 <label class="block text-sm font-medium text-gray-700 mb-1">วันเริ่มต้น <span class="text-red-500">*</span></label>
-                <input
+                <ThaiDatePicker
                   v-model="formData.to_start_date"
-                  type="date"
-                  class="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                  :class="{ 'border-red-500': validationErrors.to_start_date }"
+                  :error="validationErrors.to_start_date || ''"
                 />
-                <p v-if="validationErrors.to_start_date" class="text-red-500 text-xs mt-1">{{ validationErrors.to_start_date }}</p>
               </div>
               <div>
                 <label class="block text-sm font-medium text-gray-700 mb-1">วันสิ้นสุด <span class="text-red-500">*</span></label>
-                <input
+                <ThaiDatePicker
                   v-model="formData.to_end_date"
-                  type="date"
-                  class="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                  :class="{ 'border-red-500': validationErrors.to_end_date }"
+                  :error="validationErrors.to_end_date || ''"
                 />
-                <p v-if="validationErrors.to_end_date" class="text-red-500 text-xs mt-1">{{ validationErrors.to_end_date }}</p>
               </div>
             </div>
           </div>
@@ -386,6 +374,7 @@ import { useDiverse } from '@/composables/useDiverse.js'
 import { useApi } from '@/composables/useApi.js'
 import { useUiStore } from '@/stores/ui.js'
 import StatCard from '@/components/StatCard.vue'
+import ThaiDatePicker from '@/components/ThaiDatePicker.vue'
 import StatusBadge from '@/components/StatusBadge.vue'
 import PaginationBar from '@/components/PaginationBar.vue'
 import SkeletonLoader from '@/components/SkeletonLoader.vue'

--- a/frontend/src/pages/EquivalencePage.vue
+++ b/frontend/src/pages/EquivalencePage.vue
@@ -247,25 +247,19 @@
             <!-- request_start_date -->
             <div>
               <label class="block text-sm font-medium text-gray-700 mb-1">วันเริ่มต้น (คำขอ) <span class="text-red-500">*</span></label>
-              <input
+              <ThaiDatePicker
                 v-model="formData.request_start_date"
-                type="date"
-                class="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                :class="formErrors.request_start_date ? 'border-red-300' : 'border-gray-300'"
+                :error="formErrors.request_start_date || ''"
               />
-              <p v-if="formErrors.request_start_date" class="text-xs text-red-500 mt-1">{{ formErrors.request_start_date }}</p>
             </div>
 
             <!-- request_end_date -->
             <div>
               <label class="block text-sm font-medium text-gray-700 mb-1">วันสิ้นสุด (คำขอ) <span class="text-red-500">*</span></label>
-              <input
+              <ThaiDatePicker
                 v-model="formData.request_end_date"
-                type="date"
-                class="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                :class="formErrors.request_end_date ? 'border-red-300' : 'border-gray-300'"
+                :error="formErrors.request_end_date || ''"
               />
-              <p v-if="formErrors.request_end_date" class="text-xs text-red-500 mt-1">{{ formErrors.request_end_date }}</p>
             </div>
 
             <!-- approval_order_ref -->
@@ -316,21 +310,13 @@
             <!-- approved_start_date -->
             <div>
               <label class="block text-sm font-medium text-gray-700 mb-1">วันเริ่มต้นที่อนุมัติ <span class="text-red-500">*</span></label>
-              <input
-                v-model="approveForm.approved_start_date"
-                type="date"
-                class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-              />
+              <ThaiDatePicker v-model="approveForm.approved_start_date" />
             </div>
 
             <!-- approved_end_date -->
             <div>
               <label class="block text-sm font-medium text-gray-700 mb-1">วันสิ้นสุดที่อนุมัติ <span class="text-red-500">*</span></label>
-              <input
-                v-model="approveForm.approved_end_date"
-                type="date"
-                class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-              />
+              <ThaiDatePicker v-model="approveForm.approved_end_date" />
             </div>
           </div>
           <div class="px-6 py-4 border-t border-gray-200 flex justify-end gap-3">
@@ -471,6 +457,7 @@ import { useApi } from '@/composables/useApi.js'
 import { useUiStore } from '@/stores/ui.js'
 import { useAuthStore } from '@/stores/auth.js'
 import StatCard from '@/components/StatCard.vue'
+import ThaiDatePicker from '@/components/ThaiDatePicker.vue'
 import StatusBadge from '@/components/StatusBadge.vue'
 import SkeletonLoader from '@/components/SkeletonLoader.vue'
 import EmptyState from '@/components/EmptyState.vue'

--- a/frontend/src/pages/SupportivePage.vue
+++ b/frontend/src/pages/SupportivePage.vue
@@ -228,25 +228,19 @@
           <!-- วันเริ่มต้น -->
           <div>
             <label class="block text-sm font-medium text-gray-700 mb-1">วันเริ่มต้น</label>
-            <input
+            <ThaiDatePicker
               v-model="formData.start_date"
-              type="date"
-              class="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-              :class="formErrors.start_date ? 'border-red-500' : 'border-gray-300'"
+              :error="formErrors.start_date ? 'กรุณาระบุวันเริ่มต้น' : ''"
             />
-            <p v-if="formErrors.start_date" class="text-xs text-red-500 mt-1">กรุณาระบุวันเริ่มต้น</p>
           </div>
 
           <!-- วันสิ้นสุด -->
           <div>
             <label class="block text-sm font-medium text-gray-700 mb-1">วันสิ้นสุด</label>
-            <input
+            <ThaiDatePicker
               v-model="formData.end_date"
-              type="date"
-              class="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-              :class="formErrors.end_date ? 'border-red-500' : 'border-gray-300'"
+              :error="formErrors.end_date ? 'กรุณาระบุวันสิ้นสุด' : ''"
             />
-            <p v-if="formErrors.end_date" class="text-xs text-red-500 mt-1">กรุณาระบุวันสิ้นสุด</p>
           </div>
 
           <!-- หมายเหตุ -->
@@ -312,6 +306,8 @@ import { useSupportive } from '@/composables/useSupportive.js'
 import { useApi } from '@/composables/useApi.js'
 import { useUiStore } from '@/stores/ui.js'
 import StatCard from '@/components/StatCard.vue'
+import ThaiDatePicker from '@/components/ThaiDatePicker.vue'
+import { ymdToDate } from '@/utils/thaiDate.js'
 import SkeletonLoader from '@/components/SkeletonLoader.vue'
 import EmptyState from '@/components/EmptyState.vue'
 import PaginationBar from '@/components/PaginationBar.vue'
@@ -374,7 +370,8 @@ const recentCount = computed(() => {
   const currentYear = now.getFullYear()
   const count = rows.value.filter(r => {
     if (!r.startDate) return false
-    const d = new Date(r.startDate)
+    const d = ymdToDate(r.startDate)
+    if (!d) return false
     return d.getMonth() === currentMonth && d.getFullYear() === currentYear
   }).length
   return count || 'N/A'

--- a/frontend/src/utils/thaiDate.js
+++ b/frontend/src/utils/thaiDate.js
@@ -1,0 +1,125 @@
+// thaiDate.js — utility แปลง/format/parse วันที่ พ.ศ.↔ค.ศ. (pure, ไม่มี side effect)
+//
+// contract สำคัญ: ThaiDatePicker รับ/คืนค่าเป็น 'Y-m-d' (ค.ศ./Gregorian) เหมือน
+// <input type="date"> เดิม — โค้ดนี้แปลงเป็น พ.ศ. เฉพาะตอนแสดง/รับจากผู้ใช้เท่านั้น
+//
+// GOTCHA timezone: ห้ามใช้ Date.toISOString() หรือ new Date('YYYY-MM-DD') เพราะ
+// ตีความเป็น UTC ทำให้วันเลื่อนใน timezone +7 — ใช้ local component (getFullYear/
+// getMonth/getDate) และ new Date(y, m-1, d) เสมอ
+
+export const BE_OFFSET = 543
+
+export const THAI_MONTHS_SHORT = [
+  'ม.ค.', 'ก.พ.', 'มี.ค.', 'เม.ย.', 'พ.ค.', 'มิ.ย.',
+  'ก.ค.', 'ส.ค.', 'ก.ย.', 'ต.ค.', 'พ.ย.', 'ธ.ค.',
+]
+
+export const THAI_MONTHS_LONG = [
+  'มกราคม', 'กุมภาพันธ์', 'มีนาคม', 'เมษายน', 'พฤษภาคม', 'มิถุนายน',
+  'กรกฎาคม', 'สิงหาคม', 'กันยายน', 'ตุลาคม', 'พฤศจิกายน', 'ธันวาคม',
+]
+
+// เริ่มสัปดาห์ที่วันจันทร์ (จ=0 ... อา=6)
+export const THAI_WEEKDAYS_SHORT = ['จ', 'อ', 'พ', 'พฤ', 'ศ', 'ส', 'อา']
+
+// ช่วงปี พ.ศ. ที่ยอมรับ + เกณฑ์สงสัยว่าพิมพ์ ค.ศ.
+export const MIN_BE_YEAR = 2400
+export const MAX_BE_YEAR = 2700
+const SUSPECT_CE_THRESHOLD = 2500
+
+export function toBE(ceYear) {
+  return ceYear + BE_OFFSET
+}
+
+export function toCE(beYear) {
+  return beYear - BE_OFFSET
+}
+
+function pad2(n) {
+  return String(n).padStart(2, '0')
+}
+
+// จำนวนวันในเดือน (month = 1-12, ceYear = ค.ศ.); day 0 ของเดือนถัดไป = วันสุดท้ายเดือนนี้
+export function daysInMonth(ceYear, month) {
+  return new Date(ceYear, month, 0).getDate()
+}
+
+// แปลง getDay() (อา=0..ส=6) → จันทร์=0..อาทิตย์=6
+export function thaiDow(date) {
+  return (date.getDay() + 6) % 7
+}
+
+// Date → 'Y-m-d' จาก local component (timezone-safe; ไม่ใช้ toISOString)
+export function toYMD(date) {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) return ''
+  return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}`
+}
+
+// 'Y-m-d' (ค.ศ.) → Date local เที่ยงคืน; คืน null ถ้ารูปแบบผิดหรือวันไม่มีจริง
+export function ymdToDate(ymd) {
+  if (typeof ymd !== 'string') return null
+  const m = ymd.match(/^(\d{4})-(\d{2})-(\d{2})$/)
+  if (!m) return null
+  const year = Number(m[1])
+  const month = Number(m[2])
+  const day = Number(m[3])
+  const date = new Date(year, month - 1, day)
+  // กัน overflow เช่น '2026-02-31' ที่ JS จะเลื่อนไป มี.ค.
+  if (date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day) {
+    return null
+  }
+  return date
+}
+
+// 'Y-m-d' (ค.ศ.) → { day, month, beYear } เป็น string (zero-padded, ปีเป็น พ.ศ.); '' ถ้า invalid
+export function partsFromYMD(ymd) {
+  const date = ymdToDate(ymd)
+  if (!date) return { day: '', month: '', beYear: '' }
+  return {
+    day: pad2(date.getDate()),
+    month: pad2(date.getMonth() + 1),
+    beYear: String(toBE(date.getFullYear())),
+  }
+}
+
+// 'Y-m-d' (ค.ศ.) → '16 มิ.ย. 2569' (พ.ศ.); '' ถ้า invalid
+export function formatThaiShort(ymd) {
+  const date = ymdToDate(ymd)
+  if (!date) return ''
+  return `${date.getDate()} ${THAI_MONTHS_SHORT[date.getMonth()]} ${toBE(date.getFullYear())}`
+}
+
+// parse ช่อง วว/ดด/ปปปป(พ.ศ.) → { ok, ymd, error, warning }
+// - กรอกไม่ครบ → ok:false, error:'' (ยังไม่ถือเป็นข้อผิดพลาด)
+// - กรอกครบแต่ผิด → ok:false, error:'<ข้อความ>'
+// - ถูกต้อง → ok:true, ymd:'Y-m-d' (ค.ศ.)
+export function parseParts(day, month, beYear) {
+  const d = Number(day)
+  const mo = Number(month)
+  const by = Number(beYear)
+
+  if (!day || !month || !beYear || Number.isNaN(d) || Number.isNaN(mo) || Number.isNaN(by)) {
+    return { ok: false, ymd: '', error: '', warning: '' }
+  }
+  if (d < 1 || d > 31) {
+    return { ok: false, ymd: '', error: 'วันที่ไม่ถูกต้อง (1-31)', warning: '' }
+  }
+  if (mo < 1 || mo > 12) {
+    return { ok: false, ymd: '', error: 'เดือนไม่ถูกต้อง (1-12)', warning: '' }
+  }
+
+  const warning = by < SUSPECT_CE_THRESHOLD
+    ? 'ปีดูเหมือนเป็น ค.ศ. — กรุณากรอกเป็น พ.ศ. (เช่น 2569)'
+    : ''
+
+  if (by < MIN_BE_YEAR || by > MAX_BE_YEAR) {
+    return { ok: false, ymd: '', error: `ปี พ.ศ. ไม่ถูกต้อง (${MIN_BE_YEAR}-${MAX_BE_YEAR})`, warning }
+  }
+
+  const ceYear = toCE(by)
+  if (d > daysInMonth(ceYear, mo)) {
+    return { ok: false, ymd: '', error: 'วันที่ไม่มีในเดือนนี้', warning }
+  }
+
+  return { ok: true, ymd: `${ceYear}-${pad2(mo)}-${pad2(d)}`, error: '', warning }
+}


### PR DESCRIPTION
## สรุป

แทน `<input type="date">` ทั้ง **10 จุดใน 3 หน้า** (Supportive/Equivalence/Diverse) ด้วย Vue 3 component `ThaiDatePicker` ที่ให้ผู้ใช้ HR พิมพ์/เลือกวันที่เป็น **พ.ศ.** ได้โดยตรง — แก้ปัญหาเดิมที่ native date picker เป็น ค.ศ. แต่ระบบแสดง พ.ศ. ทำให้สับสน/กรอกผิดปี

**Drop-in replacement:** v-model in/out เป็น `Y-m-d` (ค.ศ.) เหมือน `<input type="date">` ทุกประการ → `formData` keys, backend, DB **ไม่เปลี่ยน logic ใด ๆ** (backend diff = 0)

## สิ่งที่เพิ่ม/แก้

| ไฟล์ | รายละเอียด |
|------|-----------|
| `utils/thaiDate.js` (ใหม่) | แปลง/format/parse พ.ศ.↔ค.ศ. — timezone-safe (เลี่ยง `toISOString`/UTC parse), validate leap year + month overflow |
| `components/ThaiDatePicker.vue` (ใหม่) | พิมพ์ 3-ช่อง วว/ดด/ปปปป(พ.ศ.) digit-only + auto-advance · ปฏิทินไทย day grid · decade grid กระโดดเลือกปี พ.ศ. · ARIA + `aria-modal` + Escape/click-outside |
| `pages/{Supportive,Equivalence,Diverse}.vue` | แทน input 2/4/4 จุด คง formData keys เดิม |
| `pages/SupportivePage.vue` | fix: `recentCount` ใช้ `ymdToDate` กัน UTC off-by-one วันที่ 1 |
| tests | `thaiDate.test.js` + `ThaiDatePicker.test.js` |

## Validation

- ✅ **Build** (vite): `✓ built in 8.77s`, 1621 modules, exit 0
- ✅ **Util logic**: 11/11 ใน Node จริง (conversion, timezone boundary, leap year, reject ค.ศ., overflow)
- ✅ **Audit**: `grep type="date" src/pages` = 0 · backend diff = 0
- ✅ **Code review**: APPROVE-WITH-NITS — 0 CRITICAL, ไม่มี XSS, date math ถูกต้อง (แก้ HIGH 2 + a11y แล้ว)
- ⏳ **Vitest suite (jsdom)**: รอ CI (Linux) — host+Docker worker ใช้ไม่ได้บนเครื่อง dev (Windows)

## ProbationEndPage
ตรวจแล้ว — แสดง พ.ศ. อยู่แล้ว (`useProbation` map `start_date_thai`) ไม่ต้องแก้

## Test Plan
- [ ] CI: vitest suite เขียว (util + component)
- [ ] Manual: แต่ละหน้า → modal → พิมพ์/เลือกวันที่ พ.ศ. → payload POST = `Y-m-d` (ค.ศ.) ถูกต้อง
- [ ] Manual: list/table ยังแสดง พ.ศ. เหมือนเดิม (ไม่ regress)
- [ ] a11y: keyboard tab + Escape ปิดปฏิทิน

## Follow-ups (นอกขอบเขต PR นี้)
- `servant_id` vs `personnel_id` key mismatch ใน SupportivePage `selectPersonnel` (bug เดิม)
- approveForm inline error + full focus trap