### PR TITLE
chore: ignore project-log-md/ (session logs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ secrets/
 # Local agent/tool dirs (config/session — อาจมีข้อมูล local ที่ไม่ควร public)
 .claude/
 .playwright-cli/
+
+# Session logs (prompts/paths/เนื้อหา session — local เท่านั้น)
+project-log-md/


### PR DESCRIPTION
session logs (prompts/paths) — local only, ไม่ควร track