### PR TITLE
feat: TEST_SEED multiplier Phase 0 data for local UAT

### DIFF
--- a/database/16-multiplier-test-seed-expand.sql
+++ b/database/16-multiplier-test-seed-expand.sql
@@ -1,0 +1,33 @@
+-- บังคับ client charset เป็น utf8mb4 กัน mojibake ตอน docker init (client default อาจเป็น latin1)
+SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- ============================================================================
+-- 16-multiplier-test-seed-expand.sql
+-- TEST seed expansion (user requested: do not wait for HR)
+--
+-- Adds:
+-- - Satun 4 provisional districts (never whole-province)
+-- - Post-2548 EMERGENCY_DECREE open-ended rows for Yala/Pattani/Narathiwat
+--
+-- Governance:
+-- - All legal/source refs are TEST_SEED placeholders — replace after HR Phase 0
+-- - Idempotent via INSERT IGNORE + unique (province, district_key, basis_type, effective_start_date)
+-- ============================================================================
+
+INSERT IGNORE INTO special_area_multiplier
+  (province, district, basis_type, multiplier_ratio, effective_start_date, effective_end_date, legal_reference, source_reference, is_active)
+VALUES
+  ('สตูล', 'ควนโดน', 'MARTIAL_LAW', 200.00, '2004-01-26', '2004-09-30',
+   'TEST_SEED: development placeholder (not HR-confirmed)', 'TEST_SEED: provisional Satun district list', 1),
+  ('สตูล', 'ควนกาหลง', 'MARTIAL_LAW', 200.00, '2004-01-26', '2004-09-30',
+   'TEST_SEED: development placeholder (not HR-confirmed)', 'TEST_SEED: provisional Satun district list', 1),
+  ('สตูล', 'ท่าแพ', 'MARTIAL_LAW', 200.00, '2004-01-26', '2004-09-30',
+   'TEST_SEED: development placeholder (not HR-confirmed)', 'TEST_SEED: provisional Satun district list', 1),
+  ('สตูล', 'มะนัง', 'MARTIAL_LAW', 200.00, '2004-01-26', '2004-09-30',
+   'TEST_SEED: development placeholder (not HR-confirmed)', 'TEST_SEED: provisional Satun district list', 1),
+  ('ยะลา', NULL, 'EMERGENCY_DECREE', 200.00, '2005-07-20', NULL,
+   'TEST_SEED: development placeholder (not HR-confirmed)', 'TEST_SEED: provisional post-2548 open-ended', 1),
+  ('ปัตตานี', NULL, 'EMERGENCY_DECREE', 200.00, '2005-07-20', NULL,
+   'TEST_SEED: development placeholder (not HR-confirmed)', 'TEST_SEED: provisional post-2548 open-ended', 1),
+  ('นราธิวาส', NULL, 'EMERGENCY_DECREE', 200.00, '2005-07-20', NULL,
+   'TEST_SEED: development placeholder (not HR-confirmed)', 'TEST_SEED: provisional post-2548 open-ended', 1);

--- a/docs/multiplier_phase0_hr_request.md
+++ b/docs/multiplier_phase0_hr_request.md
@@ -27,10 +27,35 @@
    - ต้องมีตัวอย่างที่วันปฏิบัติงานคร่อมวันสิ้นสุดประกาศ
    - ระบุผลลัพธ์จาก Excel เดิม: วันเข้าข่าย, วันทวีคูณ, วัน bonus, และ breakdown ปี/เดือน/วัน
 
-## ไฟล์ที่ให้ HR กรอก
+## ไฟล์ที่ให้ HR กรอก (ส่งไฟล์นี้เป็นหลัก)
+
+**ไฟล์หลัก:** `docs/multiplier_phase0_hr_workbook.xlsx`
+
+| Sheet | กรอกอะไร |
+|-------|----------|
+| `คำชี้แจง` | อ่านอย่างเดียว — วิธีกรอกวันที่ (ค.ศ. `YYYY-MM-DD`) |
+| `1-พื้นที่ทวีคูณ` | master data ทุกแถว + เอกสารอ้างอิง + ผู้ยืนยัน |
+| `2-ตัวอย่างจริง UAT` | อย่างน้อย 10 เคสจาก Excel เดิม (มีคร่อมวันเริ่ม/สิ้นสุด) |
+| `เครื่องช่วยตรวจคำนวณ` | ใช้ช่วยเทียบตัวเลขกับ Excel เดิม (ไม่บังคับ) |
+
+ไฟล์สำรอง (CSV เทียบเท่า — ใช้เมื่อ HR ไม่สะดวกกับ xlsx):
 
 - `docs/multiplier_phase0_master_data_template.csv`
 - `docs/multiplier_phase0_uat_cases_template.csv`
+
+## ช่องว่างที่ต้องปิดก่อน production (สถานะ gate)
+
+- **Dev/test gate:** `node scripts/validate-multiplier-phase0.mjs` ผ่าน **12/12** แล้วด้วย `TEST_SEED` (ไม่ใช่ HR sign-off)
+- **Production gate:** ยังต้องให้ HR กรอก workbook จริงแล้วแทนที่ `TEST_SEED` ทุกแถว
+
+| # | สิ่งที่ HR ต้องยืนยันแทน TEST_SEED |
+|---|-------------------------------------|
+| 1 | สตูล 4 อำเภอที่มีสิทธิจริง (ตอนนี้ provisional: ควนโดน/ควนกาหลง/ท่าแพ/มะนัง) |
+| 2 | `legal_reference` จากมติ/ประกาศ/หนังสือเวียนจริง |
+| 3 | `source_reference` (ไฟล์/หน้า/ลิงก์หลักฐาน) |
+| 4 | ช่วง พ.ร.ก.ฉุกเฉินหลังปี 2548 (ตอนนี้ provisional start `2005-07-20`) |
+| 5 | UAT ≥ 10 เคสจาก Excel เดิม (ตอนนี้เป็น synthetic) |
+| 6 | `verified_by` / `verified_date` ของ HR จริง |
 
 ## จุดที่ต้องยืนยันเป็นพิเศษ
 
@@ -51,12 +76,16 @@ Phase 0 ผ่านเมื่อ:
 - ไม่มี row สตูลแบบทั้งจังหวัด
 - ไม่มีช่วงเวลาซ้อนที่ทำให้ lookup ไม่ deterministic
 - มี UAT cases อย่างน้อย 10 รายการ และ HR ยืนยัน expected output
+- `node scripts/validate-multiplier-phase0.mjs` ได้ 12/12 exit 0
 - HR owner, product owner, technical owner sign off ใน `docs/multiplier_phase0_validation_pack.md`
 
 ## หลัง HR ส่งข้อมูลกลับ
 
 ทีมพัฒนาจะทำต่อ:
 
-1. อัปเดต `docs/multiplier_phase0_validation_pack.md`
-2. แปลงข้อมูลที่ยืนยันแล้วเป็น migration `database/13-multiplier-time-counting.sql`
-3. สร้าง backend/frontend ตาม GitHub issues #19-#23
+1. วางไฟล์ xlsx ที่กรอกแล้วทับ `docs/multiplier_phase0_hr_workbook.xlsx` (หรือระบุ path อื่น)
+2. `python scripts/sync-multiplier-phase0-from-xlsx.py` → อัปเดต CSV
+3. `node scripts/validate-multiplier-phase0.mjs` → ต้อง 12/12
+4. อัปเดต `docs/multiplier_phase0_validation_pack.md` + sign-off
+5. อัปเดต seed `database/13-multiplier-time-counting.sql`
+6. ปิด GitHub issues #18 / #19 แล้วเดิน UAT #23

--- a/docs/multiplier_phase0_master_data_template.csv
+++ b/docs/multiplier_phase0_master_data_template.csv
@@ -1,15 +1,15 @@
 row_id,province,district,whole_province,basis_type,multiplier_ratio,effective_start_date,effective_end_date,legal_reference,source_reference,verified_by,verified_date,notes
-M-001,ยะลา,,yes,MARTIAL_LAW,200.00,2004-01-26,2004-09-30,TODO,TODO,TODO,TODO,Confirm whole-province coverage
-M-002,ปัตตานี,,yes,MARTIAL_LAW,200.00,2004-01-26,2004-09-30,TODO,TODO,TODO,TODO,Confirm whole-province coverage
-M-003,นราธิวาส,,yes,MARTIAL_LAW,200.00,2004-01-26,2004-09-30,TODO,TODO,TODO,TODO,Confirm whole-province coverage
-M-004,สงขลา,เทพา,no,MARTIAL_LAW,200.00,2004-01-26,2004-09-30,TODO,TODO,TODO,TODO,Confirm district eligibility
-M-005,สงขลา,สะบ้าย้อย,no,MARTIAL_LAW,200.00,2004-01-26,2004-09-30,TODO,TODO,TODO,TODO,Confirm district eligibility
-M-006,สงขลา,นาทวี,no,MARTIAL_LAW,200.00,2004-01-26,2004-09-30,TODO,TODO,TODO,TODO,Confirm district eligibility
-M-007,สงขลา,จะนะ,no,MARTIAL_LAW,200.00,2004-01-26,2004-09-30,TODO,TODO,TODO,TODO,Confirm district eligibility
-M-008,สตูล,TODO อำเภอ 1,no,MARTIAL_LAW,200.00,2004-01-26,2004-09-30,TODO,TODO,TODO,TODO,Must be one of confirmed four districts
-M-009,สตูล,TODO อำเภอ 2,no,MARTIAL_LAW,200.00,2004-01-26,2004-09-30,TODO,TODO,TODO,TODO,Must be one of confirmed four districts
-M-010,สตูล,TODO อำเภอ 3,no,MARTIAL_LAW,200.00,2004-01-26,2004-09-30,TODO,TODO,TODO,TODO,Must be one of confirmed four districts
-M-011,สตูล,TODO อำเภอ 4,no,MARTIAL_LAW,200.00,2004-01-26,2004-09-30,TODO,TODO,TODO,TODO,Must be one of confirmed four districts
-E-001,ยะลา,,yes,EMERGENCY_DECREE,200.00,TODO,TODO,TODO,TODO,TODO,TODO,Post-2548 coverage
-E-002,ปัตตานี,,yes,EMERGENCY_DECREE,200.00,TODO,TODO,TODO,TODO,TODO,TODO,Post-2548 coverage
-E-003,นราธิวาส,,yes,EMERGENCY_DECREE,200.00,TODO,TODO,TODO,TODO,TODO,TODO,Post-2548 coverage
+M-001,ยะลา,,yes,MARTIAL_LAW,200.00,2004-01-26,2004-09-30,TEST_SEED: development placeholder (not HR-confirmed),TEST_SEED: docs/multiplier_phase0_validation_pack.md,TEST_SEED,2026-07-13,TEST seed — whole province
+M-002,ปัตตานี,,yes,MARTIAL_LAW,200.00,2004-01-26,2004-09-30,TEST_SEED: development placeholder (not HR-confirmed),TEST_SEED: docs/multiplier_phase0_validation_pack.md,TEST_SEED,2026-07-13,TEST seed — whole province
+M-003,นราธิวาส,,yes,MARTIAL_LAW,200.00,2004-01-26,2004-09-30,TEST_SEED: development placeholder (not HR-confirmed),TEST_SEED: docs/multiplier_phase0_validation_pack.md,TEST_SEED,2026-07-13,TEST seed — whole province
+M-004,สงขลา,เทพา,no,MARTIAL_LAW,200.00,2004-01-26,2004-09-30,TEST_SEED: development placeholder (not HR-confirmed),TEST_SEED: docs/multiplier_phase0_validation_pack.md,TEST_SEED,2026-07-13,TEST seed — district
+M-005,สงขลา,สะบ้าย้อย,no,MARTIAL_LAW,200.00,2004-01-26,2004-09-30,TEST_SEED: development placeholder (not HR-confirmed),TEST_SEED: docs/multiplier_phase0_validation_pack.md,TEST_SEED,2026-07-13,TEST seed — district
+M-006,สงขลา,นาทวี,no,MARTIAL_LAW,200.00,2004-01-26,2004-09-30,TEST_SEED: development placeholder (not HR-confirmed),TEST_SEED: docs/multiplier_phase0_validation_pack.md,TEST_SEED,2026-07-13,TEST seed — district
+M-007,สงขลา,จะนะ,no,MARTIAL_LAW,200.00,2004-01-26,2004-09-30,TEST_SEED: development placeholder (not HR-confirmed),TEST_SEED: docs/multiplier_phase0_validation_pack.md,TEST_SEED,2026-07-13,TEST seed — district
+M-008,สตูล,ควนโดน,no,MARTIAL_LAW,200.00,2004-01-26,2004-09-30,TEST_SEED: development placeholder (not HR-confirmed),TEST_SEED: provisional Satun district list,TEST_SEED,2026-07-13,TEST seed — replace after HR confirm
+M-009,สตูล,ควนกาหลง,no,MARTIAL_LAW,200.00,2004-01-26,2004-09-30,TEST_SEED: development placeholder (not HR-confirmed),TEST_SEED: provisional Satun district list,TEST_SEED,2026-07-13,TEST seed — replace after HR confirm
+M-010,สตูล,ท่าแพ,no,MARTIAL_LAW,200.00,2004-01-26,2004-09-30,TEST_SEED: development placeholder (not HR-confirmed),TEST_SEED: provisional Satun district list,TEST_SEED,2026-07-13,TEST seed — replace after HR confirm
+M-011,สตูล,มะนัง,no,MARTIAL_LAW,200.00,2004-01-26,2004-09-30,TEST_SEED: development placeholder (not HR-confirmed),TEST_SEED: provisional Satun district list,TEST_SEED,2026-07-13,TEST seed — replace after HR confirm
+E-001,ยะลา,,yes,EMERGENCY_DECREE,200.00,2005-07-20,,TEST_SEED: development placeholder (not HR-confirmed),TEST_SEED: provisional post-2548 open-ended,TEST_SEED,2026-07-13,TEST seed — start after martial period
+E-002,ปัตตานี,,yes,EMERGENCY_DECREE,200.00,2005-07-20,,TEST_SEED: development placeholder (not HR-confirmed),TEST_SEED: provisional post-2548 open-ended,TEST_SEED,2026-07-13,TEST seed — start after martial period
+E-003,นราธิวาส,,yes,EMERGENCY_DECREE,200.00,2005-07-20,,TEST_SEED: development placeholder (not HR-confirmed),TEST_SEED: provisional post-2548 open-ended,TEST_SEED,2026-07-13,TEST seed — start after martial period

--- a/docs/multiplier_phase0_uat_cases_template.csv
+++ b/docs/multiplier_phase0_uat_cases_template.csv
@@ -1,11 +1,11 @@
 case_id,personnel_ref,province,district,service_start_date,service_end_date,expected_eligible_start_date,expected_eligible_end_date,expected_service_days,expected_eligible_days,expected_effective_days,expected_bonus_days,expected_net_years,expected_net_months,expected_net_days,excel_source_ref,verified_by,verified_date,notes
-TC-001,Example clamp start,ยะลา,,2004-01-01,2004-02-10,2004-01-26,2004-02-10,41,16,32,16,0,1,2,TODO,TODO,TODO,Starts before effective period
-TC-002,Example clamp end,ยะลา,,2004-08-01,2004-10-15,2004-08-01,2004-09-30,76,61,122,61,0,4,2,TODO,TODO,TODO,Ends after effective period
-TC-003,TODO real case,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,HR Excel case
-TC-004,TODO real case,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,HR Excel case
-TC-005,TODO real case,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,HR Excel case
-TC-006,TODO real case,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,HR Excel case
-TC-007,TODO real case,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,HR Excel case
-TC-008,TODO real case,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,HR Excel case
-TC-009,TODO real case,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,HR Excel case
-TC-010,TODO real case,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,TODO,HR Excel case
+TC-001,Example clamp start,ยะลา,,2004-01-01,2004-02-10,2004-01-26,2004-02-10,41,16,32,16,0,1,2,TEST_SEED: synthetic clamp start,TEST_SEED,2026-07-13,Starts before effective period
+TC-002,Example clamp end,ยะลา,,2004-08-01,2004-10-15,2004-08-01,2004-09-30,76,61,122,61,0,4,2,TEST_SEED: synthetic clamp end,TEST_SEED,2026-07-13,Ends after effective period
+TC-003,TEST full month Yala,ยะลา,,2004-02-01,2004-02-29,2004-02-01,2004-02-29,29,29,58,29,0,1,28,TEST_SEED: synthetic,TEST_SEED,2026-07-13,Inside martial period
+TC-004,TEST Thepha,สงขลา,เทพา,2004-03-01,2004-03-31,2004-03-01,2004-03-31,31,31,62,31,0,2,2,TEST_SEED: synthetic,TEST_SEED,2026-07-13,Songkhla district
+TC-005,TEST Khuan Don,สตูล,ควนโดน,2004-04-01,2004-04-10,2004-04-01,2004-04-10,10,10,20,10,0,0,20,TEST_SEED: synthetic,TEST_SEED,2026-07-13,Satun district
+TC-006,TEST clamp start Chana,สงขลา,จะนะ,2004-01-01,2004-01-31,2004-01-26,2004-01-31,31,6,12,6,0,0,12,TEST_SEED: synthetic,TEST_SEED,2026-07-13,Clamp start district
+TC-007,TEST clamp end Pattani,ปัตตานี,,2004-09-15,2004-10-10,2004-09-15,2004-09-30,26,16,32,16,0,1,2,TEST_SEED: synthetic,TEST_SEED,2026-07-13,Clamp end province
+TC-008,TEST emergency Yala,ยะลา,,2005-08-01,2005-08-31,2005-08-01,2005-08-31,31,31,62,31,0,2,2,TEST_SEED: synthetic,TEST_SEED,2026-07-13,Emergency decree period only
+TC-009,TEST Narathiwat,นราธิวาส,,2004-05-01,2004-05-30,2004-05-01,2004-05-30,30,30,60,30,0,2,0,TEST_SEED: synthetic,TEST_SEED,2026-07-13,Inside martial period
+TC-010,TEST Saba Yoi,สงขลา,สะบ้าย้อย,2004-06-01,2004-06-15,2004-06-01,2004-06-15,15,15,30,15,0,1,0,TEST_SEED: synthetic,TEST_SEED,2026-07-13,Songkhla district

--- a/docs/multiplier_phase0_validation_pack.md
+++ b/docs/multiplier_phase0_validation_pack.md
@@ -2,7 +2,7 @@
 
 เอกสารนี้ใช้สำหรับยืนยัน master data ก่อนเริ่มพัฒนา/ทำ migration ฟีเจอร์ "การนับเวลาราชการเป็นทวีคูณ" ใน Smart Port
 
-สถานะ: `draft`
+สถานะ: `test-seed` — validator 2026-07-13: **12/12 PASS** ด้วย `TEST_SEED` (ยังไม่ใช่ HR sign-off จริง; ห้ามถือว่า production-ready จนกว่า HR ยืนยัน)
 
 ## เป้าหมาย Phase 0
 

--- a/scripts/sync-multiplier-phase0-from-xlsx.py
+++ b/scripts/sync-multiplier-phase0-from-xlsx.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""
+Sync Phase 0 HR workbook → CSV templates used by validate-multiplier-phase0.mjs
+
+Usage (from repo root):
+  python scripts/sync-multiplier-phase0-from-xlsx.py
+  python scripts/sync-multiplier-phase0-from-xlsx.py --workbook path/to/filled.xlsx
+
+After sync, run:
+  node scripts/validate-multiplier-phase0.mjs
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+from pathlib import Path
+
+from openpyxl import load_workbook
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_XLSX = ROOT / "docs" / "multiplier_phase0_hr_workbook.xlsx"
+MASTER_CSV = ROOT / "docs" / "multiplier_phase0_master_data_template.csv"
+UAT_CSV = ROOT / "docs" / "multiplier_phase0_uat_cases_template.csv"
+
+MASTER_SHEET = "1-พื้นที่ทวีคูณ"
+UAT_SHEET = "2-ตัวอย่างจริง UAT"
+
+MASTER_KEYS = [
+    "row_id",
+    "province",
+    "district",
+    "whole_province",
+    "basis_type",
+    "multiplier_ratio",
+    "effective_start_date",
+    "effective_end_date",
+    "legal_reference",
+    "source_reference",
+    "verified_by",
+    "verified_date",
+    "notes",
+]
+
+UAT_KEYS = [
+    "case_id",
+    "personnel_ref",
+    "province",
+    "district",
+    "service_start_date",
+    "service_end_date",
+    "expected_eligible_start_date",
+    "expected_eligible_end_date",
+    "expected_service_days",
+    "expected_eligible_days",
+    "expected_effective_days",
+    "expected_bonus_days",
+    "expected_net_years",
+    "expected_net_months",
+    "expected_net_days",
+    "excel_source_ref",
+    "verified_by",
+    "verified_date",
+    "notes",
+]
+
+
+def cell_str(v) -> str:
+    if v is None:
+        return ""
+    if hasattr(v, "strftime"):
+        return v.strftime("%Y-%m-%d")
+    s = str(v).strip()
+    # Excel may emit datetime as "2004-01-26 00:00:00"
+    if len(s) >= 10 and s[4] == "-" and s[7] == "-" and " " in s:
+        return s[:10]
+    return s
+
+
+def find_key_row(rows: list[list], keys: list[str]) -> int:
+    for i, row in enumerate(rows):
+        normalized = [cell_str(c) for c in row[: len(keys)]]
+        if normalized[:3] == keys[:3]:
+            return i
+    raise SystemExit(f"Cannot find English key row starting with {keys[:3]}")
+
+
+def normalize_placeholder(row: dict) -> dict:
+    """Keep validator-friendly placeholders when HR left cells blank."""
+    out = dict(row)
+    for key in (
+        "legal_reference",
+        "source_reference",
+        "verified_by",
+        "verified_date",
+        "excel_source_ref",
+        "effective_start_date",
+        "effective_end_date",
+    ):
+        if key in out and out[key] == "":
+            out[key] = "TODO"
+    # Satun must stay district-level placeholders until HR names them
+    if out.get("province") == "สตูล" and out.get("district") == "":
+        rid = out.get("row_id") or "?"
+        out["district"] = f"TODO อำเภอ ({rid})"
+        if out.get("whole_province") in ("", "yes"):
+            out["whole_province"] = "no"
+    return out
+
+
+def sheet_to_dicts(ws, keys: list[str]) -> list[dict]:
+    rows = [[c.value for c in row] for row in ws.iter_rows()]
+    key_idx = find_key_row(rows, keys)
+    out = []
+    for row in rows[key_idx + 1 :]:
+        values = [cell_str(c) for c in row[: len(keys)]]
+        if not any(values):
+            continue
+        # skip accidental duplicate header
+        if values[0] == keys[0]:
+            continue
+        out.append(normalize_placeholder(dict(zip(keys, values))))
+    return out
+
+
+def write_csv(path: Path, keys: list[str], rows: list[dict]) -> None:
+    with path.open("w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=keys, lineterminator="\n")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({k: row.get(k, "") for k in keys})
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Sync Phase 0 workbook to CSV templates")
+    parser.add_argument("--workbook", type=Path, default=DEFAULT_XLSX)
+    args = parser.parse_args()
+    wb_path = args.workbook.resolve()
+    if not wb_path.exists():
+        raise SystemExit(f"Workbook not found: {wb_path}")
+
+    wb = load_workbook(wb_path, data_only=True)
+    if MASTER_SHEET not in wb.sheetnames or UAT_SHEET not in wb.sheetnames:
+        raise SystemExit(
+            f"Expected sheets {MASTER_SHEET!r} and {UAT_SHEET!r}; found {wb.sheetnames}"
+        )
+
+    master_rows = sheet_to_dicts(wb[MASTER_SHEET], MASTER_KEYS)
+    uat_rows = sheet_to_dicts(wb[UAT_SHEET], UAT_KEYS)
+    write_csv(MASTER_CSV, MASTER_KEYS, master_rows)
+    write_csv(UAT_CSV, UAT_KEYS, uat_rows)
+    print(f"Synced {wb_path.name}")
+    print(f"  → {MASTER_CSV.relative_to(ROOT)} ({len(master_rows)} rows)")
+    print(f"  → {UAT_CSV.relative_to(ROOT)} ({len(uat_rows)} rows)")
+    print("Next: node scripts/validate-multiplier-phase0.mjs")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `database/16-multiplier-test-seed-expand.sql` with provisional Satun districts + emergency-decree periods marked `TEST_SEED` (does not rewrite deployed migration 13).
- Fill Phase 0 master/UAT CSVs so `validate-multiplier-phase0.mjs` passes **12/12** for local/dev unblocking.
- Add `scripts/sync-multiplier-phase0-from-xlsx.py` and update HR request/validation pack docs (still require real HR sign-off before production).

## Test plan
- [x] `node scripts/validate-multiplier-phase0.mjs` → exit 0 (12/12)
- [x] Apply `16-*.sql` on local Docker DB → 14 active areas (Satun 4, emergency 3)
- [x] API: `GET /multiplier/areas` total=14; `POST /multiplier` with CSRF creates record (eligible/bonus 29)
- [x] UI: `/time-multiplier` and `/settings/special-areas` show seeded data
- [x] `npx vitest run src/__tests__/composables/useMultiplier.test.js` → 3/3

## Notes
- `TEST_SEED` is **not** HR-confirmed. Do not close #18 as production-complete until legal/source refs are replaced.