### PR TITLE
fix: SET NAMES utf8mb4 ในทุก DB init script — กัน seed ภาษาไทยเป็น mojibake

### DIFF
--- a/database/03-personnel-stubs.sql
+++ b/database/03-personnel-stubs.sql
@@ -1,3 +1,6 @@
+-- บังคับ client charset เป็น utf8mb4 กัน mojibake ตอน docker init (client default อาจเป็น latin1)
+SET NAMES utf8mb4;
+
 -- ============================================================================
 -- 03-personnel-stubs.sql
 -- Personnel Foundation for Smart Port Career Path & Probation Features

--- a/database/04-career-path.sql
+++ b/database/04-career-path.sql
@@ -1,3 +1,6 @@
+-- บังคับ client charset เป็น utf8mb4 กัน mojibake ตอน docker init (client default อาจเป็น latin1)
+SET NAMES utf8mb4;
+
 -- ============================================================================
 -- 04-career-path.sql
 -- Career Path Tables & Views for Smart Port

--- a/database/05-probation.sql
+++ b/database/05-probation.sql
@@ -1,3 +1,6 @@
+-- บังคับ client charset เป็น utf8mb4 กัน mojibake ตอน docker init (client default อาจเป็น latin1)
+SET NAMES utf8mb4;
+
 -- ============================================================================
 -- 05-probation.sql
 -- Probation Tracking Tables & Dashboard View for Smart Port

--- a/database/06-seed-data.sql
+++ b/database/06-seed-data.sql
@@ -1,3 +1,6 @@
+-- บังคับ client charset เป็น utf8mb4 กัน mojibake ตอน docker init (client default อาจเป็น latin1)
+SET NAMES utf8mb4;
+
 -- ============================================================================
 -- 06-seed-data.sql
 -- Seed Data for Smart Port Career Path Features

--- a/database/07-add-education-level.sql
+++ b/database/07-add-education-level.sql
@@ -1,3 +1,6 @@
+-- บังคับ client charset เป็น utf8mb4 กัน mojibake ตอน docker init (client default อาจเป็น latin1)
+SET NAMES utf8mb4;
+
 -- ============================================================================
 -- 07-add-education-level.sql
 -- Add education_level column to personnel table

--- a/database/09-auth-users.sql
+++ b/database/09-auth-users.sql
@@ -1,3 +1,6 @@
+-- บังคับ client charset เป็น utf8mb4 กัน mojibake ตอน docker init (client default อาจเป็น latin1)
+SET NAMES utf8mb4;
+
 -- ============================================================================
 -- 09-auth-users.sql
 -- Multi-user Authentication — ขยายตาราง users (stub จาก 03-personnel-stubs.sql)

--- a/database/10-import-log.sql
+++ b/database/10-import-log.sql
@@ -1,3 +1,6 @@
+-- บังคับ client charset เป็น utf8mb4 กัน mojibake ตอน docker init (client default อาจเป็น latin1)
+SET NAMES utf8mb4;
+
 -- ============================================================================
 -- 10-import-log.sql
 -- Audit log การนำเข้า Excel (OWASP A09) + ใช้นับ rate limit ของ import endpoint

--- a/database/11-import-constraints.sql
+++ b/database/11-import-constraints.sql
@@ -1,3 +1,6 @@
+-- บังคับ client charset เป็น utf8mb4 กัน mojibake ตอน docker init (client default อาจเป็น latin1)
+SET NAMES utf8mb4;
+
 -- ============================================================================
 -- 11-import-constraints.sql
 -- UNIQUE/index gate สำหรับ HR import (find-or-create org/position) + FK indexes

--- a/database/12-import-log-fk.sql
+++ b/database/12-import-log-fk.sql
@@ -1,3 +1,6 @@
+-- บังคับ client charset เป็น utf8mb4 กัน mojibake ตอน docker init (client default อาจเป็น latin1)
+SET NAMES utf8mb4;
+
 -- ============================================================================
 -- 12-import-log-fk.sql
 -- FK import_log.user_id → users(user_id) — audit log อ้าง user ที่มีจริง (governance)

--- a/database/13-multiplier-time-counting.sql
+++ b/database/13-multiplier-time-counting.sql
@@ -1,3 +1,6 @@
+-- บังคับ client charset เป็น utf8mb4 กัน mojibake ตอน docker init (client default อาจเป็น latin1)
+SET NAMES utf8mb4;
+
 -- ============================================================================
 -- 13-multiplier-time-counting.sql
 -- การนับเวลาราชการเป็นทวีคูณ

--- a/database/14-multiplier-area-admin.sql
+++ b/database/14-multiplier-area-admin.sql
@@ -1,3 +1,6 @@
+-- บังคับ client charset เป็น utf8mb4 กัน mojibake ตอน docker init (client default อาจเป็น latin1)
+SET NAMES utf8mb4;
+
 -- ============================================================================
 -- 14-multiplier-area-admin.sql
 -- จัดการพื้นที่ทวีคูณ (master data admin) — audit column


### PR DESCRIPTION
> เปิดใหม่แทน #27 (ถูกปิดอัตโนมัติตอน base branch ถูกลบหลัง merge #25) — rebase ขึ้น main แล้ว เนื้อหาเดิมครบ

## ปัญหา

Query ข้อมูล seed ใน local แสดงเป็น "ภาษาต่างดาว" — ตรวจด้วย `HEX()` พบว่า**ข้อมูลใน DB เสียจริง** (double-encoded): `province` เก็บเป็น `à¸›à¸±à¸•à¸•à¸²à¸™à¸µ` แทน `ปัตตานี` — ขอบเขต: `special_area_multiplier` 7/8 แถว, `users.full_name` 1/2 แถว

## สาเหตุ

mysql client ใน docker entrypoint default charset เป็น latin1 (container ไม่ได้ตั้ง LANG) — ไฟล์ init 11 ไฟล์ (03–07, 09–14) ไม่มี `SET NAMES utf8mb4` จึงถูก double-encode ตอนโหลด (ไฟล์ 01/02/08 ที่มีอยู่แล้วรอด)

## การแก้

ใส่ `SET NAMES utf8mb4;` หัวไฟล์ทั้ง 11 — ไม่เปลี่ยน schema/data

**หลัง merge ต้อง re-init DB local:** `docker compose down -v && docker compose up -d db`

## Test plan

- [x] Re-init DB → `HEX()`: mojibake 0 แถว, `นราธิวาส` = `E0B899`
- [x] API ตอบ Thai ตรง codepoint + วันที่ พ.ศ. `26 ม.ค. 2547`
- [x] Backend suite เต็ม: OK (81 tests, 150 assertions)
- [x] Audit encoding ทุกชั้น (PDO/HTTP/HTML/nginx) + วันที่ พ.ศ. ทุกจุดแสดงผล ✅ (DB เก็บ ค.ศ. ตาม best practice)
- [ ] Prod (TiDB Cloud): สุ่มตรวจ `HEX(LEFT(col,1))` = `E0` ไม่ใช่ `C3A0`