### PR TITLE
refactor: align DiversePage delete state name with sibling pages

### DIFF
--- a/frontend/src/__tests__/pages/DiversePage.test.js
+++ b/frontend/src/__tests__/pages/DiversePage.test.js
@@ -94,7 +94,7 @@ describe('DiversePage', () => {
     await wrapper.vm.handleDelete()
 
     expect(mockRemove).toHaveBeenCalledWith(5)
-    expect(wrapper.vm.showDeleteDialog).toBe(false)
+    expect(wrapper.vm.showDeleteConfirm).toBe(false)
     expect(mockFetchList).toHaveBeenCalled()
   })
 })

--- a/frontend/src/pages/DiversePage.vue
+++ b/frontend/src/pages/DiversePage.vue
@@ -338,8 +338,8 @@
     </div>
 
     <!-- Delete Confirmation Dialog -->
-    <div v-if="showDeleteDialog" class="fixed inset-0 z-50 flex items-center justify-center">
-      <div class="fixed inset-0 bg-black bg-opacity-50" @click="showDeleteDialog = false"></div>
+    <div v-if="showDeleteConfirm" class="fixed inset-0 z-50 flex items-center justify-center">
+      <div class="fixed inset-0 bg-black bg-opacity-50" @click="showDeleteConfirm = false"></div>
       <div class="relative bg-white rounded-lg shadow-xl w-full max-w-md mx-4 p-6">
         <div class="text-center">
           <AlertCircle class="w-12 h-12 text-red-400 mx-auto mb-4" />
@@ -349,7 +349,7 @@
           </p>
           <div class="flex justify-center gap-3">
             <button
-              @click="showDeleteDialog = false"
+              @click="showDeleteConfirm = false"
               class="px-4 py-2 border border-gray-300 rounded-lg text-sm text-gray-700 hover:bg-gray-50 transition-colors"
             >
               ยกเลิก
@@ -491,7 +491,7 @@ function selectPersonnel(person) {
 }
 
 // Delete state
-const showDeleteDialog = ref(false)
+const showDeleteConfirm = ref(false)
 const deletingRow = ref(null)
 
 // Fetch data
@@ -602,7 +602,7 @@ async function handleSubmit() {
 // Delete actions
 function confirmDelete(row) {
   deletingRow.value = row
-  showDeleteDialog.value = true
+  showDeleteConfirm.value = true
 }
 
 async function handleDelete() {
@@ -611,7 +611,7 @@ async function handleDelete() {
   try {
     await remove(deletingRow.value.experienceId)
     ui.showToast('ลบรายการสำเร็จ', 'success')
-    showDeleteDialog.value = false
+    showDeleteConfirm.value = false
     deletingRow.value = null
     await fetchData()
   } catch (err) {


### PR DESCRIPTION
## Summary
- Rename \showDeleteDialog\ -> \showDeleteConfirm\ in \DiversePage.vue\ (template + script) and \DiversePage.test.js\ to match \SupportivePage\ and \MultiplierPage\.
- Behavior unchanged; pure naming alignment for consistency across CRUD pages.

## Why
Pending #5 from session handoff \project-log-md/kimi-code/2026-07-19_12-32-23_kimi-code_session-handoff.md\ — normalize inconsistent state name so the three delete-confirm pages share one convention.

## Changes
- \rontend/src/pages/DiversePage.vue\: 6 references renamed (template \-if\, backdrop click, cancel button, \ef\, \confirmDelete\, \handleDelete\).
- \rontend/src/__tests__/pages/DiversePage.test.js\: 1 assertion updated.

## Verification
- \
px vitest run src/__tests__/pages/DiversePage.test.js src/__tests__/pages/SupportivePage.test.js src/__tests__/pages/MultiplierPage.test.js --pool=forks --maxWorkers=2\ -> 12/12 passed.
- \grep showDeleteDialog frontend/src\ -> 0 matches after change.

## Notes
No production behavior change. Self-approve not allowed by GitHub; review notes posted as this PR body.