### PR TITLE
fix: harden production readiness for auth, audit, and deploy

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,7 +5,7 @@ FROM composer:2.7 AS vendor
 
 WORKDIR /app
 
-COPY composer.json composer.lock* ./
+COPY backend/composer.json backend/composer.lock* ./
 
 # ext-gd ถูก declare โดย phpspreadsheet แต่ใช้เฉพาะ export รูป — การอ่าน xlsx (import) ไม่ใช้
 # จึง ignore platform req เพื่อไม่ต้องลง gd (libpng/jpeg/freetype) ที่ทำให้ image ใหญ่
@@ -35,15 +35,20 @@ opcache.revalidate_freq=0" > /usr/local/etc/php/conf.d/opcache.ini
 
 WORKDIR /var/www/html
 
-# คัดลอก source code ทั้งหมด
-COPY . .
+# คัดลอก backend source + migration SQL (context = repo root)
+COPY backend/ .
+COPY database/ /var/www/database/
 
 # คัดลอก vendor ที่ติดตั้งไว้แล้วจาก stage แรก
 COPY --from=vendor /app/vendor/ ./vendor/
 
 # สร้าง runtime directories และกำหนดสิทธิ์ให้ Apache
 RUN mkdir -p /var/www/html/uploads /var/www/html/storage/rate_limits \
-    && chown -R www-data:www-data /var/www/html/uploads /var/www/html/storage
+    && chown -R www-data:www-data /var/www/html/uploads /var/www/html/storage \
+    && chmod +x /var/www/html/docker-entrypoint.sh
+
+ENV MIGRATIONS_DIR=/var/www/database
+ENV RUN_MIGRATIONS=1
 
 # ให้ Apache ส่ง environment variables เข้า PHP
 RUN echo "PassEnv MYSQL_HOST MYSQL_PORT MYSQL_DATABASE MYSQL_USER MYSQL_PASSWORD MYSQL_SSL MYSQL_SSL_CA JWT_SECRET" \
@@ -63,3 +68,5 @@ RUN printf "AddDefaultCharset UTF-8\n" > /etc/apache2/conf-enabled/charset.conf 
 
 # เปิด port 80
 EXPOSE 80
+
+ENTRYPOINT ["/var/www/html/docker-entrypoint.sh"]

--- a/backend/QualificationEngine.php
+++ b/backend/QualificationEngine.php
@@ -14,6 +14,12 @@ class QualificationEngine
 {
     private PDO $pdo;
 
+    /** @var array<string, list<string>>|null */
+    private ?array $criteriaSourceCache = null;
+
+    /** @var array<string, array{sql:string,params:array}|null>|null */
+    private ?array $builtQueryCache = null;
+
     /** ระดับเป้าหมายทั้งหมดที่แสดงในภาพรวม แยกตามประเภทตำแหน่ง */
     private const OVERVIEW_LEVELS = [
         'general' => ['O2', 'O3'],
@@ -45,12 +51,7 @@ class QualificationEngine
      */
     private function buildBaseQuery(string $targetLevel): ?array
     {
-        // ดึง source level codes สำหรับ target level นี้
-        $stmt = $this->pdo->prepare(
-            'SELECT DISTINCT source_level_code FROM promotion_criteria WHERE target_level_code = ? AND is_active = 1'
-        );
-        $stmt->execute([$targetLevel]);
-        $sourceLevels = $stmt->fetchAll(PDO::FETCH_COLUMN);
+        $sourceLevels = $this->getSourceLevelsForTarget($targetLevel);
 
         if (empty($sourceLevels)) {
             return null;
@@ -146,9 +147,44 @@ class QualificationEngine
      */
     private function buildQuery(string $targetLevel): ?array
     {
-        return in_array($targetLevel, self::EXECUTIVE_LEVELS, true)
+        if ($this->builtQueryCache !== null && array_key_exists($targetLevel, $this->builtQueryCache)) {
+            return $this->builtQueryCache[$targetLevel];
+        }
+
+        $built = in_array($targetLevel, self::EXECUTIVE_LEVELS, true)
             ? $this->buildExecutiveQuery($targetLevel)
             : $this->buildBaseQuery($targetLevel);
+
+        if ($this->builtQueryCache !== null) {
+            $this->builtQueryCache[$targetLevel] = $built;
+        }
+
+        return $built;
+    }
+
+    /**
+     * โหลด promotion_criteria ครั้งเดียวต่อ request overview — ลด N+1 lookup
+     *
+     * @return list<string>
+     */
+    private function getSourceLevelsForTarget(string $targetLevel): array
+    {
+        if ($this->criteriaSourceCache === null) {
+            $this->criteriaSourceCache = [];
+            $stmt = $this->pdo->query(
+                'SELECT target_level_code, source_level_code
+                 FROM promotion_criteria
+                 WHERE is_active = 1'
+            );
+            foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+                $target = (string) $row['target_level_code'];
+                $source = (string) $row['source_level_code'];
+                $this->criteriaSourceCache[$target][] = $source;
+            }
+        }
+
+        $levels = $this->criteriaSourceCache[$targetLevel] ?? [];
+        return array_values(array_unique($levels));
     }
 
     /**
@@ -466,6 +502,9 @@ class QualificationEngine
      */
     public function computeOverview(): array
     {
+        $this->criteriaSourceCache = null;
+        $this->builtQueryCache = [];
+
         $summary = [
             'general_total' => 0,
             'academic_total' => 0,
@@ -524,7 +563,6 @@ class QualificationEngine
                 $dataStmt->execute($base['params']);
                 $rows = $dataStmt->fetchAll(PDO::FETCH_ASSOC);
 
-                // Format fields ให้ตรงกับ data row ของ computeForLevel + ระบุระดับเป้าหมาย
                 foreach ($rows as &$r) {
                     $r['target_level'] = $level;
                     $r['qualification_date_thai'] = formatThaiDate($r['qualification_date']);

--- a/backend/api.php
+++ b/backend/api.php
@@ -48,9 +48,11 @@ if ($path[0] === 'api') {
 }
 
 $token = getAuthHeader();
+$isPublicLogin = $path[0] === 'auth' && ($path[1] ?? '') === 'login' && $method === 'POST';
+$isPasswordChange = $path[0] === 'auth' && ($path[1] ?? '') === 'change-password' && $method === 'POST';
 
-// Skip authentication for auth endpoints and options
-if ($path[0] !== 'auth' && $method !== 'OPTIONS') {
+// เฉพาะ login เท่านั้นที่เป็น public; auth endpoint อื่นต้องมี JWT เช่นเดียวกับ API ปกติ
+if (!$isPublicLogin && $method !== 'OPTIONS') {
     if (!$token || !validateJWT($token)) {
         http_response_code(401);
         echo json_encode(['error' => 'Unauthorized']);
@@ -63,10 +65,22 @@ if ($path[0] !== 'auth' && $method !== 'OPTIONS') {
 
 // CSRF Protection for state-changing requests
 $statefulMethods = ['POST', 'PUT', 'DELETE'];
-$publicPaths = ['auth', 'login'];
 
-if (in_array($method, $statefulMethods) && !in_array($path[0], $publicPaths)) {
+if (in_array($method, $statefulMethods, true) && !$isPublicLogin) {
     requireCSRFToken();
+}
+
+// ผู้ใช้ที่ถูกบังคับเปลี่ยนรหัสผ่านเข้าถึงได้เฉพาะ endpoint เปลี่ยนรหัสผ่าน
+if (!$isPublicLogin && !$isPasswordChange && $method !== 'OPTIONS') {
+    $authenticatedUser = getAuthenticatedUser();
+    if ((int) ($authenticatedUser['must_change_password'] ?? 0) === 1) {
+        http_response_code(403);
+        echo json_encode([
+            'error' => 'Password change required',
+            'code' => 'PASSWORD_CHANGE_REQUIRED',
+        ]);
+        exit;
+    }
 }
 
 switch ($path[0]) {

--- a/backend/audit.php
+++ b/backend/audit.php
@@ -108,8 +108,8 @@ function checkPermission(string $userRole, string $action, string $resource): bo
         ],
         'operator' => [
             'read' => ['*'],
-            'create' => ['multiplier', 'personnel', 'candidates', 'probation', 'equivalence'],
-            'update' => ['multiplier', 'personnel', 'candidates', 'probation', 'equivalence'],
+            'create' => ['multiplier', 'personnel', 'candidates', 'probation', 'equivalence', 'supportive', 'diverse'],
+            'update' => ['multiplier', 'personnel', 'candidates', 'probation', 'equivalence', 'supportive', 'diverse'],
             // 'equivalence_approval' ไม่อยู่ในลิสต์ — อนุมัติ/ปฏิเสธคำขอเทียบตำแหน่งเป็นสิทธิ์ admin เท่านั้น
             'delete' => [], // ห้าม delete (ยกเว้น admin)
         ],
@@ -170,7 +170,7 @@ function requirePermission(string $action, string $resource): void
 /**
  * ดึงข้อมูล authenticated user จาก JWT token
  *
- * @return array|null — ['user_id' => int, 'role' => string] หรือ null
+ * @return array|null — ['user_id' => int, 'role' => string, 'must_change_password' => int] หรือ null
  */
 function getAuthenticatedUser(): ?array
 {
@@ -197,7 +197,11 @@ function getAuthenticatedUser(): ?array
     // ดึง user จาก DB เพื่อ check role ล่าสุด (กัน cache role เก่า)
     try {
         $pdo = getDB();
-        $stmt = $pdo->prepare("SELECT user_id, role FROM users WHERE user_id = ? AND is_active = 1");
+        $stmt = $pdo->prepare(
+            "SELECT user_id, role, must_change_password
+             FROM users
+             WHERE user_id = ? AND is_active = 1"
+        );
         $stmt->execute([$payload['user_id'] ?? 0]);
         $user = $stmt->fetch(PDO::FETCH_ASSOC);
 

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -1,6 +1,5 @@
 {
     "require": {
-        "firebase/php-jwt": "^6.0",
         "phpoffice/phpspreadsheet": "^2.0"
     },
     "require-dev": {

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6d44faa9aec67d166b47d7646e617bff",
+    "content-hash": "129c6e2ea08b5806488d1207c35fbc75",
     "packages": [
         {
             "name": "composer/pcre",
@@ -81,69 +81,6 @@
                 }
             ],
             "time": "2026-06-07T11:47:49+00:00"
-        },
-        {
-            "name": "firebase/php-jwt",
-            "version": "v6.11.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/googleapis/php-jwt.git",
-                "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/php-jwt/zipball/d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
-                "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^8.0"
-            },
-            "require-dev": {
-                "guzzlehttp/guzzle": "^7.4",
-                "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.5",
-                "psr/cache": "^2.0||^3.0",
-                "psr/http-client": "^1.0",
-                "psr/http-factory": "^1.0"
-            },
-            "suggest": {
-                "ext-sodium": "Support EdDSA (Ed25519) signatures",
-                "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Firebase\\JWT\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Neuman Vong",
-                    "email": "neuman+pear@twilio.com",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Anant Narayanan",
-                    "email": "anant@php.net",
-                    "role": "Developer"
-                }
-            ],
-            "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
-            "homepage": "https://github.com/firebase/php-jwt",
-            "keywords": [
-                "jwt",
-                "php"
-            ],
-            "support": {
-                "issues": "https://github.com/googleapis/php-jwt/issues",
-                "source": "https://github.com/googleapis/php-jwt/tree/v6.11.1"
-            },
-            "time": "2025-04-09T20:32:01+00:00"
         },
         {
             "name": "maennchen/zipstream-php",

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+if [ "${RUN_MIGRATIONS:-1}" = "1" ]; then
+  php /var/www/html/scripts/run-migrations.php
+fi
+
+exec apache2-foreground

--- a/backend/middleware/rate_limit.php
+++ b/backend/middleware/rate_limit.php
@@ -1,13 +1,35 @@
 <?php
 /**
  * Rate Limiting Middleware
- * File-based sliding window (no Redis dependency)
- *
- * Implementation: Sliding window counter using JSON files
- * Each user-method combination gets its own file for concurrent access safety
+ * Primary: MySQL sliding window (persists across Render restarts)
+ * Fallback: JSON files when api_rate_limit_hits table is unavailable
  */
 
 define('RATE_LIMIT_DIR', __DIR__ . '/../storage/rate_limits/');
+
+/** @var bool|null */
+$GLOBALS['_rate_limit_db_ready'] = null;
+
+function rateLimitUsesDatabase(): bool
+{
+    if ($GLOBALS['_rate_limit_db_ready'] !== null) {
+        return $GLOBALS['_rate_limit_db_ready'];
+    }
+
+    try {
+        if (!function_exists('getDB')) {
+            require_once __DIR__ . '/../config.php';
+        }
+        $pdo = getDB();
+        $stmt = $pdo->query("SHOW TABLES LIKE 'api_rate_limit_hits'");
+        $GLOBALS['_rate_limit_db_ready'] = (bool) $stmt->fetchColumn();
+    } catch (Throwable $e) {
+        error_log('[RateLimit] DB probe failed: ' . $e->getMessage());
+        $GLOBALS['_rate_limit_db_ready'] = false;
+    }
+
+    return $GLOBALS['_rate_limit_db_ready'];
+}
 
 /**
  * Check rate limit for a specific user and method
@@ -20,6 +42,55 @@ define('RATE_LIMIT_DIR', __DIR__ . '/../storage/rate_limits/');
  */
 function checkRateLimit(int $userId, string $method, int $limit, int $windowSeconds): void
 {
+    if (rateLimitUsesDatabase()) {
+        checkRateLimitDatabase($userId, $method, $limit, $windowSeconds);
+        return;
+    }
+
+    checkRateLimitFile($userId, $method, $limit, $windowSeconds);
+}
+
+function checkRateLimitDatabase(int $userId, string $method, int $limit, int $windowSeconds): void
+{
+    $pdo = getDB();
+    $rateKey = "user_{$userId}_{$method}";
+    $now = time();
+    $windowStart = $now - $windowSeconds;
+
+    $pdo->beginTransaction();
+    try {
+        $delete = $pdo->prepare(
+            'DELETE FROM api_rate_limit_hits WHERE rate_key = ? AND hit_at <= ?'
+        );
+        $delete->execute([$rateKey, $windowStart]);
+
+        $countStmt = $pdo->prepare(
+            'SELECT COUNT(*) FROM api_rate_limit_hits WHERE rate_key = ?'
+        );
+        $countStmt->execute([$rateKey]);
+        $currentCount = (int) $countStmt->fetchColumn();
+
+        if ($currentCount >= $limit) {
+            $pdo->rollBack();
+            rateLimitExceededResponse($windowSeconds);
+        }
+
+        $insert = $pdo->prepare(
+            'INSERT INTO api_rate_limit_hits (rate_key, hit_at) VALUES (?, ?)'
+        );
+        $insert->execute([$rateKey, $now]);
+        $pdo->commit();
+    } catch (Throwable $e) {
+        if ($pdo->inTransaction()) {
+            $pdo->rollBack();
+        }
+        error_log('[RateLimit] DB check failed: ' . $e->getMessage());
+        checkRateLimitFile($userId, $method, $limit, $windowSeconds);
+    }
+}
+
+function checkRateLimitFile(int $userId, string $method, int $limit, int $windowSeconds): void
+{
     if (!is_dir(RATE_LIMIT_DIR)) {
         mkdir(RATE_LIMIT_DIR, 0775, true);
     }
@@ -28,36 +99,23 @@ function checkRateLimit(int $userId, string $method, int $limit, int $windowSeco
     $file = RATE_LIMIT_DIR . md5($key) . '.json';
     $now = time();
 
-    // เปิดไฟล์ครั้งเดียวแล้วถือ exclusive lock ตลอด read+check+write
-    // กัน race condition (TOCTOU) เมื่อ request พร้อมกันจาก user เดียวกันมาถึงพร้อมกัน
     $handle = fopen($file, 'c+');
     if ($handle === false) {
         error_log("[RateLimit] cannot open {$file}");
-        return; // fail-open: filesystem error ไม่ควรบล็อก request จริง
+        return;
     }
     flock($handle, LOCK_EX);
 
     $content = stream_get_contents($handle);
     $data = $content ? (json_decode($content, true) ?: []) : [];
-
-    // ลบ timestamps เก่าที่เกิน window (sliding window cleanup)
     $data['hits'] = array_filter($data['hits'] ?? [], fn($ts) => $ts > $now - $windowSeconds);
 
-    // ตรวจนับจำนวน requests ใน window
     if (count($data['hits']) >= $limit) {
         flock($handle, LOCK_UN);
         fclose($handle);
-        http_response_code(429);
-        header('Retry-After: ' . $windowSeconds);
-        echo json_encode([
-            'error' => 'Rate limit exceeded',
-            'message' => 'คำขอมากเกินไป กรุณารอสักครู่',
-            'retry_after' => $windowSeconds
-        ]);
-        exit;
+        rateLimitExceededResponse($windowSeconds);
     }
 
-    // เพิ่ม hit ใหม่ แล้วเขียนทับทั้งไฟล์ขณะยังถือ lock อยู่
     $data['hits'][] = $now;
     ftruncate($handle, 0);
     rewind($handle);
@@ -65,6 +123,18 @@ function checkRateLimit(int $userId, string $method, int $limit, int $windowSeco
     fflush($handle);
     flock($handle, LOCK_UN);
     fclose($handle);
+}
+
+function rateLimitExceededResponse(int $windowSeconds): void
+{
+    http_response_code(429);
+    header('Retry-After: ' . $windowSeconds);
+    echo json_encode([
+        'error' => 'Rate limit exceeded',
+        'message' => 'คำขอมากเกินไป กรุณารอสักครู่',
+        'retry_after' => $windowSeconds,
+    ]);
+    exit;
 }
 
 /**
@@ -78,12 +148,12 @@ function rateLimitGlobal(): void
 {
     $user = getAuthenticatedUser();
     if (!$user) {
-        return; // ให้ผ่าน JWT validation ก่อน
+        return;
     }
 
     $method = $_SERVER['REQUEST_METHOD'];
-    $limit = ($method === 'GET') ? 200 : 50; // GET อ่านได้มาก, POST/PUT/DELETE น้อย
-    $window = 60; // 1 นาที
+    $limit = ($method === 'GET') ? 200 : 50;
+    $window = 60;
 
     checkRateLimit($user['user_id'], $method, $limit, $window);
 }

--- a/backend/routes/auth.php
+++ b/backend/routes/auth.php
@@ -4,16 +4,19 @@
 // Authentication Route Handler — เข้าสู่ระบบจากตาราง users จริง
 //
 // Endpoints:
-//   POST /auth/login — ตรวจ username/password กับ DB + rate limit
+//   POST /auth/login           — ตรวจ username/password กับ DB + rate limit
+//   POST /auth/change-password — เปลี่ยนรหัสผ่านที่ถูกบังคับหลังเข้าสู่ระบบ
 //
 // Rate limiting (ตาราง login_attempts):
 //   ผิดติดต่อกัน 5 ครั้งภายใน 15 นาที (นับต่อ username) -> 429
 // ============================================================================
 
 include_once __DIR__ . '/../helpers.php';
+include_once __DIR__ . '/../audit.php';
 
 const MAX_LOGIN_ATTEMPTS = 5;
 const LOCKOUT_WINDOW_MINUTES = 15;
+const AUTH_PASSWORD_MIN_LENGTH = 8;
 
 /**
  * จัดการ request สำหรับ auth endpoints
@@ -29,8 +32,89 @@ function handleAuth(PDO $pdo, string $method, array $path): void
         return;
     }
 
+    if (($path[1] ?? '') === 'change-password' && $method === 'POST') {
+        $user = getAuthenticatedUser();
+        if (!$user) {
+            http_response_code(401);
+            echo json_encode(['error' => 'Unauthorized']);
+            return;
+        }
+        changePassword($pdo, $user);
+        return;
+    }
+
     http_response_code(404);
     echo json_encode(['error' => 'Not found']);
+}
+
+/**
+ * POST /auth/change-password — ยืนยันรหัสเดิมและล้าง must_change_password
+ *
+ * @param array{user_id:int} $user
+ * @param array<string,mixed>|null $input ใช้ inject ใน integration tests
+ */
+function changePassword(PDO $pdo, array $user, ?array $input = null): void
+{
+    $data = $input ?? json_decode(file_get_contents('php://input'), true);
+    if (!is_array($data)) {
+        http_response_code(400);
+        echo json_encode(['error' => 'รูปแบบข้อมูลไม่ถูกต้อง']);
+        return;
+    }
+
+    $currentPassword = (string) ($data['current_password'] ?? '');
+    $newPassword = (string) ($data['new_password'] ?? '');
+
+    if ($currentPassword === '' || $newPassword === '') {
+        http_response_code(400);
+        echo json_encode(['error' => 'กรุณาระบุรหัสผ่านเดิมและรหัสผ่านใหม่']);
+        return;
+    }
+    if (strlen($newPassword) < AUTH_PASSWORD_MIN_LENGTH) {
+        http_response_code(400);
+        echo json_encode(['error' => 'รหัสผ่านใหม่ต้องมีความยาวอย่างน้อย ' . AUTH_PASSWORD_MIN_LENGTH . ' ตัวอักษร']);
+        return;
+    }
+
+    $stmt = $pdo->prepare(
+        'SELECT password_hash, must_change_password
+         FROM users
+         WHERE user_id = ? AND is_active = 1'
+    );
+    $stmt->execute([(int) $user['user_id']]);
+    $account = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if (!$account || !password_verify($currentPassword, (string) $account['password_hash'])) {
+        http_response_code(400);
+        echo json_encode(['error' => 'รหัสผ่านเดิมไม่ถูกต้อง']);
+        return;
+    }
+    if (password_verify($newPassword, (string) $account['password_hash'])) {
+        http_response_code(400);
+        echo json_encode(['error' => 'รหัสผ่านใหม่ต้องไม่ซ้ำกับรหัสผ่านเดิม']);
+        return;
+    }
+
+    $pdo->prepare(
+        'UPDATE users
+         SET password_hash = ?, must_change_password = 0
+         WHERE user_id = ?'
+    )->execute([
+        password_hash($newPassword, PASSWORD_DEFAULT),
+        (int) $user['user_id'],
+    ]);
+
+    logAudit(
+        $pdo,
+        (int) $user['user_id'],
+        'UPDATE',
+        'users',
+        (int) $user['user_id'],
+        ['must_change_password' => (bool) $account['must_change_password']],
+        ['must_change_password' => false]
+    );
+
+    echo json_encode(['success' => true]);
 }
 
 /**

--- a/backend/routes/diverse.php
+++ b/backend/routes/diverse.php
@@ -14,6 +14,7 @@
 // ============================================================================
 
 include_once __DIR__ . '/../helpers.php';
+include_once __DIR__ . '/../audit.php';
 
 /**
  * จัดการ request สำหรับ diverse experience endpoints
@@ -24,6 +25,12 @@ include_once __DIR__ . '/../helpers.php';
  */
 function handleDiverse(PDO $pdo, string $method, array $path): void
 {
+    $actionMap = ['GET' => 'read', 'POST' => 'create', 'PUT' => 'update', 'DELETE' => 'delete'];
+    if (isset($actionMap[$method])) {
+        requirePermission($actionMap[$method], 'diverse');
+    }
+    $user = getAuthenticatedUser();
+
     switch ($method) {
         case 'GET':
             $id = $path[1] ?? null;
@@ -38,7 +45,7 @@ function handleDiverse(PDO $pdo, string $method, array $path): void
 
         case 'POST':
             // POST /diverse — สร้างรายการใหม่
-            createDiverse($pdo);
+            createDiverse($pdo, $user);
             break;
 
         case 'PUT':
@@ -49,7 +56,7 @@ function handleDiverse(PDO $pdo, string $method, array $path): void
                 return;
             }
             // PUT /diverse/{id} — อัปเดตข้อมูล
-            updateDiverse($pdo, intval($id));
+            updateDiverse($pdo, intval($id), $user);
             break;
 
         case 'DELETE':
@@ -60,7 +67,7 @@ function handleDiverse(PDO $pdo, string $method, array $path): void
                 return;
             }
             // DELETE /diverse/{id} — ลบรายการ
-            deleteDiverse($pdo, intval($id));
+            deleteDiverse($pdo, intval($id), $user);
             break;
 
         default:
@@ -176,9 +183,9 @@ function getDiverseDetail(PDO $pdo, int $id): void
  * diff_count เป็น GENERATED column จึงไม่รวมใน INSERT
  * qualified_date คำนวณจาก 4 boolean flags (>= 3 = ผ่านเกณฑ์)
  */
-function createDiverse(PDO $pdo): void
+function createDiverse(PDO $pdo, array $user, ?array $input = null): void
 {
-    $data = json_decode(file_get_contents('php://input'), true);
+    $data = $input ?? json_decode(file_get_contents('php://input'), true);
 
     // ตรวจสอบข้อมูลที่จำเป็น
     $required = ['personnel_id'];
@@ -250,10 +257,23 @@ function createDiverse(PDO $pdo): void
         $qualifiedDate
     ]);
 
-    $experienceId = $pdo->lastInsertId();
+    $experienceId = (int) $pdo->lastInsertId();
+    $afterStmt = $pdo->prepare('SELECT * FROM diverse_experience WHERE experience_id = ?');
+    $afterStmt->execute([$experienceId]);
+    $after = $afterStmt->fetch(PDO::FETCH_ASSOC);
+
+    logAudit(
+        $pdo,
+        (int) $user['user_id'],
+        'CREATE',
+        'diverse_experience',
+        $experienceId,
+        null,
+        $after ?: null
+    );
 
     http_response_code(201);
-    echo json_encode(['success' => true, 'experience_id' => intval($experienceId)]);
+    echo json_encode(['success' => true, 'experience_id' => $experienceId]);
 }
 
 /**
@@ -261,7 +281,7 @@ function createDiverse(PDO $pdo): void
  * diff_count ไม่อยู่ใน allowed fields (GENERATED column)
  * หลังอัปเดต recompute from_total_days, to_total_days, qualified_date
  */
-function updateDiverse(PDO $pdo, int $id): void
+function updateDiverse(PDO $pdo, int $id, array $user, ?array $input = null): void
 {
     // ตรวจสอบว่า record มีอยู่จริง
     $checkStmt = $pdo->prepare("SELECT * FROM diverse_experience WHERE experience_id = ?");
@@ -274,7 +294,7 @@ function updateDiverse(PDO $pdo, int $id): void
         return;
     }
 
-    $data = json_decode(file_get_contents('php://input'), true);
+    $data = $input ?? json_decode(file_get_contents('php://input'), true);
 
     // Allowed fields — ไม่รวม diff_count (GENERATED column)
     $allowed = [
@@ -343,22 +363,48 @@ function updateDiverse(PDO $pdo, int $id): void
     $stmt = $pdo->prepare($sql);
     $stmt->execute($params);
 
+    $afterStmt = $pdo->prepare('SELECT * FROM diverse_experience WHERE experience_id = ?');
+    $afterStmt->execute([$id]);
+    $after = $afterStmt->fetch(PDO::FETCH_ASSOC);
+    logAudit(
+        $pdo,
+        (int) $user['user_id'],
+        'UPDATE',
+        'diverse_experience',
+        $id,
+        $existing,
+        $after ?: null
+    );
+
     echo json_encode(['success' => true]);
 }
 
 /**
  * DELETE /diverse/{id} — ลบรายการนับแตกต่าง
  */
-function deleteDiverse(PDO $pdo, int $id): void
+function deleteDiverse(PDO $pdo, int $id, array $user): void
 {
-    $stmt = $pdo->prepare("DELETE FROM diverse_experience WHERE experience_id = ?");
-    $stmt->execute([$id]);
-
-    if ($stmt->rowCount() === 0) {
+    $beforeStmt = $pdo->prepare('SELECT * FROM diverse_experience WHERE experience_id = ?');
+    $beforeStmt->execute([$id]);
+    $before = $beforeStmt->fetch(PDO::FETCH_ASSOC);
+    if (!$before) {
         http_response_code(404);
         echo json_encode(['error' => 'ไม่พบรายการนับแตกต่าง']);
         return;
     }
+
+    $stmt = $pdo->prepare("DELETE FROM diverse_experience WHERE experience_id = ?");
+    $stmt->execute([$id]);
+
+    logAudit(
+        $pdo,
+        (int) $user['user_id'],
+        'DELETE',
+        'diverse_experience',
+        $id,
+        $before,
+        null
+    );
 
     echo json_encode(['success' => true]);
 }

--- a/backend/routes/equivalence.php
+++ b/backend/routes/equivalence.php
@@ -27,6 +27,12 @@ include_once __DIR__ . '/../audit.php';
  */
 function handleEquivalence(PDO $pdo, string $method, array $path): void
 {
+    $actionMap = ['GET' => 'read', 'POST' => 'create', 'PUT' => 'update'];
+    if (isset($actionMap[$method])) {
+        requirePermission($actionMap[$method], 'equivalence');
+    }
+    $user = getAuthenticatedUser();
+
     switch ($method) {
         case 'GET':
             $id = $path[1] ?? null;
@@ -41,7 +47,7 @@ function handleEquivalence(PDO $pdo, string $method, array $path): void
 
         case 'POST':
             // POST /equivalence — สร้างคำขอเทียบตำแหน่งใหม่
-            createEquivalence($pdo);
+            createEquivalence($pdo, $user);
             break;
 
         case 'PUT':
@@ -52,7 +58,7 @@ function handleEquivalence(PDO $pdo, string $method, array $path): void
                 return;
             }
             // PUT /equivalence/{id} — อัปเดต / อนุมัติ / ปฏิเสธ
-            updateEquivalence($pdo, intval($id));
+            updateEquivalence($pdo, intval($id), $user);
             break;
 
         default:
@@ -66,7 +72,6 @@ function handleEquivalence(PDO $pdo, string $method, array $path): void
  */
 function getEquivalenceList(PDO $pdo): void
 {
-    requirePermission('read', 'equivalence');
     $personnelId = $_GET['personnel_id'] ?? null;
     // clamp กัน limit มหาศาล / offset ติดลบ
     $limit = max(1, min(intval($_GET['limit'] ?? 20), 200));
@@ -147,7 +152,6 @@ function getEquivalenceList(PDO $pdo): void
  */
 function getEquivalenceDetail(PDO $pdo, int $id): void
 {
-    requirePermission('read', 'equivalence');
     $sql = "SELECT pe.*,
                    CONCAT(p.first_name, ' ', p.last_name) AS full_name,
                    u.username AS approved_by_name
@@ -180,10 +184,9 @@ function getEquivalenceDetail(PDO $pdo, int $id): void
  * approval_status จะเป็น PENDING เสมอ ไม่ว่า client จะส่งค่าอะไรมา
  * request_total_days คำนวณฝั่ง server จาก DATEDIFF+1
  */
-function createEquivalence(PDO $pdo): void
+function createEquivalence(PDO $pdo, array $user, ?array $input = null): void
 {
-    requirePermission('create', 'equivalence');
-    $data = json_decode(file_get_contents('php://input'), true);
+    $data = $input ?? json_decode(file_get_contents('php://input'), true);
 
     // ตรวจสอบข้อมูลที่จำเป็น
     $required = ['personnel_id', 'actual_position', 'equivalent_type'];
@@ -224,8 +227,22 @@ function createEquivalence(PDO $pdo): void
         $data['approval_order_ref'] ?? null
     ]);
 
+    $equivalenceId = (int) $pdo->lastInsertId();
+    $afterStmt = $pdo->prepare('SELECT * FROM position_equivalence WHERE equivalence_id = ?');
+    $afterStmt->execute([$equivalenceId]);
+    $after = $afterStmt->fetch(PDO::FETCH_ASSOC);
+    logAudit(
+        $pdo,
+        (int) $user['user_id'],
+        'CREATE',
+        'position_equivalence',
+        $equivalenceId,
+        null,
+        $after ?: null
+    );
+
     http_response_code(201);
-    echo json_encode(['success' => true, 'equivalence_id' => intval($pdo->lastInsertId())]);
+    echo json_encode(['success' => true, 'equivalence_id' => $equivalenceId]);
 }
 
 /**
@@ -241,11 +258,9 @@ function createEquivalence(PDO $pdo): void
  *   - อัปเดตเฉพาะ field ที่อนุญาต
  *   - คำนวณ request_total_days ใหม่หากเปลี่ยนวันที่
  */
-function updateEquivalence(PDO $pdo, int $id): void
+function updateEquivalence(PDO $pdo, int $id, array $user, ?array $input = null): void
 {
-    // ครอบทั้งฟังก์ชัน — ทั้งแก้ field ปกติและอนุมัติ/ปฏิเสธ ต้องผ่านสิทธิ์ update:equivalence ก่อนเสมอ
-    requirePermission('update', 'equivalence');
-    $data = json_decode(file_get_contents('php://input'), true);
+    $data = $input ?? json_decode(file_get_contents('php://input'), true);
 
     // ดึงข้อมูลปัจจุบัน
     $stmt = $pdo->prepare("SELECT * FROM position_equivalence WHERE equivalence_id = ?");
@@ -394,6 +409,19 @@ function updateEquivalence(PDO $pdo, int $id): void
     $sql = "UPDATE position_equivalence SET " . implode(', ', $sets) . " WHERE equivalence_id = ?";
     $stmt = $pdo->prepare($sql);
     $stmt->execute($params);
+
+    $afterStmt = $pdo->prepare('SELECT * FROM position_equivalence WHERE equivalence_id = ?');
+    $afterStmt->execute([$id]);
+    $after = $afterStmt->fetch(PDO::FETCH_ASSOC);
+    logAudit(
+        $pdo,
+        (int) $user['user_id'],
+        'UPDATE',
+        'position_equivalence',
+        $id,
+        $current,
+        $after ?: null
+    );
 
     echo json_encode(['success' => true]);
 }

--- a/backend/routes/multiplier.php
+++ b/backend/routes/multiplier.php
@@ -14,9 +14,6 @@ include_once __DIR__ . '/../audit.php';
 
 function handleMultiplier(PDO $pdo, string $method, array $path): void
 {
-    // DEBUG: Log routing info
-    error_log('[multiplier] method=' . $method . ', path=' . json_encode($path));
-
     // GET = read, POST = create, PUT = update, DELETE = delete
     $actionMap = ['GET' => 'read', 'POST' => 'create', 'PUT' => 'update', 'DELETE' => 'delete'];
     $action = $actionMap[$method] ?? 'read';
@@ -736,9 +733,9 @@ function parseStrictDate(string $value): ?DateTime
     return $date;
 }
 
-function updateMultiplier(PDO $pdo, int $multiplierId, array $user): void
+function updateMultiplier(PDO $pdo, int $multiplierId, array $user, ?array $input = null): void
 {
-    $data = json_decode(file_get_contents('php://input'), true);
+    $data = $input ?? json_decode(file_get_contents('php://input'), true);
     if (!is_array($data)) {
         http_response_code(400);
         echo json_encode(['error' => 'รูปแบบข้อมูลไม่ถูกต้อง']);
@@ -851,6 +848,19 @@ function updateMultiplier(PDO $pdo, int $multiplierId, array $user): void
         $data['description'] ?? $existing['description'],
         $multiplierId,
     ]);
+
+    $afterStmt = $pdo->prepare('SELECT * FROM multiplier_experience WHERE multiplier_id = ?');
+    $afterStmt->execute([$multiplierId]);
+    $after = $afterStmt->fetch(PDO::FETCH_ASSOC);
+    logAudit(
+        $pdo,
+        (int) $user['user_id'],
+        'UPDATE',
+        'multiplier_experience',
+        $multiplierId,
+        $existing,
+        $after ?: null
+    );
 
     // ดึงข้อมูลที่อัปเดตแล้วพร้อม decoration
     $updatedStmt = $pdo->prepare("

--- a/backend/routes/supportive.php
+++ b/backend/routes/supportive.php
@@ -14,6 +14,7 @@
 // ============================================================================
 
 include_once __DIR__ . '/../helpers.php';
+include_once __DIR__ . '/../audit.php';
 
 /**
  * จัดการ request สำหรับ supportive experience endpoints
@@ -24,6 +25,12 @@ include_once __DIR__ . '/../helpers.php';
  */
 function handleSupportive(PDO $pdo, string $method, array $path): void
 {
+    $actionMap = ['GET' => 'read', 'POST' => 'create', 'PUT' => 'update', 'DELETE' => 'delete'];
+    if (isset($actionMap[$method])) {
+        requirePermission($actionMap[$method], 'supportive');
+    }
+    $user = getAuthenticatedUser();
+
     switch ($method) {
         case 'GET':
             $id = $path[1] ?? null;
@@ -38,7 +45,7 @@ function handleSupportive(PDO $pdo, string $method, array $path): void
 
         case 'POST':
             // POST /supportive — สร้างรายการใหม่
-            createSupportive($pdo);
+            createSupportive($pdo, $user);
             break;
 
         case 'PUT':
@@ -49,7 +56,7 @@ function handleSupportive(PDO $pdo, string $method, array $path): void
                 return;
             }
             // PUT /supportive/{id} — อัปเดตรายการ
-            updateSupportive($pdo, intval($id));
+            updateSupportive($pdo, intval($id), $user);
             break;
 
         case 'DELETE':
@@ -60,7 +67,7 @@ function handleSupportive(PDO $pdo, string $method, array $path): void
                 return;
             }
             // DELETE /supportive/{id} — ลบรายการ
-            deleteSupportive($pdo, intval($id));
+            deleteSupportive($pdo, intval($id), $user);
             break;
 
         default:
@@ -232,9 +239,9 @@ function computeSupportiveFields(PDO $pdo, string $startDateStr, string $endDate
  * POST /supportive — สร้างรายการนับเกื้อกูลใหม่
  * Server-side computation: total_days, effective_days, net_* fields
  */
-function createSupportive(PDO $pdo): void
+function createSupportive(PDO $pdo, array $user, ?array $input = null): void
 {
-    $data = json_decode(file_get_contents('php://input'), true);
+    $data = $input ?? json_decode(file_get_contents('php://input'), true);
 
     // ตรวจสอบข้อมูลที่จำเป็น
     $required = ['personnel_id', 'job_series_name', 'start_date', 'end_date'];
@@ -277,17 +284,30 @@ function createSupportive(PDO $pdo): void
         $data['description'] ?? null
     ]);
 
-    $supportiveId = $pdo->lastInsertId();
+    $supportiveId = (int) $pdo->lastInsertId();
+    $afterStmt = $pdo->prepare('SELECT * FROM supportive_experience WHERE supportive_id = ?');
+    $afterStmt->execute([$supportiveId]);
+    $after = $afterStmt->fetch(PDO::FETCH_ASSOC);
+
+    logAudit(
+        $pdo,
+        (int) $user['user_id'],
+        'CREATE',
+        'supportive_experience',
+        $supportiveId,
+        null,
+        $after ?: null
+    );
 
     http_response_code(201);
-    echo json_encode(['success' => true, 'supportive_id' => intval($supportiveId)]);
+    echo json_encode(['success' => true, 'supportive_id' => $supportiveId]);
 }
 
 /**
  * PUT /supportive/{id} — อัปเดตรายการนับเกื้อกูล
  * ถ้า start_date/end_date/job_series_name เปลี่ยน จะคำนวณ computed fields ใหม่
  */
-function updateSupportive(PDO $pdo, int $id): void
+function updateSupportive(PDO $pdo, int $id, array $user, ?array $input = null): void
 {
     // ตรวจสอบว่ารายการมีอยู่จริง
     $checkStmt = $pdo->prepare("SELECT * FROM supportive_experience WHERE supportive_id = ?");
@@ -300,7 +320,7 @@ function updateSupportive(PDO $pdo, int $id): void
         return;
     }
 
-    $data = json_decode(file_get_contents('php://input'), true);
+    $data = $input ?? json_decode(file_get_contents('php://input'), true);
 
     // Allowed fields (client cannot set computed fields directly)
     $allowed = ['job_series_name', 'start_date', 'end_date', 'primary_series_name', 'description'];
@@ -360,22 +380,48 @@ function updateSupportive(PDO $pdo, int $id): void
     $stmt = $pdo->prepare($sql);
     $stmt->execute($params);
 
+    $afterStmt = $pdo->prepare('SELECT * FROM supportive_experience WHERE supportive_id = ?');
+    $afterStmt->execute([$id]);
+    $after = $afterStmt->fetch(PDO::FETCH_ASSOC);
+    logAudit(
+        $pdo,
+        (int) $user['user_id'],
+        'UPDATE',
+        'supportive_experience',
+        $id,
+        $existing,
+        $after ?: null
+    );
+
     echo json_encode(['success' => true]);
 }
 
 /**
  * DELETE /supportive/{id} — ลบรายการนับเกื้อกูล
  */
-function deleteSupportive(PDO $pdo, int $id): void
+function deleteSupportive(PDO $pdo, int $id, array $user): void
 {
-    $stmt = $pdo->prepare("DELETE FROM supportive_experience WHERE supportive_id = ?");
-    $stmt->execute([$id]);
-
-    if ($stmt->rowCount() === 0) {
+    $beforeStmt = $pdo->prepare('SELECT * FROM supportive_experience WHERE supportive_id = ?');
+    $beforeStmt->execute([$id]);
+    $before = $beforeStmt->fetch(PDO::FETCH_ASSOC);
+    if (!$before) {
         http_response_code(404);
         echo json_encode(['error' => 'ไม่พบรายการนับเกื้อกูล']);
         return;
     }
+
+    $stmt = $pdo->prepare("DELETE FROM supportive_experience WHERE supportive_id = ?");
+    $stmt->execute([$id]);
+
+    logAudit(
+        $pdo,
+        (int) $user['user_id'],
+        'DELETE',
+        'supportive_experience',
+        $id,
+        $before,
+        null
+    );
 
     echo json_encode(['success' => true]);
 }

--- a/backend/scripts/run-migrations.php
+++ b/backend/scripts/run-migrations.php
@@ -1,0 +1,278 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Apply ordered SQL migrations from database/ and record them in schema_migrations.
+ *
+ * Safety for existing TiDB/prod:
+ * - If schema_migrations is empty but core tables already exist, seed a baseline
+ *   for migrations through 14-* (already applied manually / via init scripts)
+ *   and only execute newer files (e.g. 15-api-rate-limit-hits.sql).
+ * - DDL is not wrapped in a multi-statement transaction (TiDB/MySQL auto-commit DDL).
+ * - Uses GET_LOCK when available to reduce multi-instance races.
+ *
+ * Usage:
+ *   docker compose exec backend php scripts/run-migrations.php
+ *   php scripts/run-migrations.php
+ */
+
+declare(strict_types=1);
+
+/** Last migration assumed already applied on existing production DBs */
+const MIGRATION_BASELINE_THROUGH = '14-multiplier-area-admin.sql';
+
+function migrationEnv(string $key, string $default = ''): string
+{
+    $value = getenv($key);
+    if ($value !== false && $value !== '') {
+        return $value;
+    }
+
+    return $_ENV[$key] ?? $_SERVER[$key] ?? $default;
+}
+
+function migrationPdo(): PDO
+{
+    $host = migrationEnv('MYSQL_HOST', 'db');
+    $port = migrationEnv('MYSQL_PORT', '3306');
+    $dbname = migrationEnv('MYSQL_DATABASE', 'civil_service_mgmt');
+    $username = migrationEnv('MYSQL_USER', 'root');
+    $password = migrationEnv('MYSQL_PASSWORD', 'rootpassword');
+    $useSSL = migrationEnv('MYSQL_SSL', '');
+
+    $dsn = "mysql:host={$host};port={$port};dbname={$dbname};charset=utf8mb4";
+    $options = [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        PDO::ATTR_EMULATE_PREPARES => false,
+    ];
+
+    if ($useSSL === 'true' || $useSSL === '1') {
+        $caPath = migrationEnv('MYSQL_SSL_CA', '');
+        if ($caPath === '' || !is_readable($caPath)) {
+            throw new RuntimeException('MYSQL_SSL is enabled but MYSQL_SSL_CA is missing or unreadable');
+        }
+        $options[PDO::MYSQL_ATTR_SSL_CA] = $caPath;
+        $options[PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT] = true;
+    }
+
+    return new PDO($dsn, $username, $password, $options);
+}
+
+function migrationDirectory(): string
+{
+    $configured = migrationEnv('MIGRATIONS_DIR', '');
+    $candidates = array_filter([
+        $configured !== '' ? $configured : null,
+        '/var/www/database',
+        dirname(__DIR__, 2) . '/database',
+        dirname(__DIR__) . '/migrations',
+    ]);
+
+    foreach ($candidates as $dir) {
+        if (is_dir($dir)) {
+            return $dir;
+        }
+    }
+
+    throw new RuntimeException('No migrations directory found');
+}
+
+function ensureMigrationTable(PDO $pdo): void
+{
+    $pdo->exec(
+        'CREATE TABLE IF NOT EXISTS schema_migrations (
+            migration_name VARCHAR(255) NOT NULL PRIMARY KEY,
+            applied_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci'
+    );
+}
+
+/**
+ * @return list<string> absolute paths
+ */
+function listMigrationFiles(string $directory): array
+{
+    $files = glob(rtrim($directory, '/\\') . '/*.sql') ?: [];
+    $files = array_values(array_filter($files, static function (string $path): bool {
+        $name = basename($path);
+        return $name !== 'tidb-init.sql'
+            && preg_match('/^\d{2}-/', $name) === 1;
+    }));
+
+    usort($files, static fn (string $a, string $b): int => strnatcasecmp(basename($a), basename($b)));
+
+    return $files;
+}
+
+function tableExists(PDO $pdo, string $table): bool
+{
+    $stmt = $pdo->prepare(
+        'SELECT 1 FROM information_schema.tables
+         WHERE table_schema = DATABASE() AND table_name = ?
+         LIMIT 1'
+    );
+    $stmt->execute([$table]);
+    return (bool) $stmt->fetchColumn();
+}
+
+function databaseAlreadyProvisioned(PDO $pdo): bool
+{
+    // Existing local init / TiDB prod already have core tables before schema_migrations existed
+    return tableExists($pdo, 'personnel') || tableExists($pdo, 'users');
+}
+
+/**
+ * Mark historical migrations as applied without re-running non-idempotent SQL.
+ *
+ * @param list<string> $files
+ * @return list<string> baselined names
+ */
+function seedBaselineIfNeeded(PDO $pdo, array $files): array
+{
+    $count = (int) $pdo->query('SELECT COUNT(*) FROM schema_migrations')->fetchColumn();
+    if ($count > 0 || !databaseAlreadyProvisioned($pdo)) {
+        return [];
+    }
+
+    $insert = $pdo->prepare(
+        'INSERT IGNORE INTO schema_migrations (migration_name) VALUES (?)'
+    );
+    $seeded = [];
+    foreach ($files as $file) {
+        $name = basename($file);
+        if (strnatcasecmp($name, MIGRATION_BASELINE_THROUGH) > 0) {
+            continue;
+        }
+        $insert->execute([$name]);
+        $seeded[] = $name;
+    }
+
+    return $seeded;
+}
+
+function splitSqlStatements(string $sql): array
+{
+    $statements = [];
+    $buffer = '';
+    $inSingleQuote = false;
+    $inDoubleQuote = false;
+    $length = strlen($sql);
+
+    for ($i = 0; $i < $length; $i++) {
+        $char = $sql[$i];
+        $prev = $i > 0 ? $sql[$i - 1] : '';
+
+        if ($char === "'" && !$inDoubleQuote && $prev !== '\\') {
+            $inSingleQuote = !$inSingleQuote;
+        } elseif ($char === '"' && !$inSingleQuote && $prev !== '\\') {
+            $inDoubleQuote = !$inDoubleQuote;
+        }
+
+        if ($char === ';' && !$inSingleQuote && !$inDoubleQuote) {
+            $statement = trim($buffer);
+            if ($statement !== '') {
+                $statements[] = $statement;
+            }
+            $buffer = '';
+            continue;
+        }
+
+        $buffer .= $char;
+    }
+
+    $tail = trim($buffer);
+    if ($tail !== '') {
+        $statements[] = $tail;
+    }
+
+    return $statements;
+}
+
+function applyMigration(PDO $pdo, string $file): void
+{
+    $name = basename($file);
+    $sql = file_get_contents($file);
+    if ($sql === false) {
+        throw new RuntimeException("Cannot read migration file: {$file}");
+    }
+
+    // TiDB/MySQL auto-commit DDL — do not wrap the whole file in a transaction
+    foreach (splitSqlStatements($sql) as $statement) {
+        $pdo->exec($statement);
+    }
+
+    $insert = $pdo->prepare('INSERT INTO schema_migrations (migration_name) VALUES (?)');
+    $insert->execute([$name]);
+}
+
+function acquireMigrationLock(PDO $pdo): bool
+{
+    try {
+        $stmt = $pdo->query("SELECT GET_LOCK('smartport_migrate', 30)");
+        $got = $stmt ? $stmt->fetchColumn() : false;
+        return (string) $got === '1';
+    } catch (Throwable $e) {
+        fwrite(STDERR, '[migrate] GET_LOCK unavailable, continuing without lock: ' . $e->getMessage() . PHP_EOL);
+        return true;
+    }
+}
+
+function releaseMigrationLock(PDO $pdo): void
+{
+    try {
+        $pdo->query("SELECT RELEASE_LOCK('smartport_migrate')");
+    } catch (Throwable $e) {
+        // ignore
+    }
+}
+
+try {
+    $pdo = migrationPdo();
+    ensureMigrationTable($pdo);
+
+    if (!acquireMigrationLock($pdo)) {
+        throw new RuntimeException('Could not acquire migration lock (another instance is migrating)');
+    }
+
+    try {
+        $directory = migrationDirectory();
+        $files = listMigrationFiles($directory);
+
+        $seeded = seedBaselineIfNeeded($pdo, $files);
+        if ($seeded !== []) {
+            fwrite(STDOUT, 'Baselined ' . count($seeded) . ' historical migration(s) through ' . MIGRATION_BASELINE_THROUGH . ".\n");
+        }
+
+        $applied = $pdo->query('SELECT migration_name FROM schema_migrations')
+            ->fetchAll(PDO::FETCH_COLUMN);
+        $appliedMap = array_fill_keys($applied ?: [], true);
+
+        $pending = [];
+        foreach ($files as $file) {
+            $name = basename($file);
+            if (!isset($appliedMap[$name])) {
+                $pending[$name] = $file;
+            }
+        }
+
+        if ($pending === []) {
+            fwrite(STDOUT, "No pending migrations.\n");
+            exit(0);
+        }
+
+        ksort($pending, SORT_NATURAL);
+        foreach ($pending as $name => $file) {
+            fwrite(STDOUT, "Applying {$name}...\n");
+            applyMigration($pdo, $file);
+            fwrite(STDOUT, "Applied {$name}\n");
+        }
+
+        fwrite(STDOUT, count($pending) . " migration(s) applied.\n");
+        exit(0);
+    } finally {
+        releaseMigrationLock($pdo);
+    }
+} catch (Throwable $e) {
+    fwrite(STDERR, 'Migration runner failed: ' . $e->getMessage() . PHP_EOL);
+    exit(1);
+}

--- a/backend/tests/Integration/PasswordChangeTest.php
+++ b/backend/tests/Integration/PasswordChangeTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration;
+
+use PDO;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../routes/auth.php';
+
+final class PasswordChangeTest extends TestCase
+{
+    private static ?PDO $pdo = null;
+    private int $userId = 0;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$pdo = testPdo();
+    }
+
+    protected function setUp(): void
+    {
+        if (self::$pdo === null) {
+            self::markTestSkipped('ต่อ MySQL ไม่ได้ — รัน: docker compose up -d db แล้วใช้ tests/run.sh');
+        }
+
+        foreach (['users', 'audit_log'] as $table) {
+            if (!self::$pdo->query("SHOW TABLES LIKE '{$table}'")->fetchColumn()) {
+                self::markTestSkipped("ไม่พบตาราง {$table}");
+            }
+        }
+
+        $username = 'password-change-' . bin2hex(random_bytes(5));
+        self::$pdo->prepare(
+            'INSERT INTO users
+                (username, password_hash, full_name, role, is_active, must_change_password)
+             VALUES (?, ?, ?, ?, 1, 1)'
+        )->execute([
+            $username,
+            password_hash('temporary-password', PASSWORD_DEFAULT),
+            'Password Change Test',
+            'operator',
+        ]);
+        $this->userId = (int) self::$pdo->lastInsertId();
+    }
+
+    protected function tearDown(): void
+    {
+        if (self::$pdo === null || $this->userId === 0) {
+            return;
+        }
+        self::$pdo->prepare("DELETE FROM audit_log WHERE table_name = 'users' AND record_id = ?")
+            ->execute([$this->userId]);
+        self::$pdo->prepare('DELETE FROM users WHERE user_id = ?')->execute([$this->userId]);
+    }
+
+    #[Test]
+    public function required_user_can_change_password_and_clear_the_gate(): void
+    {
+        ob_start();
+        changePassword(self::$pdo, ['user_id' => $this->userId], [
+            'current_password' => 'temporary-password',
+            'new_password' => 'new-secure-password',
+        ]);
+        $response = json_decode((string) ob_get_clean(), true);
+
+        self::assertTrue($response['success'] ?? false);
+
+        $stmt = self::$pdo->prepare(
+            'SELECT password_hash, must_change_password FROM users WHERE user_id = ?'
+        );
+        $stmt->execute([$this->userId]);
+        $user = $stmt->fetch(PDO::FETCH_ASSOC);
+        self::assertSame(0, (int) $user['must_change_password']);
+        self::assertTrue(password_verify('new-secure-password', $user['password_hash']));
+        self::assertFalse(password_verify('temporary-password', $user['password_hash']));
+
+        $audit = self::$pdo->prepare(
+            "SELECT before_value, after_value
+             FROM audit_log
+             WHERE table_name = 'users' AND record_id = ? AND action = 'UPDATE'
+             ORDER BY audit_id DESC LIMIT 1"
+        );
+        $audit->execute([$this->userId]);
+        $row = $audit->fetch(PDO::FETCH_ASSOC);
+        self::assertNotFalse($row);
+        self::assertStringNotContainsString('temporary-password', (string) $row['before_value']);
+        self::assertStringNotContainsString('new-secure-password', (string) $row['after_value']);
+        self::assertSame(
+            ['must_change_password' => false],
+            json_decode($row['after_value'], true)
+        );
+    }
+
+    #[Test]
+    public function incorrect_current_password_does_not_change_account(): void
+    {
+        http_response_code(200);
+        ob_start();
+        changePassword(self::$pdo, ['user_id' => $this->userId], [
+            'current_password' => 'wrong-password',
+            'new_password' => 'new-secure-password',
+        ]);
+        $response = json_decode((string) ob_get_clean(), true);
+
+        self::assertSame(400, http_response_code());
+        self::assertSame('รหัสผ่านเดิมไม่ถูกต้อง', $response['error'] ?? null);
+
+        $stmt = self::$pdo->prepare('SELECT must_change_password FROM users WHERE user_id = ?');
+        $stmt->execute([$this->userId]);
+        self::assertSame(1, (int) $stmt->fetchColumn());
+    }
+}

--- a/backend/tests/Integration/ProductionReadinessAuditTest.php
+++ b/backend/tests/Integration/ProductionReadinessAuditTest.php
@@ -1,0 +1,275 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration;
+
+use PDO;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../routes/supportive.php';
+require_once __DIR__ . '/../../routes/diverse.php';
+require_once __DIR__ . '/../../routes/multiplier.php';
+require_once __DIR__ . '/../../routes/equivalence.php';
+
+final class ProductionReadinessAuditTest extends TestCase
+{
+    private static ?PDO $pdo = null;
+    private static int $seedUserId = 0;
+    private static int $seedPersonnelId = 0;
+
+    /** @var array<string, list<int>> */
+    private array $records = [];
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$pdo = testPdo();
+    }
+
+    protected function setUp(): void
+    {
+        if (self::$pdo === null) {
+            self::markTestSkipped('ต่อ MySQL ไม่ได้ — รัน: docker compose up -d db แล้วใช้ tests/run.sh');
+        }
+
+        foreach ([
+            'users',
+            'personnel',
+            'audit_log',
+            'supportive_experience',
+            'diverse_experience',
+            'multiplier_experience',
+            'special_area_multiplier',
+            'position_equivalence',
+        ] as $table) {
+            if (!self::$pdo->query("SHOW TABLES LIKE '{$table}'")->fetchColumn()) {
+                self::markTestSkipped("ไม่พบตาราง {$table} — รัน migration ที่เกี่ยวข้องก่อน");
+            }
+        }
+
+        $userId = self::$pdo->query('SELECT user_id FROM users LIMIT 1')->fetchColumn();
+        $personnelId = self::$pdo->query('SELECT personnel_id FROM personnel LIMIT 1')->fetchColumn();
+        if (!$userId || !$personnelId) {
+            self::markTestSkipped('ต้องมี seed user และ personnel อย่างน้อยอย่างละ 1 แถว');
+        }
+
+        self::$seedUserId = (int) $userId;
+        self::$seedPersonnelId = (int) $personnelId;
+    }
+
+    protected function tearDown(): void
+    {
+        if (self::$pdo === null) {
+            return;
+        }
+
+        $cleanupOrder = [
+            'supportive_experience',
+            'diverse_experience',
+            'multiplier_experience',
+            'position_equivalence',
+            'special_area_multiplier',
+        ];
+        foreach ($cleanupOrder as $table) {
+            $ids = $this->records[$table] ?? [];
+            $primaryKey = match ($table) {
+                'supportive_experience' => 'supportive_id',
+                'diverse_experience' => 'experience_id',
+                'multiplier_experience' => 'multiplier_id',
+                'special_area_multiplier' => 'area_multiplier_id',
+                'position_equivalence' => 'equivalence_id',
+            };
+            foreach ($ids as $id) {
+                self::$pdo->prepare('DELETE FROM audit_log WHERE table_name = ? AND record_id = ?')
+                    ->execute([$table, $id]);
+                self::$pdo->prepare("DELETE FROM {$table} WHERE {$primaryKey} = ?")->execute([$id]);
+            }
+        }
+    }
+
+    #[Test]
+    public function supportive_create_update_and_delete_write_complete_audit_snapshots(): void
+    {
+        $user = ['user_id' => self::$seedUserId];
+        $create = $this->capture(fn () => createSupportive(self::$pdo, $user, [
+            'personnel_id' => self::$seedPersonnelId,
+            'job_series_name' => 'ทดสอบ audit เกื้อกูล',
+            'start_date' => '2025-01-01',
+            'end_date' => '2025-01-10',
+            'description' => 'ก่อนแก้ไข',
+        ]));
+        $id = (int) $create['supportive_id'];
+        $this->track('supportive_experience', $id);
+
+        $createAudit = $this->audit('supportive_experience', $id, 'CREATE');
+        self::assertSame(self::$seedUserId, (int) $createAudit['user_id']);
+        self::assertNull($createAudit['before_value']);
+        self::assertSame('ก่อนแก้ไข', $this->json($createAudit['after_value'])['description']);
+
+        $this->capture(fn () => updateSupportive(
+            self::$pdo,
+            $id,
+            $user,
+            ['description' => 'หลังแก้ไข']
+        ));
+        $updateAudit = $this->audit('supportive_experience', $id, 'UPDATE');
+        self::assertSame('ก่อนแก้ไข', $this->json($updateAudit['before_value'])['description']);
+        self::assertSame('หลังแก้ไข', $this->json($updateAudit['after_value'])['description']);
+
+        $this->capture(fn () => deleteSupportive(self::$pdo, $id, $user));
+        $deleteAudit = $this->audit('supportive_experience', $id, 'DELETE');
+        self::assertSame('หลังแก้ไข', $this->json($deleteAudit['before_value'])['description']);
+        self::assertNull($deleteAudit['after_value']);
+    }
+
+    #[Test]
+    public function diverse_create_update_and_delete_write_complete_audit_snapshots(): void
+    {
+        $user = ['user_id' => self::$seedUserId];
+        $create = $this->capture(fn () => createDiverse(self::$pdo, $user, [
+            'personnel_id' => self::$seedPersonnelId,
+            'from_job_series' => 'สายงานเดิม',
+            'to_job_series' => 'สายงานใหม่',
+            'is_diff_job_series' => 1,
+        ]));
+        $id = (int) $create['experience_id'];
+        $this->track('diverse_experience', $id);
+
+        $createAudit = $this->audit('diverse_experience', $id, 'CREATE');
+        self::assertSame('สายงานเดิม', $this->json($createAudit['after_value'])['from_job_series']);
+
+        $this->capture(fn () => updateDiverse(
+            self::$pdo,
+            $id,
+            $user,
+            ['to_job_series' => 'สายงานใหม่หลังแก้ไข']
+        ));
+        $updateAudit = $this->audit('diverse_experience', $id, 'UPDATE');
+        self::assertSame('สายงานใหม่', $this->json($updateAudit['before_value'])['to_job_series']);
+        self::assertSame('สายงานใหม่หลังแก้ไข', $this->json($updateAudit['after_value'])['to_job_series']);
+
+        $this->capture(fn () => deleteDiverse(self::$pdo, $id, $user));
+        $deleteAudit = $this->audit('diverse_experience', $id, 'DELETE');
+        self::assertSame('สายงานใหม่หลังแก้ไข', $this->json($deleteAudit['before_value'])['to_job_series']);
+        self::assertNull($deleteAudit['after_value']);
+    }
+
+    #[Test]
+    public function multiplier_update_writes_before_and_after_audit_snapshots(): void
+    {
+        self::$pdo->prepare(
+            'INSERT INTO special_area_multiplier
+                (province, basis_type, multiplier_ratio, effective_start_date, effective_end_date, is_active)
+             VALUES (?, ?, 200, ?, ?, 1)'
+        )->execute(['ทดสอบ audit update', 'TEST', '2025-01-01', '2025-12-31']);
+        $areaId = (int) self::$pdo->lastInsertId();
+        $this->track('special_area_multiplier', $areaId);
+
+        self::$pdo->prepare(
+            'INSERT INTO multiplier_experience
+                (personnel_id, area_multiplier_id, province, basis_type, start_date, end_date,
+                 eligible_start_date, eligible_end_date, service_days, eligible_days,
+                 multiplier_ratio, effective_days, bonus_days, net_end_date,
+                 net_years, net_months, net_day_remainder, description, created_by)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, 10, 10, 200, 20, 10, ?, 0, 0, 20, ?, ?)'
+        )->execute([
+            self::$seedPersonnelId,
+            $areaId,
+            'ทดสอบ audit update',
+            'TEST',
+            '2025-02-01',
+            '2025-02-10',
+            '2025-02-01',
+            '2025-02-10',
+            '2025-02-20',
+            'ก่อนแก้ไข',
+            self::$seedUserId,
+        ]);
+        $id = (int) self::$pdo->lastInsertId();
+        $this->track('multiplier_experience', $id);
+
+        $this->capture(fn () => updateMultiplier(
+            self::$pdo,
+            $id,
+            ['user_id' => self::$seedUserId],
+            ['description' => 'หลังแก้ไข']
+        ));
+
+        $audit = $this->audit('multiplier_experience', $id, 'UPDATE');
+        self::assertSame('ก่อนแก้ไข', $this->json($audit['before_value'])['description']);
+        self::assertSame('หลังแก้ไข', $this->json($audit['after_value'])['description']);
+    }
+
+    #[Test]
+    public function equivalence_create_and_regular_update_write_audit_snapshots(): void
+    {
+        $user = ['user_id' => self::$seedUserId];
+        $create = $this->capture(fn () => createEquivalence(self::$pdo, $user, [
+            'personnel_id' => self::$seedPersonnelId,
+            'actual_position' => 'ตำแหน่งเดิม',
+            'equivalent_type' => 'อำนวยการ',
+        ]));
+        $id = (int) $create['equivalence_id'];
+        $this->track('position_equivalence', $id);
+
+        $createAudit = $this->audit('position_equivalence', $id, 'CREATE');
+        self::assertSame('PENDING', $this->json($createAudit['after_value'])['approval_status']);
+
+        $this->capture(fn () => updateEquivalence(
+            self::$pdo,
+            $id,
+            $user,
+            ['actual_position' => 'ตำแหน่งหลังแก้ไข']
+        ));
+        $updateAudit = $this->audit('position_equivalence', $id, 'UPDATE');
+        self::assertSame('ตำแหน่งเดิม', $this->json($updateAudit['before_value'])['actual_position']);
+        self::assertSame('ตำแหน่งหลังแก้ไข', $this->json($updateAudit['after_value'])['actual_position']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function capture(callable $operation): array
+    {
+        http_response_code(200);
+        ob_start();
+        $operation();
+        $response = json_decode((string) ob_get_clean(), true);
+        self::assertIsArray($response);
+        self::assertTrue($response['success'] ?? false, json_encode($response, JSON_UNESCAPED_UNICODE));
+        return $response;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function audit(string $table, int $recordId, string $action): array
+    {
+        $stmt = self::$pdo->prepare(
+            'SELECT * FROM audit_log
+             WHERE table_name = ? AND record_id = ? AND action = ?
+             ORDER BY audit_id DESC LIMIT 1'
+        );
+        $stmt->execute([$table, $recordId, $action]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        self::assertNotFalse($row, "ไม่พบ audit {$action} สำหรับ {$table}:{$recordId}");
+        return $row;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function json(?string $value): array
+    {
+        self::assertNotNull($value);
+        $decoded = json_decode($value, true);
+        self::assertIsArray($decoded);
+        return $decoded;
+    }
+
+    private function track(string $table, int $id): void
+    {
+        $this->records[$table][] = $id;
+    }
+}

--- a/backend/tests/Integration/RateLimitDatabaseTest.php
+++ b/backend/tests/Integration/RateLimitDatabaseTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration;
+
+use PDO;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../middleware/rate_limit.php';
+
+final class RateLimitDatabaseTest extends TestCase
+{
+    private static ?PDO $pdo = null;
+    private const TEST_USER_ID = 999999002;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$pdo = testPdo();
+        if (!getenv('JWT_SECRET')) {
+            putenv('JWT_SECRET=test-jwt-secret-for-integration');
+            $_ENV['JWT_SECRET'] = 'test-jwt-secret-for-integration';
+        }
+    }
+
+    protected function setUp(): void
+    {
+        if (self::$pdo === null) {
+            self::markTestSkipped('ต่อ MySQL ไม่ได้ — รัน: docker compose up -d db');
+        }
+
+        if (!self::$pdo->query("SHOW TABLES LIKE 'api_rate_limit_hits'")->fetchColumn()) {
+            self::markTestSkipped('ไม่พบตาราง api_rate_limit_hits — รัน migration 15 ก่อน');
+        }
+
+        self::$pdo->prepare('DELETE FROM api_rate_limit_hits WHERE rate_key LIKE ?')
+            ->execute(['user_' . self::TEST_USER_ID . '_%']);
+        $GLOBALS['_rate_limit_db_ready'] = true;
+    }
+
+    protected function tearDown(): void
+    {
+        if (self::$pdo === null) {
+            return;
+        }
+        self::$pdo->prepare('DELETE FROM api_rate_limit_hits WHERE rate_key LIKE ?')
+            ->execute(['user_' . self::TEST_USER_ID . '_%']);
+    }
+
+    #[Test]
+    public function database_backend_records_hits_and_purges_old_entries(): void
+    {
+        if (!function_exists('getDB')) {
+            require_once __DIR__ . '/../../config.php';
+        }
+
+        checkRateLimitDatabase(self::TEST_USER_ID, 'GET_DB_TEST', 5, 60);
+        checkRateLimitDatabase(self::TEST_USER_ID, 'GET_DB_TEST', 5, 60);
+
+        $stmt = self::$pdo->prepare(
+            'SELECT COUNT(*) FROM api_rate_limit_hits WHERE rate_key = ?'
+        );
+        $stmt->execute(['user_' . self::TEST_USER_ID . '_GET_DB_TEST']);
+        self::assertSame(2, (int) $stmt->fetchColumn());
+
+        self::$pdo->prepare(
+            'UPDATE api_rate_limit_hits SET hit_at = ? WHERE rate_key = ?'
+        )->execute([time() - 7200, 'user_' . self::TEST_USER_ID . '_GET_DB_TEST']);
+
+        checkRateLimitDatabase(self::TEST_USER_ID, 'GET_DB_TEST', 5, 60);
+        $stmt->execute(['user_' . self::TEST_USER_ID . '_GET_DB_TEST']);
+        self::assertSame(1, (int) $stmt->fetchColumn());
+    }
+}

--- a/backend/tests/Unit/AuditPermissionTest.php
+++ b/backend/tests/Unit/AuditPermissionTest.php
@@ -31,6 +31,9 @@ final class AuditPermissionTest extends TestCase
     {
         return [
             'read multiplier'  => ['read', 'multiplier'],
+            'create supportive' => ['create', 'supportive'],
+            'update diverse'    => ['update', 'diverse'],
+            'delete supportive' => ['delete', 'supportive'],
             'create audit'     => ['create', 'audit'],
             'update users'     => ['update', 'users'],
             'delete anything'  => ['delete', 'ไม่มี resource นี้จริง'],
@@ -51,6 +54,8 @@ final class AuditPermissionTest extends TestCase
     {
         return [
             'multiplier' => ['multiplier'],
+            'supportive' => ['supportive'],
+            'diverse'    => ['diverse'],
             'audit'      => ['audit'],
             'users'      => ['users'],
         ];
@@ -75,6 +80,8 @@ final class AuditPermissionTest extends TestCase
             'candidates (allowed)'   => ['candidates', true],
             'probation (allowed)'    => ['probation', true],
             'equivalence (allowed)'  => ['equivalence', true],
+            'supportive (allowed)'   => ['supportive', true],
+            'diverse (allowed)'      => ['diverse', true],
             'audit (denied)'         => ['audit', false],
             'users (denied)'         => ['users', false],
         ];
@@ -100,6 +107,8 @@ final class AuditPermissionTest extends TestCase
     {
         self::assertFalse(checkPermission('operator', 'delete', 'multiplier'));
         self::assertFalse(checkPermission('operator', 'delete', 'personnel'));
+        self::assertFalse(checkPermission('operator', 'delete', 'supportive'));
+        self::assertFalse(checkPermission('operator', 'delete', 'diverse'));
     }
 
     #[Test]
@@ -117,6 +126,8 @@ final class AuditPermissionTest extends TestCase
         return [
             'multiplier (allowed)' => ['multiplier', true],
             'dashboard (allowed)'  => ['dashboard', true],
+            'supportive (denied)'  => ['supportive', false],
+            'diverse (denied)'     => ['diverse', false],
             'audit (denied)'       => ['audit', false],
             'users (denied)'       => ['users', false],
         ];
@@ -128,6 +139,9 @@ final class AuditPermissionTest extends TestCase
         self::assertFalse(checkPermission('viewer', 'create', 'multiplier'));
         self::assertFalse(checkPermission('viewer', 'update', 'multiplier'));
         self::assertFalse(checkPermission('viewer', 'delete', 'multiplier'));
+        self::assertFalse(checkPermission('viewer', 'create', 'supportive'));
+        self::assertFalse(checkPermission('viewer', 'update', 'diverse'));
+        self::assertFalse(checkPermission('viewer', 'delete', 'supportive'));
     }
 
     #[Test]

--- a/backend/tests/Unit/MigrationBaselineTest.php
+++ b/backend/tests/Unit/MigrationBaselineTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Guards the production baseline cut-off used by scripts/run-migrations.php.
+ * Existing TiDB DBs already have migrations through 14; only 15+ should execute.
+ */
+final class MigrationBaselineTest extends TestCase
+{
+    private const BASELINE_THROUGH = '14-multiplier-area-admin.sql';
+
+    #[Test]
+    public function baseline_cut_off_matches_runner_constant(): void
+    {
+        $script = file_get_contents(dirname(__DIR__, 2) . '/scripts/run-migrations.php');
+        self::assertNotFalse($script);
+        self::assertStringContainsString(
+            "const MIGRATION_BASELINE_THROUGH = '" . self::BASELINE_THROUGH . "'",
+            $script
+        );
+    }
+
+    #[Test]
+    public function net_new_rate_limit_migration_is_after_baseline(): void
+    {
+        self::assertGreaterThan(
+            0,
+            strnatcasecmp('15-api-rate-limit-hits.sql', self::BASELINE_THROUGH)
+        );
+    }
+
+    #[Test]
+    public function historical_migrations_are_at_or_before_baseline(): void
+    {
+        $historical = [
+            '03-personnel-stubs.sql',
+            '09-auth-users.sql',
+            '13-multiplier-time-counting.sql',
+            '14-multiplier-area-admin.sql',
+        ];
+
+        foreach ($historical as $name) {
+            self::assertLessThanOrEqual(
+                0,
+                strnatcasecmp($name, self::BASELINE_THROUGH),
+                "{$name} should be covered by baseline"
+            );
+        }
+    }
+}

--- a/backend/tests/Unit/RateLimitTest.php
+++ b/backend/tests/Unit/RateLimitTest.php
@@ -34,8 +34,15 @@ final class RateLimitTest extends TestCase
         return $data['hits'] ?? [];
     }
 
+    protected function setUp(): void
+    {
+        $GLOBALS['_rate_limit_db_ready'] = false;
+    }
+
     protected function tearDown(): void
     {
+        $GLOBALS['_rate_limit_db_ready'] = null;
+
         foreach (['GET_COUNT', 'GET_WINDOW', 'GET_CONCURRENT'] as $method) {
             $file = $this->fileFor($method);
             if (file_exists($file)) {
@@ -65,13 +72,11 @@ final class RateLimitTest extends TestCase
     #[Test]
     public function it_purges_hits_older_than_the_window(): void
     {
-        // seed ไฟล์เองด้วย timestamp เก่าเกิน window (2 ชม.ที่แล้ว) + timestamp ใหม่ 1 อัน
         $file = $this->fileFor('GET_WINDOW');
         file_put_contents($file, json_encode([
             'hits' => [time() - 7200, time() - 7100],
         ]));
 
-        // window 60 วิ — ของเก่าต้องถูกกรองทิ้งหมด เหลือแค่ hit ใหม่ที่เพิ่งเพิ่ม
         checkRateLimit(self::TEST_USER_ID, 'GET_WINDOW', 5, 60);
 
         self::assertCount(1, $this->readHits('GET_WINDOW'));
@@ -87,7 +92,6 @@ final class RateLimitTest extends TestCase
 
         checkRateLimit(self::TEST_USER_ID, 'GET_WINDOW', 5, 60);
 
-        // 2 hit เดิม (ยังอยู่ใน window) + 1 hit ใหม่ที่เพิ่งบันทึก = 3
         self::assertCount(3, $this->readHits('GET_WINDOW'));
     }
 
@@ -97,7 +101,6 @@ final class RateLimitTest extends TestCase
         checkRateLimit(self::TEST_USER_ID, 'GET_CONCURRENT', 5, 60);
         checkRateLimit(self::TEST_USER_ID, 'GET_CONCURRENT', 5, 60);
 
-        // method คนละตัว (ไม่ใช่ GET_CONCURRENT) ต้องเริ่มนับจากศูนย์ ไม่ปนกัน
         self::assertCount(2, $this->readHits('GET_CONCURRENT'));
         self::assertCount(0, $this->readHits('GET_COUNT'));
     }

--- a/database/15-api-rate-limit-hits.sql
+++ b/database/15-api-rate-limit-hits.sql
@@ -1,0 +1,13 @@
+-- ============================================================================
+-- 15-api-rate-limit-hits.sql
+-- Persistent API rate-limit counters (Render/TiDB — filesystem ไม่ persist)
+-- ============================================================================
+
+SET NAMES utf8mb4;
+
+CREATE TABLE IF NOT EXISTS api_rate_limit_hits (
+    hit_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    rate_key VARCHAR(128) NOT NULL,
+    hit_at INT UNSIGNED NOT NULL,
+    INDEX idx_rate_key_hit_at (rate_key, hit_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,8 +3,8 @@ services:
   # Service สำหรับ Backend (PHP API)
   backend:
     build:
-      context: ./backend
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: backend/Dockerfile
     container_name: smartport-backend
     ports:
       - "8000:80"
@@ -65,7 +65,8 @@ services:
       - ./database/12-import-log-fk.sql:/docker-entrypoint-initdb.d/12-import-log-fk.sql
       - ./database/13-multiplier-time-counting.sql:/docker-entrypoint-initdb.d/13-multiplier-time-counting.sql
       - ./database/14-multiplier-area-admin.sql:/docker-entrypoint-initdb.d/14-multiplier-area-admin.sql
-      - ./backend/migrations/03-audit-log.sql:/docker-entrypoint-initdb.d/15-audit-log.sql
+      - ./database/15-api-rate-limit-hits.sql:/docker-entrypoint-initdb.d/15-api-rate-limit-hits.sql
+      - ./backend/migrations/03-audit-log.sql:/docker-entrypoint-initdb.d/16-audit-log.sql
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "--silent"]
       interval: 10s

--- a/docs/render-tidb-production.md
+++ b/docs/render-tidb-production.md
@@ -78,6 +78,20 @@ Operational note:
 
 - Files like `database/reimport-data.sql` are generated repair/import artifacts for a specific environment and should not be committed as normal source files.
 
+## 4.1 Automated migrations on deploy
+
+The backend Docker image copies `database/` and runs pending SQL migrations on container start via `backend/scripts/run-migrations.php` (tracked in `schema_migrations`).
+
+- Local check: `docker compose exec backend php scripts/run-migrations.php`
+- Disable at runtime: set `RUN_MIGRATIONS=0` on the backend service
+- Override migration directory: set `MIGRATIONS_DIR=/var/www/database`
+
+**Existing TiDB / already-initialized DBs:** if `schema_migrations` is empty but `personnel` or `users` already exists, the runner **baselines** migrations through `14-multiplier-area-admin.sql` (marks them applied, does not re-run non-idempotent `ALTER`s). Only newer files such as `15-api-rate-limit-hits.sql` are executed.
+
+**Fresh empty database:** no baseline — every numbered `NN-*.sql` under `database/` is applied in order.
+
+New incremental SQL files must use the `NN-description.sql` naming pattern under `database/` and should prefer idempotent DDL (`CREATE TABLE IF NOT EXISTS`, etc.) when possible.
+
 ## 5. Manual Render dashboard checklist
 
 If you are updating the existing services instead of recreating them from the Blueprint:

--- a/frontend/src/__tests__/composables/useApi.test.js
+++ b/frontend/src/__tests__/composables/useApi.test.js
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockAuth = {
+  token: 'jwt-token',
+  csrfToken: 'csrf-token',
+  logout: vi.fn(),
+  setMustChangePassword: vi.fn(),
+}
+const mockPush = vi.fn()
+
+vi.mock('@/stores/auth.js', () => ({
+  useAuthStore: () => mockAuth,
+}))
+
+vi.mock('@/router', () => ({
+  default: { push: mockPush },
+}))
+
+const { useApi } = await import('@/composables/useApi.js')
+
+describe('useApi uploads', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    mockAuth.logout.mockReset()
+    mockAuth.setMustChangePassword.mockReset()
+    mockPush.mockReset()
+  })
+
+  it('adds authentication and CSRF headers without overriding multipart content type', async () => {
+    const response = new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(response)
+    const form = new FormData()
+    form.append('file', new File(['xlsx'], 'people.xlsx'))
+
+    const result = await useApi().uploadResponse('/import/executive', form)
+
+    expect(result).toBe(response)
+    expect(fetchMock).toHaveBeenCalledOnce()
+    const [, options] = fetchMock.mock.calls[0]
+    expect(options.method).toBe('POST')
+    expect(options.body).toBe(form)
+    expect(options.headers.Authorization).toBe('Bearer jwt-token')
+    expect(options.headers['X-CSRF-Token']).toBe('csrf-token')
+    expect(options.headers).not.toHaveProperty('Content-Type')
+  })
+
+  it('redirects when the backend requires a password change', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({
+      error: 'Password change required',
+      code: 'PASSWORD_CHANGE_REQUIRED',
+    }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    }))
+
+    await expect(useApi().get('/dashboard')).rejects.toThrow('Password change required')
+
+    expect(mockAuth.setMustChangePassword).toHaveBeenCalledWith(true)
+    expect(mockPush).toHaveBeenCalledWith('/change-password')
+  })
+})

--- a/frontend/src/__tests__/pages/ChangePasswordPage.test.js
+++ b/frontend/src/__tests__/pages/ChangePasswordPage.test.js
@@ -1,0 +1,50 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const changePassword = vi.fn()
+const logout = vi.fn()
+const push = vi.fn()
+
+vi.mock('@/stores/auth.js', () => ({
+  useAuthStore: () => ({ changePassword, logout }),
+}))
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push }),
+}))
+
+const ChangePasswordPage = (await import('@/pages/ChangePasswordPage.vue')).default
+
+describe('ChangePasswordPage', () => {
+  beforeEach(() => {
+    changePassword.mockReset()
+    logout.mockReset()
+    push.mockReset()
+  })
+
+  it('rejects mismatched confirmation before calling the API', async () => {
+    const wrapper = mount(ChangePasswordPage)
+    await wrapper.get('#current-password').setValue('temporary-password')
+    await wrapper.get('#new-password').setValue('new-secure-password')
+    await wrapper.get('#confirm-password').setValue('different-password')
+
+    await wrapper.get('form').trigger('submit')
+
+    expect(changePassword).not.toHaveBeenCalled()
+    expect(wrapper.get('[role="alert"]').text()).toContain('ไม่ตรงกัน')
+  })
+
+  it('changes the password and continues to the dashboard', async () => {
+    changePassword.mockResolvedValue({ success: true })
+    const wrapper = mount(ChangePasswordPage)
+    await wrapper.get('#current-password').setValue('temporary-password')
+    await wrapper.get('#new-password').setValue('new-secure-password')
+    await wrapper.get('#confirm-password').setValue('new-secure-password')
+
+    await wrapper.get('form').trigger('submit')
+    await flushPromises()
+
+    expect(changePassword).toHaveBeenCalledWith('temporary-password', 'new-secure-password')
+    expect(push).toHaveBeenCalledWith('/dashboard')
+  })
+})

--- a/frontend/src/__tests__/pages/DashboardPage.test.js
+++ b/frontend/src/__tests__/pages/DashboardPage.test.js
@@ -1,0 +1,34 @@
+import { mount, RouterLinkStub } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockGet = vi.fn()
+
+vi.mock('@/composables/useApi.js', () => ({
+  useApi: () => ({ get: mockGet }),
+}))
+
+const DashboardPage = (await import('@/pages/DashboardPage.vue')).default
+
+describe('DashboardPage quick actions', () => {
+  beforeEach(() => {
+    mockGet.mockReset()
+    mockGet.mockResolvedValue({})
+  })
+
+  it('links supportive time counting to the registered route', () => {
+    const wrapper = mount(DashboardPage, {
+      global: {
+        stubs: {
+          RouterLink: RouterLinkStub,
+        },
+      },
+    })
+
+    const supportiveLink = wrapper
+      .findAllComponents(RouterLinkStub)
+      .find((link) => link.text().includes('การนับเวลาเกื้อกูล'))
+
+    expect(supportiveLink).toBeDefined()
+    expect(supportiveLink.props('to')).toBe('/time-counting')
+  })
+})

--- a/frontend/src/__tests__/router/guards.test.js
+++ b/frontend/src/__tests__/router/guards.test.js
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockAuth = {
+  isAuthenticated: false,
+  mustChangePassword: false,
+  user: null,
+}
+
+vi.mock('@/stores/auth.js', () => ({
+  useAuthStore: () => mockAuth,
+}))
+
+vi.mock('@/composables/useNavProgress.js', () => ({
+  useNavProgress: () => ({ isNavigating: { value: false } }),
+}))
+
+vi.mock('@/utils/chunkGuard.js', () => ({
+  isChunkLoadError: () => false,
+  shouldReloadForChunkError: () => false,
+}))
+
+const router = (await import('@/router/index.js')).default
+
+describe('router auth guards', () => {
+  beforeEach(() => {
+    mockAuth.isAuthenticated = false
+    mockAuth.mustChangePassword = false
+    mockAuth.user = null
+  })
+
+  it('redirects unauthenticated users away from protected routes', async () => {
+    await router.push('/dashboard')
+    expect(router.currentRoute.value.path).toBe('/login')
+  })
+
+  it('forces password change before accessing the app shell', async () => {
+    mockAuth.isAuthenticated = true
+    mockAuth.mustChangePassword = true
+    mockAuth.user = { role: 'operator', must_change_password: true }
+
+    await router.push('/dashboard')
+    expect(router.currentRoute.value.path).toBe('/change-password')
+  })
+
+  it('allows authenticated users to reach change-password when required', async () => {
+    mockAuth.isAuthenticated = true
+    mockAuth.mustChangePassword = true
+    mockAuth.user = { role: 'operator', must_change_password: true }
+
+    await router.push('/change-password')
+    expect(router.currentRoute.value.path).toBe('/change-password')
+  })
+
+  it('redirects non-admin users away from admin-only routes', async () => {
+    mockAuth.isAuthenticated = true
+    mockAuth.mustChangePassword = false
+    mockAuth.user = { role: 'operator', must_change_password: false }
+
+    await router.push('/import')
+    expect(router.currentRoute.value.path).toBe('/dashboard')
+  })
+
+  it('allows admin users to reach admin-only routes', async () => {
+    mockAuth.isAuthenticated = true
+    mockAuth.mustChangePassword = false
+    mockAuth.user = { role: 'admin', must_change_password: false }
+
+    await router.push('/import')
+    expect(router.currentRoute.value.path).toBe('/import')
+  })
+})
+
+describe('router candidate paths', () => {
+  beforeEach(() => {
+    mockAuth.isAuthenticated = true
+    mockAuth.mustChangePassword = false
+    mockAuth.user = { role: 'operator', must_change_password: false }
+  })
+
+  it('resolves candidate overview route', async () => {
+    await router.push('/candidates/overview')
+    expect(router.currentRoute.value.name).toBe('candidates')
+    expect(router.currentRoute.value.params.section).toBe('overview')
+  })
+
+  it('does not expose legacy /supportive quick-action path', async () => {
+    await router.push('/supportive')
+    expect(router.currentRoute.value.path).toBe('/dashboard')
+  })
+})

--- a/frontend/src/composables/useApi.js
+++ b/frontend/src/composables/useApi.js
@@ -1,6 +1,6 @@
 const API_BASE = import.meta.env.VITE_API_URL || '/api'
 
-async function request(url, options = {}) {
+async function authenticatedFetch(url, options = {}) {
   const { useAuthStore } = await import('@/stores/auth.js')
   const auth = useAuthStore()
 
@@ -35,6 +35,21 @@ async function request(url, options = {}) {
     throw new Error('Unauthorized')
   }
 
+  if (response.status === 403) {
+    const body = await response.clone().json().catch(() => null)
+    if (body?.code === 'PASSWORD_CHANGE_REQUIRED') {
+      auth.setMustChangePassword(true)
+      const router = (await import('@/router')).default
+      router.push('/change-password')
+    }
+  }
+
+  return response
+}
+
+async function request(url, options = {}) {
+  const response = await authenticatedFetch(url, options)
+
   if (!response.ok) {
     const error = await response.json().catch(() => ({ error: response.statusText }))
     throw new Error(error.error || response.statusText)
@@ -50,5 +65,6 @@ export function useApi() {
     put: (url, data) => request(url, { method: 'PUT', body: JSON.stringify(data) }),
     del: (url) => request(url, { method: 'DELETE' }),
     upload: (url, formData) => request(url, { method: 'POST', body: formData }),
+    uploadResponse: (url, formData) => authenticatedFetch(url, { method: 'POST', body: formData }),
   }
 }

--- a/frontend/src/pages/ChangePasswordPage.vue
+++ b/frontend/src/pages/ChangePasswordPage.vue
@@ -1,0 +1,110 @@
+<template>
+  <main class="min-h-screen flex items-center justify-center bg-slate-100 p-4">
+    <section class="w-full max-w-md rounded-2xl bg-white p-6 shadow-lg" aria-labelledby="change-password-title">
+      <h1 id="change-password-title" class="text-2xl font-bold text-gray-900">เปลี่ยนรหัสผ่าน</h1>
+      <p class="mt-2 text-sm text-gray-600">
+        เพื่อความปลอดภัย กรุณาเปลี่ยนรหัสผ่านชั่วคราวก่อนใช้งานระบบ
+      </p>
+
+      <div
+        v-if="errorMessage"
+        role="alert"
+        class="mt-4 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700"
+      >
+        {{ errorMessage }}
+      </div>
+
+      <form class="mt-6 space-y-4" @submit.prevent="submit">
+        <div>
+          <label for="current-password" class="block text-sm font-medium text-gray-700">รหัสผ่านปัจจุบัน</label>
+          <input
+            id="current-password"
+            v-model="currentPassword"
+            type="password"
+            autocomplete="current-password"
+            required
+            class="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+          />
+        </div>
+
+        <div>
+          <label for="new-password" class="block text-sm font-medium text-gray-700">รหัสผ่านใหม่</label>
+          <input
+            id="new-password"
+            v-model="newPassword"
+            type="password"
+            autocomplete="new-password"
+            minlength="8"
+            required
+            aria-describedby="password-help"
+            class="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+          />
+          <p id="password-help" class="mt-1 text-xs text-gray-500">อย่างน้อย 8 ตัวอักษร และต้องไม่ซ้ำกับรหัสผ่านเดิม</p>
+        </div>
+
+        <div>
+          <label for="confirm-password" class="block text-sm font-medium text-gray-700">ยืนยันรหัสผ่านใหม่</label>
+          <input
+            id="confirm-password"
+            v-model="confirmPassword"
+            type="password"
+            autocomplete="new-password"
+            minlength="8"
+            required
+            class="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+          />
+        </div>
+
+        <button
+          type="submit"
+          :disabled="submitting"
+          class="w-full rounded-lg bg-blue-600 px-4 py-2.5 font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {{ submitting ? 'กำลังบันทึก…' : 'บันทึกรหัสผ่านใหม่' }}
+        </button>
+      </form>
+
+      <button type="button" class="mt-4 w-full text-sm text-gray-500 hover:text-gray-700" @click="logout">
+        ออกจากระบบ
+      </button>
+    </section>
+  </main>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { useAuthStore } from '@/stores/auth.js'
+
+const auth = useAuthStore()
+const router = useRouter()
+
+const currentPassword = ref('')
+const newPassword = ref('')
+const confirmPassword = ref('')
+const submitting = ref(false)
+const errorMessage = ref('')
+
+async function submit() {
+  errorMessage.value = ''
+  if (newPassword.value !== confirmPassword.value) {
+    errorMessage.value = 'รหัสผ่านใหม่และการยืนยันไม่ตรงกัน'
+    return
+  }
+
+  submitting.value = true
+  try {
+    await auth.changePassword(currentPassword.value, newPassword.value)
+    await router.push('/dashboard')
+  } catch (error) {
+    errorMessage.value = error?.message || 'ไม่สามารถเปลี่ยนรหัสผ่านได้'
+  } finally {
+    submitting.value = false
+  }
+}
+
+function logout() {
+  auth.logout()
+  router.push('/login')
+}
+</script>

--- a/frontend/src/pages/DashboardPage.vue
+++ b/frontend/src/pages/DashboardPage.vue
@@ -213,7 +213,7 @@ const priorityTasks = ref([])
 const quickActions = [
   { title: 'พ้นทดลองปฏิบัติราชการ', icon: UserCheck, color: 'bg-blue-500', route: '/probation-end' },
   { title: 'เลื่อนระดับตำแหน่ง', icon: TrendingUp, color: 'bg-green-500', route: '/candidates/general' },
-  { title: 'การนับเวลาเกื้อกูล', icon: Clock, color: 'bg-purple-500', route: '/supportive' },
+  { title: 'การนับเวลาเกื้อกูล', icon: Clock, color: 'bg-purple-500', route: '/time-counting' },
 ]
 
 function formatNumber(value) {

--- a/frontend/src/pages/ImportPage.vue
+++ b/frontend/src/pages/ImportPage.vue
@@ -145,19 +145,17 @@
 
 <script setup>
 import { ref, computed, nextTick } from 'vue'
-import { RouterLink, useRouter } from 'vue-router'
-import { useAuthStore } from '@/stores/auth.js'
+import { RouterLink } from 'vue-router'
+import { useApi } from '@/composables/useApi.js'
 import {
   Download, Upload, FileSpreadsheet, Loader2, CheckCircle2, AlertCircle, ArrowRight,
 } from 'lucide-vue-next'
 
 const MAX_BYTES = 5 * 1024 * 1024
-const API_BASE = import.meta.env.VITE_API_URL || '/api'
 // cache-bust เทมเพลตเมื่อ deploy ใหม่ (อัปเดต query เมื่อแก้คอลัมน์)
 const templateUrl = '/import-template.xlsx?v=2026-06-19'
 
-const router = useRouter()
-const auth = useAuthStore()
+const api = useApi()
 
 const inputEl = ref(null)
 const resultEl = ref(null)
@@ -219,21 +217,13 @@ async function submit() {
   const form = new FormData()
   form.append('file', file.value)
 
-  const headers = {}
-  if (auth.token) headers.Authorization = `Bearer ${auth.token}`
-
   let res
   try {
-    res = await fetch(`${API_BASE}/import/executive`, { method: 'POST', body: form, headers })
-  } catch {
+    res = await api.uploadResponse('/import/executive', form)
+  } catch (error) {
+    if (error?.message === 'Unauthorized') return
     // network error / timeout — fetch ไม่ throw จาก HTTP status แต่ throw จาก network
     showError(['เชื่อมต่อเซิร์ฟเวอร์ไม่ได้ กรุณาลองใหม่'])
-    return
-  }
-
-  if (res.status === 401) {
-    auth.logout()
-    router.push('/login')
     return
   }
 

--- a/frontend/src/pages/LoginPage.vue
+++ b/frontend/src/pages/LoginPage.vue
@@ -112,7 +112,7 @@ async function handleLogin() {
   loading.value = true
   try {
     await auth.login({ username: form.username, password: form.password })
-    router.push('/dashboard')
+    router.push(auth.mustChangePassword ? '/change-password' : '/dashboard')
   } catch (e) {
     errorMsg.value = e.message || 'เข้าสู่ระบบไม่สำเร็จ กรุณาลองใหม่'
   } finally {

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -10,6 +10,12 @@ const routes = [
     meta: { requiresAuth: false },
   },
   {
+    path: '/change-password',
+    name: 'change-password',
+    component: () => import('@/pages/ChangePasswordPage.vue'),
+    meta: { requiresAuth: true },
+  },
+  {
     path: '/',
     component: () => import('@/layouts/AppLayout.vue'),
     meta: { requiresAuth: true },
@@ -137,6 +143,14 @@ router.beforeEach(async (to) => {
 
   if (to.meta.requiresAuth !== false && !auth.isAuthenticated) {
     return '/login'
+  }
+
+  if (auth.isAuthenticated && auth.mustChangePassword && to.path !== '/change-password') {
+    return '/change-password'
+  }
+
+  if (to.path === '/change-password' && auth.isAuthenticated && !auth.mustChangePassword) {
+    return '/dashboard'
   }
 
   if (to.path === '/login' && auth.isAuthenticated) {

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -35,6 +35,7 @@ export const useAuthStore = defineStore('auth', () => {
 
   const isAuthenticated = computed(() => !!token.value && isTokenValid())
   const isAdmin = computed(() => user.value?.role === 'admin')
+  const mustChangePassword = computed(() => Boolean(user.value?.must_change_password))
 
   function isTokenValid() {
     if (!token.value) return false
@@ -73,6 +74,23 @@ export const useAuthStore = defineStore('auth', () => {
     return data
   }
 
+  function setMustChangePassword(required) {
+    if (!user.value) return
+    user.value = { ...user.value, must_change_password: Boolean(required) }
+    localStorage.setItem('user', JSON.stringify(user.value))
+  }
+
+  async function changePassword(currentPassword, newPassword) {
+    const { useApi } = await import('@/composables/useApi.js')
+    const api = useApi()
+    const data = await api.post('/auth/change-password', {
+      current_password: currentPassword,
+      new_password: newPassword,
+    })
+    setMustChangePassword(false)
+    return data
+  }
+
   function logout() {
     token.value = ''
     refreshToken.value = ''
@@ -86,5 +104,18 @@ export const useAuthStore = defineStore('auth', () => {
     localStorage.removeItem('user')
   }
 
-  return { token, csrfToken, user, isAuthenticated, isAdmin, isTokenValid, setAuth, login, logout }
+  return {
+    token,
+    csrfToken,
+    user,
+    isAuthenticated,
+    isAdmin,
+    mustChangePassword,
+    isTokenValid,
+    setAuth,
+    setMustChangePassword,
+    login,
+    changePassword,
+    logout,
+  }
 })

--- a/render.yaml
+++ b/render.yaml
@@ -27,7 +27,7 @@ services:
     branch: main
     rootDir: backend
     dockerfilePath: Dockerfile
-    dockerContext: .
+    dockerContext: ..
     healthCheckPath: /
     buildFilter:
       paths:


### PR DESCRIPTION
## Summary
- Enforce CSRF on Excel import, supportive/diverse permissions, and missing audit logs for HR mutations.
- Gate users with `must_change_password` (API + Vue route + ChangePassword page) and fix Dashboard quick action to `/time-counting`.
- Add baseline-safe migration runner for TiDB/Render, DB-backed rate limits, remove unused `firebase/php-jwt`, and cache overview criteria lookups.

## Test plan
- [ ] `cd frontend && npx vitest run` (expect 111+ passing)
- [ ] `bash backend/tests/run.sh --testsuite Unit` (expect 109+ passing)
- [ ] `docker compose up -d --build db backend` then `bash backend/tests/run.sh` for integration
- [ ] `docker compose exec backend php scripts/run-migrations.php` — existing DB baselines through 14, applies `15-api-rate-limit-hits.sql`
- [ ] Manual: admin import with CSRF succeeds; operator cannot DELETE supportive/diverse; forced password change blocks other APIs
- [ ] After merge: confirm Render deploy migration log does not re-run old non-idempotent ALTERs

Made with [Cursor](https://cursor.com)