### PR TITLE
feat: เพิ่มสถิติ Multiplier ใน Dashboard

### DIFF
--- a/backend/api.php
+++ b/backend/api.php
@@ -346,6 +346,32 @@ switch ($path[0]) {
 
             $candidateGrandTotal = array_sum($candidateTotals);
 
+            // Multiplier summary (รวมสถิติการนับทวีคูณ)
+            $multiplierStats = [
+                'total_records' => 0,
+                'distinct_personnel' => 0,
+                'total_bonus_days' => 0,
+                'total_bonus_years' => 0,
+            ];
+            try {
+                $stmt = $pdo->query("
+                    SELECT
+                        COUNT(*) AS total_records,
+                        COUNT(DISTINCT personnel_id) AS distinct_personnel,
+                        COALESCE(SUM(bonus_days), 0) AS total_bonus_days
+                    FROM multiplier_experience
+                ");
+                $row = $stmt->fetch(PDO::FETCH_ASSOC);
+                if ($row) {
+                    $multiplierStats['total_records'] = (int) $row['total_records'];
+                    $multiplierStats['distinct_personnel'] = (int) $row['distinct_personnel'];
+                    $multiplierStats['total_bonus_days'] = (float) $row['total_bonus_days'];
+                    $multiplierStats['total_bonus_years'] = round($multiplierStats['total_bonus_days'] / 365, 1);
+                }
+            } catch (PDOException $e) {
+                // ถ้า query fail ส่งค่า default
+            }
+
             echo json_encode([
                 'success' => true,
                 'total_personnel' => $totalPersonnel,
@@ -360,6 +386,7 @@ switch ($path[0]) {
                     'equivalence' => $equivalenceCount,
                     'total' => $supportiveCount + $diverseCount + $equivalenceCount,
                 ],
+                'multiplier' => $multiplierStats,
                 'candidates' => [
                     'total' => $candidateGrandTotal,
                     'by_level' => $candidateTotals,

--- a/frontend/src/pages/DashboardPage.vue
+++ b/frontend/src/pages/DashboardPage.vue
@@ -27,6 +27,49 @@
       <StatCard label="การนับเวลาเพิ่มเติม" :value="stats.timeCountTotal.toLocaleString()" :icon="Clock" icon-bg-class="bg-purple-50" icon-class="text-purple-600" />
     </div>
 
+    <!-- Multiplier Summary Section -->
+    <div class="bg-gradient-to-br from-indigo-50 to-purple-50 rounded-lg shadow-sm border border-indigo-100 p-6">
+      <div class="flex items-center justify-between mb-4">
+        <div class="flex items-center gap-3">
+          <div class="p-2 bg-indigo-100 rounded-lg">
+            <Clock class="w-6 h-6 text-indigo-600" />
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-gray-900">สรุปการนับทวีคูณ</h3>
+            <p class="text-sm text-gray-600">การนับเวลาราชการในพื้นที่พิเศษเป็นทวีคูณ</p>
+          </div>
+        </div>
+        <RouterLink
+          to="/time-multiplier"
+          class="text-sm text-indigo-600 hover:text-indigo-800 font-medium"
+        >
+          ดูทั้งหมด →
+        </RouterLink>
+      </div>
+      <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
+        <div class="bg-white rounded-lg p-4 shadow-sm">
+          <div class="text-sm text-gray-600 mb-1">รายการทั้งหมด</div>
+          <div class="text-2xl font-bold text-gray-900">{{ multiplierSummary.totalRecords.toLocaleString() }}</div>
+          <div class="text-xs text-gray-500 mt-1">รายการ</div>
+        </div>
+        <div class="bg-white rounded-lg p-4 shadow-sm">
+          <div class="text-sm text-gray-600 mb-1">จำนวนบุคลากร</div>
+          <div class="text-2xl font-bold text-indigo-600">{{ multiplierSummary.distinctPersonnel.toLocaleString() }}</div>
+          <div class="text-xs text-gray-500 mt-1">คน</div>
+        </div>
+        <div class="bg-white rounded-lg p-4 shadow-sm">
+          <div class="text-sm text-gray-600 mb-1">วันทวีคูณรวม</div>
+          <div class="text-2xl font-bold text-purple-600">{{ formatNumber(multiplierSummary.totalBonusDays) }}</div>
+          <div class="text-xs text-gray-500 mt-1">วัน</div>
+        </div>
+        <div class="bg-white rounded-lg p-4 shadow-sm">
+          <div class="text-sm text-gray-600 mb-1">ประมาณการ</div>
+          <div class="text-2xl font-bold text-green-600">{{ multiplierSummary.totalBonusYears.toLocaleString() }}</div>
+          <div class="text-xs text-gray-500 mt-1">ปี</div>
+        </div>
+      </div>
+    </div>
+
     <!-- Main Content Grid -->
     <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
       <!-- Priority Tasks (2/3 width) -->
@@ -158,6 +201,13 @@ const probationSummary = ref({
   overdue: 0,
 })
 
+const multiplierSummary = ref({
+  totalRecords: 0,
+  distinctPersonnel: 0,
+  totalBonusDays: 0,
+  totalBonusYears: 0,
+})
+
 const priorityTasks = ref([])
 
 const quickActions = [
@@ -165,6 +215,10 @@ const quickActions = [
   { title: 'เลื่อนระดับตำแหน่ง', icon: TrendingUp, color: 'bg-green-500', route: '/candidates/general' },
   { title: 'การนับเวลาเกื้อกูล', icon: Clock, color: 'bg-purple-500', route: '/supportive' },
 ]
+
+function formatNumber(value) {
+  return new Intl.NumberFormat('th-TH', { minimumFractionDigits: 0, maximumFractionDigits: 1 }).format(value)
+}
 
 async function fetchDashboard() {
   loading.value = true
@@ -182,6 +236,13 @@ async function fetchDashboard() {
       inProgress: Math.max(0, (d.probation?.total || 0) - (d.probation?.near_deadline || 0) - (d.probation?.overdue || 0)),
       nearDeadline: d.probation?.near_deadline || 0,
       overdue: d.probation?.overdue || 0,
+    }
+
+    multiplierSummary.value = {
+      totalRecords: d.multiplier?.total_records || 0,
+      distinctPersonnel: d.multiplier?.distinct_personnel || 0,
+      totalBonusDays: d.multiplier?.total_bonus_days || 0,
+      totalBonusYears: d.multiplier?.total_bonus_years || 0,
     }
 
     const totalCandidates = d.candidates?.total || 0


### PR DESCRIPTION
## Summary
- Recovers the stranded commit from `feature/dashboard-multiplier-stats` (authored 2026-07-08, never PR'd) by cherry-picking it onto current `main` — clean auto-merge, no conflicts.
- **Backend**: `/dashboard` endpoint now returns a `multiplier` stats block (total_records, distinct_personnel, total_bonus_days, total_bonus_years) aggregated from `multiplier_experience`, wrapped in try/catch so the dashboard degrades gracefully if the table is absent.
- **Frontend**: new "สรุปการนับทวีคูณ" section on the Dashboard — 4 stat cards with a link to `/time-multiplier`, Thai-locale number formatting.

## Test plan
- [x] `php -l backend/api.php` — no syntax errors
- [x] `npm run build` — frontend compiles clean
- [x] Full backend suite — **OK (135 tests, 265 assertions)**
- [ ] Visual check of the Dashboard section after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SG2VHfjcu22ogCb3LxTh2P