### PR TITLE
fix: align remember-me and forgot-password on one row

### DIFF
--- a/frontend/src/pages/LoginPage.vue
+++ b/frontend/src/pages/LoginPage.vue
@@ -66,21 +66,20 @@
                 <component :is="showPassword ? EyeOff : Eye" class="h-5 w-5" />
               </button>
             </div>
-            <div class="mt-1.5 flex justify-end">
+            <div class="mt-2 flex items-center justify-between gap-3">
+              <label class="flex cursor-pointer items-center">
+                <input type="checkbox" v-model="rememberMe" class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500" />
+                <span class="ml-2 text-sm text-gray-600">จดจำฉัน</span>
+              </label>
               <button
                 type="button"
-                class="cursor-pointer text-sm text-blue-600 hover:text-blue-800 hover:underline"
+                class="cursor-pointer shrink-0 text-sm text-blue-600 hover:text-blue-800 hover:underline"
                 @click="showAccountHelp('forgot')"
               >
                 ลืมรหัสผ่าน?
               </button>
             </div>
           </div>
-
-          <label class="flex items-center cursor-pointer">
-            <input type="checkbox" v-model="rememberMe" class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500" />
-            <span class="ml-2 text-sm text-gray-600">จดจำฉัน</span>
-          </label>
 
           <!-- #5: Info (forgot / create account) -->
           <div


### PR DESCRIPTION
## Summary
- Put **จดจำฉัน** and **ลืมรหัสผ่าน?** on one row under the password field (left / right).

## Test plan
- [x] Login form: remember-me and forgot-password share one line
- [ ] Login still works
