### PR TITLE
fix: Dockerfile PassEnv += MYSQL_SSL_CA (deploy blocker)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -46,7 +46,7 @@ RUN mkdir -p /var/www/html/uploads \
     && chown -R www-data:www-data /var/www/html/uploads
 
 # ให้ Apache ส่ง environment variables เข้า PHP
-RUN echo "PassEnv MYSQL_HOST MYSQL_PORT MYSQL_DATABASE MYSQL_USER MYSQL_PASSWORD MYSQL_SSL JWT_SECRET" \
+RUN echo "PassEnv MYSQL_HOST MYSQL_PORT MYSQL_DATABASE MYSQL_USER MYSQL_PASSWORD MYSQL_SSL MYSQL_SSL_CA JWT_SECRET" \
     >> /etc/apache2/conf-enabled/passenv.conf
 
 # บังคับให้ Apache/PHP ตอบ UTF-8 เสมอ เพื่อป้องกันข้อความภาษาไทยเพี้ยนบน production


### PR DESCRIPTION
PR-0 fail-closed ต้องการ MYSQL_SSL_CA แต่ PassEnv เดิมไม่ส่งเข้า PHP → backend จะต่อ DB ไม่ได้หลัง deploy. แก้ + ต้องตั้ง env Render MYSQL_SSL_CA=/etc/ssl/certs/ca-certificates.crt