### PR TITLE
fix: use personnel_id as stable :key in personnel autocomplete

### DIFF
--- a/frontend/src/pages/DiversePage.vue
+++ b/frontend/src/pages/DiversePage.vue
@@ -188,7 +188,7 @@
               >
                 <button
                   v-for="person in personnelResults"
-                  :key="person.servant_id"
+                  :key="person.personnel_id"
                   type="button"
                   @click="selectPersonnel(person)"
                   class="w-full px-4 py-2 text-left text-sm hover:bg-blue-50 flex items-center gap-2"

--- a/frontend/src/pages/SupportivePage.vue
+++ b/frontend/src/pages/SupportivePage.vue
@@ -187,7 +187,7 @@
               >
                 <button
                   v-for="person in personnelResults"
-                  :key="person.servant_id"
+                  :key="person.personnel_id"
                   type="button"
                   class="w-full px-3 py-2 text-left text-sm hover:bg-blue-50 transition-colors"
                   @click="selectPersonnel(person)"


### PR DESCRIPTION
## สรุป

แก้ duplicate-key bug ใน dropdown ค้นหาบุคลากร (autocomplete) ทั้ง 2 หน้า — `SupportivePage` และ `DiversePage` ใช้ `:key="person.servant_id"` แต่ endpoint `/personnel` (`api.php:322-335`) **ไม่เคยคืน `servant_id`** มันคืน `personnel_id` (PK)

ผลคือทุก item ใน `v-for` มี key เป็น `undefined` เหมือนกัน → Vue track list ข้าม re-render ไม่ได้ → พิมพ์ค้นหาใหม่แล้ว dropdown อาจโชว์ row ค้าง (stale) + ขึ้น duplicate-key warning `selectPersonnel()` ใช้ `person.personnel_id` อยู่แล้ว จึงเป็น stable key ที่ถูกต้อง

## การเปลี่ยนแปลง

| ไฟล์ | เดิม | ใหม่ |
|------|------|------|
| `frontend/src/pages/SupportivePage.vue:190` | `:key="person.servant_id"` | `:key="person.personnel_id"` |
| `frontend/src/pages/DiversePage.vue:191` | `:key="person.servant_id"` | `:key="person.personnel_id"` |

ไม่แตะ logic submit ฟอร์ม — แก้เฉพาะ list reconciliation

## หลักฐาน (verify)

- `api.php:322-335` — `SELECT p.personnel_id ...` คืน `personnel_id`, ไม่มี `servant_id`
- `SupportivePage.vue:520` / `DiversePage.vue:485` — `selectPersonnel()` อ่าน `person.personnel_id`

## Test plan

- [x] `npm run build` ผ่าน (37s, ทั้ง 2 หน้า compile)
- [ ] CI: Frontend Build & Test เขียว
- [ ] CI: Docker Build Check เขียว
- [ ] Manual (หลัง deploy): พิมพ์ค้นหาบุคลากรในหน้าสนับสนุน/หลากหลาย → เลือก → ไม่มี stale row / ไม่มี console warning