### PR TITLE
feat: executive track candidate lists (อำนวยการ M1/M2 + บริหาร S1/S2)

### DIFF
--- a/backend/QualificationEngine.php
+++ b/backend/QualificationEngine.php
@@ -18,7 +18,15 @@ class QualificationEngine
     private const OVERVIEW_LEVELS = [
         'general' => ['O2', 'O3'],
         'academic' => ['K2', 'K3', 'K4'],
+        'supportive' => ['M1', 'M2'],
+        'management' => ['S1', 'S2'],
     ];
+
+    /**
+     * ระดับสายอำนวยการ(M1/M2)/บริหาร(S1/S2) — ใช้ buildExecutiveQuery (multi-path combination)
+     * แทน buildBaseQuery (linear) เพราะเกณฑ์อ้าง "ระดับก่อนหน้า" + gate (3 ต่าง / เทียบตำแหน่ง)
+     */
+    private const EXECUTIVE_LEVELS = ['M1', 'M2', 'S1', 'S2'];
 
     /** เกณฑ์ "ใกล้ถึงเกณฑ์" — เหลือ 1-90 วัน (ตรงกับ NEAR_THRESHOLD_DAYS ฝั่ง frontend) */
     private const NEAR_THRESHOLD_DAYS = 90;
@@ -127,6 +135,195 @@ class QualificationEngine
     }
 
     /**
+     * เลือก query builder ตามประเภทระดับเป้าหมาย
+     * M/S (อำนวยการ/บริหาร) = multi-path combination; K/O (วิชาการ/ทั่วไป) = linear
+     */
+    private function buildQuery(string $targetLevel): ?array
+    {
+        return in_array($targetLevel, self::EXECUTIVE_LEVELS, true)
+            ? $this->buildExecutiveQuery($targetLevel)
+            : $this->buildBaseQuery($targetLevel);
+    }
+
+    /**
+     * สร้าง query สำหรับสายอำนวยการ(M1/M2)/บริหาร(S1/S2) — multi-path combination
+     *
+     * ต่างจาก buildBaseQuery (linear) ตรงที่:
+     *   - แต่ละระดับมีได้หลาย "เส้นทาง" (path) ที่ผ่านเกณฑ์ → เลือกวันที่ "เร็วสุด" (MIN) = วันมีคุณสมบัติ
+     *   - บาง path อ้าง "ระดับก่อนหน้า" (prev-level) จาก personnel_position_history (combination)
+     *   - gate: M1 ต้องผ่าน 3 ต่าง (diverse_experience), S1(K4) ต้องมีเทียบตำแหน่ง (position_equivalence)
+     *     ถ้าขาด precondition → ไม่มี path → status = check_data
+     *
+     * เกณฑ์ pin จาก Excel master-prep (ชีท to-M1/M2/S1/S2) — ดู research/executive-track-criteria.md
+     * คืน column shape เดียวกับ buildBaseQuery เพื่อให้ computeForLevel/computeOverview reuse ได้
+     *
+     * @param string $targetLevel M1, M2, S1, S2
+     * @return array|null ['sql' => ..., 'params' => []] (constant ทั้งหมด ไม่มี user input → ปลอดภัยจาก injection)
+     */
+    private function buildExecutiveQuery(string $targetLevel): ?array
+    {
+        // gate: ผ่าน 3 ต่าง (วันครบ = MIN(qualified_date) ที่ diff_count >= 3)
+        $div = "JOIN (
+                    SELECT personnel_id, MIN(qualified_date) AS diverse_date
+                    FROM diverse_experience
+                    WHERE diff_count >= 3 AND qualified_date IS NOT NULL
+                    GROUP BY personnel_id
+                ) dv ON dv.personnel_id = e.personnel_id";
+        // gate: มีเทียบตำแหน่ง (อำนวยการ) ที่อนุมัติแล้ว
+        $eqGate = "JOIN (
+                    SELECT personnel_id
+                    FROM position_equivalence
+                    WHERE approval_status = 'APPROVED'
+                    GROUP BY personnel_id
+                ) eqx ON eqx.personnel_id = e.personnel_id";
+        // prev-level start date (combination) — วันเข้าระดับก่อนหน้าจากประวัติการดำรงตำแหน่ง
+        $histK3 = "JOIN (
+                    SELECT personnel_id, MIN(effective_date) AS level_start
+                    FROM personnel_position_history WHERE position_level = 'K3'
+                    GROUP BY personnel_id
+                ) hk3 ON hk3.personnel_id = e.personnel_id";
+        $histO3 = "JOIN (
+                    SELECT personnel_id, MIN(effective_date) AS level_start
+                    FROM personnel_position_history WHERE position_level = 'O3'
+                    GROUP BY personnel_id
+                ) ho3 ON ho3.personnel_id = e.personnel_id";
+
+        // current_level_start_date ต้องไม่ NULL สำหรับ path ที่นับจากระดับปัจจุบัน
+        $curOk = "e.is_active = 1 AND e.current_level_start_date IS NOT NULL";
+
+        switch ($targetLevel) {
+            case 'M1': // ดำรง K3 +3ปี หรือ O3 +6ปี + ผ่าน 3 ต่าง; วันมีคุณสมบัติ = MAX(วันดำรงครบ, วันครบ3ต่าง)
+                $sources = ['K3', 'O3'];
+                $paths = [
+                    "SELECT e.personnel_id, GREATEST(DATE_ADD(e.current_level_start_date, INTERVAL 3 YEAR), dv.diverse_date) AS qual_date
+                     FROM personnel e {$div} WHERE e.current_level_code = 'K3' AND {$curOk}",
+                    "SELECT e.personnel_id, GREATEST(DATE_ADD(e.current_level_start_date, INTERVAL 6 YEAR), dv.diverse_date) AS qual_date
+                     FROM personnel e {$div} WHERE e.current_level_code = 'O3' AND {$curOk}",
+                ];
+                break;
+
+            case 'M2': // M1+1 / M1+K3รวม4 / M1+O3รวม7 / K3+4 / O3+7 / K4+3ต่าง (เลือก path เร็วสุด)
+                $sources = ['M1', 'K3', 'O3', 'K4'];
+                $paths = [
+                    "SELECT e.personnel_id, DATE_ADD(e.current_level_start_date, INTERVAL 1 YEAR) AS qual_date
+                     FROM personnel e WHERE e.current_level_code = 'M1' AND {$curOk}",
+                    // combination นับจาก level_start ใน history (ไม่ใช้ current_level_start_date);
+                    // effective_date เป็น NOT NULL → level_start ไม่มีทางเป็น NULL แต่ guard ไว้กัน data สกปรก
+                    "SELECT e.personnel_id, DATE_ADD(hk3.level_start, INTERVAL 4 YEAR) AS qual_date
+                     FROM personnel e {$histK3} WHERE e.current_level_code = 'M1' AND e.is_active = 1 AND hk3.level_start IS NOT NULL",
+                    "SELECT e.personnel_id, DATE_ADD(ho3.level_start, INTERVAL 7 YEAR) AS qual_date
+                     FROM personnel e {$histO3} WHERE e.current_level_code = 'M1' AND e.is_active = 1 AND ho3.level_start IS NOT NULL",
+                    "SELECT e.personnel_id, DATE_ADD(e.current_level_start_date, INTERVAL 4 YEAR) AS qual_date
+                     FROM personnel e WHERE e.current_level_code = 'K3' AND {$curOk}",
+                    "SELECT e.personnel_id, DATE_ADD(e.current_level_start_date, INTERVAL 7 YEAR) AS qual_date
+                     FROM personnel e WHERE e.current_level_code = 'O3' AND {$curOk}",
+                    "SELECT e.personnel_id, GREATEST(e.current_level_start_date, dv.diverse_date) AS qual_date
+                     FROM personnel e {$div} WHERE e.current_level_code = 'K4' AND {$curOk}",
+                ];
+                break;
+
+            case 'S1': // M1/M2/K4 ดำรง +2ปี (K4 ต้องมีเทียบตำแหน่งอำนวยการ)
+                $sources = ['M1', 'M2', 'K4'];
+                $paths = [
+                    "SELECT e.personnel_id, DATE_ADD(e.current_level_start_date, INTERVAL 2 YEAR) AS qual_date
+                     FROM personnel e WHERE e.current_level_code = 'M1' AND {$curOk}",
+                    "SELECT e.personnel_id, DATE_ADD(e.current_level_start_date, INTERVAL 2 YEAR) AS qual_date
+                     FROM personnel e WHERE e.current_level_code = 'M2' AND {$curOk}",
+                    "SELECT e.personnel_id, DATE_ADD(e.current_level_start_date, INTERVAL 2 YEAR) AS qual_date
+                     FROM personnel e {$eqGate} WHERE e.current_level_code = 'K4' AND {$curOk}",
+                ];
+                break;
+
+            case 'S2': // S1 ดำรง +1ปี (combination บต+อต/อส+เทียบ ≥3 = follow-up รอ verify Excel)
+                $sources = ['S1'];
+                $paths = [
+                    "SELECT e.personnel_id, DATE_ADD(e.current_level_start_date, INTERVAL 1 YEAR) AS qual_date
+                     FROM personnel e WHERE e.current_level_code = 'S1' AND {$curOk}",
+                ];
+                break;
+
+            default:
+                return null;
+        }
+
+        $pathsUnion = implode("\n            UNION ALL\n            ", $paths);
+        $sourceList = "'" . implode("','", $sources) . "'";
+        $minYearsCase = $this->executiveMinYearsCase($targetLevel);
+
+        $sql = "
+            SELECT
+                p.personnel_id,
+                CONCAT(p.first_name, ' ', p.last_name) AS full_name,
+                pos.position_name AS current_position,
+                p.current_level_code,
+                p.current_level_start_date,
+                COALESCE(p.education_level, 'BACHELOR') AS education_level,
+                {$minYearsCase} AS min_years,
+                o.org_name AS department,
+                COALESCE(sup.total_supportive_days, 0) AS supportive_days,
+                COALESCE(eq.total_equivalence_days, 0) AS equivalence_days,
+                COALESCE(dex.max_diff_count, 0) AS diverse_diff_count,
+                pa.qual_date AS qualification_date,
+                CASE WHEN pa.qual_date IS NULL THEN NULL ELSE DATEDIFF(pa.qual_date, CURDATE()) END AS remaining_days,
+                CASE
+                    WHEN p.current_level_code IS NULL OR p.current_level_start_date IS NULL THEN 'check_data'
+                    WHEN pa.qual_date IS NULL THEN 'check_data'
+                    WHEN DATEDIFF(pa.qual_date, CURDATE()) <= 0 THEN 'qualified'
+                    ELSE 'not_yet'
+                END AS status
+            FROM personnel p
+            LEFT JOIN position pos ON p.current_position_id = pos.position_id
+            LEFT JOIN organization o ON p.current_org_id = o.org_id
+            LEFT JOIN (
+                SELECT personnel_id, SUM(effective_days) AS total_supportive_days
+                FROM supportive_experience
+                GROUP BY personnel_id
+            ) sup ON sup.personnel_id = p.personnel_id
+            LEFT JOIN (
+                SELECT personnel_id, SUM(approved_total_days) AS total_equivalence_days
+                FROM position_equivalence
+                WHERE approval_status = 'APPROVED'
+                GROUP BY personnel_id
+            ) eq ON eq.personnel_id = p.personnel_id
+            LEFT JOIN (
+                SELECT personnel_id, MAX(diff_count) AS max_diff_count
+                FROM diverse_experience
+                GROUP BY personnel_id
+            ) dex ON dex.personnel_id = p.personnel_id
+            LEFT JOIN (
+                SELECT personnel_id, MIN(qual_date) AS qual_date
+                FROM (
+            {$pathsUnion}
+                ) u
+                GROUP BY personnel_id
+            ) pa ON pa.personnel_id = p.personnel_id
+            WHERE p.current_level_code IN ({$sourceList})
+                AND p.is_active = 1
+        ";
+
+        return ['sql' => $sql, 'params' => []];
+    }
+
+    /**
+     * เกณฑ์ขั้นต่ำ (ปี) สำหรับแสดงผล — อิง path ตรงตามระดับปัจจุบัน (ไม่รวม combination)
+     */
+    private function executiveMinYearsCase(string $targetLevel): string
+    {
+        switch ($targetLevel) {
+            case 'M1':
+                return "CASE p.current_level_code WHEN 'K3' THEN 3.0 WHEN 'O3' THEN 6.0 ELSE NULL END";
+            case 'M2':
+                return "CASE p.current_level_code WHEN 'M1' THEN 1.0 WHEN 'K3' THEN 4.0 WHEN 'O3' THEN 7.0 WHEN 'K4' THEN 0.0 ELSE NULL END";
+            case 'S1':
+                return "2.0";
+            case 'S2':
+                return "1.0";
+            default:
+                return "NULL";
+        }
+    }
+
+    /**
      * คำนวณคุณสมบัติเลื่อนระดับสำหรับบุคลากรทั้งหมดที่อยู่ในระดับต้นทาง
      *
      * @param string $targetLevel รหัสระดับเป้าหมาย (e.g. K2, K3, O2)
@@ -137,8 +334,8 @@ class QualificationEngine
      */
     public function computeForLevel(string $targetLevel, ?string $search, int $limit, int $offset): array
     {
-        // Step 1-2: สร้าง base query (แชร์ logic กับ computeOverview)
-        $base = $this->buildBaseQuery($targetLevel);
+        // Step 1-2: สร้าง base query (แชร์ logic กับ computeOverview) — dispatch K/O linear vs M/S combination
+        $base = $this->buildQuery($targetLevel);
 
         if ($base === null) {
             return [
@@ -232,6 +429,8 @@ class QualificationEngine
         $summary = [
             'general_total' => 0,
             'academic_total' => 0,
+            'supportive_total' => 0,
+            'management_total' => 0,
             'qualified_total' => 0,
             'near_qualified_total' => 0,
             'not_yet_total' => 0,
@@ -242,7 +441,7 @@ class QualificationEngine
 
         foreach (self::OVERVIEW_LEVELS as $category => $levels) {
             foreach ($levels as $level) {
-                $base = $this->buildBaseQuery($level);
+                $base = $this->buildQuery($level);
 
                 // ระดับที่ไม่มีเกณฑ์ active — ใส่ค่าศูนย์ทั้งแถว ห้าม error
                 if ($base === null) {
@@ -273,7 +472,7 @@ class QualificationEngine
                 ];
                 $byLevel[$level] = $levelSummary;
 
-                $summary[$category === 'general' ? 'general_total' : 'academic_total'] += $levelSummary['total'];
+                $summary[$category . '_total'] += $levelSummary['total'];
                 $summary['qualified_total'] += $levelSummary['qualified'];
                 $summary['near_qualified_total'] += $levelSummary['near_qualified'];
                 $summary['not_yet_total'] += $levelSummary['not_yet'];
@@ -334,6 +533,11 @@ class QualificationEngine
      */
     public function computeDetail(string $targetLevel, int $personnelId): ?array
     {
+        // M/S (อำนวยการ/บริหาร) ใช้ multi-path เดียวกับ list — detail ต้องตรงกับ list เสมอ (legal)
+        if (in_array($targetLevel, self::EXECUTIVE_LEVELS, true)) {
+            return $this->computeExecutiveDetail($targetLevel, $personnelId);
+        }
+
         $sql = "
             SELECT
                 p.personnel_id,
@@ -429,6 +633,54 @@ class QualificationEngine
         $row['supportive_days'] = (int)$row['supportive_days'];
         $row['equivalence_days'] = (int)$row['equivalence_days'];
         $row['diverse_diff_count'] = (int)$row['diverse_diff_count'];
+
+        return [
+            'success' => true,
+            'data' => $row,
+        ];
+    }
+
+    /**
+     * รายละเอียดรายบุคคลสำหรับสายอำนวยการ/บริหาร — ใช้ buildExecutiveQuery เดียวกับ list
+     * เพื่อให้ qualification_date/status ใน detail ตรงกับ list เสมอ (ไม่คำนวณซ้ำคนละสูตร)
+     */
+    private function computeExecutiveDetail(string $targetLevel, int $personnelId): ?array
+    {
+        $base = $this->buildExecutiveQuery($targetLevel);
+        if ($base === null) {
+            return null;
+        }
+
+        // กรองรายบุคคลจาก query เดียวกับ list
+        $sql = "SELECT * FROM ({$base['sql']}) AS sub WHERE sub.personnel_id = ?";
+        $params = array_merge($base['params'], [$personnelId]);
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute($params);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if (!$row) {
+            return null;
+        }
+
+        // เติม field เฉพาะ detail ที่ไม่อยู่ใน list query
+        $extraStmt = $this->pdo->prepare(
+            'SELECT citizen_id, first_name, last_name, hire_date FROM personnel WHERE personnel_id = ?'
+        );
+        $extraStmt->execute([$personnelId]);
+        $extra = $extraStmt->fetch(PDO::FETCH_ASSOC) ?: [];
+        $row = array_merge($extra, $row);
+
+        // Formatted fields (ให้ตรงกับ computeDetail ของ K/O)
+        $row['qualification_date_thai'] = formatThaiDate($row['qualification_date'] ?? null);
+        $row['level_start_date_thai'] = formatThaiDate($row['current_level_start_date'] ?? null);
+        $row['hire_date_thai'] = formatThaiDate($row['hire_date'] ?? null);
+        $row['current_level_name'] = getLevelName($row['current_level_code'] ?? '');
+        $row['education_condition'] = 'ANY'; // M/S ไม่ผูกเงื่อนไขวุฒิ
+        $row['remaining_days'] = $row['remaining_days'] !== null ? (int) $row['remaining_days'] : null;
+        $row['min_years'] = $row['min_years'] !== null ? (float) $row['min_years'] : null;
+        $row['supportive_days'] = (int) $row['supportive_days'];
+        $row['equivalence_days'] = (int) $row['equivalence_days'];
+        $row['diverse_diff_count'] = (int) $row['diverse_diff_count'];
 
         return [
             'success' => true,

--- a/backend/routes/candidates.php
+++ b/backend/routes/candidates.php
@@ -45,7 +45,7 @@ function handleCandidates(PDO $pdo, string $method, array $path): void
     }
 
     // ตรวจสอบว่าเป็นระดับเป้าหมายที่ถูกต้อง
-    $validTargets = ['K2', 'K3', 'K4', 'O2', 'O3'];
+    $validTargets = ['K2', 'K3', 'K4', 'O2', 'O3', 'M1', 'M2', 'S1', 'S2'];
     if (!in_array(strtoupper($targetLevel), $validTargets)) {
         http_response_code(400);
         echo json_encode([

--- a/backend/tests/verify-executive.sh
+++ b/backend/tests/verify-executive.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# ============================================================================
+# verify-executive.sh
+# Integration verification สำหรับ executive track (อำนวยการ M1/M2 + บริหาร S1/S2)
+# เทียบ qualification_date ที่ engine คำนวณ กับ golden values จาก Excel master-prep
+#
+# ใช้รันกับ Docker stack (db + backend) เท่านั้น — CI build image อย่างเดียว ไม่ start DB
+# วิธีใช้:
+#   docker compose up -d --build db backend
+#   bash backend/tests/verify-executive.sh
+#
+# ตั้งค่าได้ผ่าน env: BASE_URL (default http://localhost:8000), USER, PASS
+# golden cases อ้างอิง sample data ใน database/06-seed-data.sql (personnel 101-107)
+# ============================================================================
+set -u
+
+BASE_URL="${BASE_URL:-http://localhost:8000}"
+USER="${USER:-admin}"
+PASS="${PASS:-admin123}"
+
+TOKEN=""
+for i in $(seq 1 8); do
+  TOKEN=$(curl -s -X POST "$BASE_URL/auth/login" -H 'Content-Type: application/json' \
+    -d "{\"username\":\"$USER\",\"password\":\"$PASS\"}" \
+    | grep -oE '"token":"[^"]+"' | sed 's/"token":"//;s/"$//')
+  [ -n "$TOKEN" ] && break
+  sleep 4
+done
+if [ -z "$TOKEN" ]; then echo "FATAL: login failed at $BASE_URL"; exit 2; fi
+
+PASS_N=0; FAIL_N=0
+
+# check <level> <personnel_id> <expected: YYYY-MM-DD | check_data>
+check() {
+  local level="$1" id="$2" expected="$3"
+  local got
+  got=$(curl -s "$BASE_URL/candidates/$level/$id" -H "Authorization: Bearer $TOKEN" \
+    | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{try{const r=JSON.parse(d).data;if(!r){console.log("null");return}console.log(r.status==="check_data"?"check_data":(r.qualification_date||"null"))}catch(e){console.log("parse_err")}})')
+  if [ "$got" = "$expected" ]; then
+    echo "  PASS  $level/$id => $got"
+    PASS_N=$((PASS_N+1))
+  else
+    echo "  FAIL  $level/$id => got '$got', expected '$expected'"
+    FAIL_N=$((FAIL_N+1))
+  fi
+}
+
+echo "=== Executive track golden verification ==="
+# M1 อำนวยการต้น: K3 +3ปี / O3 +6ปี + gate 3 ต่าง (MAX กับวันครบ 3 ต่าง)
+check M1 101 2023-08-26   # K3 start 2020-08-26, 3ต่าง 2018-01-01 -> MAX = 2023-08-26
+check M1 102 2024-03-28   # O3 start 2018-03-28 +6y
+check M1 104 check_data   # K3 ไม่มี 3 ต่าง -> gate ปิด
+# M2 อำนวยการสูง: multi-path เลือกวันเร็วสุด
+check M2 103 2021-08-26   # M1 start 2020-08-26 +1y
+check M2 105 2023-06-01   # combination M1+K3: prevK3 2019-06-01 +4y (เร็วกว่า M1+1=2024-01-01)
+# S1 บริหารต้น: ดำรง +2ปี (K4 ต้องมีเทียบตำแหน่ง)
+check S1 103 2022-08-26   # M1 start 2020-08-26 +2y
+check S1 106 2024-01-01   # K4 start 2022-01-01 +2y + gate เทียบตำแหน่ง
+# S2 บริหารสูง: S1 +1ปี
+check S2 107 2025-01-01   # S1 start 2024-01-01 +1y
+
+echo "=== Result: $PASS_N passed, $FAIL_N failed ==="
+[ "$FAIL_N" -eq 0 ] || exit 1

--- a/database/06-seed-data.sql
+++ b/database/06-seed-data.sql
@@ -91,3 +91,59 @@ INSERT INTO probation_enrollment (personnel_id, program_id, start_date, end_date
 -- Enrollment 3: past end_date (red/negative remaining_days)
 INSERT INTO probation_enrollment (personnel_id, program_id, start_date, end_date, overall_status) VALUES
 (1, 1, '2025-06-01', '2025-12-01', 'IN_PROGRESS');
+
+-- ############################################################################
+-- SECTION 7: EXECUTIVE TRACK CRITERIA (อำนวยการ M1/M2 + บริหาร S1/S2)
+-- reference config — คำนวณจริงอยู่ใน QualificationEngine::buildExecutiveQuery (multi-path)
+-- เกณฑ์ pin จาก Excel master-prep (ชีท to-M1/M2/S1/S2) — ดู research/executive-track-criteria.md
+-- หมายเหตุ: ตัวเลขที่นี่ต้องตรงกับ constant ใน buildExecutiveQuery (review คู่กัน)
+-- ############################################################################
+
+INSERT INTO promotion_criteria
+  (target_level_code, target_level_name, source_level_code, source_level_name, min_years,
+   education_condition, career_track, combination_group, combination_min_years,
+   requires_equiv_years, requires_screening, description, legal_reference, is_active, effective_date)
+VALUES
+-- M1 อำนวยการต้น (ต้องผ่าน 3 ต่าง; วันมีคุณสมบัติ = MAX(วันดำรงครบ, วันครบ3ต่าง))
+('M1', 'อำนวยการ ต้น', 'K3', 'ชำนาญการพิเศษ', 3.0, 'ANY', 'ALL', NULL, NULL, NULL, 0, 'ดำรง K3 ครบ 3 ปี + ผ่าน 3 ต่าง', 'นร 1006/ว5 (22 มี.ค. 67)', 1, '2024-03-22'),
+('M1', 'อำนวยการ ต้น', 'O3', 'อาวุโส', 6.0, 'ANY', 'ALL', NULL, NULL, NULL, 0, 'ดำรง O3 ครบ 6 ปี + ผ่าน 3 ต่าง', 'นร 1006/ว5 (22 มี.ค. 67)', 1, '2024-03-22'),
+-- M2 อำนวยการสูง (multi-path เลือกวันเร็วสุด)
+('M2', 'อำนวยการ สูง', 'M1', 'อำนวยการ ต้น', 1.0, 'ANY', 'ALL', NULL, NULL, NULL, 0, 'ดำรง M1 ครบ 1 ปี', 'นร 1006/ว5 (22 มี.ค. 67)', 1, '2024-03-22'),
+('M2', 'อำนวยการ สูง', 'K3', 'ชำนาญการพิเศษ', 4.0, 'ANY', 'ALL', 1, 4.0, NULL, 0, 'M1+K3 รวม 4 ปี (combination นับจากวันเข้า K3) หรือ K3 ครบ 4 ปี', 'นร 1006/ว5 (22 มี.ค. 67)', 1, '2024-03-22'),
+('M2', 'อำนวยการ สูง', 'O3', 'อาวุโส', 7.0, 'ANY', 'ALL', 2, 7.0, NULL, 0, 'M1+O3 รวม 7 ปี (combination) หรือ O3 ครบ 7 ปี', 'นร 1006/ว5 (22 มี.ค. 67)', 1, '2024-03-22'),
+('M2', 'อำนวยการ สูง', 'K4', 'เชี่ยวชาญ', 0.0, 'ANY', 'ALL', NULL, NULL, NULL, 0, 'K4 + ผ่าน 3 ต่าง (lateral)', 'นร 1006/ว5 (22 มี.ค. 67)', 1, '2024-03-22'),
+-- S1 บริหารต้น (ดำรง 2 ปี; K4 ต้องมีเทียบตำแหน่งอำนวยการ)
+('S1', 'บริหาร ต้น', 'M1', 'อำนวยการ ต้น', 2.0, 'ANY', 'ALL', NULL, NULL, NULL, 0, 'ดำรง M1 ครบ 2 ปี', 'นร 1006/ว5 (22 มี.ค. 67)', 1, '2024-03-22'),
+('S1', 'บริหาร ต้น', 'M2', 'อำนวยการ สูง', 2.0, 'ANY', 'ALL', NULL, NULL, NULL, 0, 'ดำรง M2 ครบ 2 ปี', 'นร 1006/ว5 (22 มี.ค. 67)', 1, '2024-03-22'),
+('S1', 'บริหาร ต้น', 'K4', 'เชี่ยวชาญ', 2.0, 'ANY', 'ALL', NULL, NULL, 2.0, 0, 'ดำรง K4 ครบ 2 ปี + เทียบตำแหน่งอำนวยการ', 'นร 1006/ว5 (22 มี.ค. 67)', 1, '2024-03-22'),
+-- S2 บริหารสูง (combination เทียบตำแหน่ง = follow-up รอ verify Excel)
+('S2', 'บริหาร สูง', 'S1', 'บริหาร ต้น', 1.0, 'ANY', 'ALL', NULL, NULL, NULL, 0, 'ดำรง S1 ครบ 1 ปี', 'นร 1006/ว5 (22 มี.ค. 67)', 1, '2024-03-22');
+
+-- ############################################################################
+-- SECTION 8: SAMPLE EXECUTIVE PERSONNEL (เฉพาะ local/Docker — ไม่อยู่ใน tidb-init prod)
+-- ครอบคลุม golden case จาก Excel เพื่อ verify buildExecutiveQuery
+-- personnel_id 101-107 (explicit เพื่อให้ FK ของ history/diverse/equivalence อ้างได้แน่นอน)
+-- ############################################################################
+
+INSERT INTO personnel (personnel_id, citizen_id, first_name, last_name, hire_date, current_position_id, current_org_id, current_level_start_date, current_level_code, is_active) VALUES
+(101, '1100100200101', 'ทดสอบ K3', 'สู่อำนวยการต้น', '2015-01-01', 1, 1, '2020-08-26', 'K3', 1),  -- M1 = MAX(2023-08-26, 3ต่าง 2018-01-01) = 2023-08-26
+(102, '1100100200102', 'ทดสอบ O3', 'สู่อำนวยการต้น', '2010-01-01', 1, 1, '2018-03-28', 'O3', 1),  -- M1 = 2024-03-28
+(103, '1100100200103', 'ทดสอบ M1', 'สู่บริหารต้น',   '2012-01-01', 1, 1, '2020-08-26', 'M1', 1),  -- S1 = 2022-08-26 ; M2 = 2021-08-26
+(104, '1100100200104', 'ทดสอบ K3', 'ขาด3ต่าง',       '2016-01-01', 1, 1, '2021-01-01', 'K3', 1),  -- M1 = check_data (ไม่มี 3ต่าง)
+(105, '1100100200105', 'ทดสอบ M1', 'combination',     '2011-01-01', 1, 1, '2023-01-01', 'M1', 1),  -- M2 = MIN(M1+1=2024-01-01, K3start+4=2023-06-01) = 2023-06-01
+(106, '1100100200106', 'ทดสอบ K4', 'เทียบตำแหน่ง',   '2009-01-01', 1, 1, '2022-01-01', 'K4', 1),  -- S1 = 2024-01-01 (มีเทียบ)
+(107, '1100100200107', 'ทดสอบ S1', 'สู่บริหารสูง',   '2008-01-01', 1, 1, '2024-01-01', 'S1', 1);  -- S2 = 2025-01-01
+
+-- prev-level สำหรับ 105 (M2 combination M1+K3): เข้า K3 เมื่อ 2019-06-01 → K3+4 = 2023-06-01
+INSERT INTO personnel_position_history (personnel_id, position_id, org_id, position_name, position_level, effective_date, end_date, job_series_name) VALUES
+(105, 1, 1, 'นักทรัพยากรบุคคล', 'K3', '2019-06-01', '2022-12-31', 'นักทรัพยากรบุคคล'),
+(105, 1, 1, 'ผู้อำนวยการกอง',   'M1', '2023-01-01', NULL,         'อำนวยการ');
+
+-- 3 ต่าง (diff_count = sum flags ผ่าน GENERATED ใน 08; ตั้ง 3 flags = ครบ 3 ต่าง) — 101,102 ผ่าน
+INSERT INTO diverse_experience (personnel_id, is_diff_job_series, is_diff_org, is_diff_location, is_diff_work_nature, qualified_date) VALUES
+(101, 1, 1, 1, 0, '2018-01-01'),
+(102, 1, 1, 1, 0, '2017-01-01');
+
+-- เทียบตำแหน่งอำนวยการ (อนุมัติ) — 106 สำหรับ S1(K4)
+INSERT INTO position_equivalence (personnel_id, actual_position, equivalent_type, approved_start_date, approved_end_date, approved_total_days, approval_status) VALUES
+(106, 'ผู้เชี่ยวชาญ', 'อำนวยการ', '2022-01-01', '2024-01-01', 730, 'APPROVED');

--- a/database/tidb-init.sql
+++ b/database/tidb-init.sql
@@ -1059,6 +1059,25 @@ INSERT INTO promotion_criteria (target_level_code, target_level_name, source_lev
 ('O2', 'ชำนาญงาน', 'O1', 'ปฏิบัติงาน', 5.0, 'HIGH_VOCATIONAL', 'ALL', 1, '2024-03-22'),
 ('O3', 'อาวุโส', 'O2', 'ชำนาญงาน', 6.0, 'ANY', 'ALL', 1, '2024-03-22');
 
+-- Executive track: อำนวยการ M1/M2 + บริหาร S1/S2 (reference config)
+-- คำนวณจริงใน QualificationEngine::buildExecutiveQuery (multi-path) — ตัวเลขต้องตรงกับ engine
+-- เกณฑ์ pin จาก Excel master-prep (to-M1/M2/S1/S2); อ้างอิง นร 1006/ว5 (22 มี.ค. 67)
+INSERT INTO promotion_criteria
+  (target_level_code, target_level_name, source_level_code, source_level_name, min_years,
+   education_condition, career_track, combination_group, combination_min_years,
+   requires_equiv_years, requires_screening, description, legal_reference, is_active, effective_date)
+VALUES
+('M1', 'อำนวยการ ต้น', 'K3', 'ชำนาญการพิเศษ', 3.0, 'ANY', 'ALL', NULL, NULL, NULL, 0, 'ดำรง K3 ครบ 3 ปี + ผ่าน 3 ต่าง', 'นร 1006/ว5 (22 มี.ค. 67)', 1, '2024-03-22'),
+('M1', 'อำนวยการ ต้น', 'O3', 'อาวุโส', 6.0, 'ANY', 'ALL', NULL, NULL, NULL, 0, 'ดำรง O3 ครบ 6 ปี + ผ่าน 3 ต่าง', 'นร 1006/ว5 (22 มี.ค. 67)', 1, '2024-03-22'),
+('M2', 'อำนวยการ สูง', 'M1', 'อำนวยการ ต้น', 1.0, 'ANY', 'ALL', NULL, NULL, NULL, 0, 'ดำรง M1 ครบ 1 ปี', 'นร 1006/ว5 (22 มี.ค. 67)', 1, '2024-03-22'),
+('M2', 'อำนวยการ สูง', 'K3', 'ชำนาญการพิเศษ', 4.0, 'ANY', 'ALL', 1, 4.0, NULL, 0, 'M1+K3 รวม 4 ปี หรือ K3 ครบ 4 ปี', 'นร 1006/ว5 (22 มี.ค. 67)', 1, '2024-03-22'),
+('M2', 'อำนวยการ สูง', 'O3', 'อาวุโส', 7.0, 'ANY', 'ALL', 2, 7.0, NULL, 0, 'M1+O3 รวม 7 ปี หรือ O3 ครบ 7 ปี', 'นร 1006/ว5 (22 มี.ค. 67)', 1, '2024-03-22'),
+('M2', 'อำนวยการ สูง', 'K4', 'เชี่ยวชาญ', 0.0, 'ANY', 'ALL', NULL, NULL, NULL, 0, 'K4 + ผ่าน 3 ต่าง (lateral)', 'นร 1006/ว5 (22 มี.ค. 67)', 1, '2024-03-22'),
+('S1', 'บริหาร ต้น', 'M1', 'อำนวยการ ต้น', 2.0, 'ANY', 'ALL', NULL, NULL, NULL, 0, 'ดำรง M1 ครบ 2 ปี', 'นร 1006/ว5 (22 มี.ค. 67)', 1, '2024-03-22'),
+('S1', 'บริหาร ต้น', 'M2', 'อำนวยการ สูง', 2.0, 'ANY', 'ALL', NULL, NULL, NULL, 0, 'ดำรง M2 ครบ 2 ปี', 'นร 1006/ว5 (22 มี.ค. 67)', 1, '2024-03-22'),
+('S1', 'บริหาร ต้น', 'K4', 'เชี่ยวชาญ', 2.0, 'ANY', 'ALL', NULL, NULL, 2.0, 0, 'ดำรง K4 ครบ 2 ปี + เทียบตำแหน่งอำนวยการ', 'นร 1006/ว5 (22 มี.ค. 67)', 1, '2024-03-22'),
+('S2', 'บริหาร สูง', 'S1', 'บริหาร ต้น', 1.0, 'ANY', 'ALL', NULL, NULL, NULL, 0, 'ดำรง S1 ครบ 1 ปี', 'นร 1006/ว5 (22 มี.ค. 67)', 1, '2024-03-22');
+
 -- ############################################################################
 -- SECTION 3: SAMPLE PERSONNEL RECORDS (per D-12)
 -- บุคลากรตัวอย่าง — ระดับและวันที่เข้าสู่ระดับหลากหลาย

--- a/frontend/src/pages/CandidateListsPage.vue
+++ b/frontend/src/pages/CandidateListsPage.vue
@@ -20,8 +20,8 @@
       <!-- Overview Loading Skeleton (custom 2+3 layout) -->
       <template v-if="overviewLoading">
         <div class="animate-pulse space-y-4">
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div v-for="i in 2" :key="'sk2-'+i" class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+          <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
+            <div v-for="i in 4" :key="'sk2-'+i" class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
               <div class="flex items-center">
                 <div class="w-12 h-12 bg-gray-200 rounded-lg"></div>
                 <div class="ml-4 flex-1 space-y-2">
@@ -63,8 +63,8 @@
 
       <!-- Overview Data -->
       <template v-else-if="overviewData">
-        <!-- Row 1: 2 stat cards -->
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <!-- Row 1: 4 stat cards (ทั่วไป / วิชาการ / อำนวยการ / บริหาร) -->
+        <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
           <StatCard
             label="ประเภททั่วไป"
             :value="overviewData.generalTotal"
@@ -78,6 +78,20 @@
             :icon="UserCheck"
             icon-bg-class="bg-purple-50"
             icon-class="text-purple-600"
+          />
+          <StatCard
+            label="ประเภทอำนวยการ"
+            :value="overviewData.supportiveTotal"
+            :icon="Briefcase"
+            icon-bg-class="bg-amber-50"
+            icon-class="text-amber-600"
+          />
+          <StatCard
+            label="ประเภทบริหาร"
+            :value="overviewData.managementTotal"
+            :icon="Building2"
+            icon-bg-class="bg-rose-50"
+            icon-class="text-rose-600"
           />
         </div>
 
@@ -157,16 +171,7 @@
       </template>
     </template>
 
-    <!-- ==================== PLACEHOLDER SECTIONS (support/management) ==================== -->
-    <template v-else-if="isPlaceholder">
-      <EmptyState
-        :icon="Construction"
-        title="อยู่ระหว่างพัฒนา"
-        description="ฟีเจอร์นี้อยู่ระหว่างการพัฒนา จะเปิดให้ใช้งานในเร็วๆ นี้"
-      />
-    </template>
-
-    <!-- ==================== SUB-TAB SECTIONS (general/academic) ==================== -->
+    <!-- ==================== SUB-TAB SECTIONS (general/academic/support/management) ==================== -->
     <template v-else-if="hasSubTabs">
       <!-- Pill sub-tab buttons -->
       <div class="flex gap-2 mb-6">
@@ -378,7 +383,7 @@ import EmptyState from '@/components/EmptyState.vue'
 import PaginationBar from '@/components/PaginationBar.vue'
 import {
   Users, UserCheck, AlertCircle, Clock, Timer, Loader, Home,
-  Eye, Construction
+  Eye, Briefcase, Building2
 } from 'lucide-vue-next'
 
 const props = defineProps({
@@ -426,6 +431,14 @@ const subTabConfig = {
     { level: 'K3', label: 'ชำนาญการพิเศษ' },
     { level: 'K4', label: 'เชี่ยวชาญ' },
   ],
+  support: [
+    { level: 'M1', label: 'อำนวยการต้น' },
+    { level: 'M2', label: 'อำนวยการสูง' },
+  ],
+  management: [
+    { level: 'S1', label: 'บริหารต้น' },
+    { level: 'S2', label: 'บริหารสูง' },
+  ],
 }
 
 const categoryConfig = {
@@ -460,7 +473,6 @@ const categoryConfig = {
 const currentConfig = computed(() => categoryConfig[props.section] || categoryConfig.overview)
 const currentSubTabs = computed(() => subTabConfig[props.section] || [])
 const isOverview = computed(() => props.section === 'overview')
-const isPlaceholder = computed(() => ['support', 'management'].includes(props.section))
 const hasSubTabs = computed(() => currentSubTabs.value.length > 0)
 
 // Fetch data for sub-tab level pages
@@ -494,6 +506,8 @@ async function fetchOverviewData() {
     overviewData.value = {
       generalTotal: s.general_total || 0,
       academicTotal: s.academic_total || 0,
+      supportiveTotal: s.supportive_total || 0,
+      managementTotal: s.management_total || 0,
       qualifiedTotal: s.qualified_total || 0,
       nearQualifiedTotal: s.near_qualified_total || 0,
       notYetTotal: s.not_yet_total || 0,
@@ -526,8 +540,6 @@ function onPageChange(newOffset) {
 watch(() => props.section, (newSection) => {
   if (newSection === 'overview') {
     fetchOverviewData()
-  } else if (['support', 'management'].includes(newSection)) {
-    // Placeholder sections -- do nothing
   } else {
     const tabs = subTabConfig[newSection]
     if (tabs && tabs.length > 0) {
@@ -540,7 +552,7 @@ watch(() => props.section, (newSection) => {
 
 watch(activeSubTab, (newTab) => {
   if (!newTab) return
-  if (isOverview.value || isPlaceholder.value) return
+  if (isOverview.value) return
   // Reset offset and search when sub-tab changes (Pitfall 4)
   pagination.value.offset = 0
   searchQuery.value = ''
@@ -551,8 +563,6 @@ watch(activeSubTab, (newTab) => {
 onMounted(() => {
   if (props.section === 'overview') {
     fetchOverviewData()
-  } else if (['support', 'management'].includes(props.section)) {
-    // Placeholder -- do nothing
   } else {
     const tabs = subTabConfig[props.section]
     if (tabs && tabs.length > 0) {


### PR DESCRIPTION
## สรุป
เปิดบัญชีผู้มีคุณสมบัติ **สายอำนวยการ (M1/M2)** และ **สายบริหาร (S1/S2)** ที่เดิมยังเป็น placeholder — ครบ end-to-end (engine + seed + frontend + golden verification) ตามเกณฑ์ กฎ ก.พ. ที่ pin จาก Excel master-prep (ชีท `to-M1/M2/S1/S2`)

เป็น **บัญชีรายชื่อเชิงกฎหมาย** (legal eligibility list) ที่ความถูกต้องผิดไม่ได้ จึง verify ผ่าน Docker integration เทียบ golden values ก่อน (8/8 ผ่าน)

## เกณฑ์ที่ implement (pin จาก Excel formula)
| ระดับ | เกณฑ์ |
|------|-------|
| **M1** อำนวยการต้น | K3 +3ปี / O3 +6ปี **+ ผ่าน 3 ต่าง**; วันมีคุณสมบัติ = `MAX(วันดำรงครบ, วันครบ3ต่าง)` |
| **M2** อำนวยการสูง | multi-path เลือกเร็วสุด: M1+1 / M1+K3รวม4 / M1+O3รวม7 / K3+4 / O3+7 / K4+3ต่าง |
| **S1** บริหารต้น | M1/M2/K4 +2ปี (K4 ต้องมีเทียบตำแหน่งอำนวยการ) |
| **S2** บริหารสูง | S1 +1ปี *(combination เทียบตำแหน่ง = follow-up)* |

## การเปลี่ยนแปลง
**Backend**
- `QualificationEngine::buildExecutiveQuery()` — multi-path `UNION ALL` → `MIN(qual_date)` เลือกวันเร็วสุดต่อคน; gate 3 ต่าง (`diverse_experience`) + เทียบตำแหน่ง (`position_equivalence`); combination อ้าง prev-level จาก `personnel_position_history`. แยกจาก `buildBaseQuery` (K/O linear) ไม่แตะของเดิม
- `buildQuery()` dispatcher: M/S → executive, K/O → linear
- `computeDetail()` dispatch M/S ผ่าน query เดียวกับ list → **detail ตรงกับ list เสมอ** (แก้จาก code review)
- `computeOverview()` รวม 4 category (เพิ่ม supportive/management total)
- route `candidates.php`: `validTargets` += M1/M2/S1/S2

**Database** (additive อย่างเดียว — schema มีครบแล้วจาก `04-career-path.sql`)
- seed `promotion_criteria` M/S เป็น reference config (ทั้ง `06-seed-data.sql` + `tidb-init.sql`)
- sample personnel 101-107 + history/diverse/equivalence **เฉพาะ `06` (local/Docker)** ไม่ปนเข้า production rebuild

**Frontend** (`CandidateListsPage.vue`)
- ปลด placeholder, เปิด sub-tab `support` (M1/M2) + `management` (S1/S2)
- overview cards เพิ่ม ประเภทอำนวยการ/บริหาร
- วันที่แสดง **พ.ศ.** (`qualification_date_thai` จาก `formatThaiDate`) เหมือน K/O

## Test plan
- [x] **Golden verification 8/8 ผ่าน** ผ่าน Docker (`backend/tests/verify-executive.sh`)
  - M1: GREATEST(tenure, 3ต่าง) = 2023-08-26 / 2024-03-28; ไม่มี 3ต่าง → check_data
  - M2 combination: prev-level K3+4 = 2023-06-01 (เร็วกว่า M1+1)
  - S1: M1+2 = 2022-08-26; K4 gate เทียบ = 2024-01-01
  - S2: S1+1 = 2025-01-01
- [x] detail (`/candidates/{level}/{id}`) ตรงกับ list ทุกเคส
- [x] **K/O regression** (K4/3) ยังคำนวณถูก
- [x] `npm run build` ผ่าน
- [x] code-review ผ่าน (แก้ 2 HIGH: computeDetail M/S, combination NULL guard)

## หมายเหตุ
- ไม่มี PHPUnit/CI-DB ในโปรเจกต์ → ใช้ shell integration verification กับ Docker แทน (รันในเครื่อง ไม่ใช่ CI)
- screening_list ตัดออกตาม Excel parity (formula ไม่เช็กบัญชีกลั่นกรอง)
- **Follow-up**: S2 combination (บต+อต/อส+เทียบ ≥3ปี) + K4→M2 exact year รอ verify Excel เพิ่ม; operational — ตรวจว่า production มี personnel ระดับ M/S จริง