### PR TITLE
test: cover ToastContainer, API/auth gaps, and status-mapping branches

### DIFF
--- a/frontend/src/__tests__/components/ThaiDatePicker.test.js
+++ b/frontend/src/__tests__/components/ThaiDatePicker.test.js
@@ -72,4 +72,28 @@ describe('ThaiDatePicker', () => {
     await wrapper.find('[aria-label="เลือกปี"]').trigger('click')
     expect(wrapper.find('[aria-label="พ.ศ. 2569"]').exists()).toBe(true)
   })
+
+  it('closes calendar when Escape is pressed', async () => {
+    const wrapper = mount(ThaiDatePicker, {
+      props: { modelValue: '2026-06-16' },
+      attachTo: document.body,
+    })
+    await wrapper.find(sel.openCal).trigger('click')
+    expect(wrapper.find('[aria-label="20 มิถุนายน 2569"]').exists()).toBe(true)
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[aria-label="20 มิถุนายน 2569"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('navigates months with previous/next controls', async () => {
+    const wrapper = mount(ThaiDatePicker, { props: { modelValue: '2026-06-16' } })
+    await wrapper.find(sel.openCal).trigger('click')
+
+    await wrapper.find('[aria-label="เดือนก่อนหน้า"]').trigger('click')
+    await wrapper.find('[aria-label="เดือนถัดไป"]').trigger('click')
+    expect(wrapper.find(sel.openCal).exists()).toBe(true)
+  })
 })

--- a/frontend/src/__tests__/components/ToastContainer.test.js
+++ b/frontend/src/__tests__/components/ToastContainer.test.js
@@ -1,0 +1,54 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useUiStore } from '@/stores/ui.js'
+import ToastContainer from '@/components/ToastContainer.vue'
+
+describe('ToastContainer', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    setActivePinia(createPinia())
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders nothing visible when there are no toasts', () => {
+    const wrapper = mount(ToastContainer)
+    expect(wrapper.findAll('[aria-label="ปิดการแจ้งเตือน"]')).toHaveLength(0)
+  })
+
+  it('renders toast message and type styles', async () => {
+    const ui = useUiStore()
+    ui.showToast('บันทึกสำเร็จ', 'success')
+    ui.showToast('เกิดข้อผิดพลาด', 'error')
+
+    const wrapper = mount(ToastContainer)
+    expect(wrapper.text()).toContain('บันทึกสำเร็จ')
+    expect(wrapper.text()).toContain('เกิดข้อผิดพลาด')
+    expect(wrapper.html()).toContain('bg-green-600')
+    expect(wrapper.html()).toContain('bg-red-600')
+  })
+
+  it('renders warning and info toast styles', () => {
+    const ui = useUiStore()
+    ui.showToast('ระวัง', 'warning')
+    ui.showToast('ข้อมูล', 'info')
+
+    const wrapper = mount(ToastContainer)
+    expect(wrapper.html()).toContain('bg-yellow-500')
+    expect(wrapper.html()).toContain('bg-blue-600')
+  })
+
+  it('dismisses a toast when close button is clicked', async () => {
+    const ui = useUiStore()
+    ui.showToast('ปิดได้', 'info')
+
+    const wrapper = mount(ToastContainer)
+    expect(wrapper.text()).toContain('ปิดได้')
+
+    await wrapper.get('[aria-label="ปิดการแจ้งเตือน"]').trigger('click')
+    expect(ui.toasts).toHaveLength(0)
+  })
+})

--- a/frontend/src/__tests__/composables/useApi.test.js
+++ b/frontend/src/__tests__/composables/useApi.test.js
@@ -76,4 +76,59 @@ describe('useApi uploads', () => {
     expect(mockAuth.logout).not.toHaveBeenCalled()
     expect(mockPush).not.toHaveBeenCalled()
   })
+
+  it('logs out and redirects on 401 for authenticated API calls', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({
+      error: 'Unauthorized',
+    }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    }))
+
+    await expect(useApi().get('/dashboard')).rejects.toThrow('Unauthorized')
+    expect(mockAuth.logout).toHaveBeenCalled()
+    expect(mockPush).toHaveBeenCalledWith('/login')
+  })
+
+  it('put and del send the correct methods and parse JSON', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+
+    await expect(useApi().put('/users/1', { role: 'admin' })).resolves.toEqual({ success: true })
+    expect(fetchMock.mock.calls[0][1].method).toBe('PUT')
+
+    await expect(useApi().del('/users/1')).resolves.toEqual({ success: true })
+    expect(fetchMock.mock.calls[1][1].method).toBe('DELETE')
+  })
+
+  it('upload posts FormData without forcing JSON content-type', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({
+      success: true,
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }))
+    const form = new FormData()
+    form.append('file', new File(['x'], 'a.xlsx'))
+
+    await expect(useApi().upload('/import/executive', form)).resolves.toEqual({ success: true })
+    expect(fetchMock.mock.calls[0][1].body).toBe(form)
+    expect(fetchMock.mock.calls[0][1].headers).not.toHaveProperty('Content-Type')
+  })
+
+  it('throws statusText when error body is not JSON', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('oops', {
+      status: 500,
+      statusText: 'Internal Server Error',
+    }))
+
+    await expect(useApi().get('/boom')).rejects.toThrow('Internal Server Error')
+  })
 })

--- a/frontend/src/__tests__/composables/useCandidates.test.js
+++ b/frontend/src/__tests__/composables/useCandidates.test.js
@@ -155,4 +155,36 @@ describe('useCandidates', () => {
       department: 'กองบริหาร',
     })
   })
+
+  it('maps special backend statuses and remaining-day thresholds', async () => {
+    mockGet.mockResolvedValue({
+      success: true,
+      data: [
+        { personnel_id: 1, full_name: 'A', status: 'promoting', remaining_days: 5 },
+        { personnel_id: 2, full_name: 'B', status: 'check_data', remaining_days: 5 },
+        { personnel_id: 3, full_name: 'C', status: 'not_yet', remaining_days: null },
+        { personnel_id: 4, full_name: 'D', status: 'not_yet', remaining_days: 0 },
+        { personnel_id: 5, full_name: 'E', status: 'not_yet', remaining_days: -2 },
+      ],
+      pagination: {},
+    })
+
+    const { fetchByLevel } = useCandidates()
+    const result = await fetchByLevel('O2')
+
+    expect(result.data.map((r) => r.status)).toEqual([
+      'PROMOTING',
+      'check_data',
+      'NOT_MET',
+      'MET',
+      'EXCEEDED',
+    ])
+  })
+
+  it('returns empty data when API omits data field', async () => {
+    mockGet.mockResolvedValue({ success: true, pagination: {} })
+    const { fetchByLevel } = useCandidates()
+    const result = await fetchByLevel('O2')
+    expect(result.data).toEqual([])
+  })
 })

--- a/frontend/src/__tests__/composables/useProbation.test.js
+++ b/frontend/src/__tests__/composables/useProbation.test.js
@@ -89,4 +89,46 @@ describe('useProbation', () => {
       completedTasks: 2,
     })
   })
+
+  it('passes through terminal backend statuses', async () => {
+    mockGet.mockResolvedValue({
+      success: true,
+      data: [
+        { enrollment_id: 1, personnel_id: 1, full_name: 'A', status: 'COMPLETED', remaining_days: 0 },
+        { enrollment_id: 2, personnel_id: 2, full_name: 'B', status: 'FAILED', remaining_days: -1 },
+        { enrollment_id: 3, personnel_id: 3, full_name: 'C', status: 'EXTENDED', remaining_days: 10 },
+      ],
+      pagination: {},
+    })
+
+    const { fetchList } = useProbation()
+    const result = await fetchList()
+
+    expect(result.data.map((r) => r.status)).toEqual(['COMPLETED', 'FAILED', 'EXTENDED'])
+  })
+
+  it('computes IN_PROGRESS display status from remaining days', async () => {
+    mockGet.mockResolvedValue({
+      success: true,
+      data: [
+        { enrollment_id: 1, personnel_id: 1, full_name: 'A', status: 'IN_PROGRESS', remaining_days: null },
+        { enrollment_id: 2, personnel_id: 2, full_name: 'B', status: 'IN_PROGRESS', remaining_days: 15 },
+        { enrollment_id: 3, personnel_id: 3, full_name: 'C', status: 'IN_PROGRESS', remaining_days: 0 },
+        { enrollment_id: 4, personnel_id: 4, full_name: 'D', status: 'IN_PROGRESS', remaining_days: -3 },
+      ],
+      pagination: {},
+    })
+
+    const { fetchList } = useProbation()
+    const result = await fetchList()
+
+    expect(result.data.map((r) => r.status)).toEqual(['NOT_DUE', 'NEAR_DEADLINE', 'READY', 'OVERDUE'])
+  })
+
+  it('returns empty data array when API omits data field', async () => {
+    mockGet.mockResolvedValue({ success: true, pagination: {} })
+    const { fetchList } = useProbation()
+    const result = await fetchList()
+    expect(result.data).toEqual([])
+  })
 })

--- a/frontend/src/__tests__/pages/DiversePage.test.js
+++ b/frontend/src/__tests__/pages/DiversePage.test.js
@@ -269,4 +269,39 @@ describe('DiversePage', () => {
     expect(wrapper.vm.showPersonnelDropdown).toBe(true)
     vi.useRealTimers()
   })
+
+  it('personnel search clears results when query is too short', async () => {
+    vi.useFakeTimers()
+    const wrapper = await mountPage()
+    wrapper.vm.openCreateModal()
+    wrapper.vm.personnelResults = [{ personnel_id: 1 }]
+    wrapper.vm.showPersonnelDropdown = true
+    wrapper.vm.personnelSearch = 'ส'
+    wrapper.vm.onPersonnelSearch()
+
+    await vi.advanceTimersByTimeAsync(300)
+    expect(wrapper.vm.personnelResults).toEqual([])
+    expect(wrapper.vm.showPersonnelDropdown).toBe(false)
+    vi.useRealTimers()
+  })
+
+  it('personnel search swallows API errors', async () => {
+    vi.useFakeTimers()
+    mockApiGet.mockRejectedValue(new Error('down'))
+    const wrapper = await mountPage()
+    wrapper.vm.openCreateModal()
+    wrapper.vm.personnelSearch = 'สมชาย'
+    wrapper.vm.onPersonnelSearch()
+
+    await vi.advanceTimersByTimeAsync(300)
+    expect(wrapper.vm.personnelResults).toEqual([])
+    vi.useRealTimers()
+  })
+
+  it('handleDelete no-ops when deletingRow is null', async () => {
+    const wrapper = await mountPage()
+    wrapper.vm.deletingRow = null
+    await wrapper.vm.handleDelete()
+    expect(mockRemove).not.toHaveBeenCalled()
+  })
 })

--- a/frontend/src/__tests__/router/guards.test.js
+++ b/frontend/src/__tests__/router/guards.test.js
@@ -68,6 +68,24 @@ describe('router auth guards', () => {
     await router.push('/import')
     expect(router.currentRoute.value.path).toBe('/import')
   })
+
+  it('redirects away from change-password when password change is not required', async () => {
+    mockAuth.isAuthenticated = true
+    mockAuth.mustChangePassword = false
+    mockAuth.user = { role: 'operator' }
+
+    await router.push('/change-password')
+    expect(router.currentRoute.value.path).toBe('/dashboard')
+  })
+
+  it('redirects authenticated users away from login', async () => {
+    mockAuth.isAuthenticated = true
+    mockAuth.mustChangePassword = false
+    mockAuth.user = { role: 'operator' }
+
+    await router.push('/login')
+    expect(router.currentRoute.value.path).toBe('/dashboard')
+  })
 })
 
 describe('router candidate paths', () => {
@@ -85,6 +103,17 @@ describe('router candidate paths', () => {
 
   it('does not expose legacy /supportive quick-action path', async () => {
     await router.push('/supportive')
+    expect(router.currentRoute.value.path).toBe('/dashboard')
+  })
+
+  it('redirects legacy time-multiplier/areas to settings for admin', async () => {
+    mockAuth.user = { role: 'admin' }
+    await router.push('/time-multiplier/areas')
+    expect(router.currentRoute.value.path).toBe('/settings/special-areas')
+  })
+
+  it('catch-all unknown paths redirect to dashboard', async () => {
+    await router.push('/this-path-does-not-exist')
     expect(router.currentRoute.value.path).toBe('/dashboard')
   })
 })


### PR DESCRIPTION
## Summary
- Add ToastContainer tests; expand useApi (401 logout, put/del/upload), useProbation/useCandidates status mapping
- Expand router guards (login/change-password/catch-all/legacy areas redirect)
- Cover DiversePage personnel-search edge cases and ThaiDatePicker month nav / Escape close

## Test plan
- [x] Targeted vitest (ToastContainer, useApi, useProbation, useCandidates, guards): 5 files / 38 passed
- [x] DiversePage suite: 18 passed when run alone
- [ ] Full suite on CI / local forks when worker pool is healthy

Made with [Cursor](https://cursor.com)