### PR TITLE
feat: Dashboard — เพิ่มสถิติการนับทวีคูณ (Option 3)

### DIFF
--- a/backend/api.php
+++ b/backend/api.php
@@ -285,6 +285,32 @@ switch ($path[0]) {
 
             $candidateGrandTotal = array_sum($candidateTotals);
 
+            // Multiplier summary (รวมสถิติการนับทวีคูณ)
+            $multiplierStats = [
+                'total_records' => 0,
+                'distinct_personnel' => 0,
+                'total_bonus_days' => 0,
+                'total_bonus_years' => 0,
+            ];
+            try {
+                $stmt = $pdo->query("
+                    SELECT
+                        COUNT(*) AS total_records,
+                        COUNT(DISTINCT personnel_id) AS distinct_personnel,
+                        COALESCE(SUM(bonus_days), 0) AS total_bonus_days
+                    FROM multiplier_experience
+                ");
+                $row = $stmt->fetch(PDO::FETCH_ASSOC);
+                if ($row) {
+                    $multiplierStats['total_records'] = (int) $row['total_records'];
+                    $multiplierStats['distinct_personnel'] = (int) $row['distinct_personnel'];
+                    $multiplierStats['total_bonus_days'] = (float) $row['total_bonus_days'];
+                    $multiplierStats['total_bonus_years'] = round($multiplierStats['total_bonus_days'] / 365, 1);
+                }
+            } catch (PDOException $e) {
+                // ถ้า query fail ส่งค่า default
+            }
+
             echo json_encode([
                 'success' => true,
                 'total_personnel' => $totalPersonnel,
@@ -299,6 +325,7 @@ switch ($path[0]) {
                     'equivalence' => $equivalenceCount,
                     'total' => $supportiveCount + $diverseCount + $equivalenceCount,
                 ],
+                'multiplier' => $multiplierStats,
                 'candidates' => [
                     'total' => $candidateGrandTotal,
                     'by_level' => $candidateTotals,

--- a/frontend/src/pages/DashboardPage.vue
+++ b/frontend/src/pages/DashboardPage.vue
@@ -27,6 +27,49 @@
       <StatCard label="การนับเวลาเพิ่มเติม" :value="stats.timeCountTotal.toLocaleString()" :icon="Clock" icon-bg-class="bg-purple-50" icon-class="text-purple-600" />
     </div>
 
+    <!-- Multiplier Summary Section -->
+    <div class="bg-gradient-to-br from-indigo-50 to-purple-50 rounded-lg shadow-sm border border-indigo-100 p-6">
+      <div class="flex items-center justify-between mb-4">
+        <div class="flex items-center gap-3">
+          <div class="p-2 bg-indigo-100 rounded-lg">
+            <Clock class="w-6 h-6 text-indigo-600" />
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-gray-900">สรุปการนับทวีคูณ</h3>
+            <p class="text-sm text-gray-600">การนับเวลาราชการในพื้นที่พิเศษเป็นทวีคูณ</p>
+          </div>
+        </div>
+        <RouterLink
+          to="/time-multiplier"
+          class="text-sm text-indigo-600 hover:text-indigo-800 font-medium"
+        >
+          ดูทั้งหมด →
+        </RouterLink>
+      </div>
+      <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
+        <div class="bg-white rounded-lg p-4 shadow-sm">
+          <div class="text-sm text-gray-600 mb-1">รายการทั้งหมด</div>
+          <div class="text-2xl font-bold text-gray-900">{{ multiplierSummary.totalRecords.toLocaleString() }}</div>
+          <div class="text-xs text-gray-500 mt-1">รายการ</div>
+        </div>
+        <div class="bg-white rounded-lg p-4 shadow-sm">
+          <div class="text-sm text-gray-600 mb-1">จำนวนบุคลากร</div>
+          <div class="text-2xl font-bold text-indigo-600">{{ multiplierSummary.distinctPersonnel.toLocaleString() }}</div>
+          <div class="text-xs text-gray-500 mt-1">คน</div>
+        </div>
+        <div class="bg-white rounded-lg p-4 shadow-sm">
+          <div class="text-sm text-gray-600 mb-1">วันทวีคูณรวม</div>
+          <div class="text-2xl font-bold text-purple-600">{{ formatNumber(multiplierSummary.totalBonusDays) }}</div>
+          <div class="text-xs text-gray-500 mt-1">วัน</div>
+        </div>
+        <div class="bg-white rounded-lg p-4 shadow-sm">
+          <div class="text-sm text-gray-600 mb-1">ประมาณการ</div>
+          <div class="text-2xl font-bold text-green-600">{{ multiplierSummary.totalBonusYears.toLocaleString() }}</div>
+          <div class="text-xs text-gray-500 mt-1">ปี</div>
+        </div>
+      </div>
+    </div>
+
     <!-- Main Content Grid -->
     <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
       <!-- Priority Tasks (2/3 width) -->
@@ -158,6 +201,13 @@ const probationSummary = ref({
   overdue: 0,
 })
 
+const multiplierSummary = ref({
+  totalRecords: 0,
+  distinctPersonnel: 0,
+  totalBonusDays: 0,
+  totalBonusYears: 0,
+})
+
 const priorityTasks = ref([])
 
 const quickActions = [
@@ -165,6 +215,10 @@ const quickActions = [
   { title: 'เลื่อนระดับตำแหน่ง', icon: TrendingUp, color: 'bg-green-500', route: '/candidates/general' },
   { title: 'การนับเวลาเกื้อกูล', icon: Clock, color: 'bg-purple-500', route: '/supportive' },
 ]
+
+function formatNumber(value) {
+  return new Intl.NumberFormat('th-TH', { minimumFractionDigits: 0, maximumFractionDigits: 1 }).format(value)
+}
 
 async function fetchDashboard() {
   loading.value = true
@@ -182,6 +236,13 @@ async function fetchDashboard() {
       inProgress: Math.max(0, (d.probation?.total || 0) - (d.probation?.near_deadline || 0) - (d.probation?.overdue || 0)),
       nearDeadline: d.probation?.near_deadline || 0,
       overdue: d.probation?.overdue || 0,
+    }
+
+    multiplierSummary.value = {
+      totalRecords: d.multiplier?.total_records || 0,
+      distinctPersonnel: d.multiplier?.distinct_personnel || 0,
+      totalBonusDays: d.multiplier?.total_bonus_days || 0,
+      totalBonusYears: d.multiplier?.total_bonus_years || 0,
     }
 
     const totalCandidates = d.candidates?.total || 0


### PR DESCRIPTION
## สรุป

เพิ่ม **สถิติการนับทวีคูณแบบ real-time** ใน Dashboard เพื่อให้ HR เห็นภาพรวมได้ทันทีโดยไม่ต้องคลิกเข้าหน้า Multiplier

---

## การเปลี่ยนแปลง

### Backend (`api.php`)
เพิ่ม `multiplier` section ใน `/dashboard` endpoint:
```json
{
  "multiplier": {
    "total_records": 12,
    "distinct_personnel": 8,
    "total_bonus_days": 543.5,
    "total_bonus_years": 1.5
  }
}
```

**คำนวณจาก:**
- `SELECT COUNT(*) FROM multiplier_experience` → รายการทั้งหมด
- `COUNT(DISTINCT personnel_id)` → จำนวนบุคลากรที่มีทวีคูณ
- `SUM(bonus_days)` → วันทวีคูณรวม
- `bonus_days / 365` → ประมาณการเป็นปี (1 ทศนิยม)

### Frontend (`DashboardPage.vue`)
เพิ่มส่วน **"สรุปการนับทวีคูณ"** ระหว่าง stat cards และ priority tasks:

#### UI Components:
- 🎨 **Gradient Background**: `bg-gradient-to-br from-indigo-50 to-purple-50`
- 📊 **4 Stat Cards**:
  1. รายการทั้งหมด (gray)
  2. จำนวนบุคลากร (indigo)
  3. วันทวีคูณรวม (purple)
  4. ประมาณการ (ปี) (green)
- 🔗 **Link**: "ดูทั้งหมด →" ไปหน้า `/time-multiplier`
- 🔢 **Number Formatting**: `Intl.NumberFormat('th-TH')`

---

## Screenshots

### Dashboard — ส่วนสรุปการนับทวีคูณ
```
┌─────────────────────────────────────────────────────┐
│  🕐 สรุปการนับทวีคูณ          ดูทั้งหมด →          │
│  การนับเวลาราชการในพื้นที่พิเศษเป็นทวีคูณ          │
├──────────┬──────────┬──────────┬──────────────────┤
│ รายการ   │ บุคลากร │ วันทวีคูณ│ ประมาณการ       │
│ 12       │ 8 คน     │ 543.5 วัน│ 1.5 ปี          │
│ รายการ   │          │          │                  │
└──────────┴──────────┴──────────┴──────────────────┘
```

---

## ทดสอบ

### Manual Testing
1. เปิด http://localhost:8081 → Login
2. ไปหน้า Dashboard
3. ตรวจสอบส่วน "สรุปการนับทวีคูณ" แสดงผลถูกต้อง
4. คลิก "ดูทั้งหมด →" ต้อง redirect ไป `/time-multiplier`
5. ตรวจสอบตัวเลขตรงกับข้อมูลใน `multiplier_experience` table

### API Testing
```bash
# ต้อง login ก่อน
curl -H "Authorization: Bearer $TOKEN" http://localhost:8000/api/dashboard
```

**Expected Response:**
```json
{
  "success": true,
  "total_personnel": 150,
  "probation": { ... },
  "time_counting": { ... },
  "multiplier": {
    "total_records": 12,
    "distinct_personnel": 8,
    "total_bonus_days": 543.5,
    "total_bonus_years": 1.5
  },
  "candidates": { ... }
}
```

---

## Business Value

### ก่อน (Before):
- HR ต้องคลิกเข้าหน้า Multiplier ถึงจะรู้ว่ามีกี่รายการ/กี่คน
- ไม่เห็นภาพรวมการนับทวีคูณใน Dashboard

### หลัง (After):
- ✅ เห็นภาพรวม Multiplier ทันทีจาก Dashboard
- ✅ รู้ว่ามีกี่รายการ, กี่คน, วันทวีคูณรวมเท่าไร
- ✅ แสดงประมาณการเป็นปี → เข้าใจง่ายว่ามีผลกระทบต่ออายุราชการเท่าไร
- ✅ ลด click จาก 2 clicks (Dashboard → Multiplier) เหลือ 0 clicks

---

## Files Changed
- `backend/api.php` — เพิ่ม multiplier stats query ใน /dashboard
- `frontend/src/pages/DashboardPage.vue` — เพิ่ม UI section สำหรับ multiplier

---

## Next Steps
- [ ] เพิ่ม Chart แสดงการกระจายตัวของพื้นที่พิเศษ (Top 5 provinces)
- [ ] เพิ่มสถิติ "วันทวีคูณเฉลี่ยต่อคน"
- [ ] Real-time update ด้วย WebSocket (optional)

🎉 **Dashboard Enhancement — Multiplier Stats Complete!**

🤖 Generated with [Claude Code](https://claude.com/claude-code)