### PR TITLE
fix: align remember-me spacing with decoration-core

### DIFF
--- a/frontend/src/pages/LoginPage.vue
+++ b/frontend/src/pages/LoginPage.vue
@@ -66,19 +66,21 @@
                 <component :is="showPassword ? EyeOff : Eye" class="h-5 w-5" />
               </button>
             </div>
-            <div class="mt-4 flex items-center justify-between gap-3">
-              <label class="flex cursor-pointer items-center">
-                <input type="checkbox" v-model="rememberMe" class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500" />
-                <span class="ml-2 text-sm text-gray-600">จดจำฉัน</span>
-              </label>
-              <button
-                type="button"
-                class="cursor-pointer shrink-0 text-sm text-blue-600 hover:text-blue-800 hover:underline"
-                @click="showAccountHelp('forgot')"
-              >
-                ลืมรหัสผ่าน?
-              </button>
-            </div>
+          </div>
+
+          <!-- spacing like decoration-core: sibling of password under form space-y-5 (20px) -->
+          <div class="flex items-center justify-between gap-3">
+            <label class="flex cursor-pointer items-center">
+              <input type="checkbox" v-model="rememberMe" class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500" />
+              <span class="ml-2 text-sm text-gray-600">จดจำฉัน</span>
+            </label>
+            <button
+              type="button"
+              class="cursor-pointer shrink-0 text-sm text-blue-600 hover:text-blue-800 hover:underline"
+              @click="showAccountHelp('forgot')"
+            >
+              ลืมรหัสผ่าน?
+            </button>
           </div>
 
           <!-- #5: Info (forgot / create account) -->


### PR DESCRIPTION
﻿## Summary
- Align login **จดจำฉัน** spacing with [decoration-core](https://github.com/Arnutt-N/decoration-core): move remember/forgot row out of the password field so orm.space-y-5 supplies the 20px gap (was nested mt-4 = 16px).
- Keep **ลืมรหัสผ่าน?** on the same row.

## Test plan
- [ ] Open /login and confirm gap above จดจำฉัน matches decoration-core (~20px)
- [ ] Confirm จดจำฉัน and ลืมรหัสผ่าน? stay on one row
- [ ] Confirm submit button spacing still looks even
