### PR TITLE
fix: log audit trail when deleting multiplier records

### DIFF
--- a/backend/routes/multiplier.php
+++ b/backend/routes/multiplier.php
@@ -76,7 +76,7 @@ function handleMultiplier(PDO $pdo, string $method, array $path): void
             case 'DELETE':
                 // DELETE /multiplier/{id} — delete multiplier record
                 if (($path[1] ?? '') !== '' && ctype_digit($path[1])) {
-                    deleteMultiplier($pdo, (int) $path[1]);
+                    deleteMultiplier($pdo, (int) $path[1], $user);
                     return;
                 }
                 http_response_code(404);
@@ -877,13 +877,14 @@ function updateMultiplier(PDO $pdo, int $multiplierId, array $user): void
     ]);
 }
 
-function deleteMultiplier(PDO $pdo, int $multiplierId): void
+function deleteMultiplier(PDO $pdo, int $multiplierId, array $user): void
 {
-    // ตรวจว่า record มีอยู่จริง
-    $existingStmt = $pdo->prepare('SELECT 1 FROM multiplier_experience WHERE multiplier_id = ?');
+    // ดึงค่าก่อนลบเพื่อ audit log (snapshot ชุดเดียวกับที่ create เก็บเป็น after_value)
+    $existingStmt = $pdo->prepare('SELECT * FROM multiplier_experience WHERE multiplier_id = ?');
     $existingStmt->execute([$multiplierId]);
+    $existing = $existingStmt->fetch(PDO::FETCH_ASSOC);
 
-    if (!$existingStmt->fetchColumn()) {
+    if (!$existing) {
         http_response_code(404);
         echo json_encode(['error' => 'ไม่พบรายการที่ระบุ']);
         return;
@@ -892,6 +893,23 @@ function deleteMultiplier(PDO $pdo, int $multiplierId): void
     // ลบ record
     $stmt = $pdo->prepare('DELETE FROM multiplier_experience WHERE multiplier_id = ?');
     $stmt->execute([$multiplierId]);
+
+    // Audit log: บันทึกการลบรายการทวีคูณ
+    logAudit(
+        $pdo,
+        $user['user_id'],
+        'DELETE',
+        'multiplier_experience',
+        $multiplierId,
+        [
+            'personnel_id' => (int) $existing['personnel_id'],
+            'area_multiplier_id' => (int) $existing['area_multiplier_id'],
+            'start_date' => $existing['start_date'],
+            'end_date' => $existing['end_date'],
+            'bonus_days' => (float) $existing['bonus_days'],
+        ],
+        null
+    );
 
     http_response_code(200);
     echo json_encode([

--- a/backend/tests/Integration/MultiplierDeleteAuditTest.php
+++ b/backend/tests/Integration/MultiplierDeleteAuditTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration;
+
+use PDO;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../routes/multiplier.php';
+
+/**
+ * Integration test: การลบรายการทวีคูณต้องบันทึก audit log เหมือน create/update/status
+ * (issue #21 — "edit and delete multiplier records safely")
+ *
+ * ใช้ seed user/personnel ที่มีอยู่จริงเพื่อผ่าน FK และล้างข้อมูลทดสอบใน finally เสมอ
+ */
+final class MultiplierDeleteAuditTest extends TestCase
+{
+    private const TEST_PROVINCE = 'ทดสอบ-DELETE-AUDIT';
+
+    private static ?PDO $pdo = null;
+    private static int $seedUserId = 0;
+    private static int $seedPersonnelId = 0;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$pdo = testPdo();
+    }
+
+    protected function setUp(): void
+    {
+        if (self::$pdo === null) {
+            self::markTestSkipped('ต่อ MySQL ไม่ได้ — รัน: docker compose up -d db แล้วใช้ tests/run.sh');
+        }
+
+        foreach (['multiplier_experience', 'special_area_multiplier', 'audit_log'] as $table) {
+            if (!self::$pdo->query("SHOW TABLES LIKE '{$table}'")->fetchColumn()) {
+                self::markTestSkipped("ไม่พบตาราง {$table} — รัน migration ที่เกี่ยวข้องก่อน");
+            }
+        }
+
+        $userId = self::$pdo->query('SELECT user_id FROM users LIMIT 1')->fetchColumn();
+        if (!$userId) {
+            self::markTestSkipped('ไม่พบ seed user ในตาราง users');
+        }
+        self::$seedUserId = (int) $userId;
+
+        $personnelId = self::$pdo->query('SELECT personnel_id FROM personnel LIMIT 1')->fetchColumn();
+        if (!$personnelId) {
+            self::markTestSkipped('ไม่พบ seed personnel ในตาราง personnel');
+        }
+        self::$seedPersonnelId = (int) $personnelId;
+    }
+
+    #[Test]
+    public function it_logs_audit_when_deleting_a_multiplier_record(): void
+    {
+        $areaId = null;
+        $multiplierId = null;
+
+        try {
+            self::$pdo->prepare(
+                'INSERT INTO special_area_multiplier
+                    (province, district, basis_type, multiplier_ratio,
+                     effective_start_date, effective_end_date, legal_reference, is_active)
+                 VALUES (?, NULL, ?, 200.00, ?, ?, ?, 1)'
+            )->execute([self::TEST_PROVINCE, 'MARTIAL_LAW', '2004-01-26', '2004-09-30', 'TEST_ONLY']);
+            $areaId = (int) self::$pdo->lastInsertId();
+
+            self::$pdo->prepare(
+                'INSERT INTO multiplier_experience
+                    (personnel_id, area_multiplier_id, province, district, basis_type,
+                     start_date, end_date, eligible_start_date, eligible_end_date,
+                     service_days, eligible_days, multiplier_ratio, effective_days,
+                     bonus_days, net_end_date, net_years, net_months, net_day_remainder,
+                     created_by)
+                 VALUES (?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+            )->execute([
+                self::$seedPersonnelId, $areaId, self::TEST_PROVINCE, 'MARTIAL_LAW',
+                '2004-02-01', '2004-03-01', '2004-02-01', '2004-03-01',
+                30, 30, 200.00, 60,
+                30, '2004-03-31', 0, 2, 0,
+                self::$seedUserId,
+            ]);
+            $multiplierId = (int) self::$pdo->lastInsertId();
+
+            ob_start();
+            deleteMultiplier(self::$pdo, $multiplierId, ['user_id' => self::$seedUserId]);
+            $response = json_decode(ob_get_clean(), true);
+
+            self::assertTrue($response['success'] ?? false);
+
+            $gone = self::$pdo->prepare('SELECT 1 FROM multiplier_experience WHERE multiplier_id = ?');
+            $gone->execute([$multiplierId]);
+            self::assertFalse($gone->fetchColumn(), 'รายการต้องถูกลบจริง');
+
+            $auditStmt = self::$pdo->prepare(
+                "SELECT * FROM audit_log
+                 WHERE action = 'DELETE' AND table_name = 'multiplier_experience' AND record_id = ?
+                 ORDER BY audit_id DESC LIMIT 1"
+            );
+            $auditStmt->execute([$multiplierId]);
+            $audit = $auditStmt->fetch(PDO::FETCH_ASSOC);
+
+            self::assertNotFalse($audit, 'การลบต้องถูกบันทึกลง audit_log');
+            self::assertSame(self::$seedUserId, (int) $audit['user_id']);
+            self::assertNull($audit['after_value'], 'DELETE ต้องไม่มี after_value');
+
+            $before = json_decode((string) $audit['before_value'], true);
+            self::assertIsArray($before, 'DELETE ต้องเก็บ snapshot ก่อนลบไว้ใน before_value');
+            self::assertSame(self::$seedPersonnelId, (int) $before['personnel_id']);
+        } finally {
+            if ($multiplierId !== null) {
+                self::$pdo->prepare('DELETE FROM audit_log WHERE table_name = ? AND record_id = ?')
+                    ->execute(['multiplier_experience', $multiplierId]);
+                self::$pdo->prepare('DELETE FROM multiplier_experience WHERE multiplier_id = ?')
+                    ->execute([$multiplierId]);
+            }
+            if ($areaId !== null) {
+                self::$pdo->prepare('DELETE FROM special_area_multiplier WHERE area_multiplier_id = ?')
+                    ->execute([$areaId]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `deleteMultiplier()` was the only multiplier mutation handler that skipped audit logging — create, update, and area-status changes all write to `audit_log`, so deletions were invisible in the audit trail.
- Snapshot the row before deletion and record it via `logAudit()` with action `DELETE` and the snapshot as `before_value` (same field shape that `createMultiplier` logs as `after_value`: personnel_id, area_multiplier_id, start_date, end_date, bonus_days).
- Closes the remaining "safely" gap in issue #21 (edit and delete multiplier records safely).

## Test plan
- [x] TDD: new integration test `MultiplierDeleteAuditTest` written first and confirmed failing (RED — delete succeeded but no audit row)
- [x] Fix applied → test passes (GREEN — 7 assertions: response, row deleted, DELETE audit row with correct user_id, before_value snapshot, null after_value)
- [x] Full backend suite: **132 tests, 246 assertions, OK** (no regressions)

Refs #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SG2VHfjcu22ogCb3LxTh2P