### PR TITLE
feat: move special-area management into admin menu group

### DIFF
--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -99,7 +99,7 @@ import { RouterLink } from 'vue-router'
 import { useAuthStore } from '@/stores/auth.js'
 import {
   X, BookOpen, LayoutDashboard, UserCheck, Users, Clock, Award, UserMinus,
-  Briefcase, FileText, Trophy, ChevronRight, UserCog, FileUp, FileSearch,
+  Briefcase, FileText, Trophy, ChevronRight, UserCog, FileUp, FileSearch, Shield,
 } from 'lucide-vue-next'
 
 defineProps({ open: Boolean })
@@ -127,22 +127,24 @@ const menuItems = computed(() => [
     children: [
       { id: 'time-counting', label: 'การนับเกื้อกูล', to: '/time-counting' },
       { id: 'time-multiplier', label: 'การนับทวีคูณ', to: '/time-multiplier' },
-      // จัดการ master data พื้นที่ทวีคูณ — admin เท่านั้น (ตรงกับ meta.requiresAdmin ของ route)
-      ...(auth.user?.role === 'admin'
-        ? [{ id: 'time-multiplier-areas', label: 'จัดการพื้นที่พิเศษ', to: '/time-multiplier/areas' }]
-        : []),
       { id: 'time-difference', label: 'การนับแตกต่าง', to: '/time-difference' },
       { id: 'position-compare', label: 'การเทียบตำแหน่ง', to: '/position-compare' },
     ],
   },
   { id: 'royal-decorations', label: 'เครื่องราชอิสริยาภรณ์', icon: Award, to: '/royal-decorations' },
   { id: 'retirement-report', label: 'รายงานผู้เกษียณ', icon: UserMinus, to: '/retirement-report' },
-  // เมนู admin เท่านั้น — นำเข้าข้อมูล + จัดการผู้ใช้ + ประวัติการเปลี่ยนแปลง
+  // เมนู admin เท่านั้น — นำเข้าข้อมูล + จัดการผู้ใช้ + ประวัติการเปลี่ยนแปลง + กลุ่มแอดมิน
   ...(auth.user?.role === 'admin'
     ? [
         { id: 'data-import', label: 'นำเข้าข้อมูล', icon: FileUp, to: '/import' },
         { id: 'user-management', label: 'จัดการผู้ใช้', icon: UserCog, to: '/users' },
         { id: 'audit-log', label: 'ประวัติการเปลี่ยนแปลง', icon: FileSearch, to: '/audit' },
+        {
+          id: 'admin-settings', label: 'แอดมิน', icon: Shield,
+          children: [
+            { id: 'special-areas', label: 'จัดการพื้นที่พิเศษ', to: '/settings/special-areas' },
+          ],
+        },
       ]
     : []),
   { id: 'work-management', label: 'การจัดการงาน', icon: Briefcase, to: '/admin' },

--- a/frontend/src/pages/MultiplierPage.vue
+++ b/frontend/src/pages/MultiplierPage.vue
@@ -176,7 +176,7 @@
           <h2 class="text-base font-semibold text-gray-900">Master data พื้นที่พิเศษ</h2>
           <RouterLink
             v-if="isAdmin"
-            to="/time-multiplier/areas"
+            to="/settings/special-areas"
             class="text-sm text-blue-600 hover:text-blue-700"
           >
             จัดการพื้นที่ →

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -82,8 +82,13 @@ const routes = [
         component: () => import('@/pages/MultiplierPage.vue'),
       },
       {
+        // path เดิมก่อนย้ายเข้าเมนูแอดมิน — คง redirect ไว้กัน bookmark เก่าพัง
         path: 'time-multiplier/areas',
-        name: 'time-multiplier-areas',
+        redirect: '/settings/special-areas',
+      },
+      {
+        path: 'settings/special-areas',
+        name: 'settings-special-areas',
         component: () => import('@/pages/MultiplierAreasPage.vue'),
         meta: { requiresAdmin: true },
       },


### PR DESCRIPTION
## Summary
Per การตัดสินใจ 3 ข้อ:
1. กลุ่มเมนูใหม่ชื่อ **"แอดมิน"** (admin-only, Shield icon) ท้ายแถบเมนู admin เดิม
2. ย้ายเฉพาะ **จัดการพื้นที่พิเศษ** เข้ากลุ่ม (ออกจากใต้ "การนับเวลาเพิ่มเติม")
3. URL ใหม่ **`/settings/special-areas`** พร้อม redirect จาก `/time-multiplier/areas` — bookmark เก่าไม่พัง

คง cross-link "จัดการพื้นที่ →" ในหน้าการนับทวีคูณไว้ (ชี้ path ใหม่) — ผู้ใช้ที่กำลังเพิ่มรายการยังไปหน้า master data ได้ 1 คลิก

## Test plan
- [x] Full frontend suite: 11 files / 99 tests passed
- [x] `npm run build` clean
- [x] No stale `/time-multiplier/areas` links remain (grep)
- [ ] After deploy: sidebar shows แอดมิน group for admin, redirect works, operator cannot access

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SG2VHfjcu22ogCb3LxTh2P