### PR TITLE
fix: Render Docker build with backend rootDir

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -47,12 +47,13 @@ tests/
 coverage/
 phpunit.xml
 
-# Ignore SQL dumps and backups (init ใน docker-compose)
+# Ignore SQL dumps and backups — keep repo migrations for backend Docker image
 *.sql
+!database/
+!database/**
 *.sql.gz
 backups/
 
 # Ignore Docker-related files (ไม่ copy เข้า image)
-Dockerfile
 docker-compose.yml
 .dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
-# Smart Port backend — build context = backend/ directory.
-# Used by Render when Root Directory is "backend" and Docker Context is "." (not "..").
-# Migrations are not copied here (database/ is outside this context); TiDB schema is
-# expected to exist already. Set RUN_MIGRATIONS=0. For full migration bundle use repo-root Dockerfile.
+# Smart Port backend — build from repository root (docker-compose, Render with empty Root Directory).
+# Context must include backend/ and database/ (see docker-compose.yaml).
 # =========================================================================
 # STAGE 1: Composer Dependencies Stage
 # =========================================================================
@@ -9,7 +7,7 @@ FROM composer:2.7 AS vendor
 
 WORKDIR /app
 
-COPY composer.json composer.lock* ./
+COPY backend/composer.json backend/composer.lock* ./
 
 RUN composer install --no-dev --no-interaction --no-plugins --no-scripts --optimize-autoloader --ignore-platform-req=ext-gd
 
@@ -34,15 +32,16 @@ opcache.revalidate_freq=0" > /usr/local/etc/php/conf.d/opcache.ini
 
 WORKDIR /var/www/html
 
-COPY . .
+COPY backend/ .
+COPY database/ /var/www/database/
 COPY --from=vendor /app/vendor/ ./vendor/
 
-RUN mkdir -p /var/www/html/uploads /var/www/html/storage/rate_limits /var/www/database \
+RUN mkdir -p /var/www/html/uploads /var/www/html/storage/rate_limits \
     && chown -R www-data:www-data /var/www/html/uploads /var/www/html/storage \
     && chmod +x /var/www/html/docker-entrypoint.sh
 
 ENV MIGRATIONS_DIR=/var/www/database
-ENV RUN_MIGRATIONS=0
+ENV RUN_MIGRATIONS=1
 
 RUN echo "PassEnv MYSQL_HOST MYSQL_PORT MYSQL_DATABASE MYSQL_USER MYSQL_PASSWORD MYSQL_SSL MYSQL_SSL_CA JWT_SECRET" \
     >> /etc/apache2/conf-enabled/passenv.conf

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   backend:
     build:
       context: .
-      dockerfile: backend/Dockerfile
+      dockerfile: Dockerfile
     container_name: smartport-backend
     ports:
       - "8000:80"

--- a/docs/render-tidb-production.md
+++ b/docs/render-tidb-production.md
@@ -18,10 +18,14 @@ The source of truth for new deployments is [render.yaml](D:/hrProject/smart-port
 - `smartport-backend`
   - Type: Web Service
   - Runtime: Docker
-  - Root Directory: *(repo root — leave empty)* — Dockerfile must see both `backend/` and `database/`
-  - Dockerfile Path: `./backend/Dockerfile`
-  - Docker Context: `.` (repository root; matches `docker-compose.yaml`)
+  - Root Directory: `backend`
+  - Dockerfile Path: `./backend/Dockerfile` (relative to **repository root**, not Root Directory)
+  - Docker Context: `.` (meaning the `backend/` folder — **never** `..`)
   - Health Check Path: `/`
+
+  If Docker Context is `..`, Render sends an empty build context (`transferring context: 2B`) and the build fails with `"/backend/composer.json": not found`. The `backend/Dockerfile` uses paths relative to the `backend/` folder (`COPY composer.json`, `COPY . .`).
+
+  Local `docker compose` uses the repo-root [`Dockerfile`](../../Dockerfile) so both `backend/` and `database/` migrations are included.
 
 ## 2. Required backend environment variables
 
@@ -101,10 +105,10 @@ If you are updating the existing services instead of recreating them from the Bl
 
 1. Open Render Dashboard.
 2. Edit `smartport-backend` **Build & Deploy** settings:
-   - Root Directory: clear / leave empty (repo root)
+   - Root Directory: `backend`
    - Dockerfile Path: `./backend/Dockerfile`
-   - Docker Context: `.`
-   - If Root Directory stays `backend`, the build context is empty and deploy fails with `"/backend/composer.json": not found`.
+   - Docker Context: `.` (**must not** be `..`)
+   - If the log shows `transferring context: 2B` or `"/backend/composer.json": not found`, Docker Context is wrong.
 3. Edit `smartport-backend` environment variables.
 4. Add or correct all TiDB values listed above.
 5. Redeploy `smartport-backend`.

--- a/render.yaml
+++ b/render.yaml
@@ -25,9 +25,9 @@ services:
     name: smartport-backend
     runtime: docker
     branch: main
-    # No rootDir: Dockerfile needs both backend/ and database/ (same as docker-compose.yaml).
-    # With rootDir: backend, Render hides sibling dirs → empty context ("transferring context: 2B")
-    # and COPY backend/... / database/... fail with "not found".
+    # Render dashboard often keeps Root Directory = backend. Use backend/ as context (NOT "..").
+    # dockerContext ".." hides files outside rootDir → empty context ("transferring context: 2B").
+    rootDir: backend
     dockerfilePath: ./backend/Dockerfile
     dockerContext: .
     healthCheckPath: /


### PR DESCRIPTION
﻿## Summary
- Render still failed with `transferring context: 2B` when Root Directory is `backend` but Docker Context is `..` (parent dir blocked → empty context).
- `backend/Dockerfile` now uses backend-relative paths for Render rootDir=backend + dockerContext=.
- Repo-root `Dockerfile` keeps full backend/ + database/ for local docker compose.

## Test plan
- [ ] Render: Root Directory backend, Docker Context ., Dockerfile ./backend/Dockerfile
- [ ] docker compose build backend
- [ ] POST /auth/change-password returns 401 without token after deploy
