### PR TITLE
test: cover LoginPage, CandidateListsPage, AppTopbar, AppSidebar, useDiverse, useEquivalence

### DIFF
--- a/frontend/src/__tests__/components/AppSidebar.test.js
+++ b/frontend/src/__tests__/components/AppSidebar.test.js
@@ -1,0 +1,210 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+
+let userVal = null
+
+vi.mock('@/stores/auth.js', () => ({
+  useAuthStore: () => ({
+    get user() { return userVal },
+  }),
+}))
+
+let currentPath = '/dashboard'
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ get path() { return currentPath } }),
+  RouterLink: { template: '<a :href="to"><slot /></a>', props: ['to'] },
+}))
+const AppSidebar = (await import('@/components/AppSidebar.vue')).default
+
+function mountSidebar() {
+  return mount(AppSidebar, { props: { open: true } })
+}
+
+describe('AppSidebar', () => {
+  beforeEach(() => {
+    userVal = { name: 'สมชาย', email: 'somchai@example.go.th', role: 'operator' }
+    currentPath = '/dashboard'
+  })
+
+  it('renders 3 section labels for operator (ภาพรวม, MAIN, no ADMIN)', () => {
+    userVal = { name: 'op', role: 'operator' }
+    const wrapper = mountSidebar()
+    const text = wrapper.text()
+    expect(text).toContain('ภาพรวม')
+    expect(text).toContain('MAIN')
+    expect(text).not.toContain('ADMIN')
+  })
+
+  it('renders all 3 section labels (ภาพรวม, MAIN, ADMIN) for admin', () => {
+    userVal = { name: 'admin', role: 'admin' }
+    const wrapper = mountSidebar()
+    const text = wrapper.text()
+    expect(text).toContain('ภาพรวม')
+    expect(text).toContain('MAIN')
+    expect(text).toContain('ADMIN')
+  })
+
+  it('shows admin-only items only for admin', () => {
+    userVal = { name: 'admin', role: 'admin' }
+    let wrapper = mountSidebar()
+    expect(wrapper.text()).toContain('นำเข้าข้อมูล')
+    expect(wrapper.text()).toContain('จัดการผู้ใช้')
+    expect(wrapper.text()).toContain('ประวัติการเปลี่ยนแปลง')
+    expect(wrapper.text()).toContain('จัดการพื้นที่พิเศษ')
+    wrapper.unmount()
+
+    userVal = { name: 'op', role: 'operator' }
+    wrapper = mountSidebar()
+    expect(wrapper.text()).not.toContain('นำเข้าข้อมูล')
+    expect(wrapper.text()).not.toContain('จัดการผู้ใช้')
+    expect(wrapper.text()).not.toContain('จัดการพื้นที่พิเศษ')
+  })
+
+  it('renders Dashboard under ภาพรวม section', () => {
+    const wrapper = mountSidebar()
+    expect(wrapper.text()).toContain('Dashboard')
+  })
+
+  it('renders all MAIN items for every role', () => {
+    userVal = { name: 'op', role: 'operator' }
+    const wrapper = mountSidebar()
+    const text = wrapper.text()
+    expect(text).toContain('พ้นทดลองปฏิบัติราชการ')
+    expect(text).toContain('Candidate Lists')
+    expect(text).toContain('การนับเวลาเพิ่มเติม')
+    expect(text).toContain('เครื่องราชอิสริยาภรณ์')
+    expect(text).toContain('รายงานผู้เกษียณ')
+    expect(text).toContain('การจัดการงาน')
+    expect(text).toContain('ผลงานและข้อเสนอ')
+    expect(text).toContain('รางวัล/ความดีความชอบ')
+  })
+
+  it('collapses single-child admin-settings submenu into a flat จัดการพื้นที่พิเศษ item', () => {
+    userVal = { name: 'admin', role: 'admin' }
+    const wrapper = mountSidebar()
+    // flat item — no submenu toggle, should be a direct RouterLink
+    expect(wrapper.text()).toContain('จัดการพื้นที่พิเศษ')
+    // should NOT have a submenu toggle button labeled "แอดมิน"
+    expect(wrapper.text()).not.toContain('แอดมิน')
+  })
+
+  it('toggles submenu open and closed when parent button clicked', async () => {
+    const wrapper = mountSidebar()
+    expect(wrapper.vm.openSubmenus.has('candidates')).toBe(false)
+
+    // find the Candidate Lists parent button (has children, so it's a <button> not a RouterLink)
+    const parentBtn = wrapper.findAll('button').find((b) => b.text().includes('Candidate Lists'))
+    await parentBtn.trigger('click')
+    expect(wrapper.vm.openSubmenus.has('candidates')).toBe(true)
+
+    // sub-items now visible
+    expect(wrapper.text()).toContain('ภาพรวม')
+    expect(wrapper.text()).toContain('ทั่วไป')
+    expect(wrapper.text()).toContain('วิชาการ')
+    expect(wrapper.text()).toContain('อำนวยการ')
+    expect(wrapper.text()).toContain('บริหาร')
+
+    await parentBtn.trigger('click')
+    expect(wrapper.vm.openSubmenus.has('candidates')).toBe(false)
+  })
+
+  it('marks parent as active when a child route is current', async () => {
+    currentPath = '/candidates/academic'
+    const wrapper = mountSidebar()
+    const parentBtn = wrapper.findAll('button').find((b) => b.text().includes('Candidate Lists'))
+    // isParentActive -> parent button has the active class (bg-blue-600/10)
+    expect(parentBtn.classes()).toContain('bg-blue-600/10')
+  })
+
+  it('emits close when mobile X button clicked', async () => {
+    const wrapper = mountSidebar()
+    const closeBtn = wrapper.find('button[aria-label="ปิดเมนู"]')
+    await closeBtn.trigger('click')
+    expect(wrapper.emitted('close')).toBeTruthy()
+  })
+
+  it('shows user name and role badge in user card', () => {
+    userVal = { name: 'สมชาย ใจดี', email: 's@x.go.th', role: 'admin' }
+    const wrapper = mountSidebar()
+    const text = wrapper.text()
+    expect(text).toContain('สมชาย ใจดี')
+    expect(text).toContain('Admin')
+  })
+
+  it('shows Operator badge for non-admin', () => {
+    userVal = { name: 'op', role: 'operator' }
+    const wrapper = mountSidebar()
+    expect(wrapper.text()).toContain('Operator')
+  })
+
+  it('shows "A" fallback initial when user has no name', () => {
+    userVal = { name: '', role: 'operator' }
+    const wrapper = mountSidebar()
+    expect(wrapper.text()).toContain('A')
+  })
+
+  it('hides sidebar off-canvas when open=false (translate-x-full on mobile)', () => {
+    const wrapper = mount(AppSidebar, { props: { open: false } })
+    const aside = wrapper.find('aside')
+    // when closed, the aside has -translate-x-full (mobile hidden), but lg:translate-x-0 keeps it visible on desktop
+    expect(aside.classes()).toContain('-translate-x-full')
+  })
+
+  it('shows sidebar when open=true', () => {
+    const wrapper = mountSidebar()
+    const aside = wrapper.find('aside')
+    expect(aside.classes()).toContain('translate-x-0')
+  })
+
+  it('renders Candidate Lists sub-items with correct routes when expanded', async () => {
+    const wrapper = mountSidebar()
+    const parentBtn = wrapper.findAll('button').find((b) => b.text().includes('Candidate Lists'))
+    await parentBtn.trigger('click')
+    await nextTick()
+
+    // RouterLink is mocked to render <a href="to">
+    const links = wrapper.findAll('a')
+    const hrefs = links.map((a) => a.attributes('href'))
+    expect(hrefs).toContain('/candidates/overview')
+    expect(hrefs).toContain('/candidates/general')
+    expect(hrefs).toContain('/candidates/academic')
+    expect(hrefs).toContain('/candidates/support')
+    expect(hrefs).toContain('/candidates/management')
+  })
+
+  it('renders การนับเวลาเพิ่มเติม sub-items with correct routes when expanded', async () => {
+    const wrapper = mountSidebar()
+    const parentBtn = wrapper.findAll('button').find((b) => b.text().includes('การนับเวลาเพิ่มเติม'))
+    await parentBtn.trigger('click')
+    await nextTick()
+
+    const links = wrapper.findAll('a')
+    const hrefs = links.map((a) => a.attributes('href'))
+    expect(hrefs).toContain('/time-counting')
+    expect(hrefs).toContain('/time-multiplier')
+    expect(hrefs).toContain('/time-difference')
+    expect(hrefs).toContain('/position-compare')
+  })
+
+  it('marks simple item active when its route is current', () => {
+    currentPath = '/probation-end'
+    const wrapper = mountSidebar()
+    // find the RouterLink for /probation-end — it should have the active class
+    const links = wrapper.findAll('a')
+    const probationLink = links.find((a) => a.attributes('href') === '/probation-end')
+    expect(probationLink).toBeTruthy()
+    expect(probationLink.classes()).toContain('bg-blue-600/10')
+  })
+
+  it('marks flat admin item (จัดการพื้นที่พิเศษ) active when its route is current', () => {
+    userVal = { name: 'admin', role: 'admin' }
+    currentPath = '/settings/special-areas'
+    const wrapper = mountSidebar()
+    const links = wrapper.findAll('a')
+    const areasLink = links.find((a) => a.attributes('href') === '/settings/special-areas')
+    expect(areasLink).toBeTruthy()
+    expect(areasLink.classes()).toContain('bg-blue-600/10')
+  })
+})

--- a/frontend/src/__tests__/components/AppTopbar.test.js
+++ b/frontend/src/__tests__/components/AppTopbar.test.js
@@ -1,0 +1,174 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+
+const logout = vi.fn()
+const push = vi.fn()
+
+let userVal = null
+let isAdminVal = false
+
+vi.mock('@/stores/auth.js', () => ({
+  useAuthStore: () => ({
+    get user() { return userVal },
+    get isAdmin() { return isAdminVal },
+    logout,
+  }),
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ path: currentPath }),
+  useRouter: () => ({ push }),
+}))
+
+let currentPath = '/dashboard'
+
+const AppTopbar = (await import('@/components/AppTopbar.vue')).default
+
+function mountTopbar() {
+  return mount(AppTopbar, { attachTo: document.body })
+}
+
+describe('AppTopbar', () => {
+  beforeEach(() => {
+    logout.mockReset()
+    push.mockReset()
+    userVal = { name: 'สมชาย', email: 'somchai@example.go.th' }
+    isAdminVal = false
+    currentPath = '/dashboard'
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders the current page title from route path', () => {
+    currentPath = '/users'
+    const wrapper = mountTopbar()
+    expect(wrapper.text()).toContain('จัดการผู้ใช้')
+  })
+
+  it('falls back to Dashboard title for unknown routes', () => {
+    currentPath = '/unknown/route'
+    const wrapper = mountTopbar()
+    expect(wrapper.text()).toContain('Dashboard')
+  })
+
+  it('matches the longest path prefix (e.g. /candidates/overview -> Candidate Lists)', () => {
+    currentPath = '/candidates/overview'
+    const wrapper = mountTopbar()
+    expect(wrapper.text()).toContain('Candidate Lists')
+  })
+
+  it('shows user name initial and full name', () => {
+    const wrapper = mountTopbar()
+    expect(wrapper.text()).toContain('สมชาย')
+  })
+
+  it('shows fallback "A" initial and "ผู้ใช้" when user is null', () => {
+    userVal = null
+    const wrapper = mountTopbar()
+    expect(wrapper.text()).toContain('A')
+    expect(wrapper.text()).toContain('ผู้ใช้')
+  })
+
+  it('toggles dropdown open and closed on avatar button click', async () => {
+    const wrapper = mountTopbar()
+    expect(wrapper.vm.dropdownOpen).toBe(false)
+
+    await wrapper.get('button[aria-label="เมนูผู้ใช้"]').trigger('click')
+    expect(wrapper.vm.dropdownOpen).toBe(true)
+
+    await wrapper.get('button[aria-label="เมนูผู้ใช้"]').trigger('click')
+    expect(wrapper.vm.dropdownOpen).toBe(false)
+  })
+
+  it('navigates to /profile and closes dropdown when โปรไฟล์ clicked', async () => {
+    const wrapper = mountTopbar()
+    await wrapper.get('button[aria-label="เมนูผู้ใช้"]').trigger('click')
+    const profileBtn = wrapper.findAll('button').find((b) => b.text().includes('โปรไฟล์'))
+    await profileBtn.trigger('click')
+
+    expect(push).toHaveBeenCalledWith('/profile')
+    expect(wrapper.vm.dropdownOpen).toBe(false)
+  })
+
+  it('navigates to /change-password when ตั้งค่า clicked', async () => {
+    const wrapper = mountTopbar()
+    await wrapper.get('button[aria-label="เมนูผู้ใช้"]').trigger('click')
+    const settingsBtn = wrapper.findAll('button').find((b) => b.text().includes('ตั้งค่า'))
+    await settingsBtn.trigger('click')
+
+    expect(push).toHaveBeenCalledWith('/change-password')
+  })
+
+  it('shows ผู้ดูแล menu item only for admin', async () => {
+    // operator: no ผู้ดูแล button
+    isAdminVal = false
+    let wrapper = mountTopbar()
+    await wrapper.get('button[aria-label="เมนูผู้ใช้"]').trigger('click')
+    let adminBtn = wrapper.findAll('button').find((b) => b.text().includes('ผู้ดูแล'))
+    expect(adminBtn).toBeUndefined()
+
+    wrapper.unmount()
+
+    // admin: ผู้ดูแล button present and navigates to /users
+    isAdminVal = true
+    wrapper = mountTopbar()
+    await wrapper.get('button[aria-label="เมนูผู้ใช้"]').trigger('click')
+    adminBtn = wrapper.findAll('button').find((b) => b.text().includes('ผู้ดูแล'))
+    expect(adminBtn).toBeTruthy()
+    await adminBtn.trigger('click')
+    expect(push).toHaveBeenCalledWith('/users')
+
+    wrapper.unmount()
+  })
+
+  it('logs out and redirects to /login when ออกจากระบบ clicked', async () => {
+    const wrapper = mountTopbar()
+    await wrapper.get('button[aria-label="เมนูผู้ใช้"]').trigger('click')
+    const logoutBtn = wrapper.findAll('button').find((b) => b.text().includes('ออกจากระบบ'))
+    await logoutBtn.trigger('click')
+
+    expect(logout).toHaveBeenCalledTimes(1)
+    expect(push).toHaveBeenCalledWith('/login')
+    expect(wrapper.vm.dropdownOpen).toBe(false)
+  })
+
+  it('emits toggle-sidebar when hamburger button clicked', async () => {
+    const wrapper = mountTopbar()
+    await wrapper.get('button[aria-label="เปิด/ปิดเมนู"]').trigger('click')
+    expect(wrapper.emitted('toggle-sidebar')).toBeTruthy()
+    expect(wrapper.emitted('toggle-sidebar').length).toBe(1)
+  })
+
+  it('closes dropdown when clicking outside the dropdown container', async () => {
+    const wrapper = mountTopbar()
+    await wrapper.get('button[aria-label="เมนูผู้ใช้"]').trigger('click')
+    expect(wrapper.vm.dropdownOpen).toBe(true)
+
+    // simulate a click outside the dropdown container
+    const outsideEvent = new MouseEvent('click', { bubbles: true })
+    Object.defineProperty(outsideEvent, 'target', { value: document.body })
+    document.dispatchEvent(outsideEvent)
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.vm.dropdownOpen).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('keeps dropdown open when clicking inside the dropdown container', async () => {
+    const wrapper = mountTopbar()
+    await wrapper.get('button[aria-label="เมนูผู้ใช้"]').trigger('click')
+    expect(wrapper.vm.dropdownOpen).toBe(true)
+
+    // click on the dropdown user-info header (inside the dropdown container)
+    const userInfo = wrapper.find('.px-4.py-3.border-b')
+    const insideEvent = new MouseEvent('click', { bubbles: true })
+    Object.defineProperty(insideEvent, 'target', { value: userInfo.element })
+    document.dispatchEvent(insideEvent)
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.vm.dropdownOpen).toBe(true)
+    wrapper.unmount()
+  })
+})

--- a/frontend/src/__tests__/composables/useDiverse.test.js
+++ b/frontend/src/__tests__/composables/useDiverse.test.js
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockGet = vi.fn()
+const mockPost = vi.fn()
+const mockPut = vi.fn()
+const mockDel = vi.fn()
+
+vi.mock('@/composables/useApi.js', () => ({
+  useApi: () => ({ get: mockGet, post: mockPost, put: mockPut, del: mockDel }),
+}))
+
+const { useDiverse } = await import('@/composables/useDiverse.js')
+
+const serverRow = {
+  experience_id: 5,
+  personnel_id: 12,
+  full_name: 'สมชาย ใจดี',
+  from_job_series: 'ปกครอง',
+  from_work_group: 'อำนเภอ A',
+  from_division: 'กลุ่ม A',
+  from_org_id: 100,
+  from_province: 'กรุงเทพมหานคร',
+  from_start_date: '2020-01-01',
+  from_end_date: '2022-12-31',
+  from_start_date_thai: '1 ม.ค. 2563',
+  from_end_date_thai: '31 ธ.ค. 2565',
+  to_job_series: 'เทคโนโลยีสารสนเทศ',
+  to_work_group: 'กลุ่ม B',
+  to_division: 'ฝ่าย B',
+  to_org_id: 200,
+  to_province: 'เชียงใหม่',
+  to_start_date: '2023-01-01',
+  to_end_date: '2025-12-31',
+  to_start_date_thai: '1 ม.ค. 2566',
+  to_end_date_thai: '31 ธ.ค. 2568',
+  is_diff_job_series: 1,
+  is_diff_org: 1,
+  is_diff_location: 1,
+  is_diff_work_nature: 0,
+  diff_count: 3,
+  qualified_date: '2025-06-01',
+  qualified_date_thai: '1 มิ.ย. 2568',
+}
+
+describe('useDiverse', () => {
+  beforeEach(() => {
+    mockGet.mockReset()
+    mockPost.mockReset()
+    mockPut.mockReset()
+    mockDel.mockReset()
+  })
+
+  it('fetchList calls GET /diverse with search/limit/offset and maps rows', async () => {
+    mockGet.mockResolvedValue({
+      success: true,
+      data: [serverRow],
+      summary: { total: 1 },
+      pagination: { total: 1, limit: 20, offset: 0, has_more: false },
+    })
+
+    const { fetchList } = useDiverse()
+    const result = await fetchList({ search: 'สม', limit: 10, offset: 5 })
+
+    expect(mockGet).toHaveBeenCalledTimes(1)
+    const url = mockGet.mock.calls[0][0]
+    expect(url).toContain('/diverse?')
+    expect(url).toContain('search=')
+    expect(url).toContain('limit=10')
+    expect(url).toContain('offset=5')
+
+    expect(result.data).toHaveLength(1)
+    expect(result.data[0]).toMatchObject({
+      experienceId: 5,
+      personnelId: 12,
+      fullName: 'สมชาย ใจดี',
+      fromJobSeries: 'ปกครอง',
+      toJobSeries: 'เทคโนโลยีสารสนเทศ',
+      isDiffJobSeries: 1,
+      diffCount: 3,
+      qualifiedDateThai: '1 มิ.ย. 2568',
+    })
+    expect(result.pagination.total).toBe(1)
+  })
+
+  it('fetchList omits search param when search is empty', async () => {
+    mockGet.mockResolvedValue({ success: true, data: [], pagination: {} })
+
+    const { fetchList } = useDiverse()
+    await fetchList()
+
+    const url = mockGet.mock.calls[0][0]
+    expect(url).not.toContain('search=')
+    expect(url).toContain('limit=20')
+    expect(url).toContain('offset=0')
+  })
+
+  it('fetchList returns empty data array when API returns no data field', async () => {
+    mockGet.mockResolvedValue({ success: true, pagination: {} })
+
+    const { fetchList } = useDiverse()
+    const result = await fetchList()
+
+    expect(result.data).toEqual([])
+  })
+
+  it('fetchDetail calls GET /diverse/:id and maps the single row', async () => {
+    mockGet.mockResolvedValue({ success: true, data: serverRow })
+
+    const { fetchDetail } = useDiverse()
+    const result = await fetchDetail(5)
+
+    expect(mockGet).toHaveBeenCalledWith('/diverse/5')
+    expect(result.data.experienceId).toBe(5)
+    expect(result.data.fullName).toBe('สมชาย ใจดี')
+  })
+
+  it('create posts to /diverse with the given payload', async () => {
+    mockPost.mockResolvedValue({ success: true, experience_id: 5 })
+    const payload = { personnel_id: 12, from_job_series: 'ปกครอง' }
+
+    const { create } = useDiverse()
+    const result = await create(payload)
+
+    expect(mockPost).toHaveBeenCalledWith('/diverse', payload)
+    expect(result.experience_id).toBe(5)
+  })
+
+  it('update puts to /diverse/:id with the given payload', async () => {
+    mockPut.mockResolvedValue({ success: true })
+    const payload = { from_job_series: 'ปกครองแผนใหม่' }
+
+    const { update } = useDiverse()
+    const result = await update(5, payload)
+
+    expect(mockPut).toHaveBeenCalledWith('/diverse/5', payload)
+    expect(result.success).toBe(true)
+  })
+
+  it('remove calls DELETE /diverse/:id', async () => {
+    mockDel.mockResolvedValue({ success: true })
+
+    const { remove } = useDiverse()
+    const result = await remove(5)
+
+    expect(mockDel).toHaveBeenCalledWith('/diverse/5')
+    expect(result.success).toBe(true)
+  })
+
+  it('mapRow handles null/undefined fields gracefully', () => {
+    // mapRow is internal but exercised via fetchList with a sparse row
+    mockGet.mockResolvedValue({
+      success: true,
+      data: [{
+        experience_id: 1,
+        personnel_id: 2,
+        full_name: 'X',
+        // all other fields missing
+      }],
+      pagination: {},
+    })
+
+    const { fetchList } = useDiverse()
+    return fetchList().then((result) => {
+      expect(result.data[0]).toMatchObject({
+        experienceId: 1,
+        personnelId: 2,
+        fullName: 'X',
+        fromJobSeries: undefined,
+        toProvince: undefined,
+        diffCount: undefined,
+      })
+    })
+  })
+})

--- a/frontend/src/__tests__/composables/useEquivalence.test.js
+++ b/frontend/src/__tests__/composables/useEquivalence.test.js
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockGet = vi.fn()
+const mockPost = vi.fn()
+const mockPut = vi.fn()
+
+vi.mock('@/composables/useApi.js', () => ({
+  useApi: () => ({ get: mockGet, post: mockPost, put: mockPut }),
+}))
+
+const { useEquivalence } = await import('@/composables/useEquivalence.js')
+
+const serverRow = {
+  equivalence_id: 7,
+  personnel_id: 20,
+  full_name: 'สมหญิง รักงาน',
+  actual_position: 'นักวิเคราะห์',
+  equivalent_type: 'CROSS_SERIES',
+  request_start_date: '2024-01-01',
+  request_end_date: '2024-12-31',
+  request_start_date_thai: '1 ม.ค. 2567',
+  request_end_date_thai: '31 ธ.ค. 2567',
+  request_total_days: 366,
+  approval_status: 'PENDING',
+  approved_start_date: null,
+  approved_end_date: null,
+  approved_start_date_thai: null,
+  approved_end_date_thai: null,
+  approved_total_days: null,
+  approved_by: null,
+  approved_by_name: null,
+  approval_order_ref: null,
+}
+
+describe('useEquivalence', () => {
+  beforeEach(() => {
+    mockGet.mockReset()
+    mockPost.mockReset()
+    mockPut.mockReset()
+  })
+
+  it('fetchList calls GET /equivalence with search/limit/offset and maps rows', async () => {
+    mockGet.mockResolvedValue({
+      success: true,
+      data: [serverRow],
+      summary: { total: 1 },
+      pagination: { total: 1, limit: 20, offset: 0, has_more: false },
+    })
+
+    const { fetchList } = useEquivalence()
+    const result = await fetchList({ search: 'สมหญิง', limit: 5, offset: 10 })
+
+    const url = mockGet.mock.calls[0][0]
+    expect(url).toContain('/equivalence?')
+    expect(url).toContain('search=')
+    expect(url).toContain('limit=5')
+    expect(url).toContain('offset=10')
+
+    expect(result.data).toHaveLength(1)
+    expect(result.data[0]).toMatchObject({
+      equivalenceId: 7,
+      personnelId: 20,
+      fullName: 'สมหญิง รักงาน',
+      actualPosition: 'นักวิเคราะห์',
+      equivalentType: 'CROSS_SERIES',
+      requestTotalDays: 366,
+      approvalStatus: 'PENDING',
+    })
+  })
+
+  it('fetchList omits search param when empty', async () => {
+    mockGet.mockResolvedValue({ success: true, data: [], pagination: {} })
+
+    const { fetchList } = useEquivalence()
+    await fetchList()
+
+    const url = mockGet.mock.calls[0][0]
+    expect(url).not.toContain('search=')
+    expect(url).toContain('limit=20')
+  })
+
+  it('fetchList returns empty array when API returns no data field', async () => {
+    mockGet.mockResolvedValue({ success: true, pagination: {} })
+
+    const { fetchList } = useEquivalence()
+    const result = await fetchList()
+
+    expect(result.data).toEqual([])
+  })
+
+  it('fetchDetail calls GET /equivalence/:id and maps the single row', async () => {
+    mockGet.mockResolvedValue({ success: true, data: serverRow })
+
+    const { fetchDetail } = useEquivalence()
+    const result = await fetchDetail(7)
+
+    expect(mockGet).toHaveBeenCalledWith('/equivalence/7')
+    expect(result.data.equivalenceId).toBe(7)
+    expect(result.data.approvalStatus).toBe('PENDING')
+  })
+
+  it('create posts to /equivalence with the given payload', async () => {
+    mockPost.mockResolvedValue({ success: true, equivalence_id: 7 })
+    const payload = { personnel_id: 20, equivalent_type: 'CROSS_SERIES' }
+
+    const { create } = useEquivalence()
+    const result = await create(payload)
+
+    expect(mockPost).toHaveBeenCalledWith('/equivalence', payload)
+    expect(result.equivalence_id).toBe(7)
+  })
+
+  it('update puts to /equivalence/:id with the given payload', async () => {
+    mockPut.mockResolvedValue({ success: true })
+    const payload = { actual_position: 'นักวิเคราะห์นโยบาย' }
+
+    const { update } = useEquivalence()
+    const result = await update(7, payload)
+
+    expect(mockPut).toHaveBeenCalledWith('/equivalence/7', payload)
+    expect(result.success).toBe(true)
+  })
+
+  it('approve puts approval_status=APPROVED with approved date range', async () => {
+    mockPut.mockResolvedValue({ success: true })
+
+    const { approve } = useEquivalence()
+    await approve(7, { approvedStartDate: '2024-02-01', approvedEndDate: '2024-11-30' })
+
+    expect(mockPut).toHaveBeenCalledWith('/equivalence/7', {
+      approval_status: 'APPROVED',
+      approved_start_date: '2024-02-01',
+      approved_end_date: '2024-11-30',
+    })
+  })
+
+  it('reject puts approval_status=REJECTED with no extra fields', async () => {
+    mockPut.mockResolvedValue({ success: true })
+
+    const { reject } = useEquivalence()
+    await reject(7)
+
+    expect(mockPut).toHaveBeenCalledWith('/equivalence/7', {
+      approval_status: 'REJECTED',
+    })
+  })
+
+  it('mapRow handles sparse rows with undefined fields', async () => {
+    mockGet.mockResolvedValue({
+      success: true,
+      data: [{ equivalence_id: 1, personnel_id: 2, full_name: 'Y' }],
+      pagination: {},
+    })
+
+    const { fetchList } = useEquivalence()
+    const result = await fetchList()
+
+    expect(result.data[0]).toMatchObject({
+      equivalenceId: 1,
+      personnelId: 2,
+      fullName: 'Y',
+      actualPosition: undefined,
+      approvedBy: undefined,
+    })
+  })
+})

--- a/frontend/src/__tests__/pages/CandidateListsPage.test.js
+++ b/frontend/src/__tests__/pages/CandidateListsPage.test.js
@@ -1,0 +1,277 @@
+import { mount, flushPromises } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+
+const mockFetchOverview = vi.fn()
+const mockFetchByLevel = vi.fn()
+
+vi.mock('@/composables/useCandidates.js', () => ({
+  useCandidates: () => ({
+    fetchOverview: mockFetchOverview,
+    fetchByLevel: mockFetchByLevel,
+  }),
+}))
+
+vi.mock('@/composables/useRemainingDays.js', () => ({
+  getCandidateRemainingDaysClass: (days) => {
+    if (days === null || days === undefined) return 'text-gray-400'
+    if (days < 0) return 'text-gray-700'
+    if (days === 0) return 'text-green-600 font-medium'
+    if (days <= 30) return 'text-orange-600 font-medium'
+    return 'text-yellow-600'
+  },
+  formatRemainingDays: (days) => {
+    if (days === null || days === undefined) return '-'
+    if (days < 0) return `เกิน ${Math.abs(days)} วัน`
+    if (days === 0) return 'ครบกำหนดวันนี้'
+    return `${days} วัน`
+  },
+}))
+
+const CandidateListsPage = (await import('@/pages/CandidateListsPage.vue')).default
+
+const overviewPayload = {
+  success: true,
+  summary: {
+    general_total: 12,
+    academic_total: 8,
+    support_total: 5,
+    management_total: 3,
+    qualified_total: 4,
+    near_qualified_total: 6,
+    not_yet_total: 18,
+    check_data_total: 2,
+  },
+  by_level: {},
+  top5: [
+    {
+      personnelId: 1,
+      name: 'สมชาย ใจดี',
+      currentPosition: 'นักวิเคราะห์นโยบาย',
+      currentLevelName: 'ชำนาญงาน',
+      qualificationDate: '15/08/2568',
+      remainingDays: 10,
+      status: 'check_data',
+    },
+  ],
+}
+
+const byLevelPayload = {
+  success: true,
+  data: [
+    {
+      personnelId: 10,
+      name: 'สมหญิง รักงาน',
+      currentPosition: 'นักวิเคราะห์',
+      currentLevelCode: 'O2',
+      currentLevelName: 'ชำนาญงาน',
+      levelStartDate: '01/01/2562',
+      qualificationDate: '01/01/2569',
+      remainingDays: 200,
+      status: 'NOT_MET',
+      department: 'กลุ่มงาน A',
+      supportiveDays: 0,
+      equivalenceDays: 0,
+      diverseStatus: null,
+    },
+  ],
+  summary: { total: 1 },
+  pagination: { total: 1, limit: 20, offset: 0, has_more: false },
+}
+
+describe('CandidateListsPage', () => {
+  beforeEach(() => {
+    mockFetchOverview.mockReset()
+    mockFetchByLevel.mockReset()
+  })
+
+  it('renders overview stat cards and top-5 table after fetch', async () => {
+    mockFetchOverview.mockResolvedValue(overviewPayload)
+    const wrapper = mount(CandidateListsPage, { props: { section: 'overview' } })
+    await flushPromises()
+    await nextTick()
+
+    expect(mockFetchOverview).toHaveBeenCalledTimes(1)
+    // 4 category stat cards + 4 status stat cards = 8 StatCard values rendered
+    const html = wrapper.html()
+    expect(html).toContain('12') // generalTotal
+    expect(html).toContain('8')  // academicTotal
+    expect(html).toContain('5')  // supportiveTotal
+    expect(html).toContain('3')  // managementTotal
+    // top5 table
+    expect(html).toContain('สมชาย ใจดี')
+    expect(html).toContain('นักวิเคราะห์นโยบาย')
+    expect(wrapper.text()).toContain('ใกล้ครบกำหนดที่สุด')
+  })
+
+  it('shows overview error state with retry button', async () => {
+    mockFetchOverview.mockRejectedValueOnce(new Error('เซิร์ฟเวอร์ล่ม'))
+    const wrapper = mount(CandidateListsPage, { props: { section: 'overview' } })
+    await flushPromises()
+    await nextTick()
+
+    expect(wrapper.text()).toContain('เกิดข้อผิดพลาด')
+    expect(wrapper.text()).toContain('เซิร์ฟเวอร์ล่ม')
+
+    mockFetchOverview.mockResolvedValueOnce(overviewPayload)
+    await wrapper.get('button').trigger('click')
+    await flushPromises()
+    await nextTick()
+
+    expect(mockFetchOverview).toHaveBeenCalledTimes(2)
+    expect(wrapper.text()).toContain('สมชาย ใจดี')
+  })
+
+  it('shows empty row when top5 is empty', async () => {
+    mockFetchOverview.mockResolvedValue({ ...overviewPayload, top5: [] })
+    const wrapper = mount(CandidateListsPage, { props: { section: 'overview' } })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('ไม่พบข้อมูล')
+  })
+
+  it('renders sub-tabs for general section and loads first tab on mount', async () => {
+    mockFetchByLevel.mockResolvedValue(byLevelPayload)
+    const wrapper = mount(CandidateListsPage, { props: { section: 'general' } })
+    await flushPromises()
+    await nextTick()
+
+    // sub-tab buttons: O2 ชำนาญงาน, O3 อาวุโส
+    const tabButtons = wrapper.findAll('button')
+    const tabLabels = tabButtons.map((b) => b.text())
+    expect(tabLabels).toContain('ชำนาญงาน')
+    expect(tabLabels).toContain('อาวุโส')
+
+    // first tab (O2) auto-loaded
+    expect(mockFetchByLevel).toHaveBeenCalledWith('O2', expect.objectContaining({ search: '', limit: 20, offset: 0 }))
+    expect(wrapper.text()).toContain('สมหญิง รักงาน')
+  })
+
+  it('switching sub-tab resets offset+search and fetches new level', async () => {
+    mockFetchByLevel.mockResolvedValue(byLevelPayload)
+    const wrapper = mount(CandidateListsPage, { props: { section: 'academic' } })
+    await flushPromises()
+
+    // first tab K2 auto-loaded
+    expect(mockFetchByLevel).toHaveBeenLastCalledWith('K2', expect.objectContaining({ offset: 0, search: '' }))
+
+    // click K3
+    const k3Btn = wrapper.findAll('button').find((b) => b.text() === 'ชำนาญการพิเศษ')
+    await k3Btn.trigger('click')
+    await flushPromises()
+
+    expect(wrapper.vm.activeSubTab).toBe('K3')
+    expect(mockFetchByLevel).toHaveBeenLastCalledWith('K3', expect.objectContaining({ offset: 0, search: '' }))
+  })
+
+  it('debounces search input by 300ms then resets offset and fetches', async () => {
+    vi.useFakeTimers()
+    mockFetchByLevel.mockResolvedValue(byLevelPayload)
+    const wrapper = mount(CandidateListsPage, { props: { section: 'general' } })
+    await flushPromises()
+    mockFetchByLevel.mockClear()
+
+    await wrapper.get('input[placeholder="ค้นหาชื่อ หรือตำแหน่ง..."]').setValue('สม')
+    // not yet called (debounce)
+    expect(mockFetchByLevel).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(300)
+    expect(mockFetchByLevel).toHaveBeenCalledTimes(1)
+    expect(mockFetchByLevel).toHaveBeenCalledWith('O2', expect.objectContaining({ search: 'สม', offset: 0 }))
+    vi.useRealTimers()
+  })
+
+  it('shows error state with retry for sub-tab fetch', async () => {
+    mockFetchByLevel.mockRejectedValueOnce(new Error('network down'))
+    const wrapper = mount(CandidateListsPage, { props: { section: 'general' } })
+    await flushPromises()
+    await nextTick()
+
+    expect(wrapper.text()).toContain('network down')
+
+    mockFetchByLevel.mockResolvedValueOnce(byLevelPayload)
+    // retry button is the first button in the EmptyState slot
+    const retryBtn = wrapper.findAll('button').find((b) => b.text() === 'ลองใหม่')
+    await retryBtn.trigger('click')
+    await flushPromises()
+    await nextTick()
+
+    expect(wrapper.text()).toContain('สมหญิง รักงาน')
+  })
+
+  it('opens and closes the view modal via the row eye button and backdrop', async () => {
+    mockFetchByLevel.mockResolvedValue(byLevelPayload)
+    const wrapper = mount(CandidateListsPage, {
+      props: { section: 'general' },
+      attachTo: document.body,
+    })
+    await flushPromises()
+    await nextTick()
+
+    expect(wrapper.vm.showViewModal).toBe(false)
+    // eye button is the last button in each row
+    const eyeBtn = wrapper.findAll('button').find((b) => b.attributes('title') === 'ดูรายละเอียด')
+    await eyeBtn.trigger('click')
+    await nextTick()
+    expect(wrapper.vm.showViewModal).toBe(true)
+    expect(wrapper.vm.viewingRow?.name).toBe('สมหญิง รักงาน')
+
+    // close via backdrop (the absolute inset div)
+    const backdrop = document.body.querySelector('.fixed.inset-0.z-50 .absolute.inset-0')
+    expect(backdrop).toBeTruthy()
+    backdrop.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await nextTick()
+    await flushPromises()
+    expect(wrapper.vm.showViewModal).toBe(false)
+
+    wrapper.unmount()
+  })
+
+  it('changes page via PaginationBar and fetches with new offset', async () => {
+    mockFetchByLevel.mockResolvedValue({
+      ...byLevelPayload,
+      pagination: { total: 50, limit: 20, offset: 0, has_more: true },
+    })
+    const wrapper = mount(CandidateListsPage, { props: { section: 'general' } })
+    await flushPromises()
+    mockFetchByLevel.mockClear()
+
+    // PaginationBar emits update:offset
+    wrapper.findComponent({ name: 'PaginationBar' }).vm.$emit('update:offset', 20)
+    await flushPromises()
+
+    expect(wrapper.vm.pagination.offset).toBe(20)
+    expect(mockFetchByLevel).toHaveBeenCalledWith('O2', expect.objectContaining({ offset: 20 }))
+  })
+
+  it('falls back to overview config when section is unknown (no fetch fired)', async () => {
+    const wrapper = mount(CandidateListsPage, { props: { section: 'unknown' } })
+    await flushPromises()
+    await nextTick()
+
+    // unknown section -> currentConfig falls back to overview label,
+    // but onMounted only fetches overview when section === 'overview' exactly,
+    // so no fetch fires (subTabConfig[unknown] is undefined -> no sub-tab load either)
+    expect(mockFetchOverview).not.toHaveBeenCalled()
+    expect(mockFetchByLevel).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain('ภาพรวมบัญชีรายชื่อผู้มีคุณสมบัติ')
+  })
+
+  it('reloads when section prop changes from overview to a sub-tab section', async () => {
+    mockFetchOverview.mockResolvedValue(overviewPayload)
+    mockFetchByLevel.mockResolvedValue(byLevelPayload)
+    const wrapper = mount(CandidateListsPage, { props: { section: 'overview' } })
+    await flushPromises()
+
+    expect(mockFetchOverview).toHaveBeenCalledTimes(1)
+    expect(mockFetchByLevel).not.toHaveBeenCalled()
+
+    await wrapper.setProps({ section: 'support' })
+    await flushPromises()
+
+    // watcher resets state and triggers fetch for first sub-tab (M1)
+    expect(wrapper.vm.searchQuery).toBe('')
+    expect(wrapper.vm.pagination.offset).toBe(0)
+    expect(mockFetchByLevel).toHaveBeenCalledWith('M1', expect.objectContaining({ offset: 0, search: '' }))
+  })
+})

--- a/frontend/src/__tests__/pages/LoginPage.test.js
+++ b/frontend/src/__tests__/pages/LoginPage.test.js
@@ -1,0 +1,182 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const login = vi.fn()
+const push = vi.fn()
+
+vi.mock('@/stores/auth.js', () => ({
+  useAuthStore: () => ({
+    login,
+    get mustChangePassword() {
+      return mustChangePasswordVal
+    },
+  }),
+}))
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push }),
+}))
+
+let mustChangePasswordVal = false
+
+const LoginPage = (await import('@/pages/LoginPage.vue')).default
+
+function mountPage() {
+  return mount(LoginPage, { attachTo: document.body })
+}
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    login.mockReset()
+    push.mockReset()
+    mustChangePasswordVal = false
+  })
+
+  it('toggles password visibility', async () => {
+    const wrapper = mountPage()
+    const input = wrapper.get('input[autocomplete="current-password"]')
+    expect(input.attributes('type')).toBe('password')
+
+    await wrapper.get('button[aria-label="แสดง/ซ่อนรหัสผ่าน"]').trigger('click')
+    expect(input.attributes('type')).toBe('text')
+
+    await wrapper.get('button[aria-label="แสดง/ซ่อนรหัสผ่าน"]').trigger('click')
+    expect(input.attributes('type')).toBe('password')
+  })
+
+  it('binds username and password inputs and remember-me checkbox', async () => {
+    const wrapper = mountPage()
+    await wrapper.get('input[autocomplete="username"]').setValue('admin')
+    await wrapper.get('input[autocomplete="current-password"]').setValue('secret123')
+    await wrapper.get('input[type="checkbox"]').setValue(true)
+
+    expect(wrapper.vm.form.username).toBe('admin')
+    expect(wrapper.vm.form.password).toBe('secret123')
+    expect(wrapper.vm.rememberMe).toBe(true)
+  })
+
+  it('shows forgot-password info and clears prior error', async () => {
+    const wrapper = mountPage()
+    wrapper.vm.errorMsg = 'previous error'
+    await wrapper.vm.showAccountHelp('forgot')
+
+    expect(wrapper.vm.infoMsg).toContain('ลืมรหัสผ่าน')
+    expect(wrapper.vm.infoMsg).toContain('ผู้ดูแลระบบ')
+    expect(wrapper.vm.errorMsg).toBe('')
+    expect(wrapper.find('[role="status"]').text()).toContain('ลืมรหัสผ่าน')
+  })
+
+  it('shows register info and clears prior error', async () => {
+    const wrapper = mountPage()
+    wrapper.vm.errorMsg = 'previous error'
+    await wrapper.vm.showAccountHelp('register')
+
+    expect(wrapper.vm.infoMsg).toContain('สร้างบัญชีใหม่')
+    expect(wrapper.vm.infoMsg).toContain('ผู้ดูแลระบบ')
+    expect(wrapper.vm.errorMsg).toBe('')
+  })
+
+  it('logs in and navigates to the dashboard when password change is not required', async () => {
+    login.mockResolvedValue({ token: 't', user: { id: 1, role: 'admin' } })
+    mustChangePasswordVal = false
+    const wrapper = mountPage()
+    await wrapper.get('input[autocomplete="username"]').setValue('admin')
+    await wrapper.get('input[autocomplete="current-password"]').setValue('admin123')
+
+    await wrapper.get('form').trigger('submit')
+    await flushPromises()
+
+    expect(login).toHaveBeenCalledWith({ username: 'admin', password: 'admin123' })
+    expect(push).toHaveBeenCalledWith('/dashboard')
+    expect(wrapper.vm.loading).toBe(false)
+  })
+
+  it('redirects to change-password when mustChangePassword is true', async () => {
+    login.mockResolvedValue({ token: 't', user: { id: 2, role: 'operator', must_change_password: true } })
+    mustChangePasswordVal = true
+    const wrapper = mountPage()
+    await wrapper.get('input[autocomplete="username"]').setValue('operator1')
+    await wrapper.get('input[autocomplete="current-password"]').setValue('tempPass1')
+
+    await wrapper.get('form').trigger('submit')
+    await flushPromises()
+
+    expect(login).toHaveBeenCalledWith({ username: 'operator1', password: 'tempPass1' })
+    expect(push).toHaveBeenCalledWith('/change-password')
+  })
+
+  it('shows error message and re-enables the button when login fails', async () => {
+    login.mockRejectedValue(new Error('รหัสผ่านไม่ถูกต้อง'))
+    const wrapper = mountPage()
+    await wrapper.get('input[autocomplete="username"]').setValue('admin')
+    await wrapper.get('input[autocomplete="current-password"]').setValue('wrong')
+
+    await wrapper.get('form').trigger('submit')
+    await flushPromises()
+
+    expect(push).not.toHaveBeenCalled()
+    expect(wrapper.vm.errorMsg).toBe('รหัสผ่านไม่ถูกต้อง')
+    expect(wrapper.vm.loading).toBe(false)
+    expect(wrapper.find('.bg-red-50').text()).toContain('รหัสผ่านไม่ถูกต้อง')
+  })
+
+  it('falls back to a generic error message when the API error has no message', async () => {
+    login.mockRejectedValue({})
+    const wrapper = mountPage()
+    await wrapper.get('input[autocomplete="username"]').setValue('admin')
+    await wrapper.get('input[autocomplete="current-password"]').setValue('whatever')
+
+    await wrapper.get('form').trigger('submit')
+    await flushPromises()
+
+    expect(wrapper.vm.errorMsg).toBe('เข้าสู่ระบบไม่สำเร็จ กรุณาลองใหม่')
+  })
+
+  it('clears info and error messages at the start of a new submit', async () => {
+    login.mockImplementation(async () => {
+      // first call throws, second succeeds
+      if (login.mock.calls.length === 1) {
+        throw new Error('first fail')
+      }
+      return { token: 't', user: { id: 1 } }
+    })
+    mustChangePasswordVal = false
+    const wrapper = mountPage()
+    await wrapper.get('input[autocomplete="username"]').setValue('admin')
+    await wrapper.get('input[autocomplete="current-password"]').setValue('pw')
+
+    await wrapper.get('form').trigger('submit')
+    await flushPromises()
+    expect(wrapper.vm.errorMsg).toBe('first fail')
+
+    // seed an infoMsg to ensure submit clears it
+    wrapper.vm.infoMsg = 'leftover info'
+
+    await wrapper.get('form').trigger('submit')
+    await flushPromises()
+
+    expect(wrapper.vm.infoMsg).toBe('')
+    expect(wrapper.vm.errorMsg).toBe('')
+    expect(push).toHaveBeenCalledWith('/dashboard')
+  })
+
+  it('disables the submit button and shows spinner while loading', async () => {
+    let resolveLogin
+    login.mockReturnValue(new Promise((resolve) => { resolveLogin = resolve }))
+    const wrapper = mountPage()
+    await wrapper.get('input[autocomplete="username"]').setValue('admin')
+    await wrapper.get('input[autocomplete="current-password"]').setValue('pw')
+
+    await wrapper.get('form').trigger('submit')
+    await flushPromises()
+
+    const submitBtn = wrapper.get('button[type="submit"]')
+    expect(submitBtn.attributes('disabled')).toBeDefined()
+    expect(submitBtn.text()).toContain('กำลังเข้าสู่ระบบ')
+    expect(wrapper.vm.loading).toBe(true)
+
+    resolveLogin({ token: 't', user: { id: 1 } })
+    await flushPromises()
+    expect(wrapper.vm.loading).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
เพิ่ม 6 ไฟล์เทสใหม่ (+69 tests, 190→259) ครอบ surface ที่ coverage ต่ำตาม pending #6 จาก session handoff `2026-07-19_12-32-23_kimi-code_session-handoff.md` — **ไม่แตะ production code แม้บรรทัดเดียว**

## Why
Pending #6 ระบุว่า LoginPage (26%), CandidateListsPage (35%), AppTopbar (32%), AppSidebar (54%), useDiverse (0%), useEquivalence (0%) ยังขาดเทส — เป้า ~70% ขึ้นไป

## Files Added (6 ไฟล์, +69 tests)

### `frontend/src/__tests__/pages/LoginPage.test.js` (10 tests)
- toggle แสดง/ซ่อนรหัสผ่าน (type=password ↔ text)
- bind username/password/remember-me
- ลืมรหัสผ่าน / สร้างบัญชี info message + ล้าง error เดิม
- login สำเร็จ → navigate `/dashboard`
- mustChangePassword=true → navigate `/change-password`
- login ล้มเหลว → แสดง error + เปิดปุ่มใหม่
- error ไม่มี message → fallback generic
- submit ใหม่ล้าง info/error เดิม
- loading state: disable ปุ่ม + spinner

### `frontend/src/__tests__/pages/CandidateListsPage.test.js` (11 tests)
- overview: 8 stat cards + top5 table render
- overview error + retry button
- top5 ว่าง → empty row
- sub-tab render + first tab auto-load on mount
- switch sub-tab → reset offset/search + fetch level ใหม่
- debounced search 300ms (vi.useFakeTimers)
- sub-tab error + retry
- view modal open (eye button) + close (backdrop click)
- pagination offset change → fetch ใหม่
- unknown section → fallback config (ไม่ fetch)
- section prop change overview→support → reload

### `frontend/src/__tests__/components/AppTopbar.test.js` (13 tests)
- pageTitle จาก route path + fallback + longest prefix match
- user name/initial/fallback (A)
- dropdown toggle open/close
- navigate โปรไฟล์ → `/profile`
- navigate ตั้งค่า → `/change-password`
- ผู้ดูแล admin-only (v-if auth.isAdmin) → `/users`, ซ่อนจาก operator
- logout → auth.logout() + push `/login`
- hamburger → emit `toggle-sidebar`
- click-outside ปิด dropdown
- click-inside คงเปิด

### `frontend/src/__tests__/components/AppSidebar.test.js` (18 tests)
- 3 section labels (ภาพรวม/MAIN/ADMIN) สำหรับ admin, 2 สำหรับ operator (ซ่อน ADMIN)
- admin-only items (นำเข้าข้อมูล/จัดการผู้ใช้/ประวัติ/พื้นที่พิเศษ) ซ่อนจาก operator
- Dashboard อยู่ใน ภาพรวม
- 8 MAIN items ทุก role เห็น
- flat จัดการพื้นที่พิเศษ (ไม่มี submenu แอดมินเดิม)
- submenu toggle open/close (Candidate Lists)
- parent active เมื่อ child route current (isParentActive)
- mobile X → emit close
- user card name/role badge/fallback initial
- open prop → translate classes
- sub-item routes ถูกต้อง (5 + 4)
- simple item active class
- flat admin item active class

### `frontend/src/__tests__/composables/useDiverse.test.js` (9 tests)
- fetchList with search/limit/offset + mapRow camelCase
- empty search ไม่ส่ง param
- empty data field → []
- fetchDetail /diverse/:id
- create /diverse, update /diverse/:id, remove /diverse/:id
- sparse row mapping (undefined fields)

### `frontend/src/__tests__/composables/useEquivalence.test.js` (8 tests)
- fetchList + mapRow
- empty search, empty data
- fetchDetail /equivalence/:id
- create, update
- approve → PUT approval_status=APPROVED + approved_start_date + approved_end_date
- reject → PUT approval_status=REJECTED (ไม่มี field อื่น)
- sparse row mapping

## Verification
- `npx vitest run --pool=forks --maxWorkers=2 --coverage` → **33 files / 259 tests passed** (204s)
- `npm run build` → **สำเร็จ 27s** ไม่มี error
- ไม่แตะ production code, auth.js, router, AppLayout, style.css ใด ๆ

## Coverage Delta
- **All files lines: 68.64% → 76.46%** (+7.82 pp)
- LoginPage: 26% → **94.73%** (lines 80, 111 ยังไม่ครอบ — background orbs animation)
- CandidateListsPage: 35% → **96.32%** (lines 363, 542 — edge case ของ view modal field)
- AppTopbar: 32% → **100%** stmts / 92.3% branch (lines 40-41 — email/username fallback ใน dropdown header)
- AppSidebar: 54% → logic ครอบ 18 tests (ครอบ menuSections computed + RBAC + submenu toggle + active state + user card + open prop)
- useDiverse: 0% → ครอบ (9 tests)
- useEquivalence: 0% → ครอบ (8 tests)

## Test Pattern Used (จาก PR #57/#58 ใช้ซ้ำได้)
- `vi.mock('@/stores/auth.js')` + `vi.mock('vue-router')` + mount ด้วย `@vue/test-utils`
- async data ใช้ `flushPromises()` + `await nextTick()` ก่อน assert DOM
- mock composable ทั้ง function → ต้องส่งข้อมูลกลับเป็น **mapped fields** (camelCase) ไม่ใช่ raw backend fields (snake_case) เพราะ mapRow ถูก mock ข้าม
- debounce ใช้ `vi.useFakeTimers()` + `advanceTimersByTimeAsync(300)`
- Teleport modal ใช้ `attachTo: document.body` + query `document.body` หา backdrop
- click-outside ใช้ `document.dispatchEvent(new MouseEvent(...))` กำหนด target เอง

## Notes
Self-approve not allowed by GitHub; review notes posted as this PR body. ใช้ `karpathy-guidelines` (surgical changes, verify success criteria) + pattern จาก PR #57/#58 — ไม่เปิด collection เพิ่ม.