### PR TITLE
fix: route sidebar menus and profile link to their own pages

### DIFF
--- a/frontend/src/__tests__/router/placeholder-routes.test.js
+++ b/frontend/src/__tests__/router/placeholder-routes.test.js
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/stores/auth.js', () => ({
+  useAuthStore: () => ({ isAuthenticated: true, mustChangePassword: false, user: { role: 'admin' } }),
+}))
+
+vi.mock('@/composables/useNavProgress.js', () => ({
+  useNavProgress: () => ({ isNavigating: { value: false } }),
+}))
+
+vi.mock('@/utils/chunkGuard.js', () => ({
+  isChunkLoadError: () => false,
+  shouldReloadForChunkError: () => false,
+}))
+
+const router = (await import('@/router/index.js')).default
+
+describe('placeholder routes', () => {
+  it.each([
+    ['/work-results', 'work-results'],
+    ['/awards', 'awards'],
+    ['/profile', 'my-profile'],
+  ])('resolves %s to its own route (%s), not the catch-all redirect', (path, name) => {
+    expect(router.resolve(path).name).toBe(name)
+  })
+
+  it('work-results and awards no longer share the analytics destination', () => {
+    expect(router.resolve('/work-results').path).not.toBe(router.resolve('/analytics').path)
+    expect(router.resolve('/awards').path).not.toBe(router.resolve('/analytics').path)
+    expect(router.resolve('/work-results').path).not.toBe(router.resolve('/awards').path)
+  })
+
+  it('keeps the personnel profile/:id route intact', () => {
+    expect(router.resolve('/profile/42').name).toBe('profile')
+  })
+})

--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -148,8 +148,8 @@ const menuItems = computed(() => [
       ]
     : []),
   { id: 'work-management', label: 'การจัดการงาน', icon: Briefcase, to: '/admin' },
-  { id: 'work-results', label: 'ผลงานและข้อเสนอ', icon: FileText, to: '/analytics' },
-  { id: 'awards', label: 'รางวัล/ความดีความชอบ', icon: Trophy, to: '/analytics' },
+  { id: 'work-results', label: 'ผลงานและข้อเสนอ', icon: FileText, to: '/work-results' },
+  { id: 'awards', label: 'รางวัล/ความดีความชอบ', icon: Trophy, to: '/awards' },
 ])
 
 function toggleSubmenu(id) {

--- a/frontend/src/components/AppTopbar.vue
+++ b/frontend/src/components/AppTopbar.vue
@@ -44,7 +44,7 @@
           <!-- Menu items -->
           <div class="py-1">
             <button
-              @click="navigateTo('/profile/1')"
+              @click="navigateTo('/profile')"
               class="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 transition-colors cursor-pointer"
             >
               <User class="w-4 h-4 text-gray-400" />
@@ -101,6 +101,9 @@ const pageTitles = {
   '/position-compare': 'การเทียบตำแหน่ง',
   '/royal-decorations': 'เครื่องราชอิสริยาภรณ์',
   '/retirement-report': 'รายงานผู้เกษียณ',
+  '/work-results': 'ผลงานและข้อเสนอ',
+  '/awards': 'รางวัล/ความดีความชอบ',
+  '/profile': 'โปรไฟล์ของฉัน',
 }
 
 const pageTitle = computed(() => {

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -42,10 +42,28 @@ const routes = [
         component: () => import('@/pages/ProbationEndPage.vue'),
       },
       {
+        path: 'profile',
+        name: 'my-profile',
+        component: () => import('@/pages/PlaceholderPage.vue'),
+        props: { title: 'โปรไฟล์ของฉัน', description: 'โปรไฟล์ของฉัน - กำลังพัฒนา' },
+      },
+      {
         path: 'profile/:id',
         name: 'profile',
         component: () => import('@/pages/PlaceholderPage.vue'),
         props: (route) => ({ title: 'โปรไฟล์', description: `กำลังโหลดโปรไฟล์ ID: ${route.params.id}` }),
+      },
+      {
+        path: 'work-results',
+        name: 'work-results',
+        component: () => import('@/pages/PlaceholderPage.vue'),
+        props: { title: 'ผลงานและข้อเสนอ', description: 'ผลงานและข้อเสนอ - กำลังพัฒนา' },
+      },
+      {
+        path: 'awards',
+        name: 'awards',
+        component: () => import('@/pages/PlaceholderPage.vue'),
+        props: { title: 'รางวัล/ความดีความชอบ', description: 'รางวัล/ความดีความชอบ - กำลังพัฒนา' },
       },
       {
         path: 'analytics',


### PR DESCRIPTION
## Summary
- เมนู 'ผลงานและข้อเสนอ' กับ 'รางวัล/ความดีความชอบ' ชี้ไป \/analytics\ placeholder จุดเดียวกัน — แยกเป็น \/work-results\ และ \/awards\
- ปุ่ม 'โปรไฟล์ของฉัน' บน topbar hardcode \/profile/1\ — เปลี่ยนเป็น \/profile\ (route ใหม่ my-profile) คง \/profile/:id\ สำหรับ personnel profile เดิม
- เพิ่ม pageTitles ของหน้าใหม่ใน AppTopbar

## Verification
- \
px vitest run --pool=forks --maxWorkers=2\ → 117 tests passed (16 files) รวมเทสใหม่ \placeholder-routes.test.js\ 5 tests
- \
pm run build\ ผ่าน