### PR TITLE
test: raise FE coverage for pages, composables, layout, and App

### DIFF
--- a/frontend/src/__tests__/App.test.js
+++ b/frontend/src/__tests__/App.test.js
@@ -1,0 +1,51 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+const isNavigating = ref(false)
+
+vi.mock('@/composables/useNavProgress.js', () => ({
+  useNavProgress: () => ({ isNavigating }),
+}))
+
+vi.mock('@/components/ToastContainer.vue', () => ({
+  default: { name: 'ToastContainer', template: '<div data-testid="toast" />' },
+}))
+
+const App = (await import('@/App.vue')).default
+
+describe('App.vue', () => {
+  beforeEach(() => {
+    isNavigating.value = false
+  })
+
+  function mountApp() {
+    return mount(App, {
+      global: {
+        stubs: {
+          RouterView: { template: '<div data-testid="router-view" />' },
+          Transition: false,
+          Suspense: false,
+        },
+      },
+    })
+  }
+
+  it('renders router outlet and toast container', () => {
+    const wrapper = mountApp()
+    expect(wrapper.find('[data-testid="router-view"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="toast"]').exists()).toBe(true)
+  })
+
+  it('shows nav progress bar when navigating', async () => {
+    isNavigating.value = true
+    const wrapper = mountApp()
+    expect(wrapper.find('[role="progressbar"]').exists()).toBe(true)
+    expect(wrapper.find('[aria-label="กำลังโหลดหน้า"]').exists()).toBe(true)
+  })
+
+  it('hides nav progress bar when not navigating', () => {
+    const wrapper = mountApp()
+    expect(wrapper.find('[role="progressbar"]').exists()).toBe(false)
+  })
+})

--- a/frontend/src/__tests__/components/PaginationBar.test.js
+++ b/frontend/src/__tests__/components/PaginationBar.test.js
@@ -51,4 +51,37 @@ describe('PaginationBar', () => {
     })
     expect(wrapper.text()).toContain('0 รายการ')
   })
+
+  it('emits update:offset when previous is clicked', async () => {
+    const wrapper = mount(PaginationBar, {
+      props: { total: 50, limit: 10, offset: 20 },
+    })
+    const prevBtn = wrapper.findAll('button')[0]
+    await prevBtn.trigger('click')
+    expect(wrapper.emitted('update:offset')[0]).toEqual([10])
+  })
+
+  it('emits update:offset when a page number is clicked', async () => {
+    const wrapper = mount(PaginationBar, { props: defaultProps })
+    const page3 = wrapper.findAll('button').find((b) => b.text() === '3')
+    await page3.trigger('click')
+    expect(wrapper.emitted('update:offset')[0]).toEqual([20])
+  })
+
+  it('shows ellipsis for many pages when not near edges', () => {
+    const wrapper = mount(PaginationBar, {
+      props: { total: 200, limit: 10, offset: 100 },
+    })
+    expect(wrapper.text()).toContain('...')
+    expect(wrapper.text()).toContain('1')
+    expect(wrapper.text()).toContain('20')
+  })
+
+  it('highlights the current page button', () => {
+    const wrapper = mount(PaginationBar, {
+      props: { total: 50, limit: 10, offset: 20 },
+    })
+    const page3 = wrapper.findAll('button').find((b) => b.text() === '3')
+    expect(page3.classes()).toContain('bg-blue-500')
+  })
 })

--- a/frontend/src/__tests__/components/StatCard.test.js
+++ b/frontend/src/__tests__/components/StatCard.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { h } from 'vue'
+import StatCard from '@/components/StatCard.vue'
+
+const DummyIcon = { render: () => h('svg') }
+
+describe('StatCard', () => {
+  it('renders label and value', () => {
+    const wrapper = mount(StatCard, {
+      props: { label: 'ทั้งหมด', value: 42, icon: DummyIcon },
+    })
+    expect(wrapper.text()).toContain('ทั้งหมด')
+    expect(wrapper.text()).toContain('42')
+  })
+
+  it('shows green change class for positive change', () => {
+    const wrapper = mount(StatCard, {
+      props: { label: 'A', value: 1, icon: DummyIcon, change: '+5%' },
+    })
+    expect(wrapper.text()).toContain('+5% จากเดือนที่แล้ว')
+    expect(wrapper.find('.text-green-600').exists()).toBe(true)
+  })
+
+  it('shows red change class for negative change', () => {
+    const wrapper = mount(StatCard, {
+      props: { label: 'A', value: 1, icon: DummyIcon, change: '-3%' },
+    })
+    expect(wrapper.find('.text-red-600').exists()).toBe(true)
+  })
+
+  it('shows gray change class for neutral change', () => {
+    const wrapper = mount(StatCard, {
+      props: { label: 'A', value: 1, icon: DummyIcon, change: 'คงที่' },
+    })
+    expect(wrapper.find('.text-gray-600').exists()).toBe(true)
+  })
+
+  it('renders sparkline bars when sparkline is true', () => {
+    const wrapper = mount(StatCard, {
+      props: { label: 'A', value: 1, icon: DummyIcon, sparkline: true },
+    })
+    const bars = wrapper.findAll('.flex.items-end .flex-1')
+    expect(bars.length).toBe(8)
+  })
+
+  it('hides change and sparkline by default', () => {
+    const wrapper = mount(StatCard, {
+      props: { label: 'A', value: 1, icon: DummyIcon },
+    })
+    expect(wrapper.text()).not.toContain('จากเดือนที่แล้ว')
+    expect(wrapper.findAll('.flex.items-end .flex-1')).toHaveLength(0)
+  })
+})

--- a/frontend/src/__tests__/composables/useMultiplier.test.js
+++ b/frontend/src/__tests__/composables/useMultiplier.test.js
@@ -4,8 +4,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 const mockGet = vi.fn()
 const mockPost = vi.fn()
 const mockPut = vi.fn()
+const mockDel = vi.fn()
 vi.mock('@/composables/useApi.js', () => ({
-  useApi: () => ({ get: mockGet, post: mockPost, put: mockPut }),
+  useApi: () => ({ get: mockGet, post: mockPost, put: mockPut, del: mockDel }),
 }))
 
 const { useMultiplier } = await import('@/composables/useMultiplier.js')
@@ -27,11 +28,154 @@ const serverAreaRow = {
   source_pending: false,
 }
 
+const serverRow = {
+  multiplier_id: 7,
+  personnel_id: 3,
+  full_name: 'สมชาย ใจดี',
+  area_multiplier_id: 8,
+  province: 'สตูล',
+  district: 'ควนโดน',
+  area_label: 'สตูล / ควนโดน',
+  basis_type: 'MARTIAL_LAW',
+  start_date: '2020-01-01',
+  end_date: '2020-12-31',
+  start_date_thai: '1 ม.ค. 2563',
+  end_date_thai: '31 ธ.ค. 2563',
+  eligible_start_date: '2020-01-01',
+  eligible_end_date: '2020-12-31',
+  eligible_start_date_thai: '1 ม.ค. 2563',
+  eligible_end_date_thai: '31 ธ.ค. 2563',
+  service_days: 366,
+  eligible_days: 366,
+  multiplier_ratio: 150,
+  effective_days: 549,
+  bonus_days: 183,
+  net_years: 1,
+  net_months: 6,
+  net_day_remainder: 0,
+  proof_reference: 'คส.1/2563',
+  description: '',
+}
+
+describe('useMultiplier — list / CRUD', () => {
+  beforeEach(() => {
+    mockGet.mockReset()
+    mockPost.mockReset()
+    mockPut.mockReset()
+    mockDel.mockReset()
+  })
+
+  it('fetchList calls GET /multiplier with limit/offset and maps rows', async () => {
+    mockGet.mockResolvedValue({
+      success: true,
+      data: [serverRow],
+      summary: { total: 1 },
+      pagination: { total: 1, limit: 10, offset: 5, has_more: false },
+    })
+
+    const { fetchList } = useMultiplier()
+    const result = await fetchList({ limit: 10, offset: 5 })
+
+    const url = mockGet.mock.calls[0][0]
+    expect(url).toContain('/multiplier?')
+    expect(url).toContain('limit=10')
+    expect(url).toContain('offset=5')
+    expect(result.data[0]).toMatchObject({
+      multiplierId: 7,
+      personnelId: 3,
+      fullName: 'สมชาย ใจดี',
+      areaLabel: 'สตูล / ควนโดน',
+      effectiveDays: 549,
+      bonusDays: 183,
+    })
+    expect(result.pagination.total).toBe(1)
+  })
+
+  it('fetchList uses default pagination and empty data when API omits fields', async () => {
+    mockGet.mockResolvedValue({ success: true })
+
+    const { fetchList } = useMultiplier()
+    const result = await fetchList()
+
+    expect(result.data).toEqual([])
+    expect(result.summary).toEqual({})
+    expect(result.pagination).toMatchObject({ total: 0, limit: 20, offset: 0, has_more: false })
+  })
+
+  it('fetchAreas passes province/district/active_only and maps areas', async () => {
+    mockGet.mockResolvedValue({
+      success: true,
+      data: [serverAreaRow],
+      summary: { total: 1, source_pending: 0 },
+    })
+
+    const { fetchAreas } = useMultiplier()
+    const result = await fetchAreas({ province: 'สตูล', district: 'ควนโดน', activeOnly: true })
+
+    const url = mockGet.mock.calls[0][0]
+    expect(url).toContain('/multiplier/areas?')
+    expect(url).toContain('province=')
+    expect(url).toContain('district=')
+    expect(url).toContain('active_only=1')
+    expect(result.data[0]).toMatchObject({
+      areaMultiplierId: 8,
+      province: 'สตูล',
+      isActive: true,
+      sourcePending: false,
+    })
+  })
+
+  it('fetchAreas omits filters and sets active_only=0 when inactive included', async () => {
+    mockGet.mockResolvedValue({ success: true, data: [] })
+
+    const { fetchAreas } = useMultiplier()
+    await fetchAreas({ activeOnly: false })
+
+    const url = mockGet.mock.calls[0][0]
+    expect(url).not.toContain('province=')
+    expect(url).not.toContain('district=')
+    expect(url).toContain('active_only=0')
+  })
+
+  it('create posts to /multiplier', async () => {
+    mockPost.mockResolvedValue({ success: true, multiplier_id: 7 })
+    const payload = { personnel_id: 3, area_multiplier_id: 8 }
+
+    const { create } = useMultiplier()
+    const result = await create(payload)
+
+    expect(mockPost).toHaveBeenCalledWith('/multiplier', payload)
+    expect(result.multiplier_id).toBe(7)
+  })
+
+  it('update puts to /multiplier/:id and maps returned row', async () => {
+    mockPut.mockResolvedValue({ success: true, data: serverRow, computed: { bonus_days: 183 } })
+
+    const { update } = useMultiplier()
+    const result = await update(7, { proof_reference: 'คส.1/2563' })
+
+    expect(mockPut).toHaveBeenCalledWith('/multiplier/7', { proof_reference: 'คส.1/2563' })
+    expect(result.data.multiplierId).toBe(7)
+    expect(result.computed.bonus_days).toBe(183)
+  })
+
+  it('remove calls DELETE /multiplier/:id', async () => {
+    mockDel.mockResolvedValue({ success: true })
+
+    const { remove } = useMultiplier()
+    const result = await remove(7)
+
+    expect(mockDel).toHaveBeenCalledWith('/multiplier/7')
+    expect(result.success).toBe(true)
+  })
+})
+
 describe('useMultiplier — area admin', () => {
   beforeEach(() => {
     mockGet.mockReset()
     mockPost.mockReset()
     mockPut.mockReset()
+    mockDel.mockReset()
   })
 
   it('createArea posts to /multiplier/areas and maps returned row to camelCase', async () => {

--- a/frontend/src/__tests__/composables/useNavProgress.test.js
+++ b/frontend/src/__tests__/composables/useNavProgress.test.js
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import { useNavProgress } from '@/composables/useNavProgress.js'
+
+describe('useNavProgress', () => {
+  it('exposes shared isNavigating ref', () => {
+    const a = useNavProgress()
+    const b = useNavProgress()
+
+    expect(a.isNavigating).toBe(b.isNavigating)
+
+    a.isNavigating.value = true
+    expect(b.isNavigating.value).toBe(true)
+
+    a.isNavigating.value = false
+    expect(b.isNavigating.value).toBe(false)
+  })
+})

--- a/frontend/src/__tests__/composables/useSupportive.test.js
+++ b/frontend/src/__tests__/composables/useSupportive.test.js
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockGet = vi.fn()
+const mockPost = vi.fn()
+const mockPut = vi.fn()
+const mockDel = vi.fn()
+
+vi.mock('@/composables/useApi.js', () => ({
+  useApi: () => ({ get: mockGet, post: mockPost, put: mockPut, del: mockDel }),
+}))
+
+const { useSupportive } = await import('@/composables/useSupportive.js')
+
+const serverRow = {
+  supportive_id: 11,
+  personnel_id: 3,
+  full_name: 'สมชาย ใจดี',
+  job_series_name: 'ทรัพยากรบุคคล',
+  primary_series_name: 'บริหารทั่วไป',
+  start_date: '2021-01-01',
+  end_date: '2021-12-31',
+  start_date_thai: '1 ม.ค. 2564',
+  end_date_thai: '31 ธ.ค. 2564',
+  total_days: 365,
+  ratio_percent: 50,
+  effective_days: 183,
+  net_end_date: '2022-06-30',
+  description: 'ทดสอบ',
+}
+
+describe('useSupportive', () => {
+  beforeEach(() => {
+    mockGet.mockReset()
+    mockPost.mockReset()
+    mockPut.mockReset()
+    mockDel.mockReset()
+  })
+
+  it('fetchList calls GET /supportive with search/limit/offset and maps rows', async () => {
+    mockGet.mockResolvedValue({
+      success: true,
+      data: [serverRow],
+      summary: { total: 1 },
+      pagination: { total: 1, limit: 20, offset: 0, has_more: false },
+    })
+
+    const { fetchList } = useSupportive()
+    const result = await fetchList({ search: 'สม', limit: 10, offset: 5 })
+
+    const url = mockGet.mock.calls[0][0]
+    expect(url).toContain('/supportive?')
+    expect(url).toContain('search=')
+    expect(url).toContain('limit=10')
+    expect(url).toContain('offset=5')
+
+    expect(result.data).toHaveLength(1)
+    expect(result.data[0]).toMatchObject({
+      supportiveId: 11,
+      personnelId: 3,
+      fullName: 'สมชาย ใจดี',
+      jobSeriesName: 'ทรัพยากรบุคคล',
+      primarySeriesName: 'บริหารทั่วไป',
+      totalDays: 365,
+      ratioPercent: 50,
+      effectiveDays: 183,
+      description: 'ทดสอบ',
+    })
+    expect(result.pagination.total).toBe(1)
+  })
+
+  it('fetchList omits search param when search is empty', async () => {
+    mockGet.mockResolvedValue({ success: true, data: [], pagination: {} })
+
+    const { fetchList } = useSupportive()
+    await fetchList()
+
+    const url = mockGet.mock.calls[0][0]
+    expect(url).not.toContain('search=')
+    expect(url).toContain('limit=20')
+    expect(url).toContain('offset=0')
+  })
+
+  it('fetchList returns empty data array when API returns no data field', async () => {
+    mockGet.mockResolvedValue({ success: true, pagination: {} })
+
+    const { fetchList } = useSupportive()
+    const result = await fetchList()
+
+    expect(result.data).toEqual([])
+  })
+
+  it('fetchDetail calls GET /supportive/:id and maps the single row', async () => {
+    mockGet.mockResolvedValue({ success: true, data: serverRow })
+
+    const { fetchDetail } = useSupportive()
+    const result = await fetchDetail(11)
+
+    expect(mockGet).toHaveBeenCalledWith('/supportive/11')
+    expect(result.data.supportiveId).toBe(11)
+    expect(result.data.fullName).toBe('สมชาย ใจดี')
+  })
+
+  it('create posts to /supportive with the given payload', async () => {
+    mockPost.mockResolvedValue({ success: true, supportive_id: 11 })
+    const payload = { personnel_id: 3, job_series_name: 'ทรัพยากรบุคคล' }
+
+    const { create } = useSupportive()
+    const result = await create(payload)
+
+    expect(mockPost).toHaveBeenCalledWith('/supportive', payload)
+    expect(result.supportive_id).toBe(11)
+  })
+
+  it('update puts to /supportive/:id with the given payload', async () => {
+    mockPut.mockResolvedValue({ success: true })
+    const payload = { description: 'อัปเดต' }
+
+    const { update } = useSupportive()
+    const result = await update(11, payload)
+
+    expect(mockPut).toHaveBeenCalledWith('/supportive/11', payload)
+    expect(result.success).toBe(true)
+  })
+
+  it('remove calls DELETE /supportive/:id', async () => {
+    mockDel.mockResolvedValue({ success: true })
+
+    const { remove } = useSupportive()
+    const result = await remove(11)
+
+    expect(mockDel).toHaveBeenCalledWith('/supportive/11')
+    expect(result.success).toBe(true)
+  })
+
+  it('mapRow handles sparse rows with undefined fields', async () => {
+    mockGet.mockResolvedValue({
+      success: true,
+      data: [{ supportive_id: 1, personnel_id: 2, full_name: 'X' }],
+      pagination: {},
+    })
+
+    const { fetchList } = useSupportive()
+    const result = await fetchList()
+
+    expect(result.data[0]).toMatchObject({
+      supportiveId: 1,
+      personnelId: 2,
+      fullName: 'X',
+      jobSeriesName: undefined,
+      effectiveDays: undefined,
+    })
+  })
+})

--- a/frontend/src/__tests__/layouts/AppLayout.test.js
+++ b/frontend/src/__tests__/layouts/AppLayout.test.js
@@ -1,0 +1,102 @@
+import { mount, RouterLinkStub } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { nextTick } from 'vue'
+
+vi.mock('@/components/AppSidebar.vue', () => ({
+  default: {
+    name: 'AppSidebar',
+    props: ['open'],
+    emits: ['close'],
+    template: '<aside data-testid="sidebar" :data-open="open" @click="$emit(\'close\')" />',
+  },
+}))
+
+vi.mock('@/components/AppTopbar.vue', () => ({
+  default: {
+    name: 'AppTopbar',
+    emits: ['toggle-sidebar'],
+    template: '<header data-testid="topbar" @click="$emit(\'toggle-sidebar\')" />',
+  },
+}))
+
+const AppLayout = (await import('@/layouts/AppLayout.vue')).default
+
+describe('AppLayout', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.stubGlobal('innerWidth', 1280)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  function mountLayout() {
+    return mount(AppLayout, {
+      global: {
+        stubs: {
+          RouterView: { template: '<div data-testid="router-view" />' },
+          RouterLink: RouterLinkStub,
+        },
+      },
+    })
+  }
+
+  it('opens sidebar by default on desktop widths', () => {
+    const wrapper = mountLayout()
+    expect(wrapper.vm.sidebarOpen).toBe(true)
+  })
+
+  it('keeps sidebar closed by default on mobile widths', () => {
+    vi.stubGlobal('innerWidth', 800)
+    const wrapper = mountLayout()
+    expect(wrapper.vm.sidebarOpen).toBe(false)
+  })
+
+  it('toggles sidebar when topbar emits toggle-sidebar', async () => {
+    const wrapper = mountLayout()
+    expect(wrapper.vm.sidebarOpen).toBe(true)
+
+    await wrapper.get('[data-testid="topbar"]').trigger('click')
+    expect(wrapper.vm.sidebarOpen).toBe(false)
+
+    await wrapper.get('[data-testid="topbar"]').trigger('click')
+    expect(wrapper.vm.sidebarOpen).toBe(true)
+  })
+
+  it('closes sidebar when overlay is clicked on mobile', async () => {
+    vi.stubGlobal('innerWidth', 800)
+    const wrapper = mountLayout()
+    wrapper.vm.sidebarOpen = true
+    await nextTick()
+
+    const overlay = wrapper.find('.fixed.inset-0')
+    expect(overlay.exists()).toBe(true)
+    await overlay.trigger('click')
+    expect(wrapper.vm.sidebarOpen).toBe(false)
+  })
+
+  it('updates sidebarOpen on window resize', async () => {
+    const wrapper = mountLayout()
+    expect(wrapper.vm.sidebarOpen).toBe(true)
+
+    vi.stubGlobal('innerWidth', 500)
+    window.dispatchEvent(new Event('resize'))
+    await nextTick()
+    expect(wrapper.vm.sidebarOpen).toBe(false)
+
+    vi.stubGlobal('innerWidth', 1400)
+    window.dispatchEvent(new Event('resize'))
+    await nextTick()
+    expect(wrapper.vm.sidebarOpen).toBe(true)
+  })
+
+  it('removes resize listener on unmount', () => {
+    const removeSpy = vi.spyOn(window, 'removeEventListener')
+    const wrapper = mountLayout()
+    wrapper.unmount()
+    expect(removeSpy).toHaveBeenCalledWith('resize', expect.any(Function))
+    removeSpy.mockRestore()
+  })
+})

--- a/frontend/src/__tests__/pages/DiversePage.test.js
+++ b/frontend/src/__tests__/pages/DiversePage.test.js
@@ -29,6 +29,7 @@ const sampleRow = {
   fullName: 'สมชาย ใจดี',
   fromJobSeries: 'ธุรการ',
   fromWorkGroup: 'บริหารทั่วไป',
+  fromDivision: 'ฝ่าย A',
   fromProvince: 'กรุงเทพมหานคร',
   fromStartDate: '2019-01-01',
   fromEndDate: '2020-12-31',
@@ -36,6 +37,7 @@ const sampleRow = {
   fromEndDateThai: '31 ธ.ค. 2563',
   toJobSeries: 'ทรัพยากรบุคคล',
   toWorkGroup: 'บริหารทั่วไป',
+  toDivision: 'ฝ่าย B',
   toProvince: 'นนทบุรี',
   toStartDate: '2021-01-01',
   toEndDate: '2022-12-31',
@@ -44,6 +46,7 @@ const sampleRow = {
   isDiffJobSeries: 1,
   isDiffOrg: 0,
   isDiffLocation: 1,
+  isDiffWorkNature: 0,
   diffCount: 2,
   description: '',
 }
@@ -54,6 +57,28 @@ async function mountPage() {
   await vi.waitFor(() => expect(mockFetchList).toHaveBeenCalled())
   await wrapper.vm.$nextTick()
   return wrapper
+}
+
+function fillValidForm(wrapper) {
+  wrapper.vm.formData = {
+    personnel_id: 3,
+    from_job_series: 'ธุรการ',
+    from_work_group: '',
+    from_division: '',
+    from_province: '',
+    from_start_date: '2019-01-01',
+    from_end_date: '2020-12-31',
+    to_job_series: 'ทรัพยากรบุคคล',
+    to_work_group: '',
+    to_division: '',
+    to_province: '',
+    to_start_date: '2021-01-01',
+    to_end_date: '2022-12-31',
+    is_diff_job_series: true,
+    is_diff_org: false,
+    is_diff_location: true,
+    is_diff_work_nature: false,
+  }
 }
 
 describe('DiversePage', () => {
@@ -74,6 +99,30 @@ describe('DiversePage', () => {
     expect(wrapper.text()).toContain('ทรัพยากรบุคคล')
   })
 
+  it('shows error state when fetch fails', async () => {
+    mockFetchList.mockRejectedValueOnce(new Error('โหลดไม่ได้'))
+    const wrapper = await mountPage()
+    expect(wrapper.text()).toContain('โหลดไม่ได้')
+  })
+
+  it('uses summary counts when present for pass/not-yet stats', async () => {
+    mockFetchList.mockResolvedValue({
+      success: true,
+      data: [sampleRow],
+      summary: { total: 10, qualified_count: 4 },
+      pagination: { total: 10, limit: 20, offset: 0 },
+    })
+    const wrapper = await mountPage()
+    expect(wrapper.vm.passCount).toBe(4)
+    expect(wrapper.vm.notYetCount).toBe(6)
+  })
+
+  it('computes pass/not-yet from rows when summary is null', async () => {
+    const wrapper = await mountPage()
+    expect(wrapper.vm.passCount).toBe(0) // diffCount 2 < 3
+    expect(wrapper.vm.notYetCount).toBe(1)
+  })
+
   it('blocks submit when required form fields are missing', async () => {
     const wrapper = await mountPage()
     wrapper.vm.openCreateModal()
@@ -83,6 +132,57 @@ describe('DiversePage', () => {
 
     expect(mockCreate).not.toHaveBeenCalled()
     expect(wrapper.vm.showModal).toBe(true)
+  })
+
+  it('create success closes modal and refreshes list', async () => {
+    const wrapper = await mountPage()
+    mockCreate.mockResolvedValue({ success: true })
+    mockFetchList.mockClear()
+
+    wrapper.vm.openCreateModal()
+    fillValidForm(wrapper)
+    await wrapper.vm.handleSubmit()
+
+    expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({
+      personnel_id: 3,
+      is_diff_job_series: 1,
+      is_diff_location: 1,
+      is_diff_org: 0,
+    }))
+    expect(wrapper.vm.showModal).toBe(false)
+    expect(mockFetchList).toHaveBeenCalled()
+  })
+
+  it('edit success calls update with experience id', async () => {
+    const wrapper = await mountPage()
+    mockUpdate.mockResolvedValue({ success: true })
+    mockFetchList.mockClear()
+
+    wrapper.vm.openEditModal(sampleRow)
+    expect(wrapper.vm.formData.personnel_id).toBe(3)
+    expect(wrapper.vm.formData.from_job_series).toBe('ธุรการ')
+    expect(wrapper.vm.diffCountPreview).toBe(2)
+
+    await wrapper.vm.handleSubmit()
+
+    expect(mockUpdate).toHaveBeenCalledWith(5, expect.objectContaining({
+      personnel_id: 3,
+      from_job_series: 'ธุรการ',
+    }))
+    expect(wrapper.vm.showModal).toBe(false)
+    expect(mockFetchList).toHaveBeenCalled()
+  })
+
+  it('shows toast on submit error and keeps modal open', async () => {
+    const wrapper = await mountPage()
+    mockCreate.mockRejectedValue(new Error('บันทึกไม่ได้'))
+    wrapper.vm.openCreateModal()
+    fillValidForm(wrapper)
+
+    await wrapper.vm.handleSubmit()
+
+    expect(wrapper.vm.showModal).toBe(true)
+    expect(wrapper.vm.submitting).toBe(false)
   })
 
   it('delete flow calls remove with the experience id', async () => {
@@ -96,5 +196,77 @@ describe('DiversePage', () => {
     expect(mockRemove).toHaveBeenCalledWith(5)
     expect(wrapper.vm.showDeleteConfirm).toBe(false)
     expect(mockFetchList).toHaveBeenCalled()
+  })
+
+  it('delete error keeps confirm dialog open', async () => {
+    const wrapper = await mountPage()
+    mockRemove.mockRejectedValue(new Error('ลบไม่ได้'))
+
+    wrapper.vm.confirmDelete(sampleRow)
+    await wrapper.vm.handleDelete()
+
+    expect(wrapper.vm.showDeleteConfirm).toBe(true)
+  })
+
+  it('closeModal clears editing state', async () => {
+    const wrapper = await mountPage()
+    wrapper.vm.openEditModal(sampleRow)
+    wrapper.vm.closeModal()
+    expect(wrapper.vm.showModal).toBe(false)
+    expect(wrapper.vm.editingRow).toBeNull()
+  })
+
+  it('debounces search and refetches after 300ms', async () => {
+    vi.useFakeTimers()
+    const wrapper = await mountPage()
+    mockFetchList.mockClear()
+
+    wrapper.vm.searchQuery = 'สม'
+    wrapper.vm.onSearchInput()
+    expect(mockFetchList).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(300)
+    expect(mockFetchList).toHaveBeenCalledWith(expect.objectContaining({ search: 'สม', offset: 0 }))
+    vi.useRealTimers()
+  })
+
+  it('skips search while IME is composing then runs on composition end', async () => {
+    vi.useFakeTimers()
+    const wrapper = await mountPage()
+    mockFetchList.mockClear()
+
+    wrapper.vm.isComposing = true
+    wrapper.vm.onSearchInput()
+    expect(mockFetchList).not.toHaveBeenCalled()
+
+    wrapper.vm.onCompositionEnd()
+    await vi.advanceTimersByTimeAsync(300)
+    expect(mockFetchList).toHaveBeenCalled()
+    vi.useRealTimers()
+  })
+
+  it('selectPersonnel fills form and clears dropdown', async () => {
+    const wrapper = await mountPage()
+    wrapper.vm.openCreateModal()
+    wrapper.vm.selectPersonnel({ personnel_id: 9, full_name: 'สมหญิง รักงาน' })
+
+    expect(wrapper.vm.formData.personnel_id).toBe(9)
+    expect(wrapper.vm.selectedPersonnelName).toBe('สมหญิง รักงาน')
+    expect(wrapper.vm.showPersonnelDropdown).toBe(false)
+  })
+
+  it('personnel search fetches results after debounce when query length >= 2', async () => {
+    vi.useFakeTimers()
+    mockApiGet.mockResolvedValue({ data: [{ personnel_id: 1, full_name: 'A' }] })
+    const wrapper = await mountPage()
+    wrapper.vm.openCreateModal()
+    wrapper.vm.personnelSearch = 'สมช'
+    wrapper.vm.onPersonnelSearch()
+
+    await vi.advanceTimersByTimeAsync(300)
+    expect(mockApiGet).toHaveBeenCalled()
+    expect(wrapper.vm.personnelResults).toHaveLength(1)
+    expect(wrapper.vm.showPersonnelDropdown).toBe(true)
+    vi.useRealTimers()
   })
 })

--- a/frontend/src/__tests__/pages/EquivalencePage.test.js
+++ b/frontend/src/__tests__/pages/EquivalencePage.test.js
@@ -49,11 +49,22 @@ const sampleRow = {
 async function mountPage({ role = 'admin' } = {}) {
   setActivePinia(createPinia())
   const auth = useAuthStore()
-  auth.user = { user_id: 1, role }
+  auth.user = { id: 1, role }
   const wrapper = mount(EquivalencePage)
   await vi.waitFor(() => expect(mockFetchList).toHaveBeenCalled())
   await wrapper.vm.$nextTick()
   return wrapper
+}
+
+function fillValidForm(wrapper) {
+  wrapper.vm.formData = {
+    personnel_id: 3,
+    actual_position: 'นักทรัพยากรบุคคลชำนาญการ',
+    equivalent_type: 'ACADEMIC',
+    request_start_date: '2020-01-01',
+    request_end_date: '2021-12-31',
+    approval_order_ref: '',
+  }
 }
 
 describe('EquivalencePage', () => {
@@ -73,6 +84,29 @@ describe('EquivalencePage', () => {
     expect(wrapper.text()).toContain('นักทรัพยากรบุคคลชำนาญการ')
   })
 
+  it('shows error state when fetch fails', async () => {
+    mockFetchList.mockRejectedValueOnce(new Error('network'))
+    const wrapper = await mountPage()
+    expect(wrapper.text()).toContain('network')
+  })
+
+  it('computes status counts from rows when summary is null', async () => {
+    const wrapper = await mountPage()
+    expect(wrapper.vm.statusCounts).toEqual({ pending: 1, approved: 0, rejected: 0 })
+  })
+
+  it('uses summary status counts when present', async () => {
+    mockFetchList.mockResolvedValue({
+      success: true,
+      data: [sampleRow],
+      summary: { total: 5, pending_count: 2, approved_count: 2, rejected_count: 1 },
+      pagination: { total: 5, limit: 20, offset: 0 },
+    })
+    const wrapper = await mountPage()
+    expect(wrapper.vm.statusCounts).toEqual({ pending: 2, approved: 2, rejected: 1 })
+    expect(wrapper.vm.totalCount).toBe(5)
+  })
+
   it('blocks save when required form fields are missing', async () => {
     const wrapper = await mountPage()
     wrapper.vm.openCreate()
@@ -82,6 +116,36 @@ describe('EquivalencePage', () => {
 
     expect(mockCreate).not.toHaveBeenCalled()
     expect(wrapper.vm.showModal).toBe(true)
+  })
+
+  it('create success closes modal and refreshes list', async () => {
+    const wrapper = await mountPage()
+    mockCreate.mockResolvedValue({ success: true })
+    mockFetchList.mockClear()
+
+    wrapper.vm.openCreate()
+    fillValidForm(wrapper)
+    await wrapper.vm.handleSave()
+
+    expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({
+      personnel_id: 3,
+      equivalent_type: 'ACADEMIC',
+    }))
+    expect(wrapper.vm.showModal).toBe(false)
+    expect(mockFetchList).toHaveBeenCalled()
+  })
+
+  it('edit success calls update with equivalence id', async () => {
+    const wrapper = await mountPage()
+    mockUpdate.mockResolvedValue({ success: true })
+
+    wrapper.vm.openEdit(sampleRow)
+    expect(wrapper.vm.formData.actual_position).toBe('นักทรัพยากรบุคคลชำนาญการ')
+    await wrapper.vm.handleSave()
+
+    expect(mockUpdate).toHaveBeenCalledWith(9, expect.objectContaining({
+      personnel_id: 3,
+    }))
   })
 
   it('approve flow sends approved dates for the record', async () => {
@@ -100,6 +164,17 @@ describe('EquivalencePage', () => {
     expect(mockFetchList).toHaveBeenCalled()
   })
 
+  it('approve without dates does not call API', async () => {
+    const wrapper = await mountPage()
+    wrapper.vm.openApprove(sampleRow)
+    wrapper.vm.approveForm.approved_start_date = ''
+    wrapper.vm.approveForm.approved_end_date = ''
+
+    await wrapper.vm.handleApprove()
+
+    expect(mockApprove).not.toHaveBeenCalled()
+  })
+
   it('reject flow calls reject with the record id', async () => {
     const wrapper = await mountPage()
     mockReject.mockResolvedValue({ success: true })
@@ -109,5 +184,35 @@ describe('EquivalencePage', () => {
 
     expect(mockReject).toHaveBeenCalledWith(9)
     expect(wrapper.vm.showRejectConfirm).toBe(false)
+  })
+
+  it('openView sets viewing record and shows modal', async () => {
+    const wrapper = await mountPage()
+    wrapper.vm.openView(sampleRow)
+    expect(wrapper.vm.viewingRecord).toEqual(sampleRow)
+    expect(wrapper.vm.showViewModal).toBe(true)
+  })
+
+  it('debounces search and refetches after 300ms', async () => {
+    vi.useFakeTimers()
+    const wrapper = await mountPage()
+    mockFetchList.mockClear()
+
+    wrapper.vm.searchQuery = 'สม'
+    wrapper.vm.onSearchInput()
+    await vi.advanceTimersByTimeAsync(300)
+
+    expect(mockFetchList).toHaveBeenCalledWith(expect.objectContaining({ search: 'สม', offset: 0 }))
+    vi.useRealTimers()
+  })
+
+  it('selectPersonnel fills form and closes dropdown', async () => {
+    const wrapper = await mountPage()
+    wrapper.vm.openCreate()
+    wrapper.vm.selectPersonnel({ personnel_id: 9, full_name: 'สมหญิง รักงาน' })
+
+    expect(wrapper.vm.formData.personnel_id).toBe(9)
+    expect(wrapper.vm.personnelSearch).toBe('สมหญิง รักงาน')
+    expect(wrapper.vm.showPersonnelDropdown).toBe(false)
   })
 })

--- a/frontend/src/__tests__/pages/MultiplierPage.test.js
+++ b/frontend/src/__tests__/pages/MultiplierPage.test.js
@@ -80,7 +80,7 @@ function resolvedData() {
 async function mountPage({ role = 'admin' } = {}) {
   setActivePinia(createPinia())
   const auth = useAuthStore()
-  auth.user = { user_id: 1, role }
+  auth.user = { id: 1, role }
   const wrapper = mount(MultiplierPage, {
     global: { stubs: { RouterLink: RouterLinkStub } },
   })
@@ -89,6 +89,17 @@ async function mountPage({ role = 'admin' } = {}) {
   })
   await wrapper.vm.$nextTick()
   return wrapper
+}
+
+function fillValidForm(wrapper) {
+  wrapper.vm.formData = {
+    personnel_id: 3,
+    area_multiplier_id: 2,
+    start_date: '2020-01-01',
+    end_date: '2020-12-31',
+    proof_reference: 'คส.123/2563',
+    description: '',
+  }
 }
 
 describe('MultiplierPage', () => {
@@ -133,6 +144,68 @@ describe('MultiplierPage', () => {
     expect(wrapper.vm.showModal).toBe(true)
   })
 
+  it('create success closes modal and refreshes list', async () => {
+    const wrapper = await mountPage()
+    mockCreate.mockResolvedValue({ success: true })
+    mockFetchList.mockClear()
+
+    wrapper.vm.openCreateModal()
+    fillValidForm(wrapper)
+    await wrapper.vm.handleSubmit()
+
+    expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({
+      personnel_id: 3,
+      area_multiplier_id: 2,
+    }))
+    expect(wrapper.vm.showModal).toBe(false)
+    expect(mockFetchList).toHaveBeenCalled()
+  })
+
+  it('edit success calls update with multiplier id', async () => {
+    const wrapper = await mountPage()
+    mockUpdate.mockResolvedValue({ success: true, data: sampleRow })
+
+    wrapper.vm.openEditModal(sampleRow)
+    expect(wrapper.vm.isEditMode).toBe(true)
+    expect(wrapper.vm.editingId).toBe(7)
+    await wrapper.vm.handleSubmit()
+
+    expect(mockUpdate).toHaveBeenCalledWith(7, expect.objectContaining({
+      personnel_id: 3,
+      area_multiplier_id: 2,
+    }))
+  })
+
+  it('rejects end_date before start_date in validation', async () => {
+    const wrapper = await mountPage()
+    wrapper.vm.openCreateModal()
+    wrapper.vm.formData = {
+      personnel_id: 3,
+      area_multiplier_id: 2,
+      start_date: '2020-12-31',
+      end_date: '2020-01-01',
+      proof_reference: '',
+      description: '',
+    }
+
+    await wrapper.vm.handleSubmit()
+
+    expect(mockCreate).not.toHaveBeenCalled()
+    expect(wrapper.vm.formErrors.end_date).toBe(true)
+  })
+
+  it('shows submitError when create fails', async () => {
+    const wrapper = await mountPage()
+    mockCreate.mockRejectedValue(new Error('บันทึกไม่ได้'))
+    wrapper.vm.openCreateModal()
+    fillValidForm(wrapper)
+
+    await wrapper.vm.handleSubmit()
+
+    expect(wrapper.vm.submitError).toBe('บันทึกไม่ได้')
+    expect(wrapper.vm.showModal).toBe(true)
+  })
+
   it('delete flow calls remove and refreshes the list', async () => {
     const wrapper = await mountPage()
     mockRemove.mockResolvedValue({ success: true })
@@ -144,5 +217,50 @@ describe('MultiplierPage', () => {
     expect(mockRemove).toHaveBeenCalledWith(7)
     expect(mockFetchList).toHaveBeenCalled()
     expect(wrapper.vm.showDeleteConfirm).toBe(false)
+  })
+
+  it('closeDeleteConfirm clears deleting row', async () => {
+    const wrapper = await mountPage()
+    wrapper.vm.openDeleteConfirm(sampleRow)
+    wrapper.vm.closeDeleteConfirm()
+    expect(wrapper.vm.showDeleteConfirm).toBe(false)
+    expect(wrapper.vm.deletingRow).toBeNull()
+  })
+
+  it('onPageChange updates offset and refetches', async () => {
+    const wrapper = await mountPage()
+    mockFetchList.mockClear()
+    wrapper.vm.onPageChange(20)
+    expect(wrapper.vm.pagination.offset).toBe(20)
+    expect(mockFetchList).toHaveBeenCalled()
+  })
+
+  it('basisTypeLabel and formatNumber helpers work', async () => {
+    const wrapper = await mountPage()
+    expect(wrapper.vm.basisTypeLabel('MARTIAL_LAW')).toBe('กฎอัยการศึก')
+    expect(wrapper.vm.basisTypeLabel('EMERGENCY_DECREE')).toBe('พ.ร.ก.ฉุกเฉิน')
+    expect(wrapper.vm.basisTypeLabel('UNKNOWN')).toBe('UNKNOWN')
+    expect(wrapper.vm.formatNumber(1234)).toMatch(/1[,.]?234/)
+  })
+
+  it('Escape key closes modal when open', async () => {
+    const wrapper = await mountPage()
+    wrapper.vm.openCreateModal()
+    expect(wrapper.vm.showModal).toBe(true)
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.vm.showModal).toBe(false)
+  })
+
+  it('selectPersonnel fills form and closes dropdown', async () => {
+    const wrapper = await mountPage()
+    wrapper.vm.openCreateModal()
+    wrapper.vm.selectPersonnel({ personnel_id: 9, full_name: 'สมหญิง รักงาน' })
+
+    expect(wrapper.vm.formData.personnel_id).toBe(9)
+    expect(wrapper.vm.personnelSearch).toBe('สมหญิง รักงาน')
+    expect(wrapper.vm.showPersonnelDropdown).toBe(false)
   })
 })

--- a/frontend/src/__tests__/pages/PlaceholderPage.test.js
+++ b/frontend/src/__tests__/pages/PlaceholderPage.test.js
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import PlaceholderPage from '@/pages/PlaceholderPage.vue'
+
+describe('PlaceholderPage', () => {
+  it('renders default title and description', () => {
+    const wrapper = mount(PlaceholderPage)
+    expect(wrapper.text()).toContain('หน้านี้')
+    expect(wrapper.text()).toContain('กำลังพัฒนา')
+  })
+
+  it('renders custom title and description props', () => {
+    const wrapper = mount(PlaceholderPage, {
+      props: {
+        title: 'ผลงานและข้อเสนอ',
+        description: 'โมดูลนี้อยู่ระหว่างพัฒนา',
+      },
+    })
+    expect(wrapper.text()).toContain('ผลงานและข้อเสนอ')
+    expect(wrapper.text()).toContain('โมดูลนี้อยู่ระหว่างพัฒนา')
+  })
+})

--- a/frontend/src/__tests__/pages/SupportivePage.test.js
+++ b/frontend/src/__tests__/pages/SupportivePage.test.js
@@ -48,6 +48,17 @@ async function mountPage() {
   return wrapper
 }
 
+function fillValidForm(wrapper) {
+  wrapper.vm.formData = {
+    personnel_id: 3,
+    primary_series_name: 'บริหารทั่วไป',
+    job_series_name: 'ทรัพยากรบุคคล',
+    start_date: '2021-01-01',
+    end_date: '2021-12-31',
+    description: '',
+  }
+}
+
 describe('SupportivePage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -65,6 +76,23 @@ describe('SupportivePage', () => {
     expect(wrapper.text()).toContain('ทรัพยากรบุคคล')
   })
 
+  it('shows error state when fetch fails', async () => {
+    mockFetchList.mockRejectedValueOnce(new Error('เซิร์ฟเวอร์ล่ม'))
+    const wrapper = await mountPage()
+    expect(wrapper.text()).toContain('เซิร์ฟเวอร์ล่ม')
+  })
+
+  it('uses summary distinct_personnel when present', async () => {
+    mockFetchList.mockResolvedValue({
+      success: true,
+      data: [sampleRow],
+      summary: { distinct_personnel: 7 },
+      pagination: { total: 1, limit: 20, offset: 0 },
+    })
+    const wrapper = await mountPage()
+    expect(wrapper.vm.distinctPersonnelCount).toBe(7)
+  })
+
   it('blocks save when required form fields are missing', async () => {
     const wrapper = await mountPage()
     wrapper.vm.openCreate()
@@ -74,6 +102,38 @@ describe('SupportivePage', () => {
 
     expect(mockCreate).not.toHaveBeenCalled()
     expect(wrapper.vm.showModal).toBe(true)
+  })
+
+  it('create success closes modal and refreshes list', async () => {
+    const wrapper = await mountPage()
+    mockCreate.mockResolvedValue({ success: true })
+    mockFetchList.mockClear()
+
+    wrapper.vm.openCreate()
+    fillValidForm(wrapper)
+    await wrapper.vm.handleSave()
+
+    expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({
+      personnel_id: 3,
+      job_series_name: 'ทรัพยากรบุคคล',
+    }))
+    expect(wrapper.vm.showModal).toBe(false)
+    expect(mockFetchList).toHaveBeenCalled()
+  })
+
+  it('edit success calls update with supportive id', async () => {
+    const wrapper = await mountPage()
+    mockUpdate.mockResolvedValue({ success: true })
+    mockFetchList.mockClear()
+
+    wrapper.vm.openEdit(sampleRow)
+    expect(wrapper.vm.formData.personnel_id).toBe(3)
+    await wrapper.vm.handleSave()
+
+    expect(mockUpdate).toHaveBeenCalledWith(11, expect.objectContaining({
+      primary_series_name: 'บริหารทั่วไป',
+    }))
+    expect(wrapper.vm.showModal).toBe(false)
   })
 
   it('delete flow calls remove with the record id', async () => {
@@ -87,5 +147,64 @@ describe('SupportivePage', () => {
     expect(mockRemove).toHaveBeenCalledWith(11)
     expect(wrapper.vm.showDeleteConfirm).toBe(false)
     expect(mockFetchList).toHaveBeenCalled()
+  })
+
+  it('delete error keeps confirm dialog open', async () => {
+    const wrapper = await mountPage()
+    mockRemove.mockRejectedValue(new Error('ลบไม่ได้'))
+
+    wrapper.vm.confirmDelete(11)
+    await wrapper.vm.handleDelete()
+
+    expect(wrapper.vm.showDeleteConfirm).toBe(true)
+  })
+
+  it('closeModal clears form errors', async () => {
+    const wrapper = await mountPage()
+    wrapper.vm.openCreate()
+    wrapper.vm.formErrors = { personnel_id: true }
+    wrapper.vm.closeModal()
+    expect(wrapper.vm.showModal).toBe(false)
+    expect(wrapper.vm.formErrors).toEqual({})
+  })
+
+  it('debounces search and refetches after 300ms', async () => {
+    vi.useFakeTimers()
+    const wrapper = await mountPage()
+    mockFetchList.mockClear()
+
+    wrapper.vm.searchQuery = 'สม'
+    wrapper.vm.onSearchInput()
+    expect(mockFetchList).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(300)
+    expect(mockFetchList).toHaveBeenCalledWith(expect.objectContaining({ search: 'สม', offset: 0 }))
+    vi.useRealTimers()
+  })
+
+  it('selectPersonnel fills form and closes dropdown', async () => {
+    const wrapper = await mountPage()
+    wrapper.vm.openCreate()
+    wrapper.vm.selectPersonnel({ personnel_id: 9, full_name: 'สมหญิง รักงาน' })
+
+    expect(wrapper.vm.formData.personnel_id).toBe(9)
+    expect(wrapper.vm.personnelSearch).toBe('สมหญิง รักงาน')
+    expect(wrapper.vm.showPersonnelDropdown).toBe(false)
+  })
+
+  it('personnel input clears selection and fetches after debounce', async () => {
+    vi.useFakeTimers()
+    mockApiGet.mockResolvedValue({ data: [{ personnel_id: 1, full_name: 'A' }] })
+    const wrapper = await mountPage()
+    wrapper.vm.openCreate()
+    wrapper.vm.formData.personnel_id = 3
+    wrapper.vm.personnelSearch = 'สมช'
+    wrapper.vm.onPersonnelInput()
+
+    expect(wrapper.vm.formData.personnel_id).toBeNull()
+    await vi.advanceTimersByTimeAsync(300)
+    expect(mockApiGet).toHaveBeenCalled()
+    expect(wrapper.vm.showPersonnelDropdown).toBe(true)
+    vi.useRealTimers()
   })
 })


### PR DESCRIPTION
## Summary
- Expand Vitest coverage for Diverse/Supportive/Equivalence/Multiplier pages (create/edit/search/personnel/error paths)
- Add suites for useSupportive, useMultiplier CRUD, AppLayout, StatCard, PlaceholderPage, useNavProgress, and App.vue
- Lines coverage 76.46% -> 86.14% (259 -> 332 tests); production code unchanged

## Test plan
- [x] `npx vitest run --pool=forks --maxWorkers=2` — 38 files / 332 tests passed
- [x] `npx vitest run --coverage --pool=forks --maxWorkers=2` — lines 86.14%

Made with [Cursor](https://cursor.com)