### PR TITLE
test: cover auth store and time-counting CRUD pages

### DIFF
--- a/frontend/src/__tests__/pages/DiversePage.test.js
+++ b/frontend/src/__tests__/pages/DiversePage.test.js
@@ -1,0 +1,100 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+const mockFetchList = vi.fn()
+const mockCreate = vi.fn()
+const mockUpdate = vi.fn()
+const mockRemove = vi.fn()
+
+vi.mock('@/composables/useDiverse.js', () => ({
+  useDiverse: () => ({
+    fetchList: mockFetchList,
+    create: mockCreate,
+    update: mockUpdate,
+    remove: mockRemove,
+  }),
+}))
+
+const mockApiGet = vi.fn()
+vi.mock('@/composables/useApi.js', () => ({
+  useApi: () => ({ get: mockApiGet }),
+}))
+
+const DiversePage = (await import('@/pages/DiversePage.vue')).default
+
+const sampleRow = {
+  experienceId: 5,
+  personnelId: 3,
+  fullName: 'สมชาย ใจดี',
+  fromJobSeries: 'ธุรการ',
+  fromWorkGroup: 'บริหารทั่วไป',
+  fromProvince: 'กรุงเทพมหานคร',
+  fromStartDate: '2019-01-01',
+  fromEndDate: '2020-12-31',
+  fromStartDateThai: '1 ม.ค. 2562',
+  fromEndDateThai: '31 ธ.ค. 2563',
+  toJobSeries: 'ทรัพยากรบุคคล',
+  toWorkGroup: 'บริหารทั่วไป',
+  toProvince: 'นนทบุรี',
+  toStartDate: '2021-01-01',
+  toEndDate: '2022-12-31',
+  toStartDateThai: '1 ม.ค. 2564',
+  toEndDateThai: '31 ธ.ค. 2565',
+  isDiffJobSeries: 1,
+  isDiffOrg: 0,
+  isDiffLocation: 1,
+  diffCount: 2,
+  description: '',
+}
+
+async function mountPage() {
+  setActivePinia(createPinia())
+  const wrapper = mount(DiversePage)
+  await vi.waitFor(() => expect(mockFetchList).toHaveBeenCalled())
+  await wrapper.vm.$nextTick()
+  return wrapper
+}
+
+describe('DiversePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFetchList.mockResolvedValue({
+      success: true,
+      data: [sampleRow],
+      summary: null,
+      pagination: { total: 1, limit: 20, offset: 0 },
+    })
+  })
+
+  it('loads and renders diverse-experience records on mount', async () => {
+    const wrapper = await mountPage()
+    expect(wrapper.text()).toContain('สมชาย ใจดี')
+    expect(wrapper.text()).toContain('ธุรการ')
+    expect(wrapper.text()).toContain('ทรัพยากรบุคคล')
+  })
+
+  it('blocks submit when required form fields are missing', async () => {
+    const wrapper = await mountPage()
+    wrapper.vm.openCreateModal()
+    await wrapper.vm.$nextTick()
+
+    await wrapper.vm.handleSubmit()
+
+    expect(mockCreate).not.toHaveBeenCalled()
+    expect(wrapper.vm.showModal).toBe(true)
+  })
+
+  it('delete flow calls remove with the experience id', async () => {
+    const wrapper = await mountPage()
+    mockRemove.mockResolvedValue({ success: true })
+    mockFetchList.mockClear()
+
+    wrapper.vm.confirmDelete(sampleRow)
+    await wrapper.vm.handleDelete()
+
+    expect(mockRemove).toHaveBeenCalledWith(5)
+    expect(wrapper.vm.showDeleteDialog).toBe(false)
+    expect(mockFetchList).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/__tests__/pages/EquivalencePage.test.js
+++ b/frontend/src/__tests__/pages/EquivalencePage.test.js
@@ -1,0 +1,113 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useAuthStore } from '@/stores/auth.js'
+
+const mockFetchList = vi.fn()
+const mockCreate = vi.fn()
+const mockUpdate = vi.fn()
+const mockApprove = vi.fn()
+const mockReject = vi.fn()
+
+vi.mock('@/composables/useEquivalence.js', () => ({
+  useEquivalence: () => ({
+    fetchList: mockFetchList,
+    create: mockCreate,
+    update: mockUpdate,
+    approve: mockApprove,
+    reject: mockReject,
+  }),
+}))
+
+const mockApiGet = vi.fn()
+vi.mock('@/composables/useApi.js', () => ({
+  useApi: () => ({ get: mockApiGet }),
+}))
+
+const EquivalencePage = (await import('@/pages/EquivalencePage.vue')).default
+
+const sampleRow = {
+  equivalenceId: 9,
+  personnelId: 3,
+  fullName: 'สมชาย ใจดี',
+  actualPosition: 'นักทรัพยากรบุคคลชำนาญการ',
+  equivalentType: 'ACADEMIC',
+  requestStartDate: '2020-01-01',
+  requestEndDate: '2021-12-31',
+  requestStartDateThai: '1 ม.ค. 2563',
+  requestEndDateThai: '31 ธ.ค. 2564',
+  requestTotalDays: 731,
+  approvalStatus: 'PENDING',
+  approvedStartDate: null,
+  approvedEndDate: null,
+  approvedTotalDays: null,
+  approvedBy: null,
+  approvedByName: null,
+  approvalOrderRef: null,
+}
+
+async function mountPage({ role = 'admin' } = {}) {
+  setActivePinia(createPinia())
+  const auth = useAuthStore()
+  auth.user = { user_id: 1, role }
+  const wrapper = mount(EquivalencePage)
+  await vi.waitFor(() => expect(mockFetchList).toHaveBeenCalled())
+  await wrapper.vm.$nextTick()
+  return wrapper
+}
+
+describe('EquivalencePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFetchList.mockResolvedValue({
+      success: true,
+      data: [sampleRow],
+      summary: null,
+      pagination: { total: 1, limit: 20, offset: 0 },
+    })
+  })
+
+  it('loads and renders equivalence requests on mount', async () => {
+    const wrapper = await mountPage()
+    expect(wrapper.text()).toContain('สมชาย ใจดี')
+    expect(wrapper.text()).toContain('นักทรัพยากรบุคคลชำนาญการ')
+  })
+
+  it('blocks save when required form fields are missing', async () => {
+    const wrapper = await mountPage()
+    wrapper.vm.openCreate()
+    await wrapper.vm.$nextTick()
+
+    await wrapper.vm.handleSave()
+
+    expect(mockCreate).not.toHaveBeenCalled()
+    expect(wrapper.vm.showModal).toBe(true)
+  })
+
+  it('approve flow sends approved dates for the record', async () => {
+    const wrapper = await mountPage()
+    mockApprove.mockResolvedValue({ success: true })
+    mockFetchList.mockClear()
+
+    wrapper.vm.openApprove(sampleRow)
+    await wrapper.vm.handleApprove()
+
+    expect(mockApprove).toHaveBeenCalledWith(9, {
+      approvedStartDate: '2020-01-01',
+      approvedEndDate: '2021-12-31',
+    })
+    expect(wrapper.vm.showApproveModal).toBe(false)
+    expect(mockFetchList).toHaveBeenCalled()
+  })
+
+  it('reject flow calls reject with the record id', async () => {
+    const wrapper = await mountPage()
+    mockReject.mockResolvedValue({ success: true })
+
+    wrapper.vm.confirmReject(9)
+    await wrapper.vm.handleReject()
+
+    expect(mockReject).toHaveBeenCalledWith(9)
+    expect(wrapper.vm.showRejectConfirm).toBe(false)
+  })
+})

--- a/frontend/src/__tests__/pages/MultiplierPage.test.js
+++ b/frontend/src/__tests__/pages/MultiplierPage.test.js
@@ -1,0 +1,148 @@
+import { mount, RouterLinkStub } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useAuthStore } from '@/stores/auth.js'
+
+const mockFetchList = vi.fn()
+const mockFetchAreas = vi.fn()
+const mockCreate = vi.fn()
+const mockUpdate = vi.fn()
+const mockRemove = vi.fn()
+
+vi.mock('@/composables/useMultiplier.js', () => ({
+  useMultiplier: () => ({
+    fetchList: mockFetchList,
+    fetchAreas: mockFetchAreas,
+    create: mockCreate,
+    update: mockUpdate,
+    remove: mockRemove,
+  }),
+}))
+
+const mockApiGet = vi.fn()
+vi.mock('@/composables/useApi.js', () => ({
+  useApi: () => ({ get: mockApiGet }),
+}))
+
+const MultiplierPage = (await import('@/pages/MultiplierPage.vue')).default
+
+const sampleRow = {
+  multiplierId: 7,
+  personnelId: 3,
+  fullName: 'สมชาย ใจดี',
+  areaMultiplierId: 2,
+  province: 'ยะลา',
+  district: null,
+  areaLabel: 'ยะลา / ทั้งจังหวัด',
+  basisType: 'EMERGENCY_DECREE',
+  startDate: '2020-01-01',
+  endDate: '2020-12-31',
+  startDateThai: '1 ม.ค. 2563',
+  endDateThai: '31 ธ.ค. 2563',
+  eligibleDays: 366,
+  multiplierRatio: 200,
+  effectiveDays: 732,
+  bonusDays: 366,
+  netYears: 2,
+  netMonths: 0,
+  netDayRemainder: 1,
+  proofReference: 'คส.123/2563',
+  description: '',
+}
+
+const sampleArea = {
+  areaMultiplierId: 2,
+  province: 'ยะลา',
+  district: null,
+  areaLabel: 'ยะลา / ทั้งจังหวัด',
+  basisType: 'EMERGENCY_DECREE',
+  multiplierRatio: 200,
+  legalReference: 'TEST_SEED',
+  sourceReference: '',
+  isActive: true,
+  sourcePending: true,
+}
+
+function resolvedData() {
+  mockFetchList.mockResolvedValue({
+    success: true,
+    data: [sampleRow],
+    summary: { total: 1, distinct_personnel: 1, total_effective_days: 732, total_bonus_days: 366 },
+    pagination: { total: 1, limit: 20, offset: 0, has_more: false },
+  })
+  mockFetchAreas.mockResolvedValue({
+    success: true,
+    data: [sampleArea],
+    summary: { total: 1, source_pending: 1 },
+  })
+}
+
+async function mountPage({ role = 'admin' } = {}) {
+  setActivePinia(createPinia())
+  const auth = useAuthStore()
+  auth.user = { user_id: 1, role }
+  const wrapper = mount(MultiplierPage, {
+    global: { stubs: { RouterLink: RouterLinkStub } },
+  })
+  await vi.waitFor(() => {
+    expect(mockFetchList).toHaveBeenCalled()
+  })
+  await wrapper.vm.$nextTick()
+  return wrapper
+}
+
+describe('MultiplierPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resolvedData()
+  })
+
+  it('loads records and areas on mount and renders them', async () => {
+    const wrapper = await mountPage()
+    expect(mockFetchAreas).toHaveBeenCalled()
+    expect(wrapper.text()).toContain('สมชาย ใจดี')
+    expect(wrapper.text()).toContain('ยะลา / ทั้งจังหวัด')
+  })
+
+  it('shows error banner when loading fails', async () => {
+    mockFetchList.mockRejectedValue(new Error('boom'))
+    const wrapper = await mountPage()
+    await vi.waitFor(() => expect(wrapper.text()).toContain('boom'))
+  })
+
+  it('hides the special-areas settings link from non-admin users', async () => {
+    const wrapper = await mountPage({ role: 'operator' })
+    const links = wrapper.findAllComponents(RouterLinkStub)
+    expect(links.some((l) => l.props('to') === '/settings/special-areas')).toBe(false)
+  })
+
+  it('shows the settings link to admins', async () => {
+    const wrapper = await mountPage({ role: 'admin' })
+    const links = wrapper.findAllComponents(RouterLinkStub)
+    expect(links.some((l) => l.props('to') === '/settings/special-areas')).toBe(true)
+  })
+
+  it('blocks submit when required form fields are missing', async () => {
+    const wrapper = await mountPage()
+    wrapper.vm.openCreateModal()
+    await wrapper.vm.$nextTick()
+
+    await wrapper.vm.handleSubmit()
+
+    expect(mockCreate).not.toHaveBeenCalled()
+    expect(wrapper.vm.showModal).toBe(true)
+  })
+
+  it('delete flow calls remove and refreshes the list', async () => {
+    const wrapper = await mountPage()
+    mockRemove.mockResolvedValue({ success: true })
+    mockFetchList.mockClear()
+
+    wrapper.vm.openDeleteConfirm(sampleRow)
+    await wrapper.vm.handleDelete()
+
+    expect(mockRemove).toHaveBeenCalledWith(7)
+    expect(mockFetchList).toHaveBeenCalled()
+    expect(wrapper.vm.showDeleteConfirm).toBe(false)
+  })
+})

--- a/frontend/src/__tests__/pages/SupportivePage.test.js
+++ b/frontend/src/__tests__/pages/SupportivePage.test.js
@@ -1,0 +1,91 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+const mockFetchList = vi.fn()
+const mockCreate = vi.fn()
+const mockUpdate = vi.fn()
+const mockRemove = vi.fn()
+
+vi.mock('@/composables/useSupportive.js', () => ({
+  useSupportive: () => ({
+    fetchList: mockFetchList,
+    create: mockCreate,
+    update: mockUpdate,
+    remove: mockRemove,
+  }),
+}))
+
+const mockApiGet = vi.fn()
+vi.mock('@/composables/useApi.js', () => ({
+  useApi: () => ({ get: mockApiGet }),
+}))
+
+const SupportivePage = (await import('@/pages/SupportivePage.vue')).default
+
+const sampleRow = {
+  supportiveId: 11,
+  personnelId: 3,
+  fullName: 'สมชาย ใจดี',
+  jobSeriesName: 'ทรัพยากรบุคคล',
+  primarySeriesName: 'บริหารทั่วไป',
+  startDate: '2021-01-01',
+  endDate: '2021-12-31',
+  startDateThai: '1 ม.ค. 2564',
+  endDateThai: '31 ธ.ค. 2564',
+  totalDays: 365,
+  ratioPercent: 50,
+  effectiveDays: 183,
+  netEndDate: '2022-06-30',
+  description: '',
+}
+
+async function mountPage() {
+  setActivePinia(createPinia())
+  const wrapper = mount(SupportivePage)
+  await vi.waitFor(() => expect(mockFetchList).toHaveBeenCalled())
+  await wrapper.vm.$nextTick()
+  return wrapper
+}
+
+describe('SupportivePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFetchList.mockResolvedValue({
+      success: true,
+      data: [sampleRow],
+      summary: null,
+      pagination: { total: 1, limit: 20, offset: 0 },
+    })
+  })
+
+  it('loads and renders supportive records on mount', async () => {
+    const wrapper = await mountPage()
+    expect(wrapper.text()).toContain('สมชาย ใจดี')
+    expect(wrapper.text()).toContain('ทรัพยากรบุคคล')
+  })
+
+  it('blocks save when required form fields are missing', async () => {
+    const wrapper = await mountPage()
+    wrapper.vm.openCreate()
+    await wrapper.vm.$nextTick()
+
+    await wrapper.vm.handleSave()
+
+    expect(mockCreate).not.toHaveBeenCalled()
+    expect(wrapper.vm.showModal).toBe(true)
+  })
+
+  it('delete flow calls remove with the record id', async () => {
+    const wrapper = await mountPage()
+    mockRemove.mockResolvedValue({ success: true })
+    mockFetchList.mockClear()
+
+    wrapper.vm.confirmDelete(11)
+    await wrapper.vm.handleDelete()
+
+    expect(mockRemove).toHaveBeenCalledWith(11)
+    expect(wrapper.vm.showDeleteConfirm).toBe(false)
+    expect(mockFetchList).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/__tests__/stores/auth.test.js
+++ b/frontend/src/__tests__/stores/auth.test.js
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useAuthStore } from '@/stores/auth.js'
+
+const mockPost = vi.fn()
+
+vi.mock('@/composables/useApi.js', () => ({
+  useApi: () => ({ post: mockPost }),
+}))
+
+function makeJwt(expSeconds) {
+  const b64 = (obj) => btoa(JSON.stringify(obj)).replace(/=+$/, '').replace(/\+/g, '-').replace(/\//g, '_')
+  return `${b64({ alg: 'HS256', typ: 'JWT' })}.${b64({ sub: 1, role: 'admin', exp: expSeconds })}.sig`
+}
+
+const validToken = () => makeJwt(Math.floor(Date.now() / 1000) + 3600)
+const expiredToken = () => makeJwt(Math.floor(Date.now() / 1000) - 10)
+
+const authData = () => ({
+  token: validToken(),
+  csrf_token: 'csrf-123',
+  user: { user_id: 1, username: 'admin', name: 'Admin', role: 'admin', must_change_password: false },
+})
+
+describe('auth store', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    setActivePinia(createPinia())
+    mockPost.mockReset()
+  })
+
+  it('starts unauthenticated with empty storage', () => {
+    const auth = useAuthStore()
+    expect(auth.isAuthenticated).toBe(false)
+    expect(auth.user).toBeNull()
+    expect(auth.isAdmin).toBe(false)
+  })
+
+  it('setAuth persists token/user/csrf and authenticates', () => {
+    const auth = useAuthStore()
+    auth.setAuth(authData())
+
+    expect(auth.isAuthenticated).toBe(true)
+    expect(auth.isAdmin).toBe(true)
+    expect(auth.csrfToken).toBe('csrf-123')
+    expect(JSON.parse(localStorage.getItem('user')).username).toBe('admin')
+    expect(localStorage.getItem('auth_token')).toBe(auth.token)
+  })
+
+  it('rejects expired tokens', () => {
+    const auth = useAuthStore()
+    auth.setAuth({ ...authData(), token: expiredToken() })
+    expect(auth.isAuthenticated).toBe(false)
+  })
+
+  it('rejects malformed tokens without throwing', () => {
+    const auth = useAuthStore()
+    auth.setAuth({ ...authData(), token: 'not-a-jwt' })
+    expect(auth.isAuthenticated).toBe(false)
+  })
+
+  it('login posts credentials and stores the session', async () => {
+    mockPost.mockResolvedValue(authData())
+    const auth = useAuthStore()
+
+    await auth.login({ username: 'admin', password: 'x' })
+
+    expect(mockPost).toHaveBeenCalledWith('/auth/login', { username: 'admin', password: 'x' })
+    expect(auth.isAuthenticated).toBe(true)
+  })
+
+  it('mustChangePassword reflects the user flag and persists updates', () => {
+    const auth = useAuthStore()
+    auth.setAuth({ ...authData(), user: { ...authData().user, must_change_password: true } })
+    expect(auth.mustChangePassword).toBe(true)
+
+    auth.setMustChangePassword(false)
+    expect(auth.mustChangePassword).toBe(false)
+    expect(JSON.parse(localStorage.getItem('user')).must_change_password).toBe(false)
+  })
+
+  it('changePassword posts and clears the forced-change flag', async () => {
+    mockPost.mockResolvedValue({ status: 'success' })
+    const auth = useAuthStore()
+    auth.setAuth({ ...authData(), user: { ...authData().user, must_change_password: true } })
+
+    await auth.changePassword('old-pass', 'new-pass-123')
+
+    expect(mockPost).toHaveBeenCalledWith('/auth/change-password', {
+      current_password: 'old-pass',
+      new_password: 'new-pass-123',
+    })
+    expect(auth.mustChangePassword).toBe(false)
+  })
+
+  it('logout clears every persisted key', () => {
+    const auth = useAuthStore()
+    auth.setAuth({ ...authData(), refreshToken: 'refresh-1' })
+    auth.logout()
+
+    expect(auth.isAuthenticated).toBe(false)
+    expect(auth.user).toBeNull()
+    for (const key of ['auth_token', 'authToken', 'refresh_token', 'refreshToken', 'csrf_token', 'user']) {
+      expect(localStorage.getItem(key)).toBeNull()
+    }
+  })
+
+  it('treats corrupted storage values as empty', () => {
+    localStorage.setItem('user', '{not json')
+    localStorage.setItem('auth_token', 'undefined')
+    setActivePinia(createPinia())
+    const auth = useAuthStore()
+
+    expect(auth.user).toBeNull()
+    expect(auth.isAuthenticated).toBe(false)
+    expect(localStorage.getItem('user')).toBeNull()
+    expect(localStorage.getItem('auth_token')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- \stores/auth.test.js\ (9 tests): session lifecycle, token validity (expired/malformed), forced password change flow, logout cleanup, corrupted storage
- \MultiplierPage\ (6): load/render, error banner, admin-only settings link, validation blocks submit, delete flow
- \SupportivePage\ (3) / \DiversePage\ (3): load/render, validation, delete flow
- \EquivalencePage\ (4): load/render, validation, approve with dates, reject flow

## Coverage impact
- Overall line coverage **25% → 50%** · tests **117 → 142**
- auth.js: 0% → 94% · CRUD pages: 0% → ~60%+

## Verification
\
px vitest run --pool=forks --maxWorkers=2\ → 21 files / 142 tests passed