### PR TITLE
fix: recover from stale chunk loads and show navigation progress

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -22,8 +22,12 @@ server {
     gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml+rss application/javascript application/json;
 
     # Handle client-side routing
+    # expires -1 → Cache-Control: no-cache กัน browser/CDN เก็บ index.html เก่า
+    # ที่อ้าง chunk hash ซึ่งหายไปหลัง deploy ใหม่ (ใช้ expires แทน add_header
+    # เพื่อไม่ตัด security headers ที่ inherit จากระดับ server)
     location / {
         try_files $uri $uri/ /index.html;
+        expires -1;
     }
 
     # API proxy to backend

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,4 +1,7 @@
 <template>
+  <Transition name="nav-progress">
+    <div v-if="isNavigating" class="nav-progress-bar" role="progressbar" aria-label="กำลังโหลดหน้า" />
+  </Transition>
   <RouterView v-slot="{ Component }">
     <Suspense timeout="0">
       <component :is="Component" />
@@ -18,4 +21,33 @@
 
 <script setup>
 import ToastContainer from '@/components/ToastContainer.vue'
+import { useNavProgress } from '@/composables/useNavProgress.js'
+
+const { isNavigating } = useNavProgress()
 </script>
+
+<style scoped>
+.nav-progress-bar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  z-index: 9999;
+  background: linear-gradient(90deg, #0ea5e9, #6366f1);
+  transform-origin: left;
+  animation: nav-progress-slide 1.2s ease-in-out infinite;
+}
+
+@keyframes nav-progress-slide {
+  0% { transform: scaleX(0); opacity: 1; }
+  60% { transform: scaleX(0.75); opacity: 1; }
+  100% { transform: scaleX(1); opacity: 0.4; }
+}
+
+/* หน่วงการโผล่ 150ms — navigation เร็วๆ จะไม่เห็นแถบกระพริบ */
+.nav-progress-enter-active { transition: opacity 100ms ease 150ms; }
+.nav-progress-enter-from { opacity: 0; }
+.nav-progress-leave-active { transition: opacity 120ms ease; }
+.nav-progress-leave-to { opacity: 0; }
+</style>

--- a/frontend/src/__tests__/utils/chunkGuard.test.js
+++ b/frontend/src/__tests__/utils/chunkGuard.test.js
@@ -1,0 +1,71 @@
+import { describe, test, expect, beforeEach } from 'vitest'
+import { isChunkLoadError, shouldReloadForChunkError, RELOAD_WINDOW_MS } from '@/utils/chunkGuard.js'
+
+function fakeStorage() {
+  const map = new Map()
+  return {
+    getItem: (k) => (map.has(k) ? map.get(k) : null),
+    setItem: (k, v) => map.set(k, String(v)),
+    removeItem: (k) => map.delete(k),
+  }
+}
+
+describe('isChunkLoadError', () => {
+  test('จับ error ของ Chrome/Vite เมื่อ chunk หายหลัง deploy ใหม่', () => {
+    expect(isChunkLoadError(new TypeError('Failed to fetch dynamically imported module: https://x/assets/a.js'))).toBe(true)
+  })
+
+  test('จับ error ของ Firefox', () => {
+    expect(isChunkLoadError(new TypeError('error loading dynamically imported module'))).toBe(true)
+  })
+
+  test('จับ error ของ Safari', () => {
+    expect(isChunkLoadError(new TypeError('Importing a module script failed.'))).toBe(true)
+  })
+
+  test('จับ CSS preload error ของ Vite', () => {
+    expect(isChunkLoadError(new Error('Unable to preload CSS for /assets/x.css'))).toBe(true)
+  })
+
+  test('ไม่จับ error ทั่วไป', () => {
+    expect(isChunkLoadError(new Error('Network request failed'))).toBe(false)
+    expect(isChunkLoadError(new TypeError('x is not a function'))).toBe(false)
+    expect(isChunkLoadError(null)).toBe(false)
+    expect(isChunkLoadError(undefined)).toBe(false)
+  })
+})
+
+describe('shouldReloadForChunkError', () => {
+  let storage
+
+  beforeEach(() => {
+    storage = fakeStorage()
+  })
+
+  test('อนุญาต reload ครั้งแรกของ path', () => {
+    expect(shouldReloadForChunkError('/dashboard', storage, 1_000_000)).toBe(true)
+  })
+
+  test('บล็อก reload ซ้ำ path เดิมภายใน window กัน reload วนลูป', () => {
+    expect(shouldReloadForChunkError('/dashboard', storage, 1_000_000)).toBe(true)
+    expect(shouldReloadForChunkError('/dashboard', storage, 1_000_000 + RELOAD_WINDOW_MS - 1)).toBe(false)
+  })
+
+  test('อนุญาต reload path เดิมอีกครั้งเมื่อพ้น window', () => {
+    expect(shouldReloadForChunkError('/dashboard', storage, 1_000_000)).toBe(true)
+    expect(shouldReloadForChunkError('/dashboard', storage, 1_000_000 + RELOAD_WINDOW_MS + 1)).toBe(true)
+  })
+
+  test('path ต่างกันนับแยกกัน', () => {
+    expect(shouldReloadForChunkError('/dashboard', storage, 1_000_000)).toBe(true)
+    expect(shouldReloadForChunkError('/audit', storage, 1_000_001)).toBe(true)
+  })
+
+  test('storage พัง (เช่น private mode) ต้องไม่ throw และยอมให้ reload ครั้งเดียว', () => {
+    const broken = {
+      getItem: () => { throw new Error('denied') },
+      setItem: () => { throw new Error('denied') },
+    }
+    expect(shouldReloadForChunkError('/dashboard', broken, 1_000_000)).toBe(true)
+  })
+})

--- a/frontend/src/composables/useNavProgress.js
+++ b/frontend/src/composables/useNavProgress.js
@@ -1,0 +1,8 @@
+import { ref } from 'vue'
+
+// state ระดับ module (ไม่ใช้ Pinia) เพราะ router ต้อง set ค่าได้ก่อน app/pinia ถูก mount
+const isNavigating = ref(false)
+
+export function useNavProgress() {
+  return { isNavigating }
+}

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,4 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router'
+import { isChunkLoadError, shouldReloadForChunkError } from '@/utils/chunkGuard.js'
+import { useNavProgress } from '@/composables/useNavProgress.js'
 
 const routes = [
   {
@@ -120,7 +122,11 @@ const router = createRouter({
   routes,
 })
 
+const { isNavigating } = useNavProgress()
+
 router.beforeEach(async (to) => {
+  isNavigating.value = true
+
   const { useAuthStore } = await import('@/stores/auth.js')
   const auth = useAuthStore()
 
@@ -135,6 +141,20 @@ router.beforeEach(async (to) => {
   // หน้า admin only — operator เด้งกลับ dashboard
   if (to.meta.requiresAdmin && auth.user?.role !== 'admin') {
     return '/dashboard'
+  }
+})
+
+router.afterEach(() => {
+  isNavigating.value = false
+})
+
+// chunk เก่าหายหลัง deploy ใหม่ → dynamic import พังและ navigation ถูกยกเลิกเงียบๆ
+// (อาการ: กดเมนูแล้วคอนเทนต์ค้าง/ไม่เปลี่ยน) — hard reload เพื่อดึง asset ชุดใหม่
+router.onError((error, to) => {
+  isNavigating.value = false
+  const target = to?.fullPath ?? window.location.pathname
+  if (isChunkLoadError(error) && shouldReloadForChunkError(target, window.sessionStorage, Date.now())) {
+    window.location.assign(target)
   }
 })
 

--- a/frontend/src/utils/chunkGuard.js
+++ b/frontend/src/utils/chunkGuard.js
@@ -1,0 +1,45 @@
+// กันอาการ "เปลี่ยนเมนูแล้วค้าง" หลัง deploy ใหม่: Render เก็บเฉพาะ build ล่าสุด
+// ทำให้ chunk hash เก่าตอบ 404 — dynamic import พังและ Vue Router ยกเลิก navigation เงียบๆ
+// ทางแก้คือ hard reload เพื่อดึง index.html ชุดใหม่ โดยมี window กัน reload วนลูป
+
+export const RELOAD_WINDOW_MS = 30_000
+
+const KEY_PREFIX = 'chunk-reload:'
+
+const CHUNK_ERROR_PATTERNS = [
+  /failed to fetch dynamically imported module/i, // Chrome/Edge
+  /error loading dynamically imported module/i, // Firefox
+  /importing a module script failed/i, // Safari
+  /unable to preload css/i, // Vite CSS preload
+]
+
+export function isChunkLoadError(error) {
+  const message = error?.message ?? ''
+  return CHUNK_ERROR_PATTERNS.some((pattern) => pattern.test(message))
+}
+
+// fallback ในหน่วยความจำ สำหรับกรณี storage ใช้ไม่ได้ (เช่น Safari private mode)
+const memoryFallback = new Map()
+
+export function shouldReloadForChunkError(path, storage, now) {
+  const key = KEY_PREFIX + path
+
+  let last
+  try {
+    last = Number(storage.getItem(key))
+  } catch {
+    last = memoryFallback.get(key) ?? 0
+  }
+
+  if (Number.isFinite(last) && last > 0 && now - last < RELOAD_WINDOW_MS) {
+    return false
+  }
+
+  try {
+    storage.setItem(key, String(now))
+  } catch {
+    // storage เขียนไม่ได้ (เช่น private mode) — จดใน memory แทน
+    memoryFallback.set(key, now)
+  }
+  return true
+}


### PR DESCRIPTION
## Problem (user-reported)
เปลี่ยนแท็บเมนูแล้วคอนเทนต์โหลดนาน หรือค้างไม่แสดงตรง content panel

## Root cause (verified on production)
1. Render static hosting keeps only the latest build — old hashed chunks return **404** (confirmed: `/assets/index-JZODuJ8e.js` → 404 after today's 5 deploys)
2. When an already-open client navigates, the dynamic import fails and Vue Router **silently aborts navigation** (no `router.onError` handler existed) → content panel stays stuck
3. Every route is lazy-loaded with **zero visual feedback** during chunk download → slow networks see a frozen page

## Fix
- **`router.onError` + chunk-error detection** (`utils/chunkGuard.js`): matches Chrome/Firefox/Safari dynamic-import failure messages + Vite CSS preload errors → hard-reloads the target route to pick up fresh `index.html`; 30-second per-path sessionStorage guard prevents reload loops (in-memory fallback for Safari private mode)
- **Navigation progress bar** (`useNavProgress` + App.vue): slim top bar with 150ms appearance delay — fast navs stay clean, slow chunk loads are no longer a silent wait
- **nginx**: `expires -1` on the SPA fallback so `index.html` is never cached stale (uses `expires` rather than `add_header` to preserve inherited security headers)

## Test plan
- [x] TDD: 10 new `chunkGuard` tests written first (RED → GREEN), including reload-loop guard and broken-storage edge cases
- [x] Full frontend suite: **11 files / 99 tests passed**
- [x] `npm run build` clean
- [ ] After deploy: switch menus mid-session across a redeploy to confirm auto-recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SG2VHfjcu22ogCb3LxTh2P