### PR TITLE
test: cover remaining admin pages and ui store

### DIFF
--- a/frontend/src/__tests__/pages/AuditLogPage.test.js
+++ b/frontend/src/__tests__/pages/AuditLogPage.test.js
@@ -1,0 +1,119 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockGet = vi.fn()
+
+vi.mock('@/composables/useApi.js', () => ({
+  useApi: () => ({ get: mockGet }),
+}))
+
+const AuditLogPage = (await import('@/pages/AuditLogPage.vue')).default
+
+const sampleRow = {
+  audit_id: 11,
+  created_at: '2026-07-01T10:30:00',
+  user_id: 1,
+  username: 'admin',
+  full_name: 'ผู้ดูแลระบบ',
+  action: 'UPDATE',
+  table_name: 'personnel',
+  record_id: 42,
+  before_value: { full_name: 'เดิม' },
+  after_value: { full_name: 'ใหม่' },
+  ip_address: '10.0.0.1',
+}
+
+function resolvedData(rows = [sampleRow], total = rows.length) {
+  mockGet.mockResolvedValue({
+    data: rows,
+    pagination: { total, limit: 50, offset: 0 },
+  })
+}
+
+async function mountPage() {
+  const wrapper = mount(AuditLogPage)
+  await vi.waitFor(() => {
+    expect(mockGet).toHaveBeenCalled()
+  })
+  await wrapper.vm.$nextTick()
+  return wrapper
+}
+
+describe('AuditLogPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resolvedData()
+  })
+
+  it('loads audit rows on mount and renders labels', async () => {
+    const wrapper = await mountPage()
+    expect(wrapper.text()).toContain('ผู้ดูแลระบบ')
+    expect(wrapper.text()).toContain('แก้ไข') // action UPDATE
+    expect(wrapper.text()).toContain('บุคลากร') // table personnel
+    expect(wrapper.text()).toContain('42')
+  })
+
+  it('shows empty state when there are no rows', async () => {
+    resolvedData([], 0)
+    const wrapper = await mountPage()
+    await vi.waitFor(() => expect(wrapper.text()).toContain('ไม่พบประวัติการเปลี่ยนแปลง'))
+  })
+
+  it('shows error state when loading fails', async () => {
+    mockGet.mockRejectedValue(new Error('เซิร์ฟเวอร์ล่ม'))
+    const wrapper = await mountPage()
+    await vi.waitFor(() => expect(wrapper.text()).toContain('เซิร์ฟเวอร์ล่ม'))
+  })
+
+  it('changing table filter resets offset and refetches with the filter', async () => {
+    const wrapper = await mountPage()
+    mockGet.mockClear()
+
+    wrapper.vm.pagination.offset = 50
+    wrapper.vm.filters.table = 'users'
+    wrapper.vm.onFilterChange()
+
+    await vi.waitFor(() => {
+      expect(mockGet).toHaveBeenCalled()
+      const url = mockGet.mock.calls[0][0]
+      expect(url).toContain('table=users')
+      expect(url).toContain('offset=0')
+    })
+    expect(wrapper.vm.pagination.offset).toBe(0)
+  })
+
+  it('page change keeps filters and moves offset', async () => {
+    resolvedData([sampleRow], 200)
+    const wrapper = await mountPage()
+    mockGet.mockClear()
+
+    wrapper.vm.onPageChange(50)
+
+    await vi.waitFor(() => {
+      const url = mockGet.mock.calls[0][0]
+      expect(url).toContain('offset=50')
+      expect(url).toContain('limit=50')
+    })
+  })
+
+  it('opens detail modal with before/after values and closes via Escape', async () => {
+    const wrapper = await mountPage()
+
+    wrapper.vm.showDetail(sampleRow)
+    await wrapper.vm.$nextTick()
+    expect(wrapper.text()).toContain('รายละเอียดการเปลี่ยนแปลง')
+    expect(wrapper.text()).toContain('10.0.0.1')
+    expect(wrapper.text()).toContain('"full_name": "ใหม่"')
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.selectedRow).toBeNull()
+  })
+
+  it('maps unknown actions and tables to raw values', async () => {
+    resolvedData([{ ...sampleRow, action: 'LOGIN', table_name: 'sessions' }])
+    const wrapper = await mountPage()
+    expect(wrapper.text()).toContain('LOGIN')
+    expect(wrapper.text()).toContain('sessions')
+  })
+})

--- a/frontend/src/__tests__/pages/ImportPage.test.js
+++ b/frontend/src/__tests__/pages/ImportPage.test.js
@@ -1,0 +1,151 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockUploadResponse = vi.fn()
+
+vi.mock('@/composables/useApi.js', () => ({
+  useApi: () => ({ uploadResponse: mockUploadResponse }),
+}))
+
+const ImportPage = (await import('@/pages/ImportPage.vue')).default
+
+function makeFile(name, size = 1024) {
+  const file = new File(['x'], name, { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' })
+  Object.defineProperty(file, 'size', { value: size })
+  return file
+}
+
+function mockResponse({ ok, status = ok ? 200 : 422, body }) {
+  return {
+    ok,
+    status,
+    statusText: 'Error',
+    json: vi.fn().mockResolvedValue(body),
+  }
+}
+
+async function mountPage() {
+  const wrapper = mount(ImportPage, {
+    global: { stubs: { RouterLink: { template: '<a><slot /></a>' } } },
+  })
+  await wrapper.vm.$nextTick()
+  return wrapper
+}
+
+describe('ImportPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders template download link and upload dropzone', async () => {
+    const wrapper = await mountPage()
+    const link = wrapper.find('a[download]')
+    expect(link.exists()).toBe(true)
+    expect(link.attributes('href')).toContain('/import-template.xlsx')
+    expect(wrapper.text()).toContain('รองรับ .xlsx ขนาดไม่เกิน 5MB')
+  })
+
+  it('rejects non-xlsx files before upload', async () => {
+    const wrapper = await mountPage()
+    wrapper.vm.pick(makeFile('data.csv'))
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.text()).toContain('รองรับเฉพาะไฟล์ .xlsx')
+    expect(wrapper.vm.file).toBeNull()
+    expect(mockUploadResponse).not.toHaveBeenCalled()
+  })
+
+  it('rejects files larger than 5MB', async () => {
+    const wrapper = await mountPage()
+    wrapper.vm.pick(makeFile('big.xlsx', 5 * 1024 * 1024 + 1))
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.text()).toContain('ไฟล์ใหญ่เกิน 5MB')
+    expect(wrapper.vm.file).toBeNull()
+  })
+
+  it('accepts a valid xlsx and shows its name', async () => {
+    const wrapper = await mountPage()
+    wrapper.vm.pick(makeFile('personnel.xlsx'))
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.vm.file.name).toBe('personnel.xlsx')
+    expect(wrapper.text()).toContain('personnel.xlsx')
+  })
+
+  it('submits and shows summary on success', async () => {
+    const wrapper = await mountPage()
+    mockUploadResponse.mockResolvedValue(
+      mockResponse({
+        ok: true,
+        body: { success: true, summary: { personnel: 10, diverse: 3, equivalence: 2, history: 5 } },
+      }),
+    )
+
+    wrapper.vm.pick(makeFile('personnel.xlsx'))
+    await wrapper.vm.submit()
+    await wrapper.vm.$nextTick()
+
+    expect(mockUploadResponse).toHaveBeenCalledWith('/import/executive', expect.any(FormData))
+    expect(wrapper.vm.status).toBe('success')
+    expect(wrapper.text()).toContain('นำเข้าสำเร็จ')
+    expect(wrapper.text()).toContain('10')
+  })
+
+  it('shows server validation errors on failure response', async () => {
+    const wrapper = await mountPage()
+    mockUploadResponse.mockResolvedValue(
+      mockResponse({
+        ok: false,
+        body: { success: false, errors: ['แถวที่ 3: ไม่พบเลขบัตรประชาชน', 'แถวที่ 7: วันที่ไม่ถูกต้อง'] },
+      }),
+    )
+
+    wrapper.vm.pick(makeFile('personnel.xlsx'))
+    await wrapper.vm.submit()
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.vm.status).toBe('error')
+    expect(wrapper.text()).toContain('นำเข้าไม่สำเร็จ (2 รายการ)')
+    expect(wrapper.text()).toContain('ไม่พบเลขบัตรประชาชน')
+  })
+
+  it('handles non-JSON error responses gracefully', async () => {
+    const wrapper = await mountPage()
+    mockUploadResponse.mockResolvedValue({
+      ok: false,
+      status: 413,
+      statusText: 'Payload Too Large',
+      json: vi.fn().mockRejectedValue(new Error('not json')),
+    })
+
+    wrapper.vm.pick(makeFile('personnel.xlsx'))
+    await wrapper.vm.submit()
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.vm.status).toBe('error')
+    expect(wrapper.text()).toContain('Payload Too Large')
+  })
+
+  it('shows connection error when upload throws', async () => {
+    const wrapper = await mountPage()
+    mockUploadResponse.mockRejectedValue(new Error('network down'))
+
+    wrapper.vm.pick(makeFile('personnel.xlsx'))
+    await wrapper.vm.submit()
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.text()).toContain('เชื่อมต่อเซิร์ฟเวอร์ไม่ได้')
+  })
+
+  it('reset clears file, status and results', async () => {
+    const wrapper = await mountPage()
+    wrapper.vm.pick(makeFile('personnel.xlsx'))
+    wrapper.vm.reset()
+
+    expect(wrapper.vm.file).toBeNull()
+    expect(wrapper.vm.status).toBe('idle')
+    expect(wrapper.vm.errors).toEqual([])
+    expect(wrapper.vm.summary).toBeNull()
+  })
+})

--- a/frontend/src/__tests__/pages/MultiplierAreasPage.test.js
+++ b/frontend/src/__tests__/pages/MultiplierAreasPage.test.js
@@ -1,0 +1,228 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockFetchAreas = vi.fn()
+const mockCreateArea = vi.fn()
+const mockSetAreaStatus = vi.fn()
+
+vi.mock('@/composables/useMultiplier.js', () => ({
+  useMultiplier: () => ({
+    fetchAreas: mockFetchAreas,
+    createArea: mockCreateArea,
+    setAreaStatus: mockSetAreaStatus,
+  }),
+}))
+
+const MultiplierAreasPage = (await import('@/pages/MultiplierAreasPage.vue')).default
+
+const activeArea = {
+  areaMultiplierId: 1,
+  province: 'ยะลา',
+  district: null,
+  areaLabel: 'ยะลา / ทั้งจังหวัด',
+  basisType: 'EMERGENCY_DECREE',
+  multiplierRatio: 200,
+  effectiveStartDateThai: '1 ม.ค. 2563',
+  effectiveEndDateThai: null,
+  legalReference: '',
+  sourceReference: '',
+  isActive: true,
+  sourcePending: true,
+}
+
+const inactiveArea = {
+  areaMultiplierId: 2,
+  province: 'นราธิวาส',
+  district: 'เบตง',
+  areaLabel: 'นราธิวาส / เบตง',
+  basisType: 'MARTIAL_LAW',
+  multiplierRatio: 150,
+  effectiveStartDateThai: '1 ม.ค. 2560',
+  effectiveEndDateThai: '31 ธ.ค. 2562',
+  legalReference: 'ประกาศ กศ.123',
+  sourceReference: 'หนังสือเวียน',
+  isActive: false,
+  sourcePending: false,
+}
+
+function resolvedData(areas = [activeArea, inactiveArea]) {
+  mockFetchAreas.mockResolvedValue({ data: areas })
+}
+
+async function mountPage() {
+  const wrapper = mount(MultiplierAreasPage, {
+    global: { stubs: { RouterLink: { template: '<a><slot /></a>' } } },
+  })
+  await vi.waitFor(() => {
+    expect(mockFetchAreas).toHaveBeenCalled()
+  })
+  await wrapper.vm.$nextTick()
+  return wrapper
+}
+
+describe('MultiplierAreasPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resolvedData()
+    window.confirm = vi.fn(() => true)
+  })
+
+  it('loads areas on mount and renders labels, ratios and statuses', async () => {
+    const wrapper = await mountPage()
+    expect(mockFetchAreas).toHaveBeenCalledWith({ activeOnly: false })
+    expect(wrapper.text()).toContain('ยะลา / ทั้งจังหวัด')
+    expect(wrapper.text()).toContain('พ.ร.ก.ฉุกเฉิน')
+    expect(wrapper.text()).toContain('กฎอัยการศึก')
+    expect(wrapper.text()).toContain('200%')
+    expect(wrapper.text()).toContain('ไม่กำหนด')
+    expect(wrapper.text()).toContain('รอเอกสาร')
+    expect(wrapper.text()).toContain('ยืนยันแล้ว')
+    expect(wrapper.text()).toContain('ปิดใช้งาน')
+  })
+
+  it('computes summary counts for active and source-pending areas', async () => {
+    const wrapper = await mountPage()
+    expect(wrapper.vm.activeCount).toBe(1)
+    expect(wrapper.vm.pendingCount).toBe(1)
+    expect(wrapper.vm.basisOptions).toEqual(['EMERGENCY_DECREE', 'MARTIAL_LAW'])
+  })
+
+  it('shows error state when loading fails', async () => {
+    mockFetchAreas.mockRejectedValue(new Error('โหลดพื้นที่ไม่สำเร็จ'))
+    const wrapper = await mountPage()
+    await vi.waitFor(() => expect(wrapper.text()).toContain('โหลดพื้นที่ไม่สำเร็จ'))
+  })
+
+  it('toggle status confirms then calls setAreaStatus and refetches', async () => {
+    const wrapper = await mountPage()
+    mockSetAreaStatus.mockResolvedValue({ success: true })
+    mockFetchAreas.mockClear()
+
+    await wrapper.vm.toggleStatus(activeArea)
+
+    expect(window.confirm).toHaveBeenCalled()
+    expect(mockSetAreaStatus).toHaveBeenCalledWith(1, false)
+    expect(mockFetchAreas).toHaveBeenCalled()
+    expect(wrapper.vm.togglingId).toBeNull()
+  })
+
+  it('toggle status does nothing when user cancels confirm', async () => {
+    window.confirm = vi.fn(() => false)
+    const wrapper = await mountPage()
+
+    await wrapper.vm.toggleStatus(activeArea)
+
+    expect(mockSetAreaStatus).not.toHaveBeenCalled()
+  })
+
+  it('shows action error banner when toggle fails', async () => {
+    const wrapper = await mountPage()
+    mockSetAreaStatus.mockRejectedValue(new Error('เปลี่ยนสถานะไม่สำเร็จ'))
+
+    await wrapper.vm.toggleStatus(inactiveArea)
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.text()).toContain('เปลี่ยนสถานะไม่สำเร็จ')
+  })
+
+  it('blocks submit when required fields are missing', async () => {
+    const wrapper = await mountPage()
+    wrapper.vm.openCreateModal()
+    await wrapper.vm.handleSubmit()
+
+    expect(mockCreateArea).not.toHaveBeenCalled()
+    expect(wrapper.vm.showModal).toBe(true)
+    expect(wrapper.vm.formErrors.province).toBe(true)
+    expect(wrapper.vm.formErrors.basis_type).toBe(true)
+    expect(wrapper.vm.formErrors.effective_start_date).toBe(true)
+  })
+
+  it('blocks submit when end date is before start date', async () => {
+    const wrapper = await mountPage()
+    wrapper.vm.openCreateModal()
+    wrapper.vm.formData = {
+      province: 'ยะลา',
+      district: '',
+      basis_type: 'EMERGENCY_DECREE',
+      multiplier_ratio: 200,
+      effective_start_date: '2026-01-01',
+      effective_end_date: '2025-01-01',
+      legal_reference: '',
+      source_reference: '',
+    }
+    await wrapper.vm.handleSubmit()
+
+    expect(mockCreateArea).not.toHaveBeenCalled()
+    expect(wrapper.vm.formErrors.effective_end_date).toBe(true)
+  })
+
+  it('blocks submit when ratio is out of range', async () => {
+    const wrapper = await mountPage()
+    wrapper.vm.openCreateModal()
+    wrapper.vm.formData = {
+      ...wrapper.vm.formData,
+      province: 'ยะลา',
+      basis_type: 'EMERGENCY_DECREE',
+      multiplier_ratio: 50,
+      effective_start_date: '2026-01-01',
+      effective_end_date: '',
+    }
+    await wrapper.vm.handleSubmit()
+
+    expect(mockCreateArea).not.toHaveBeenCalled()
+    expect(wrapper.vm.formErrors.multiplier_ratio).toBe(true)
+  })
+
+  it('creates an area with numeric ratio and refreshes', async () => {
+    const wrapper = await mountPage()
+    mockCreateArea.mockResolvedValue({ success: true })
+    mockFetchAreas.mockClear()
+
+    wrapper.vm.openCreateModal()
+    wrapper.vm.formData = {
+      province: 'ปัตตานี',
+      district: '',
+      basis_type: 'EMERGENCY_DECREE',
+      multiplier_ratio: '200',
+      effective_start_date: '2026-01-01',
+      effective_end_date: '',
+      legal_reference: 'พ.ร.ก. ฉบับที่ 1',
+      source_reference: '',
+    }
+    await wrapper.vm.handleSubmit()
+
+    expect(mockCreateArea).toHaveBeenCalledWith(
+      expect.objectContaining({ province: 'ปัตตานี', multiplier_ratio: 200 }),
+    )
+    expect(wrapper.vm.showModal).toBe(false)
+    expect(mockFetchAreas).toHaveBeenCalled()
+  })
+
+  it('keeps modal open with submit error when create fails', async () => {
+    const wrapper = await mountPage()
+    mockCreateArea.mockRejectedValue(new Error('พื้นที่ซ้ำ'))
+
+    wrapper.vm.openCreateModal()
+    wrapper.vm.formData = {
+      ...wrapper.vm.formData,
+      province: 'ยะลา',
+      basis_type: 'EMERGENCY_DECREE',
+      effective_start_date: '2026-01-01',
+    }
+    await wrapper.vm.handleSubmit()
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.vm.showModal).toBe(true)
+    expect(wrapper.text()).toContain('พื้นที่ซ้ำ')
+  })
+
+  it('closes modal via Escape key', async () => {
+    const wrapper = await mountPage()
+    wrapper.vm.openCreateModal()
+    await wrapper.vm.$nextTick()
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.showModal).toBe(false)
+  })
+})

--- a/frontend/src/__tests__/pages/ProbationEndPage.test.js
+++ b/frontend/src/__tests__/pages/ProbationEndPage.test.js
@@ -1,0 +1,107 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockFetchList = vi.fn()
+
+vi.mock('@/composables/useProbation.js', () => ({
+  useProbation: () => ({ fetchList: mockFetchList }),
+}))
+
+const ProbationEndPage = (await import('@/pages/ProbationEndPage.vue')).default
+
+const sampleRow = {
+  enrollmentId: 9,
+  name: 'สมหญิง รักดี',
+  position: 'นักวิชาการศึกษา',
+  department: 'สำนักงานเขตพื้นที่การศึกษา',
+  startDate: '1 ต.ค. 2567',
+  endDate: '30 ก.ย. 2569',
+  remainingDays: 120,
+  status: 'in_progress',
+  totalTasks: 4,
+  completedTasks: 1,
+}
+
+function resolvedData(rows = [sampleRow]) {
+  mockFetchList.mockResolvedValue({
+    data: rows,
+    summary: { total: 10, in_progress: 6, near_deadline: 3, overdue: 1 },
+    pagination: { total: rows.length, limit: 20, offset: 0, has_more: false },
+  })
+}
+
+async function mountPage() {
+  const wrapper = mount(ProbationEndPage)
+  await vi.waitFor(() => {
+    expect(mockFetchList).toHaveBeenCalled()
+  })
+  await wrapper.vm.$nextTick()
+  return wrapper
+}
+
+describe('ProbationEndPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resolvedData()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    document.body.innerHTML = ''
+  })
+
+  it('loads data on mount and renders summary cards and rows', async () => {
+    const wrapper = await mountPage()
+    expect(wrapper.text()).toContain('สมหญิง รักดี')
+    expect(wrapper.text()).toContain('นักวิชาการศึกษา')
+    expect(wrapper.text()).toContain('ทั้งหมด')
+    expect(wrapper.text()).toContain('ใกล้ครบกำหนด')
+    expect(wrapper.text()).toContain('เกินกำหนด')
+  })
+
+  it('shows error state with retry when loading fails', async () => {
+    mockFetchList.mockRejectedValue(new Error('โหลดข้อมูลไม่สำเร็จ'))
+    const wrapper = await mountPage()
+    await vi.waitFor(() => expect(wrapper.text()).toContain('โหลดข้อมูลไม่สำเร็จ'))
+  })
+
+  it('opens view modal with details and closes it', async () => {
+    const wrapper = await mountPage()
+
+    wrapper.vm.openView(sampleRow)
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.vm.showViewModal).toBe(true)
+    expect(document.body.textContent).toContain('รายละเอียดการทดลองปฏิบัติราชการ')
+    expect(document.body.textContent).toContain('1/4 ภารกิจ')
+
+    wrapper.vm.showViewModal = false
+    await wrapper.vm.$nextTick()
+    expect(document.body.textContent).not.toContain('รายละเอียดการทดลองปฏิบัติราชการ')
+  })
+
+  it('search input debounces and resets offset before refetching', async () => {
+    vi.useFakeTimers()
+    const wrapper = await mountPage()
+    await vi.waitFor(() => expect(mockFetchList).toHaveBeenCalled())
+    mockFetchList.mockClear()
+
+    wrapper.vm.searchQuery = 'สมหญิง'
+    wrapper.vm.pagination.offset = 40
+    wrapper.vm.onSearchInput()
+    expect(mockFetchList).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(300)
+
+    expect(mockFetchList).toHaveBeenCalledTimes(1)
+    expect(mockFetchList).toHaveBeenCalledWith(
+      expect.objectContaining({ search: 'สมหญิง', offset: 0 }),
+    )
+  })
+
+  it('shows empty state when no rows match', async () => {
+    resolvedData([])
+    const wrapper = await mountPage()
+    await vi.waitFor(() => expect(wrapper.text()).toContain('ไม่พบข้อมูล'))
+  })
+})

--- a/frontend/src/__tests__/pages/UserManagementPage.test.js
+++ b/frontend/src/__tests__/pages/UserManagementPage.test.js
@@ -1,0 +1,210 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useAuthStore } from '@/stores/auth.js'
+
+const mockFetchList = vi.fn()
+const mockCreate = vi.fn()
+const mockUpdate = vi.fn()
+
+vi.mock('@/composables/useUsers.js', () => ({
+  useUsers: () => ({
+    fetchList: mockFetchList,
+    create: mockCreate,
+    update: mockUpdate,
+  }),
+}))
+
+const UserManagementPage = (await import('@/pages/UserManagementPage.vue')).default
+
+const selfRow = {
+  userId: 1,
+  username: 'admin',
+  fullName: 'ผู้ดูแลระบบ',
+  email: 'admin@example.go.th',
+  role: 'admin',
+  isActive: true,
+  lastLoginAt: '2026-07-01 10:00:00',
+  mustChangePassword: false,
+}
+
+const otherRow = {
+  userId: 2,
+  username: 'somchai.j',
+  fullName: 'สมชาย ใจดี',
+  email: null,
+  role: 'operator',
+  isActive: true,
+  lastLoginAt: null,
+  mustChangePassword: true,
+}
+
+function resolvedData(rows = [selfRow, otherRow]) {
+  mockFetchList.mockResolvedValue({
+    data: rows,
+    pagination: { total: rows.length, limit: 20, offset: 0, has_more: false },
+  })
+}
+
+async function mountPage() {
+  setActivePinia(createPinia())
+  const auth = useAuthStore()
+  auth.user = { id: 1, role: 'admin' }
+  const wrapper = mount(UserManagementPage)
+  await vi.waitFor(() => {
+    expect(mockFetchList).toHaveBeenCalled()
+  })
+  await wrapper.vm.$nextTick()
+  return wrapper
+}
+
+describe('UserManagementPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resolvedData()
+  })
+
+  it('loads users on mount and renders rows', async () => {
+    const wrapper = await mountPage()
+    expect(wrapper.text()).toContain('somchai.j')
+    expect(wrapper.text()).toContain('สมชาย ใจดี')
+    expect(wrapper.text()).toContain('ยังไม่เปลี่ยนรหัสผ่าน')
+    expect(wrapper.text()).toContain('Admin')
+    expect(wrapper.text()).toContain('Operator')
+  })
+
+  it('hides the deactivate button for the logged-in user (self-guard)', async () => {
+    const wrapper = await mountPage()
+    const toggleButtons = wrapper.findAll('button[title="ปิดบัญชี"]')
+    expect(toggleButtons).toHaveLength(1) // เฉพาะแถวของคนอื่น
+  })
+
+  it('shows error state with retry when loading fails', async () => {
+    mockFetchList.mockRejectedValue(new Error('โหลดไม่สำเร็จ'))
+    const wrapper = await mountPage()
+    await vi.waitFor(() => expect(wrapper.text()).toContain('โหลดไม่สำเร็จ'))
+
+    resolvedData()
+    const retry = wrapper.findAll('button').find((b) => b.text() === 'ลองใหม่')
+    await retry.trigger('click')
+    await vi.waitFor(() => expect(wrapper.text()).toContain('somchai.j'))
+  })
+
+  it('blocks create when password is too short', async () => {
+    const wrapper = await mountPage()
+    wrapper.vm.openCreate()
+    wrapper.vm.formData = {
+      username: 'new.user',
+      password: 'short',
+      passwordConfirm: 'short',
+      fullName: 'ผู้ใช้ใหม่',
+      email: '',
+      role: 'operator',
+    }
+
+    await wrapper.vm.submitForm()
+
+    expect(mockCreate).not.toHaveBeenCalled()
+    expect(wrapper.vm.showFormModal).toBe(true)
+  })
+
+  it('blocks create when password confirmation mismatches', async () => {
+    const wrapper = await mountPage()
+    wrapper.vm.openCreate()
+    wrapper.vm.formData = {
+      username: 'new.user',
+      password: 'password1',
+      passwordConfirm: 'password2',
+      fullName: 'ผู้ใช้ใหม่',
+      email: '',
+      role: 'operator',
+    }
+
+    await wrapper.vm.submitForm()
+
+    expect(mockCreate).not.toHaveBeenCalled()
+  })
+
+  it('creates a user and refreshes the list', async () => {
+    const wrapper = await mountPage()
+    mockCreate.mockResolvedValue({ success: true })
+    mockFetchList.mockClear()
+
+    wrapper.vm.openCreate()
+    wrapper.vm.formData = {
+      username: 'new.user',
+      password: 'password1',
+      passwordConfirm: 'password1',
+      fullName: 'ผู้ใช้ใหม่',
+      email: 'new@example.go.th',
+      role: 'operator',
+    }
+    await wrapper.vm.submitForm()
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      username: 'new.user',
+      password: 'password1',
+      fullName: 'ผู้ใช้ใหม่',
+      email: 'new@example.go.th',
+      role: 'operator',
+    })
+    expect(wrapper.vm.showFormModal).toBe(false)
+    expect(mockFetchList).toHaveBeenCalled()
+  })
+
+  it('edits a user without touching username/password', async () => {
+    const wrapper = await mountPage()
+    mockUpdate.mockResolvedValue({ success: true })
+
+    wrapper.vm.openEdit(otherRow)
+    expect(wrapper.vm.formData.username).toBe('somchai.j')
+    wrapper.vm.formData.fullName = 'สมชาย แก้ไข'
+    await wrapper.vm.submitForm()
+
+    expect(mockUpdate).toHaveBeenCalledWith(2, {
+      fullName: 'สมชาย แก้ไข',
+      email: null,
+      role: 'operator',
+    })
+    expect(wrapper.vm.showFormModal).toBe(false)
+  })
+
+  it('reset password flow validates and submits new password', async () => {
+    const wrapper = await mountPage()
+    mockUpdate.mockResolvedValue({ success: true })
+
+    wrapper.vm.openResetPassword(otherRow)
+    wrapper.vm.resetForm = { password: 'newpass123', passwordConfirm: 'different' }
+    await wrapper.vm.submitResetPassword()
+    expect(mockUpdate).not.toHaveBeenCalled()
+
+    wrapper.vm.resetForm = { password: 'newpass123', passwordConfirm: 'newpass123' }
+    await wrapper.vm.submitResetPassword()
+    expect(mockUpdate).toHaveBeenCalledWith(2, { password: 'newpass123' })
+    expect(wrapper.vm.showResetModal).toBe(false)
+  })
+
+  it('toggle active confirms and calls update with flipped status', async () => {
+    const wrapper = await mountPage()
+    mockUpdate.mockResolvedValue({ success: true })
+    mockFetchList.mockClear()
+
+    wrapper.vm.openToggleActive(otherRow)
+    expect(wrapper.vm.showToggleConfirm).toBe(true)
+    await wrapper.vm.submitToggleActive()
+
+    expect(mockUpdate).toHaveBeenCalledWith(2, { isActive: false })
+    expect(wrapper.vm.showToggleConfirm).toBe(false)
+    expect(mockFetchList).toHaveBeenCalled()
+  })
+
+  it('keeps API error visible as toast when update fails', async () => {
+    const wrapper = await mountPage()
+    mockUpdate.mockRejectedValue(new Error('ชื่อผู้ใช้ซ้ำ'))
+
+    wrapper.vm.openEdit(otherRow)
+    await wrapper.vm.submitForm()
+
+    expect(wrapper.vm.showFormModal).toBe(true)
+  })
+})

--- a/frontend/src/__tests__/stores/ui.test.js
+++ b/frontend/src/__tests__/stores/ui.test.js
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useUiStore } from '@/stores/ui.js'
+
+describe('ui store', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    setActivePinia(createPinia())
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('showToast adds a toast with default type info', () => {
+    const ui = useUiStore()
+    ui.showToast('บันทึกสำเร็จ')
+
+    expect(ui.toasts).toHaveLength(1)
+    expect(ui.toasts[0]).toMatchObject({ message: 'บันทึกสำเร็จ', type: 'info' })
+  })
+
+  it('showToast assigns incrementing ids and keeps custom type', () => {
+    const ui = useUiStore()
+    ui.showToast('แจ้งเตือน', 'error')
+    ui.showToast('สำเร็จ', 'success')
+
+    expect(ui.toasts).toHaveLength(2)
+    expect(ui.toasts[1].id).toBeGreaterThan(ui.toasts[0].id)
+    expect(ui.toasts[0].type).toBe('error')
+    expect(ui.toasts[1].type).toBe('success')
+  })
+
+  it('auto-removes toast after the default duration', () => {
+    const ui = useUiStore()
+    ui.showToast('ชั่วคราว')
+
+    vi.advanceTimersByTime(5000)
+    expect(ui.toasts).toHaveLength(0)
+  })
+
+  it('auto-removes toast after a custom duration without touching others', () => {
+    const ui = useUiStore()
+    ui.showToast('สั้น', 'info', 1000)
+    ui.showToast('ยาว', 'info', 10000)
+
+    vi.advanceTimersByTime(1000)
+    expect(ui.toasts).toHaveLength(1)
+    expect(ui.toasts[0].message).toBe('ยาว')
+  })
+
+  it('removeToast removes only the matching id', () => {
+    const ui = useUiStore()
+    ui.showToast('หนึ่ง')
+    ui.showToast('สอง')
+
+    ui.removeToast(ui.toasts[0].id)
+    expect(ui.toasts).toHaveLength(1)
+    expect(ui.toasts[0].message).toBe('สอง')
+  })
+})


### PR DESCRIPTION
## Summary
ต่อยอดจาก PR #57 (coverage 25% -> 50%) — เพิ่มเทสหน้าที่ coverage ยัง 0% ตาม handoff pending #3

- **UserManagementPage** (10 tests): self-guard ปุ่มปิดบัญชีตัวเอง, validate รหัสผ่านสั้น/ไม่ตรง, create/edit/reset password/toggle active, error + retry
- **AuditLogPage** (7 tests): filter รีเซ็ต offset, pagination คง filter, detail modal ปิดด้วย Escape, label mapping fallback
- **ImportPage** (9 tests): validate .xlsx/5MB ก่อนอัปโหลด, success summary, server validation errors, non-JSON response (413), network error, reset
- **ProbationEndPage** (5 tests): stat cards, view modal (Teleport), search debounce 300ms + reset offset, empty/error states
- **MultiplierAreasPage** (12 tests): toggle status confirm/cancel, form validation (required/ช่วงวันที่/อัตรา 100-999.99), create แปลง ratio เป็นตัวเลข, Escape ปิด modal
- **stores/ui** (5 tests): toast lifecycle, auto-remove ตาม duration, removeToast

## Results
- Tests: 142 -> **190** (+48), ผ่านทั้งหมด 27 files
- Coverage (lines): 50% -> **68.64%** (เป้า 65-70% จาก handoff)
- หน้าที่เพิ่ม: UserManagement 79.7%, AuditLog 85.7%, Import 86.3%, ProbationEnd 91.9%, MultiplierAreas 88.3%, ui.js 100%

## Verification
- `npx vitest run --pool=forks --maxWorkers=2` — 190/190 ผ่าน
- `npm run test:coverage` — All files 67.9% stmts / 68.64% lines
- เปลี่ยนเฉพาะไฟล์เทส ไม่แตะ production code