### PR TITLE
fix: detect stale change-password backend deploys

### DIFF
--- a/backend/routes/auth.php
+++ b/backend/routes/auth.php
@@ -44,7 +44,7 @@ function handleAuth(PDO $pdo, string $method, array $path): void
     }
 
     http_response_code(404);
-    echo json_encode(['error' => 'Not found']);
+    echo json_encode(['error' => 'ไม่พบ endpoint การยืนยันตัวตน']);
 }
 
 /**

--- a/docs/render-tidb-production.md
+++ b/docs/render-tidb-production.md
@@ -137,7 +137,18 @@ curl -i \
 
 Expected result: JSON token payload, not a database connection error.
 
-3. Open the frontend:
+3. Confirm change-password route is deployed (no token needed):
+
+```bash
+curl -i -X POST https://smartport-backend.onrender.com/auth/change-password \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+Expected result: **`401`** with `{"error":"Unauthorized"}`.  
+If you get **`404`**, the live backend image is behind `main` — redeploy `smartport-backend` (Deploy Latest) before testing `/change-password` in the UI.
+
+4. Open the frontend:
 
 ```text
 https://smart-port.onrender.com/
@@ -148,6 +159,7 @@ Expected result:
 - no white blank screen during first route load
 - login page renders
 - login succeeds if TiDB env is correct
+- after forced password change, `POST /auth/change-password` succeeds (not 404)
 
 ## 7. Current production failure mode
 


### PR DESCRIPTION
﻿## Summary
- Production `/change-password` was failing with `404 Not found` because the live backend image lacked `POST /auth/change-password` (behind main).
- Add a deploy verification check: unauthenticated `POST /auth/change-password` must return `401`, not `404`.
- Return a Thai message for unknown auth routes so mis-deploys are easier to spot.

## Test plan
- [ ] Unauthenticated POST /auth/change-password returns 401 after backend redeploy
- [ ] Login on production, forced change password succeeds (not 404)
- [ ] Redeploy smartport-backend from main if still 404
