### PR TITLE
feat: harden TEST_SEED UX, overview perf, and Playwright E2E

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,12 @@ backend/storage/rate_limits/*
 coverage/
 .nyc_output/
 
+# Playwright
+frontend/playwright-report/
+frontend/test-results/
+frontend/blob-report/
+frontend/playwright/.cache/
+
 # Project specific
 project-bolt
 admin-dashboard-integration-test.html

--- a/backend/QualificationEngine.php
+++ b/backend/QualificationEngine.php
@@ -495,8 +495,9 @@ class QualificationEngine
     }
 
     /**
-     * สรุปภาพรวมบัญชีรายชื่อทุกระดับ (ทั่วไป + วิชาการ) จาก full dataset
-     * แทนการให้ frontend ยิงรายระดับแล้วรวมเลขเอง (ผิดเมื่อข้อมูลเกิน limit ต่อหน้า)
+     * สรุปภาพรวมบัญชีรายชื่อทุกระดับ จาก full dataset
+     * ใช้ UNION ALL ทุกระดับ + aggregate/window (~3 queries รวม criteria cache)
+     * แทนการยิง summary+top5 ทีละระดับ (~18 queries)
      *
      * @return array summary รวมทุกระดับ, by_level รายระดับ, top5 ใกล้ครบเกณฑ์ที่สุดข้ามระดับ
      */
@@ -516,90 +517,166 @@ class QualificationEngine
             'check_data_total' => 0,
         ];
         $byLevel = [];
-        $top5Pool = [];
+        $levelCategory = [];
 
         foreach (self::OVERVIEW_LEVELS as $category => $levels) {
             foreach ($levels as $level) {
-                $base = $this->buildQuery($level);
-
-                // ระดับที่ไม่มีเกณฑ์ active — ใส่ค่าศูนย์ทั้งแถว ห้าม error
-                if ($base === null) {
-                    $byLevel[$level] = ['total' => 0, 'qualified' => 0, 'not_yet' => 0, 'check_data' => 0, 'near_qualified' => 0];
-                    continue;
-                }
-
-                // Summary ต่อระดับจาก full dataset (BETWEEN 1 AND 90 — NULL ไม่ถูกนับโดยธรรมชาติ)
-                $summarySql = "
-                    SELECT
-                        COUNT(*) AS total,
-                        SUM(CASE WHEN sub.status = 'qualified' THEN 1 ELSE 0 END) AS qualified,
-                        SUM(CASE WHEN sub.status = 'not_yet' THEN 1 ELSE 0 END) AS not_yet,
-                        SUM(CASE WHEN sub.status = 'check_data' THEN 1 ELSE 0 END) AS check_data,
-                        SUM(CASE WHEN sub.remaining_days BETWEEN 1 AND " . self::NEAR_THRESHOLD_DAYS . " THEN 1 ELSE 0 END) AS near_qualified
-                    FROM ({$base['sql']}) AS sub
-                ";
-                $stmt = $this->pdo->prepare($summarySql);
-                $stmt->execute($base['params']);
-                $row = $stmt->fetch(PDO::FETCH_ASSOC);
-
-                $levelSummary = [
-                    'total' => (int) ($row['total'] ?? 0),
-                    'qualified' => (int) ($row['qualified'] ?? 0),
-                    'not_yet' => (int) ($row['not_yet'] ?? 0),
-                    'check_data' => (int) ($row['check_data'] ?? 0),
-                    'near_qualified' => (int) ($row['near_qualified'] ?? 0),
+                $levelCategory[$level] = $category;
+                $byLevel[$level] = [
+                    'total' => 0,
+                    'qualified' => 0,
+                    'not_yet' => 0,
+                    'check_data' => 0,
+                    'near_qualified' => 0,
                 ];
-                $byLevel[$level] = $levelSummary;
-
-                $summary[$category . '_total'] += $levelSummary['total'];
-                $summary['qualified_total'] += $levelSummary['qualified'];
-                $summary['near_qualified_total'] += $levelSummary['near_qualified'];
-                $summary['not_yet_total'] += $levelSummary['not_yet'];
-                $summary['check_data_total'] += $levelSummary['check_data'];
-
-                // Top 5 ของระดับนี้ — NULL remaining_days ไปท้ายสุด (ตรง logic ฝั่ง frontend เดิม)
-                $dataSql = "{$base['sql']} ORDER BY (remaining_days IS NULL), remaining_days ASC LIMIT 5";
-                $dataStmt = $this->pdo->prepare($dataSql);
-                $dataStmt->execute($base['params']);
-                $rows = $dataStmt->fetchAll(PDO::FETCH_ASSOC);
-
-                foreach ($rows as &$r) {
-                    $r['target_level'] = $level;
-                    $r['qualification_date_thai'] = formatThaiDate($r['qualification_date']);
-                    $r['level_start_date_thai'] = formatThaiDate($r['current_level_start_date']);
-                    $r['current_level_name'] = getLevelName($r['current_level_code'] ?? '');
-                    $r['remaining_days'] = $r['remaining_days'] !== null ? (int) $r['remaining_days'] : null;
-                    $r['min_years'] = $r['min_years'] !== null ? (float) $r['min_years'] : null;
-                    $r['supportive_days'] = (int) $r['supportive_days'];
-                    $r['equivalence_days'] = (int) $r['equivalence_days'];
-                    $r['diverse_diff_count'] = (int) $r['diverse_diff_count'];
-                    $r['multiplier_days'] = (int) ($r['multiplier_days'] ?? 0);
-                }
-                unset($r);
-
-                $top5Pool = array_merge($top5Pool, $rows);
             }
         }
 
-        // รวมทุกระดับ → เรียง remaining_days น้อยสุดก่อน (NULL ท้ายสุด) → ตัด 5 อันดับแรก
-        usort($top5Pool, function (array $a, array $b): int {
-            if ($a['remaining_days'] === null && $b['remaining_days'] === null) {
-                return 0;
+        $union = $this->buildOverviewUnionSql();
+        if ($union === null) {
+            return [
+                'success' => true,
+                'summary' => $summary,
+                'by_level' => $byLevel,
+                'top5' => [],
+            ];
+        }
+
+        $near = self::NEAR_THRESHOLD_DAYS;
+        $summarySql = "
+            SELECT
+                target_level,
+                COUNT(*) AS total,
+                SUM(CASE WHEN status = 'qualified' THEN 1 ELSE 0 END) AS qualified,
+                SUM(CASE WHEN status = 'not_yet' THEN 1 ELSE 0 END) AS not_yet,
+                SUM(CASE WHEN status = 'check_data' THEN 1 ELSE 0 END) AS check_data,
+                SUM(CASE WHEN remaining_days BETWEEN 1 AND {$near} THEN 1 ELSE 0 END) AS near_qualified
+            FROM ({$union['sql']}) AS all_levels
+            GROUP BY target_level
+        ";
+        $summaryStmt = $this->pdo->prepare($summarySql);
+        $summaryStmt->execute($union['params']);
+        foreach ($summaryStmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $level = (string) $row['target_level'];
+            $levelSummary = [
+                'total' => (int) ($row['total'] ?? 0),
+                'qualified' => (int) ($row['qualified'] ?? 0),
+                'not_yet' => (int) ($row['not_yet'] ?? 0),
+                'check_data' => (int) ($row['check_data'] ?? 0),
+                'near_qualified' => (int) ($row['near_qualified'] ?? 0),
+            ];
+            $byLevel[$level] = $levelSummary;
+
+            $category = $levelCategory[$level] ?? null;
+            if ($category !== null) {
+                $summary[$category . '_total'] += $levelSummary['total'];
             }
-            if ($a['remaining_days'] === null) {
-                return 1;
-            }
-            if ($b['remaining_days'] === null) {
-                return -1;
-            }
-            return $a['remaining_days'] <=> $b['remaining_days'];
-        });
+            $summary['qualified_total'] += $levelSummary['qualified'];
+            $summary['near_qualified_total'] += $levelSummary['near_qualified'];
+            $summary['not_yet_total'] += $levelSummary['not_yet'];
+            $summary['check_data_total'] += $levelSummary['check_data'];
+        }
+
+        // Top 5 ข้ามระดับ — NULL remaining_days ท้ายสุด (ตรง logic เดิม)
+        $top5Sql = "
+            SELECT *
+            FROM (
+                SELECT
+                    all_levels.*,
+                    ROW_NUMBER() OVER (
+                        ORDER BY (remaining_days IS NULL), remaining_days ASC
+                    ) AS overview_rank
+                FROM ({$union['sql']}) AS all_levels
+            ) AS ranked
+            WHERE overview_rank <= 5
+            ORDER BY overview_rank
+        ";
+        $top5Stmt = $this->pdo->prepare($top5Sql);
+        $top5Stmt->execute($union['params']);
+        $top5 = $top5Stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        foreach ($top5 as &$r) {
+            unset($r['overview_rank']);
+            $r['qualification_date_thai'] = formatThaiDate($r['qualification_date']);
+            $r['level_start_date_thai'] = formatThaiDate($r['current_level_start_date']);
+            $r['current_level_name'] = getLevelName($r['current_level_code'] ?? '');
+            $r['remaining_days'] = $r['remaining_days'] !== null ? (int) $r['remaining_days'] : null;
+            $r['min_years'] = $r['min_years'] !== null ? (float) $r['min_years'] : null;
+            $r['supportive_days'] = (int) $r['supportive_days'];
+            $r['equivalence_days'] = (int) $r['equivalence_days'];
+            $r['diverse_diff_count'] = (int) $r['diverse_diff_count'];
+            $r['multiplier_days'] = (int) ($r['multiplier_days'] ?? 0);
+        }
+        unset($r);
 
         return [
             'success' => true,
             'summary' => $summary,
             'by_level' => $byLevel,
-            'top5' => array_slice($top5Pool, 0, 5),
+            'top5' => $top5,
+        ];
+    }
+
+    /**
+     * รวม base query ทุกระดับใน OVERVIEW_LEVELS เป็น UNION ALL
+     * โปรเจกต์คอลัมน์ร่วม — M/S ยังไม่มี multiplier_days ใน buildExecutiveQuery → ใส่ 0
+     *
+     * @return array{sql:string,params:array}|null
+     */
+    private function buildOverviewUnionSql(): ?array
+    {
+        $branches = [];
+        $params = [];
+        $aliasIndex = 0;
+
+        foreach (self::OVERVIEW_LEVELS as $levels) {
+            foreach ($levels as $level) {
+                $base = $this->buildQuery($level);
+                if ($base === null) {
+                    continue;
+                }
+
+                $alias = 'ov' . $aliasIndex++;
+                $isExecutive = in_array($level, self::EXECUTIVE_LEVELS, true);
+                $multiplierExpr = $isExecutive
+                    ? '0 AS multiplier_days'
+                    : "{$alias}.multiplier_days AS multiplier_days";
+
+                // คอลัมน์ร่วม + target_level (bind เป็น param กัน hardcode ซ้ำ)
+                $branches[] = "
+                    SELECT
+                        {$alias}.personnel_id AS personnel_id,
+                        {$alias}.full_name AS full_name,
+                        {$alias}.current_position AS current_position,
+                        {$alias}.current_level_code AS current_level_code,
+                        {$alias}.current_level_start_date AS current_level_start_date,
+                        {$alias}.education_level AS education_level,
+                        {$alias}.min_years AS min_years,
+                        {$alias}.department AS department,
+                        {$alias}.supportive_days AS supportive_days,
+                        {$alias}.equivalence_days AS equivalence_days,
+                        {$alias}.diverse_diff_count AS diverse_diff_count,
+                        {$multiplierExpr},
+                        {$alias}.qualification_date AS qualification_date,
+                        {$alias}.remaining_days AS remaining_days,
+                        {$alias}.status AS status,
+                        ? AS target_level
+                    FROM ({$base['sql']}) AS {$alias}
+                ";
+                foreach ($base['params'] as $param) {
+                    $params[] = $param;
+                }
+                $params[] = $level;
+            }
+        }
+
+        if ($branches === []) {
+            return null;
+        }
+
+        return [
+            'sql' => implode("\nUNION ALL\n", $branches),
+            'params' => $params,
         ];
     }
 

--- a/backend/routes/multiplier.php
+++ b/backend/routes/multiplier.php
@@ -467,7 +467,13 @@ function decorateAreaRow(array &$row): void
         ? "{$row['province']} / {$row['district']}"
         : "{$row['province']} / ทั้งจังหวัด";
     $legalReference = trim((string) $row['legal_reference']);
-    $row['source_pending'] = $legalReference === '' || str_contains($legalReference, 'SOURCE_PENDING');
+    $sourceReference = trim((string) ($row['source_reference'] ?? ''));
+    // SOURCE_PENDING / TEST_SEED = ยังไม่ใช่เอกสาร HR จริง → ติดสถานะรอเอกสาร
+    $row['source_pending'] = $legalReference === ''
+        || str_contains($legalReference, 'SOURCE_PENDING')
+        || str_contains($legalReference, 'TEST_SEED')
+        || str_contains($sourceReference, 'SOURCE_PENDING')
+        || str_contains($sourceReference, 'TEST_SEED');
 }
 
 /**

--- a/backend/scripts/run-migrations.php
+++ b/backend/scripts/run-migrations.php
@@ -261,13 +261,30 @@ try {
         }
 
         ksort($pending, SORT_NATURAL);
+        $skippedTestSeed = [];
+        $allowTestSeed = migrationEnv('APPLY_TEST_SEED_MIGRATIONS', '0') === '1';
         foreach ($pending as $name => $file) {
+            // กัน TEST_SEED ขึ้น production โดยไม่ตั้งใจ — เปิดด้วย APPLY_TEST_SEED_MIGRATIONS=1 เท่านั้น
+            if (!$allowTestSeed && str_contains($name, 'test-seed')) {
+                $skippedTestSeed[] = $name;
+                fwrite(
+                    STDOUT,
+                    "Skipping {$name} (TEST_SEED). Set APPLY_TEST_SEED_MIGRATIONS=1 to apply.\n"
+                );
+                continue;
+            }
             fwrite(STDOUT, "Applying {$name}...\n");
             applyMigration($pdo, $file);
             fwrite(STDOUT, "Applied {$name}\n");
         }
 
-        fwrite(STDOUT, count($pending) . " migration(s) applied.\n");
+        $appliedCount = count($pending) - count($skippedTestSeed);
+        if ($appliedCount === 0 && $skippedTestSeed !== []) {
+            fwrite(STDOUT, "No migrations applied ({$skippedTestSeed[0]} skipped as TEST_SEED).\n");
+            exit(0);
+        }
+
+        fwrite(STDOUT, $appliedCount . " migration(s) applied.\n");
         exit(0);
     } finally {
         releaseMigrationLock($pdo);

--- a/backend/tests/Integration/QualificationEngineTest.php
+++ b/backend/tests/Integration/QualificationEngineTest.php
@@ -251,4 +251,65 @@ final class QualificationEngineTest extends TestCase
                 ->execute([$personnelId, $areaId]);
         }
     }
+
+    /**
+     * computeOverview — shape + สอดคล้องระหว่าง summary / by_level / top5
+     * (หลัง refactor UNION ALL + window ต้องไม่พัง response contract)
+     */
+    #[Test]
+    public function it_computes_overview_shape_and_totals(): void
+    {
+        $result = $this->engine->computeOverview();
+
+        self::assertTrue($result['success']);
+        self::assertArrayHasKey('summary', $result);
+        self::assertArrayHasKey('by_level', $result);
+        self::assertArrayHasKey('top5', $result);
+
+        $expectedLevels = ['O2', 'O3', 'K2', 'K3', 'K4', 'M1', 'M2', 'S1', 'S2'];
+        foreach ($expectedLevels as $level) {
+            self::assertArrayHasKey($level, $result['by_level'], "by_level ต้องมี {$level}");
+            $row = $result['by_level'][$level];
+            self::assertSame(
+                $row['total'],
+                $row['qualified'] + $row['not_yet'] + $row['check_data'],
+                "{$level}: total ต้องเท่ากับผลรวมสถานะ"
+            );
+        }
+
+        $sumQualified = 0;
+        $sumNear = 0;
+        $sumNotYet = 0;
+        $sumCheck = 0;
+        foreach ($result['by_level'] as $row) {
+            $sumQualified += $row['qualified'];
+            $sumNear += $row['near_qualified'];
+            $sumNotYet += $row['not_yet'];
+            $sumCheck += $row['check_data'];
+        }
+        self::assertSame($sumQualified, $result['summary']['qualified_total']);
+        self::assertSame($sumNear, $result['summary']['near_qualified_total']);
+        self::assertSame($sumNotYet, $result['summary']['not_yet_total']);
+        self::assertSame($sumCheck, $result['summary']['check_data_total']);
+
+        self::assertLessThanOrEqual(5, count($result['top5']));
+        $prev = null;
+        foreach ($result['top5'] as $row) {
+            self::assertArrayHasKey('target_level', $row);
+            self::assertArrayHasKey('remaining_days', $row);
+            self::assertArrayHasKey('multiplier_days', $row);
+            if ($prev !== null) {
+                if ($prev['remaining_days'] === null) {
+                    self::assertNull($row['remaining_days'], 'หลัง NULL ใน top5 ต้องเป็น NULL ต่อ');
+                } elseif ($row['remaining_days'] !== null) {
+                    self::assertLessThanOrEqual(
+                        $row['remaining_days'],
+                        $prev['remaining_days'],
+                        'top5 ต้องเรียง remaining_days น้อย→มาก'
+                    );
+                }
+            }
+            $prev = $row;
+        }
+    }
 }

--- a/backend/tests/Unit/MultiplierAreaDecorateTest.php
+++ b/backend/tests/Unit/MultiplierAreaDecorateTest.php
@@ -12,7 +12,7 @@ require_once __DIR__ . '/../../routes/multiplier.php';
 
 /**
  * Unit tests สำหรับ decorateAreaRow() — pure function, ไม่ใช้ DB
- * โฟกัส source_pending: "รอเอกสาร" ต้องครอบคลุมทั้ง marker SOURCE_PENDING
+ * โฟกัส source_pending: "รอเอกสาร" ต้องครอบคลุม SOURCE_PENDING / TEST_SEED
  * และกรณีไม่มี legal_reference เลย (NULL/ว่าง) ตามที่ฟอร์มสัญญาไว้ว่า
  * "เว้นว่างจะติดสถานะรอเอกสาร"
  */
@@ -35,25 +35,31 @@ final class MultiplierAreaDecorateTest extends TestCase
     }
 
     /**
-     * @return array<string, array{mixed, bool}>  [legal_reference, source_pending ที่คาดหวัง]
+     * @return array<string, array{mixed, mixed, bool}>  [legal_reference, source_reference, expected]
      */
-    public static function legalReferenceProvider(): array
+    public static function pendingReferenceProvider(): array
     {
         return [
-            'NULL = ไม่มีเอกสาร → รอเอกสาร'            => [null, true],
-            'สตริงว่าง → รอเอกสาร'                     => ['', true],
-            'ช่องว่างล้วน → รอเอกสาร'                  => ['   ', true],
-            'marker SOURCE_PENDING → รอเอกสาร'         => ['SOURCE_PENDING: user-approved development seed', true],
-            'มีเอกสารจริง → ยืนยันแล้ว'                => ['ประกาศ กห. ลง 26 ม.ค. 2547', false],
+            'NULL = ไม่มีเอกสาร → รอเอกสาร' => [null, null, true],
+            'สตริงว่าง → รอเอกสาร' => ['', null, true],
+            'ช่องว่างล้วน → รอเอกสาร' => ['   ', null, true],
+            'marker SOURCE_PENDING → รอเอกสาร' => ['SOURCE_PENDING: user-approved development seed', null, true],
+            'marker TEST_SEED ใน legal → รอเอกสาร' => ['TEST_SEED: development placeholder', null, true],
+            'marker TEST_SEED ใน source → รอเอกสาร' => ['ประกาศ กห. ลง 26 ม.ค. 2547', 'TEST_SEED: provisional', true],
+            'มีเอกสารจริง → ยืนยันแล้ว' => ['ประกาศ กห. ลง 26 ม.ค. 2547', 'แฟ้ม HR หน้า 12', false],
         ];
     }
 
     #[Test]
-    #[DataProvider('legalReferenceProvider')]
-    public function it_flags_source_pending_from_legal_reference(mixed $legalReference, bool $expectedPending): void
-    {
+    #[DataProvider('pendingReferenceProvider')]
+    public function it_flags_source_pending_from_references(
+        mixed $legalReference,
+        mixed $sourceReference,
+        bool $expectedPending
+    ): void {
         $row = self::baseRow();
         $row['legal_reference'] = $legalReference;
+        $row['source_reference'] = $sourceReference;
 
         decorateAreaRow($row);
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,6 +17,8 @@ services:
       - MYSQL_USER=${MYSQL_USER}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD}
       - JWT_SECRET=${JWT_SECRET}
+      # Local/dev only — production Render ต้องไม่ตั้งค่านี้จนกว่าจะตั้งใจใช้ TEST_SEED
+      - APPLY_TEST_SEED_MIGRATIONS=1
     depends_on:
       db:
         condition: service_healthy

--- a/docs/render-tidb-production.md
+++ b/docs/render-tidb-production.md
@@ -88,7 +88,9 @@ The backend Docker image copies `database/` and runs pending SQL migrations on c
 
 **Existing TiDB / already-initialized DBs:** if `schema_migrations` is empty but `personnel` or `users` already exists, the runner **baselines** migrations through `14-multiplier-area-admin.sql` (marks them applied, does not re-run non-idempotent `ALTER`s). Only newer files such as `15-api-rate-limit-hits.sql` are executed.
 
-**Fresh empty database:** no baseline — every numbered `NN-*.sql` under `database/` is applied in order.
+**TEST_SEED migrations:** files whose name contains `test-seed` (e.g. `16-multiplier-test-seed-expand.sql`) are **skipped by default** so provisional data does not land on production. To apply them on a dedicated UAT/dev database, set `APPLY_TEST_SEED_MIGRATIONS=1` on the backend service. Local Docker can set the same env when you intentionally want TEST_SEED rows.
+
+**Fresh empty database:** no baseline — every numbered `NN-*.sql` under `database/` is applied in order (except skipped `test-seed` files unless the env above is set).
 
 New incremental SQL files must use the `NN-description.sql` naming pattern under `database/` and should prefer idempotent DDL (`CREATE TABLE IF NOT EXISTS`, etc.) when possible.
 

--- a/frontend/e2e/auth/login.spec.js
+++ b/frontend/e2e/auth/login.spec.js
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test'
+import { adminPass, adminUser, loginAs, loginAsAdmin } from '../helpers/auth.js'
+
+test.describe('login', () => {
+  test('rejects invalid credentials', async ({ page }) => {
+    await loginAs(page, adminUser, 'wrong-password-xxx')
+    await expect(page.getByText('ชื่อผู้ใช้หรือรหัสผ่านไม่ถูกต้อง')).toBeVisible()
+    await expect(page).toHaveURL(/\/login/)
+  })
+
+  test('admin can sign in and reach dashboard', async ({ page }) => {
+    await loginAsAdmin(page)
+    await expect(page).toHaveURL(/\/dashboard/)
+    await expect(page.getByRole('heading', { level: 1 }).first()).toBeVisible()
+  })
+})

--- a/frontend/e2e/features/candidates.spec.js
+++ b/frontend/e2e/features/candidates.spec.js
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test'
+import { loginAsAdmin } from '../helpers/auth.js'
+
+test.describe('candidates', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page)
+  })
+
+  test('overview page loads summary UI', async ({ page }) => {
+    await page.goto('/candidates')
+    await expect(page).toHaveURL(/\/candidates/)
+    await expect(page.getByRole('heading', { level: 1 })).toBeVisible()
+    // Overview stats cards / section should render after API
+    await expect(page.locator('body')).toContainText(/บัญชีรายชื่อ|ภาพรวม|คุณสมบัติ/)
+  })
+})

--- a/frontend/e2e/features/import.spec.js
+++ b/frontend/e2e/features/import.spec.js
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test'
+import { loginAsAdmin } from '../helpers/auth.js'
+
+test.describe('import (admin)', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page)
+  })
+
+  test('admin can open import page and see template step', async ({ page }) => {
+    await page.goto('/import')
+    await expect(page).toHaveURL(/\/import/)
+    await expect(page.getByRole('heading', { name: 'นำเข้าข้อมูลบุคลากร' })).toBeVisible()
+    await expect(page.getByRole('link', { name: /ดาวน์โหลดเทมเพลต/ })).toBeVisible()
+    await expect(page.getByText('2. อัปโหลดไฟล์')).toBeVisible()
+  })
+})

--- a/frontend/e2e/features/permissions.spec.js
+++ b/frontend/e2e/features/permissions.spec.js
@@ -1,0 +1,72 @@
+import { test, expect } from '@playwright/test'
+import {
+  adminPass,
+  adminUser,
+  apiBase,
+  apiLogin,
+  loginAs,
+  loginAsAdmin,
+} from '../helpers/auth.js'
+
+test.describe('permissions', () => {
+  test('unauthenticated user is redirected to login', async ({ page }) => {
+    await page.goto('/candidates')
+    await expect(page).toHaveURL(/\/login/)
+
+    await page.goto('/import')
+    await expect(page).toHaveURL(/\/login/)
+  })
+
+  test('operator cannot open admin-only import page', async ({ page, request }) => {
+    const stamp = Date.now()
+    const username = `e2e_op_${stamp}`
+    const tempPass = 'TempPass1!'
+    const finalPass = 'OperPass1!'
+
+    const admin = await apiLogin(request, adminUser, adminPass)
+
+    const create = await request.post(`${apiBase()}/users`, {
+      headers: {
+        Authorization: `Bearer ${admin.token}`,
+        'X-CSRF-Token': admin.csrf_token,
+      },
+      data: {
+        username,
+        password: tempPass,
+        full_name: 'E2E Operator',
+        role: 'operator',
+      },
+    })
+    expect(create.status(), await create.text()).toBe(201)
+
+    // First login forces password change
+    const first = await apiLogin(request, username, tempPass)
+    expect(first.user.must_change_password).toBeTruthy()
+
+    const changed = await request.post(`${apiBase()}/auth/change-password`, {
+      headers: {
+        Authorization: `Bearer ${first.token}`,
+        'X-CSRF-Token': first.csrf_token,
+      },
+      data: {
+        current_password: tempPass,
+        new_password: finalPass,
+      },
+    })
+    expect(changed.ok(), await changed.text()).toBeTruthy()
+
+    await loginAs(page, username, finalPass)
+    await page.waitForURL('**/dashboard')
+
+    await page.goto('/import')
+    await expect(page).toHaveURL(/\/dashboard/)
+    await expect(page.getByRole('heading', { name: 'นำเข้าข้อมูลบุคลากร' })).toHaveCount(0)
+  })
+
+  test('admin retains access to import', async ({ page }) => {
+    await loginAsAdmin(page)
+    await page.goto('/import')
+    await expect(page).toHaveURL(/\/import/)
+    await expect(page.getByRole('heading', { name: 'นำเข้าข้อมูลบุคลากร' })).toBeVisible()
+  })
+})

--- a/frontend/e2e/helpers/auth.js
+++ b/frontend/e2e/helpers/auth.js
@@ -1,0 +1,39 @@
+/**
+ * Shared auth helpers for Playwright E2E (local seed / Docker).
+ * Credentials from env — defaults match database/09-auth-users.sql comment (dev only).
+ */
+export const adminUser = process.env.E2E_ADMIN_USER || 'admin'
+export const adminPass = process.env.E2E_ADMIN_PASS || 'admin123'
+
+export async function loginAs(page, username, password) {
+  await page.goto('/login')
+  await page.getByPlaceholder('กรุณาใส่ชื่อผู้ใช้ของคุณ').fill(username)
+  await page.getByPlaceholder('กรุณาใส่รหัสผ่านของคุณ').fill(password)
+  await page.getByRole('button', { name: /เข้าสู่ระบบ/i }).click()
+}
+
+export async function loginAsAdmin(page) {
+  await loginAs(page, adminUser, adminPass)
+  await page.waitForURL(/\/(dashboard|change-password)/)
+  if (page.url().includes('/change-password')) {
+    throw new Error(
+      'Admin must_change_password=1 — clear flag locally or change password before E2E'
+    )
+  }
+  await page.waitForURL('**/dashboard')
+}
+
+/** API base as seen from the browser (Vite proxy). */
+export function apiBase() {
+  return process.env.E2E_API_BASE || 'http://127.0.0.1:8000'
+}
+
+export async function apiLogin(request, username, password) {
+  const res = await request.post(`${apiBase()}/auth/login`, {
+    data: { username, password },
+  })
+  if (!res.ok()) {
+    throw new Error(`API login failed (${res.status()}): ${await res.text()}`)
+  }
+  return res.json()
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "vue-router": "^4.5.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.55.0",
         "@tailwindcss/vite": "^4.1.0",
         "@vitejs/plugin-vue": "^5.2.0",
         "@vue/test-utils": "^2.4.6",
@@ -814,6 +815,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -2902,6 +2919,53 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,9 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "chart.js": "^4.4.0",
@@ -19,6 +21,7 @@
     "vue-router": "^4.5.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.55.0",
     "@tailwindcss/vite": "^4.1.0",
     "@vitejs/plugin-vue": "^5.2.0",
     "@vue/test-utils": "^2.4.6",

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -1,0 +1,31 @@
+// @ts-check
+import { defineConfig, devices } from '@playwright/test'
+
+/**
+ * E2E against Vite dev + Docker backend.
+ * Prerequisite: `docker compose up -d db backend` (API :8000)
+ * Vite is started by webServer (or reuseExistingServer if already up).
+ */
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: [['list'], ['html', { open: 'never' }]],
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
+  use: {
+    baseURL: process.env.E2E_BASE_URL || 'http://127.0.0.1:5174',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'off',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: {
+    command: 'npm run dev -- --host 127.0.0.1 --port 5174',
+    url: 'http://127.0.0.1:5174',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+})

--- a/frontend/src/__tests__/composables/useApi.test.js
+++ b/frontend/src/__tests__/composables/useApi.test.js
@@ -61,4 +61,19 @@ describe('useApi uploads', () => {
     expect(mockAuth.setMustChangePassword).toHaveBeenCalledWith(true)
     expect(mockPush).toHaveBeenCalledWith('/change-password')
   })
+
+  it('surfaces Thai login error on 401 without logout redirect', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({
+      error: 'ชื่อผู้ใช้หรือรหัสผ่านไม่ถูกต้อง',
+    }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    }))
+
+    await expect(useApi().post('/auth/login', { username: 'x', password: 'y' }))
+      .rejects.toThrow('ชื่อผู้ใช้หรือรหัสผ่านไม่ถูกต้อง')
+
+    expect(mockAuth.logout).not.toHaveBeenCalled()
+    expect(mockPush).not.toHaveBeenCalled()
+  })
 })

--- a/frontend/src/composables/useApi.js
+++ b/frontend/src/composables/useApi.js
@@ -29,6 +29,15 @@ async function authenticatedFetch(url, options = {}) {
   })
 
   if (response.status === 401) {
+    // Login 401 ต้องโชว์ข้อความจาก API (ไทย) — ห้ามกลายเป็น "Unauthorized" แล้วเด้ง logout
+    const isPublicAuth =
+      typeof url === 'string' &&
+      (url.includes('/auth/login') || url === '/login' || url.endsWith('/login'))
+    if (isPublicAuth) {
+      const body = await response.clone().json().catch(() => null)
+      throw new Error(body?.error || 'ชื่อผู้ใช้หรือรหัสผ่านไม่ถูกต้อง')
+    }
+
     auth.logout()
     const router = (await import('@/router')).default
     router.push('/login')

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -15,5 +15,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    include: ['src/__tests__/**/*.{test,spec}.{js,ts}'],
+    exclude: ['e2e/**', 'node_modules/**', 'dist/**'],
   },
 })

--- a/scripts/cleanup-multiplier-smoke-leftover.mjs
+++ b/scripts/cleanup-multiplier-smoke-leftover.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/**
+ * Delete leftover local smoke multiplier rows that break golden baseline tests
+ * (personnel_id=1 must have multiplier_days=0).
+ *
+ * Only deletes rows whose description/proof looks like prior smoke/UAT, OR
+ * the single bonus=29 row on personnel 1 if --force-bonus29 is set.
+ *
+ * Usage: node scripts/cleanup-multiplier-smoke-leftover.mjs
+ */
+const API = (process.env.API_BASE || 'http://127.0.0.1:8000').replace(/\/$/, '')
+const USER = process.env.UAT_USER || 'admin'
+const PASS = process.env.UAT_PASS || 'admin123'
+
+async function api(method, path, { token, csrf, body } = {}) {
+  const headers = { 'Content-Type': 'application/json' }
+  if (token) headers.Authorization = `Bearer ${token}`
+  if (csrf) headers['X-CSRF-Token'] = csrf
+  const res = await fetch(`${API}${path}`, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  })
+  const text = await res.text()
+  let json = null
+  try {
+    json = text ? JSON.parse(text) : null
+  } catch {
+    json = { raw: text }
+  }
+  return { status: res.status, json }
+}
+
+function isSmokeLike(row) {
+  const proof = String(row.proof_reference || '')
+  const desc = String(row.description || '')
+  if (/^UAT-TC-/i.test(proof)) return true
+  if (/Live API UAT/i.test(desc)) return true
+  if (/smoke/i.test(proof) || /smoke/i.test(desc)) return true
+  // Prior handoff smoke: eligible/bonus 29/29 on personnel 1
+  if (
+    Number(row.personnel_id) === 1 &&
+    Number(row.bonus_days) === 29 &&
+    Number(row.eligible_days) === 29
+  ) {
+    return true
+  }
+  return false
+}
+
+async function main() {
+  const login = await api('POST', '/auth/login', {
+    body: { username: USER, password: PASS },
+  })
+  if (login.status !== 200 || !login.json?.token) {
+    console.error('LOGIN FAIL', login.status, login.json?.error || 'unknown')
+    process.exit(2)
+  }
+  const token = login.json.token
+  const csrf = login.json.csrf_token
+
+  const list = await api('GET', '/multiplier?limit=100', { token })
+  if (list.status !== 200) {
+    console.error('LIST FAIL', list.status, list.json?.error || 'unknown')
+    process.exit(2)
+  }
+  const rows = list.json.data || []
+  const targets = rows.filter(isSmokeLike)
+  console.log(`listed=${rows.length} smoke_like=${targets.length}`)
+
+  let deleted = 0
+  for (const row of targets) {
+    const id = row.multiplier_id
+    const del = await api('DELETE', `/multiplier/${id}`, { token, csrf })
+    if (del.status >= 200 && del.status < 300) {
+      deleted++
+      console.log(`deleted multiplier_id=${id} bonus=${row.bonus_days}`)
+    } else {
+      console.error(`DELETE FAIL id=${id} status=${del.status}`)
+    }
+  }
+
+  const after = await api('GET', '/multiplier?limit=100', { token })
+  const summary = after.json?.summary || {}
+  console.log(
+    `after total=${summary.total ?? '?'} bonus_sum=${summary.total_bonus_days ?? '?'}`
+  )
+  console.log(`RESULT deleted=${deleted}`)
+  process.exit(0)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(2)
+})

--- a/scripts/uat-multiplier-live-api.mjs
+++ b/scripts/uat-multiplier-live-api.mjs
@@ -1,0 +1,286 @@
+#!/usr/bin/env node
+/**
+ * Live API UAT — TC-001..TC-010 from docs/multiplier_phase0_uat_cases_template.csv
+ * against POST /multiplier (local Docker backend). Creates then deletes each row.
+ *
+ * Usage: node scripts/uat-multiplier-live-api.mjs
+ * Env: API_BASE (default http://127.0.0.1:8000), UAT_USER, UAT_PASS
+ */
+import { readFileSync } from 'node:fs'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const API = (process.env.API_BASE || 'http://127.0.0.1:8000').replace(/\/$/, '')
+const USER = process.env.UAT_USER || 'admin'
+const PASS = process.env.UAT_PASS || 'admin123'
+const CSV = resolve(ROOT, 'docs/multiplier_phase0_uat_cases_template.csv')
+
+function parseCsv(text) {
+  const lines = text.trim().split(/\r?\n/)
+  const headers = lines[0].split(',')
+  return lines.slice(1).filter(Boolean).map((line) => {
+    const cols = []
+    let cur = ''
+    let inQ = false
+    for (const ch of line) {
+      if (ch === '"') {
+        inQ = !inQ
+        continue
+      }
+      if (ch === ',' && !inQ) {
+        cols.push(cur)
+        cur = ''
+        continue
+      }
+      cur += ch
+    }
+    cols.push(cur)
+    const row = {}
+    headers.forEach((h, i) => {
+      row[h] = cols[i] ?? ''
+    })
+    return row
+  })
+}
+
+async function api(method, path, { token, csrf, body } = {}) {
+  const headers = { 'Content-Type': 'application/json' }
+  if (token) headers.Authorization = `Bearer ${token}`
+  if (csrf) headers['X-CSRF-Token'] = csrf
+  const res = await fetch(`${API}${path}`, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  })
+  const text = await res.text()
+  let json = null
+  try {
+    json = text ? JSON.parse(text) : null
+  } catch {
+    json = { raw: text }
+  }
+  return { status: res.status, json }
+}
+
+function districtKey(d) {
+  return !d || d === 'NULL' ? '' : String(d).trim()
+}
+
+function datesOverlap(aStart, aEnd, bStart, bEnd) {
+  const as = aStart
+  const ae = aEnd || '9999-12-31'
+  const bs = bStart
+  const be = bEnd || '9999-12-31'
+  return as <= be && bs <= ae
+}
+
+function pickArea(areas, tc) {
+  const province = tc.province.trim()
+  const district = districtKey(tc.district)
+  const start = tc.service_start_date
+  const end = tc.service_end_date
+  const preferEmergency = start >= '2005-01-01'
+
+  const candidates = areas.filter((a) => {
+    if (a.province !== province) return false
+    if (districtKey(a.district) !== district) return false
+    if (!datesOverlap(a.effective_start_date, a.effective_end_date, start, end)) return false
+    return true
+  })
+
+  if (!candidates.length) return null
+
+  const ranked = [...candidates].sort((a, b) => {
+    const aEm = a.basis_type === 'EMERGENCY_DECREE' ? 1 : 0
+    const bEm = b.basis_type === 'EMERGENCY_DECREE' ? 1 : 0
+    if (preferEmergency) return bEm - aEm
+    return aEm - bEm
+  })
+  return ranked[0]
+}
+
+function num(v) {
+  return Number(v)
+}
+
+function compare(tc, computed) {
+  const checks = [
+    ['eligible_start_date', tc.expected_eligible_start_date, computed.eligible_start_date],
+    ['eligible_end_date', tc.expected_eligible_end_date, computed.eligible_end_date],
+    ['service_days', num(tc.expected_service_days), num(computed.service_days)],
+    ['eligible_days', num(tc.expected_eligible_days), num(computed.eligible_days)],
+    ['effective_days', num(tc.expected_effective_days), num(computed.effective_days)],
+    ['bonus_days', num(tc.expected_bonus_days), num(computed.bonus_days)],
+    ['net_years', num(tc.expected_net_years), num(computed.net_years)],
+    ['net_months', num(tc.expected_net_months), num(computed.net_months)],
+    ['net_day_remainder', num(tc.expected_net_days), num(computed.net_day_remainder)],
+  ]
+  const fails = checks.filter(([, exp, got]) => String(exp) !== String(got))
+  return fails.map(([field, exp, got]) => `${field}: expected ${exp}, got ${got}`)
+}
+
+async function main() {
+  const cases = parseCsv(readFileSync(CSV, 'utf8')).filter((r) =>
+    /^TC-\d+$/.test(r.case_id)
+  )
+
+  const login = await api('POST', '/auth/login', {
+    body: { username: USER, password: PASS },
+  })
+  if (login.status !== 200 || !login.json?.token) {
+    console.error('LOGIN FAIL', login.status, login.json?.error || login.json)
+    process.exit(2)
+  }
+  const token = login.json.token
+  const csrf = login.json.csrf_token
+  if (login.json.user?.must_change_password) {
+    console.error('LOGIN OK but must_change_password=true — change password first')
+    process.exit(2)
+  }
+
+  const areasRes = await api('GET', '/multiplier/areas?limit=100', { token })
+  if (areasRes.status !== 200) {
+    console.error('AREAS FAIL', areasRes.status, areasRes.json)
+    process.exit(2)
+  }
+  const areas = areasRes.json.data || areasRes.json.areas || areasRes.json
+  if (!Array.isArray(areas)) {
+    console.error('AREAS unexpected shape', Object.keys(areasRes.json || {}))
+    process.exit(2)
+  }
+
+  // /personnel requires a non-empty search; use common Thai vowel to collect a pool
+  const peopleRes = await api('GET', `/personnel?search=${encodeURIComponent('า')}&limit=20`, {
+    token,
+  })
+  if (peopleRes.status !== 200) {
+    console.error('PERSONNEL FAIL', peopleRes.status, peopleRes.json?.error || 'unknown')
+    process.exit(2)
+  }
+  const people = peopleRes.json.data || peopleRes.json
+  const personnelIds = (Array.isArray(people) ? people : [])
+    .map((p) => p.personnel_id)
+    .filter(Boolean)
+  if (personnelIds.length < 1) {
+    console.error('No personnel_id available for UAT create (search pool empty)')
+    process.exit(2)
+  }
+
+  console.log(`API ${API}`)
+  console.log(`Areas loaded: ${areas.length}; personnel pool size: ${personnelIds.length}`)
+  console.log('---')
+
+  let pass = 0
+  let fail = 0
+  const results = []
+
+  for (let i = 0; i < cases.length; i++) {
+    const tc = cases[i]
+    const area = pickArea(areas, tc)
+    if (!area) {
+      fail++
+      results.push({
+        id: tc.case_id,
+        ok: false,
+        detail: `no matching area for ${tc.province}/${tc.district || '(whole)'} @ ${tc.service_start_date}..${tc.service_end_date}`,
+      })
+      console.log(`FAIL ${tc.case_id} — no matching area`)
+      continue
+    }
+
+    // rotate personnel to reduce overlap 409 risk across cases
+    const personnelId = personnelIds[i % personnelIds.length]
+    const create = await api('POST', '/multiplier', {
+      token,
+      csrf,
+      body: {
+        personnel_id: personnelId,
+        area_multiplier_id: area.area_multiplier_id,
+        start_date: tc.service_start_date,
+        end_date: tc.service_end_date,
+        proof_reference: `UAT-${tc.case_id}`,
+        description: `Live API UAT ${tc.case_id}`,
+      },
+    })
+
+    if (create.status === 409) {
+      // retry with next personnel
+      let created = null
+      for (const pid of personnelIds) {
+        if (pid === personnelId) continue
+        const retry = await api('POST', '/multiplier', {
+          token,
+          csrf,
+          body: {
+            personnel_id: pid,
+            area_multiplier_id: area.area_multiplier_id,
+            start_date: tc.service_start_date,
+            end_date: tc.service_end_date,
+            proof_reference: `UAT-${tc.case_id}`,
+            description: `Live API UAT ${tc.case_id}`,
+          },
+        })
+        if (retry.status === 201) {
+          created = retry
+          break
+        }
+      }
+      if (!created) {
+        fail++
+        results.push({
+          id: tc.case_id,
+          ok: false,
+          detail: `409 overlap for all personnel (area ${area.area_multiplier_id})`,
+        })
+        console.log(`FAIL ${tc.case_id} — overlap 409`)
+        continue
+      }
+      Object.assign(create, created)
+    }
+
+    if (create.status !== 201 || !create.json?.computed) {
+      fail++
+      results.push({
+        id: tc.case_id,
+        ok: false,
+        detail: `HTTP ${create.status}: ${create.json?.error || JSON.stringify(create.json)}`,
+      })
+      console.log(`FAIL ${tc.case_id} — HTTP ${create.status}`)
+      continue
+    }
+
+    const mismatches = compare(tc, create.json.computed)
+    const mid = create.json.multiplier_id
+
+    // cleanup always
+    if (mid) {
+      await api('DELETE', `/multiplier/${mid}`, { token, csrf })
+    }
+
+    if (mismatches.length) {
+      fail++
+      results.push({ id: tc.case_id, ok: false, detail: mismatches.join('; ') })
+      console.log(`FAIL ${tc.case_id} — ${mismatches.join('; ')}`)
+    } else {
+      pass++
+      results.push({
+        id: tc.case_id,
+        ok: true,
+        detail: `area=${area.area_multiplier_id} ${area.basis_type} eligible=${create.json.computed.eligible_days} bonus=${create.json.computed.bonus_days}`,
+      })
+      console.log(
+        `PASS ${tc.case_id} — area ${area.area_multiplier_id} (${area.basis_type}) eligible=${create.json.computed.eligible_days} bonus=${create.json.computed.bonus_days}`
+      )
+    }
+  }
+
+  console.log('---')
+  console.log(`RESULT: ${pass}/${cases.length} PASS, ${fail} FAIL`)
+  process.exit(fail ? 1 : 0)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(2)
+})


### PR DESCRIPTION
## Summary
- Treat `TEST_SEED` / empty legal refs as `source_pending` (รอเอกสาร); show Thai login errors on auth 401 instead of `Unauthorized`.
- Gate `*test-seed*` migrations behind `APPLY_TEST_SEED_MIGRATIONS=1` (enabled in local `docker-compose`; off by default on Render) so provisional seed does not auto-apply to prod.
- Optimize `computeOverview` with UNION ALL + window ranking (~3 queries).
- Add Playwright E2E for login / candidates / import / permissions; exclude `e2e/` from Vitest; add local multiplier UAT helper scripts.

## Test plan
- [x] `MultiplierAreaDecorateTest` + live areas `source_pending=14`
- [x] `QualificationEngineTest` including overview shape
- [x] `useApi` Vitest login-401 case
- [x] `npm run test:e2e` (7 passed) with `db`+`backend` up
- [ ] After merge/deploy: confirm Render applies migration 15 if pending; confirm migration 16 is skipped unless env set
- [ ] Smoke prod: backend `/` 200, frontend `/login` 200, bad login returns Thai 401 JSON
