### PR TITLE
chore: ignore smartport/ runtime data and .kilo/ tool config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ frontend/playwright/.cache/
 # Project specific
 project-bolt
 admin-dashboard-integration-test.html
+smartport/
 
 # Backup files
 *.backup
@@ -101,6 +102,7 @@ secrets/
 
 # Local agent/tool dirs (config/session — อาจมีข้อมูล local ที่ไม่ควร public)
 .claude/
+.kilo/
 .playwright-cli/
 .playwright-mcp/
 


### PR DESCRIPTION
## Summary
- เพิ่ม `smartport/` และ `.kilo/` ใน `.gitignore` — ปิด pending #4 จาก session handoff `2026-07-19_12-32-23_kimi-code_session-handoff.md`
- ลบ `smartport/` folder (193 ไฟล์ untracked) ออกจาก working tree เนื่องจากเป็น runtime artifact ที่ไม่ถูกใช้แล้ว

## Why
`smartport/` เคยเป็น gitlink ใน repo และถูกถอดออกแล้วใน PR #56 (`085369c chore: drop legacy SQL duplicates and broken smartport gitlink`) แต่ไฟล์ใน working tree ยังค้างเป็น untracked ทุกครั้งที่รัน `git status` — เป็นโอกาสให้ถูก `git add .` โดยไม่ตั้งใจและ leak:
- MySQL 8 auto-generated TLS material (`db-data/*.pem` — 8 ไฟล์รวม private keys)
- สำเนา `docker-compose.yml` / `docker-compose.dev.yml` ที่ฝัง `MYSQL_ROOT_PASSWORD: smartport_2025` เป็น plaintext
- ข้อมูล MySQL volume (`db-data/#innodb_redo/`, `*.dblwr`, `binlog.*`)

`.kilo/` เป็น Kilo tool config dir (เทียบเท่า `.claude/` ที่ถูก ignore อยู่แล้ว) — ควร ignore ด้วยเหตุผลเดียวกัน

## Changes
- `.gitignore`: เพิ่ม `smartport/` ในกลุ่ม "Project specific" + `.kilo/` ในกลุ่ม "Local agent/tool dirs"
- working tree: ลบ `smartport/` folder ทิ้ง (ไม่ใช่การ commit removal เพราะไม่เคยถูก track)

## Verification
- `docker ps` หลังลบ: `smartport-db` (healthy) + `smartport-backend` ยัง Up ปกติ — ยืนยันไม่กระทบ container เพราะใช้ named volume `smart-port_db-data` (จาก `docker inspect smartport-db`) ไม่ใช่ bind mount ไป `smartport/db-data/`
- root `docker-compose.yaml` ใช้ named volume `db-data:` (บรรทัด 87) ไม่ได้อ้าง `smartport/` folder
- `git status` หลังลบ + ignore: เหลือแค่ `.gitignore` modified สะอาด
- ไม่มี test/build ที่ต้องรัน (เปลี่ยนเฉพาะ `.gitignore` อย่างเดียว)

## Safety
- MySQL certs เป็น local-only auto-generated (`MySQL_Server_8.0.42_Auto_Generated` — ถอดจาก cert subject) ไม่ใช่ production secret จึงไม่ต้อง rotate
- DB password `smartport_2025` ใน `smartport/docker-compose.yml` เป็น local dev credential ที่ใช้อยู่ใน root compose เหมือนกัน — ไม่ใช่ leak ใหม่ แค่เลิกเก็บสำเนาที่ไม่ใช้

## Notes
Self-approve not allowed by GitHub; review notes posted as this PR body.