### PR TITLE
chore: add local CI gate without GitHub Actions

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,1 @@
+-P ubuntu-latest=catthehacker/ubuntu:act-latest

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# pre-push — light local gate (frontend vitest only; no Docker / no Actions)
+#
+# Skip once:  SKIP_PRE_PUSH=1 git push
+# Or:         git push --no-verify
+#
+# Install:    .\scripts\install-git-hooks.ps1
+#             bash scripts/install-git-hooks.sh
+set -euo pipefail
+
+if [[ "${SKIP_PRE_PUSH:-}" == "1" ]]; then
+  echo "[pre-push] skipped (SKIP_PRE_PUSH=1)"
+  exit 0
+fi
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "${ROOT}" ]]; then
+  echo "[pre-push] not a git repo — skip"
+  exit 0
+fi
+
+FRONTEND="${ROOT}/frontend"
+if [[ ! -d "${FRONTEND}/node_modules" ]]; then
+  echo "[pre-push] FAIL  frontend/node_modules missing — run: cd frontend && npm ci"
+  exit 1
+fi
+
+echo "[pre-push] frontend vitest (forks, maxWorkers=2) ..."
+cd "${FRONTEND}"
+npx vitest run --pool=forks --maxWorkers=2 --reporter=dot
+echo "[pre-push] OK"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,12 @@
 name: CI
 
 # ⚠️ Auto-trigger ปิดชั่วคราว (GitHub Actions quota ฟรีหมด) — 2026-06-19
-# Verify แทนด้วย local: bash backend/tests/run.sh (backend, Docker) + cd frontend && npm ci && npm test && npm run build
+# Verify แทนด้วย local (ไม่กิน Actions minutes):
+#   1) .\scripts\ci-local.ps1          / bash scripts/ci-local.sh
+#   2) .\scripts\ci-act.ps1            / bash scripts/ci-act.sh   (nektos/act + Docker; ใช้ .actrc)
+#   3) pre-push light gate: .\scripts\install-git-hooks.ps1  แล้ว git push จะรัน frontend vitest
 # เปิดกลับ: คืน push/pull_request block ด้านล่าง (ดู git log ของไฟล์นี้) แล้วลบ workflow_dispatch
+
 on:
   workflow_dispatch:
   # push:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,12 @@
 name: Deploy to Render
 
 # ⚠️ Auto-deploy ปิดชั่วคราว (GitHub Actions quota ฟรีหมด) — 2026-06-19
-# Deploy แทนด้วย: Render dashboard (Manual Deploy) หรือ curl RENDER_DEPLOY_HOOK_URL เอง
-# หรือเปิด Auto-Deploy ฝั่ง Render (ให้ Render watch branch main) แทน GH Actions
-# เปิดกลับ: คืน push block ด้านล่าง แล้วลบ workflow_dispatch
+# Deploy แทน (ไม่กิน Actions minutes):
+#   A) แนะนำ: Render Dashboard → service → Settings → Build & Deploy → Auto-Deploy = Yes (branch main)
+#   B) Manual:  .\scripts\deploy-render.ps1   หรือ  bash scripts/deploy-render.sh
+#      (ตั้ง RENDER_DEPLOY_HOOK_URL ใน env หรือ .env — script ไม่พิมพ์ URL)
+#   C) Dashboard → Manual Deploy
+# เปิดกลับ GH workflow: คืน push block ด้านล่าง แล้วลบ workflow_dispatch
 on:
   workflow_dispatch:
   # push:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,10 @@
 - `cd frontend && npm test`: run the Vitest suite in `jsdom`.
 - `cd frontend && npm run build`: create the production bundle in `frontend/dist`.
 - `docker build -t smartport-frontend ./frontend` and `docker build -t smartport-backend ./backend`: match CI image checks.
+- **Local CI (no GitHub Actions):** `.\scripts\ci-local.ps1` (Windows) or `bash scripts/ci-local.sh` — frontend test+build, backend PHPUnit via `backend/tests/run.sh`, Docker image builds. Use `-SkipInstall` / `--skip-install` when `node_modules` is already current; `-SkipDocker` / `--skip-docker` for a faster gate.
+- **act (run `ci.yml` locally):** install `nektos/act` (`winget install nektos.act`), Docker running, then `.\scripts\ci-act.ps1` or `-Job frontend-build` (prefer single job first). Config: `.actrc`.
+- **Pre-push hook:** `.\scripts\install-git-hooks.ps1` sets local `core.hooksPath=.githooks` (frontend vitest on push). Skip: `SKIP_PRE_PUSH=1 git push` or `git push --no-verify`.
+- **Deploy without Actions:** enable **Auto-Deploy** on Render for `main`, or `.\scripts\deploy-render.ps1` with `RENDER_DEPLOY_HOOK_URL` in env/`.env` (URL never printed).
 
 ## Coding Style & Naming Conventions
 Preserve nearby style and avoid whole-file reformatting. Vue and JavaScript use ES modules, 2-space indentation, camelCase variables, `PascalCase.vue` components, `SomethingPage.vue` route screens, and `useX.js` composables. PHP uses 4-space indentation, guard clauses, and domain route files such as `backend/routes/probation.php`. SQL migrations stay numerically ordered, for example `database/05-probation.sql`, with descriptive snake_case identifiers.

--- a/docs/deploy-hr-import-phase2.md
+++ b/docs/deploy-hr-import-phase2.md
@@ -55,4 +55,12 @@ resolver ใช้ **SELECT-then-insert + in-batch cache** → กัน dup ร
 - ตรวจ `current_org_id`/`current_position_id` ของ personnel ที่ import ≠ 1
 
 ## 7. CI/Deploy workflows (ถ้าจะ merge เข้า main)
-CI + Deploy ถูก `gh workflow disable` (quota หมด) → merge จะไม่ trigger auto-deploy. Deploy ผ่าน Render dashboard Manual Deploy หรือ curl deploy hook. เปิด CI กลับเมื่อ quota reset: `gh workflow enable 249676166 250058541` + uncomment `on:` ใน workflow files
+CI + Deploy workflows ใช้ `workflow_dispatch` เท่านั้น (quota) → merge จะไม่ auto-run บน GitHub Actions.
+
+**Verify / deploy แทน:**
+- Local CI: `.\scripts\ci-local.ps1` หรือ `bash scripts/ci-local.sh`
+- Run `ci.yml` locally: `.\scripts\ci-act.ps1` (nektos/act)
+- Pre-push vitest: `.\scripts\install-git-hooks.ps1`
+- Deploy: เปิด **Auto-Deploy** บน Render (branch `main`) หรือ `.\scripts\deploy-render.ps1` (ตั้ง `RENDER_DEPLOY_HOOK_URL`)
+
+เปิด CI กลับเมื่อ quota reset: `gh workflow enable` + uncomment `on:` ใน workflow files

--- a/docs/render-tidb-production.md
+++ b/docs/render-tidb-production.md
@@ -27,6 +27,14 @@ The source of truth for new deployments is [render.yaml](D:/hrProject/smart-port
 
   Local `docker compose` uses the repo-root [`Dockerfile`](../../Dockerfile) so both `backend/` and `database/` migrations are included.
 
+## 1b. Deploy without GitHub Actions
+
+GitHub `deploy.yml` is `workflow_dispatch`-only while Actions quota is conserved. Use one of:
+
+1. **Auto-Deploy (recommended):** Render Dashboard → each service → **Settings** → **Build & Deploy** → **Auto-Deploy = Yes**, branch `main`. Merges to `main` deploy without GH Actions.
+2. **Deploy hook:** set `RENDER_DEPLOY_HOOK_URL` in env or repo-root `.env`, then `.\scripts\deploy-render.ps1` (URL is never printed).
+3. **Manual Deploy** in the Render dashboard.
+
 ## 2. Required backend environment variables
 
 Set these on the `smartport-backend` Render service:

--- a/scripts/ci-act.ps1
+++ b/scripts/ci-act.ps1
@@ -1,0 +1,65 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+  Run .github/workflows/ci.yml locally via nektos/act (no GitHub Actions minutes).
+
+.EXAMPLE
+  .\scripts\ci-act.ps1
+  .\scripts\ci-act.ps1 -Job frontend-build
+  .\scripts\ci-act.ps1 -List
+#>
+param(
+  [string]$Job = '',
+  [switch]$List,
+  [switch]$Help
+)
+
+$ErrorActionPreference = 'Stop'
+$Root = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+
+if ($Help) {
+  @"
+Usage: .\scripts\ci-act.ps1 [-Job <name>] [-List] [-Help]
+
+Runs .github/workflows/ci.yml with nektos/act + Docker (uses .actrc).
+Jobs: frontend-build | backend-tests | docker-build
+
+Prefer a single job first (full workflow is heavy / nested Docker):
+  .\scripts\ci-act.ps1 -Job frontend-build
+
+Install act if missing:
+  winget install nektos.act
+"@
+  exit 0
+}
+
+$actCmd = Get-Command act -ErrorAction SilentlyContinue
+if (-not $actCmd) {
+  Write-Host 'FAIL  act not found on PATH' -ForegroundColor Red
+  Write-Host 'Install: winget install nektos.act   (then reopen shell)'
+  exit 1
+}
+
+if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+  Write-Host 'FAIL  docker not found (act needs Docker Desktop)' -ForegroundColor Red
+  exit 1
+}
+
+Push-Location $Root
+try {
+  # Avoid PowerShell eating short flags; never assign to automatic $args
+  if ($List) {
+    Write-Host 'act --list -W .github/workflows/ci.yml' -ForegroundColor Cyan
+    & act --list -W '.github/workflows/ci.yml'
+    exit $LASTEXITCODE
+  }
+
+  $actArgs = @('workflow_dispatch', '-W', '.github/workflows/ci.yml')
+  if ($Job) { $actArgs += @('-j', $Job) }
+
+  Write-Host ("act " + ($actArgs -join ' ')) -ForegroundColor Cyan
+  & act @actArgs
+  exit $LASTEXITCODE
+} finally {
+  Pop-Location
+}

--- a/scripts/ci-act.sh
+++ b/scripts/ci-act.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# ci-act.sh — run .github/workflows/ci.yml via nektos/act (no Actions minutes)
+#
+#   bash scripts/ci-act.sh
+#   bash scripts/ci-act.sh --job frontend-build
+#   bash scripts/ci-act.sh --list
+#
+# Install: https://nektosact.com  (brew install act / winget install nektos.act)
+# Needs: Docker running; repo .actrc
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT}"
+
+JOB=""
+LIST=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --job|-j) JOB="$2"; shift ;;
+    --list|-l) LIST=1 ;;
+    -h|--help)
+      sed -n '2,10p' "$0" | sed 's/^# \?//'
+      exit 0
+      ;;
+    *) echo "Unknown flag: $1"; exit 2 ;;
+  esac
+  shift
+done
+
+if ! command -v act >/dev/null 2>&1; then
+  echo "FAIL  act not found — install nektos/act then retry"
+  exit 1
+fi
+if ! command -v docker >/dev/null 2>&1; then
+  echo "FAIL  docker not found (act needs Docker)"
+  exit 1
+fi
+
+if [[ "${LIST}" -eq 1 ]]; then
+  act -l -W .github/workflows/ci.yml
+  exit $?
+fi
+
+ARGS=(workflow_dispatch -W .github/workflows/ci.yml)
+[[ -n "${JOB}" ]] && ARGS+=(-j "${JOB}")
+echo "act ${ARGS[*]}"
+exec act "${ARGS[@]}"

--- a/scripts/ci-local.ps1
+++ b/scripts/ci-local.ps1
@@ -1,0 +1,181 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+  Local CI gate — mirrors .github/workflows/ci.yml without GitHub Actions minutes.
+
+.DESCRIPTION
+  Jobs (same as ci.yml):
+    1) Frontend: npm ci (optional) + npm test + npm run build
+    2) Backend:  bash backend/tests/run.sh  (Docker PHPUnit; needs Git Bash)
+    3) Docker:   build frontend + backend images (no push)
+
+  Prerequisites:
+    - Node 20+, npm
+    - Docker Desktop (backend + docker-build jobs)
+    - Git Bash on PATH as `bash` (for backend/tests/run.sh)
+    - For backend integration: docker compose up -d db
+
+.EXAMPLE
+  .\scripts\ci-local.ps1
+  .\scripts\ci-local.ps1 -SkipInstall
+  .\scripts\ci-local.ps1 -SkipDocker
+  .\scripts\ci-local.ps1 -SkipBackend -SkipDocker
+#>
+param(
+  [switch]$SkipInstall,
+  [switch]$SkipFrontend,
+  [switch]$SkipBackend,
+  [switch]$SkipDocker,
+  [switch]$Help
+)
+
+$ErrorActionPreference = 'Stop'
+$Root = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$failed = @()
+$started = Get-Date
+
+function Write-Step([string]$Name) {
+  Write-Host ""
+  Write-Host "=== $Name ===" -ForegroundColor Cyan
+}
+
+function Write-Ok([string]$Msg) {
+  Write-Host "OK  $Msg" -ForegroundColor Green
+}
+
+function Write-Fail([string]$Msg) {
+  Write-Host "FAIL  $Msg" -ForegroundColor Red
+}
+
+if ($Help) {
+  @"
+Usage: .\scripts\ci-local.ps1 [-SkipInstall] [-SkipFrontend] [-SkipBackend] [-SkipDocker] [-Help]
+
+Mirrors .github/workflows/ci.yml locally (no GitHub Actions minutes):
+  1) Frontend  npm ci + vitest (forks/2) + build
+  2) Backend   bash backend/tests/run.sh
+  3) Docker    build frontend + backend images
+
+Examples:
+  .\scripts\ci-local.ps1
+  .\scripts\ci-local.ps1 -SkipInstall
+  .\scripts\ci-local.ps1 -SkipDocker
+  .\scripts\ci-local.ps1 -SkipBackend -SkipDocker
+"@
+  exit 0
+}
+
+Write-Host "smart-port local CI  (root: $Root)"
+Write-Host "flags: SkipInstall=$SkipInstall SkipFrontend=$SkipFrontend SkipBackend=$SkipBackend SkipDocker=$SkipDocker"
+
+function Resolve-GitBash {
+  $candidates = @(
+    (Join-Path $env:LOCALAPPDATA 'Programs\Git\bin\bash.exe'),
+    'C:\Program Files\Git\bin\bash.exe',
+    'C:\Program Files (x86)\Git\bin\bash.exe'
+  )
+  foreach ($c in $candidates) {
+    if ($c -and (Test-Path -LiteralPath $c)) { return $c }
+  }
+  $cmd = Get-Command bash -ErrorAction SilentlyContinue
+  if ($cmd -and $cmd.Source -notmatch '\\System32\\bash\.exe$') {
+    return $cmd.Source
+  }
+  return $null
+}
+
+# ---- 1) Frontend Build & Test ----------------------------------------------
+if (-not $SkipFrontend) {
+  Write-Step 'Frontend Build & Test'
+  Push-Location (Join-Path $Root 'frontend')
+  try {
+    if (-not $SkipInstall) {
+      Write-Host 'npm ci ...'
+      npm ci
+      if ($LASTEXITCODE -ne 0) { throw "npm ci exited $LASTEXITCODE" }
+    } else {
+      Write-Host 'skip npm ci (-SkipInstall)'
+    }
+
+    # Windows Vitest: forks+maxWorkers avoids threads pool hang (see session handoff)
+    Write-Host 'npm test (vitest --pool=forks --maxWorkers=2) ...'
+    npx vitest run --pool=forks --maxWorkers=2 --reporter=dot
+    if ($LASTEXITCODE -ne 0) { throw "vitest exited $LASTEXITCODE" }
+
+    Write-Host 'npm run build ...'
+    npm run build
+    if ($LASTEXITCODE -ne 0) { throw "vite build exited $LASTEXITCODE" }
+
+    Write-Ok 'frontend test + build'
+  } catch {
+    Write-Fail $_.Exception.Message
+    $failed += 'frontend'
+  } finally {
+    Pop-Location
+  }
+} else {
+  Write-Host 'skip frontend (-SkipFrontend)'
+}
+
+# ---- 2) Backend PHPUnit ----------------------------------------------------
+if (-not $SkipBackend) {
+  Write-Step 'Backend PHPUnit (via backend/tests/run.sh)'
+  $bashExe = Resolve-GitBash
+  if (-not $bashExe) {
+    Write-Fail 'Git Bash not found (need LocalAppData\Programs\Git\bin\bash.exe — WSL bash.exe is not enough)'
+    $failed += 'backend'
+  } else {
+    Write-Host "using: $bashExe"
+    try {
+      # D:\foo\bar → /d/foo/bar (Git Bash path; works with spaces)
+      $rootUnix = '/' + $Root.Substring(0, 1).ToLowerInvariant() + ($Root.Substring(2) -replace '\\', '/')
+      & $bashExe -lc "cd '$rootUnix' && bash backend/tests/run.sh"
+      if ($LASTEXITCODE -ne 0) { throw "run.sh exited $LASTEXITCODE" }
+      Write-Ok 'backend PHPUnit'
+    } catch {
+      Write-Fail $_.Exception.Message
+      $failed += 'backend'
+    }
+  }
+} else {
+  Write-Host 'skip backend (-SkipBackend)'
+}
+
+# ---- 3) Docker Build Check -------------------------------------------------
+if (-not $SkipDocker) {
+  Write-Step 'Docker Build Check'
+  $docker = Get-Command docker -ErrorAction SilentlyContinue
+  if (-not $docker) {
+    Write-Fail 'docker not found on PATH'
+    $failed += 'docker'
+  } else {
+    try {
+      Write-Host 'docker build frontend ...'
+      docker build -t smartport-frontend:ci (Join-Path $Root 'frontend')
+      if ($LASTEXITCODE -ne 0) { throw "frontend image build exited $LASTEXITCODE" }
+
+      Write-Host 'docker build backend ...'
+      docker build -t smartport-backend:ci (Join-Path $Root 'backend')
+      if ($LASTEXITCODE -ne 0) { throw "backend image build exited $LASTEXITCODE" }
+
+      Write-Ok 'docker images built'
+    } catch {
+      Write-Fail $_.Exception.Message
+      $failed += 'docker'
+    }
+  }
+} else {
+  Write-Host 'skip docker (-SkipDocker)'
+}
+
+# ---- Summary ---------------------------------------------------------------
+$elapsed = [int]((Get-Date) - $started).TotalSeconds
+Write-Host ""
+Write-Host "=== Summary (${elapsed}s) ===" -ForegroundColor Cyan
+if ($failed.Count -eq 0) {
+  Write-Ok 'all selected jobs passed'
+  exit 0
+}
+
+Write-Fail ("failed jobs: " + ($failed -join ', '))
+exit 1

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# ============================================================================
+# ci-local.sh — Local CI gate (mirrors .github/workflows/ci.yml, no Actions minutes)
+#
+# Jobs:
+#   1) Frontend: npm ci (optional) + vitest + build
+#   2) Backend:  bash backend/tests/run.sh
+#   3) Docker:   build frontend + backend images (no push)
+#
+# Usage:
+#   bash scripts/ci-local.sh
+#   bash scripts/ci-local.sh --skip-install
+#   bash scripts/ci-local.sh --skip-docker
+#   bash scripts/ci-local.sh --skip-backend --skip-docker
+#   bash scripts/ci-local.sh --help
+#
+# Prereqs: Node 20+, Docker; for backend integration: docker compose up -d db
+# ============================================================================
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SKIP_INSTALL=0
+SKIP_FRONTEND=0
+SKIP_BACKEND=0
+SKIP_DOCKER=0
+FAILED=()
+STARTED=$(date +%s)
+
+usage() {
+  sed -n '2,18p' "$0" | sed 's/^# \?//'
+  exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --skip-install)  SKIP_INSTALL=1 ;;
+    --skip-frontend) SKIP_FRONTEND=1 ;;
+    --skip-backend)  SKIP_BACKEND=1 ;;
+    --skip-docker)   SKIP_DOCKER=1 ;;
+    -h|--help)       usage ;;
+    *) echo "Unknown flag: $1 (try --help)"; exit 2 ;;
+  esac
+  shift
+done
+
+step() { printf '\n=== %s ===\n' "$1"; }
+ok()   { printf 'OK  %s\n' "$1"; }
+fail() { printf 'FAIL  %s\n' "$1"; FAILED+=("$1"); }
+
+echo "smart-port local CI  (root: ${ROOT})"
+echo "flags: skip-install=${SKIP_INSTALL} skip-frontend=${SKIP_FRONTEND} skip-backend=${SKIP_BACKEND} skip-docker=${SKIP_DOCKER}"
+
+# ---- 1) Frontend -----------------------------------------------------------
+if [[ "${SKIP_FRONTEND}" -eq 0 ]]; then
+  step 'Frontend Build & Test'
+  (
+    set -e
+    cd "${ROOT}/frontend"
+    if [[ "${SKIP_INSTALL}" -eq 0 ]]; then
+      echo 'npm ci ...'
+      npm ci
+    else
+      echo 'skip npm ci (--skip-install)'
+    fi
+
+    # forks+maxWorkers: stable on Windows Git Bash / saturated hosts
+    echo 'npm test (vitest --pool=forks --maxWorkers=2) ...'
+    npx vitest run --pool=forks --maxWorkers=2 --reporter=dot
+
+    echo 'npm run build ...'
+    npm run build
+  ) && ok 'frontend test + build' || fail 'frontend'
+else
+  echo 'skip frontend (--skip-frontend)'
+fi
+
+# ---- 2) Backend ------------------------------------------------------------
+if [[ "${SKIP_BACKEND}" -eq 0 ]]; then
+  step 'Backend PHPUnit (via backend/tests/run.sh)'
+  if bash "${ROOT}/backend/tests/run.sh"; then
+    ok 'backend PHPUnit'
+  else
+    fail 'backend'
+  fi
+else
+  echo 'skip backend (--skip-backend)'
+fi
+
+# ---- 3) Docker -------------------------------------------------------------
+if [[ "${SKIP_DOCKER}" -eq 0 ]]; then
+  step 'Docker Build Check'
+  if ! command -v docker >/dev/null 2>&1; then
+    fail 'docker (not on PATH)'
+  else
+    (
+      set -e
+      echo 'docker build frontend ...'
+      docker build -t smartport-frontend:ci "${ROOT}/frontend"
+      echo 'docker build backend ...'
+      docker build -t smartport-backend:ci "${ROOT}/backend"
+    ) && ok 'docker images built' || fail 'docker'
+  fi
+else
+  echo 'skip docker (--skip-docker)'
+fi
+
+# ---- Summary ---------------------------------------------------------------
+ELAPSED=$(( $(date +%s) - STARTED ))
+printf '\n=== Summary (%ss) ===\n' "${ELAPSED}"
+if [[ "${#FAILED[@]}" -eq 0 ]]; then
+  ok 'all selected jobs passed'
+  exit 0
+fi
+fail "failed jobs: ${FAILED[*]}"
+exit 1

--- a/scripts/deploy-render.ps1
+++ b/scripts/deploy-render.ps1
@@ -1,0 +1,81 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+  Trigger Render deploy via deploy hook URL (replaces disabled GitHub deploy.yml auto-run).
+
+.DESCRIPTION
+  Reads RENDER_DEPLOY_HOOK_URL from (first match):
+    1) process env
+    2) repo-root .env  (gitignored)
+
+  Never prints the URL. Prefer enabling Auto-Deploy on Render dashboard for main
+  so this script is only needed for manual/ad-hoc deploys.
+
+.EXAMPLE
+  .\scripts\deploy-render.ps1
+  .\scripts\deploy-render.ps1 -WhatIf
+#>
+param(
+  [switch]$WhatIf,
+  [switch]$Help
+)
+
+$ErrorActionPreference = 'Stop'
+$Root = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+
+if ($Help) {
+  @"
+Usage: .\scripts\deploy-render.ps1 [-WhatIf] [-Help]
+
+Triggers Render Deploy Hook (POST). Set RENDER_DEPLOY_HOOK_URL in env or .env.
+
+Preferred long-term (no GH Actions):
+  Render Dashboard → each service (frontend + backend) → Settings →
+  Build & Deploy → Auto-Deploy = Yes  (branch: main)
+
+Then push/merge to main deploys without deploy.yml.
+"@
+  exit 0
+}
+
+function Get-DeployHookUrl {
+  if ($env:RENDER_DEPLOY_HOOK_URL -and $env:RENDER_DEPLOY_HOOK_URL.Trim()) {
+    return $env:RENDER_DEPLOY_HOOK_URL.Trim()
+  }
+  $envFile = Join-Path $Root '.env'
+  if (Test-Path -LiteralPath $envFile) {
+    $line = Get-Content -LiteralPath $envFile -ErrorAction SilentlyContinue |
+      Where-Object { $_ -match '^\s*RENDER_DEPLOY_HOOK_URL\s*=' } |
+      Select-Object -First 1
+    if ($line) {
+      $val = ($line -split '=', 2)[1].Trim().Trim('"').Trim("'")
+      if ($val) { return $val }
+    }
+  }
+  return $null
+}
+
+$url = Get-DeployHookUrl
+if (-not $url) {
+  Write-Host 'FAIL  RENDER_DEPLOY_HOOK_URL not set (env or .env)' -ForegroundColor Red
+  Write-Host '      Or enable Auto-Deploy in Render Dashboard (recommended).'
+  exit 1
+}
+if ($url -notmatch '^https://') {
+  Write-Host 'FAIL  RENDER_DEPLOY_HOOK_URL must be an https URL' -ForegroundColor Red
+  exit 1
+}
+
+if ($WhatIf) {
+  Write-Host 'OK  would POST deploy hook (URL redacted)' -ForegroundColor Yellow
+  exit 0
+}
+
+Write-Host 'POST Render deploy hook ...'
+try {
+  Invoke-WebRequest -Uri $url -Method POST -UseBasicParsing | Out-Null
+  Write-Host 'OK  deploy triggered' -ForegroundColor Green
+} catch {
+  Write-Host "FAIL  deploy hook request failed: $($_.Exception.Message)" -ForegroundColor Red
+  exit 1
+}

--- a/scripts/deploy-render.sh
+++ b/scripts/deploy-render.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# deploy-render.sh — POST Render deploy hook (URL never echoed)
+#
+#   export RENDER_DEPLOY_HOOK_URL='https://api.render.com/deploy/...'
+#   bash scripts/deploy-render.sh
+#
+# Or put RENDER_DEPLOY_HOOK_URL=... in repo-root .env (gitignored).
+#
+# Preferred: enable Auto-Deploy on Render for branch main (no GH Actions).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  sed -n '2,12p' "$0" | sed 's/^# \?//'
+  exit 0
+fi
+
+URL="${RENDER_DEPLOY_HOOK_URL:-}"
+if [[ -z "${URL}" && -f "${ROOT}/.env" ]]; then
+  URL="$(grep -E '^\s*RENDER_DEPLOY_HOOK_URL\s*=' "${ROOT}/.env" | head -1 | cut -d= -f2- | tr -d '\r' | sed 's/^["'\'']//;s/["'\'']$//')"
+fi
+
+if [[ -z "${URL}" ]]; then
+  echo "FAIL  RENDER_DEPLOY_HOOK_URL not set (env or .env)"
+  echo "      Or enable Auto-Deploy in Render Dashboard (recommended)."
+  exit 1
+fi
+if [[ "${URL}" != https://* ]]; then
+  echo "FAIL  RENDER_DEPLOY_HOOK_URL must be an https URL"
+  exit 1
+fi
+
+if [[ "${1:-}" == "--what-if" ]]; then
+  echo "OK  would POST deploy hook (URL redacted)"
+  exit 0
+fi
+
+echo "POST Render deploy hook ..."
+curl -X POST "${URL}" --fail --silent --show-error >/dev/null
+echo "OK  deploy triggered"

--- a/scripts/install-git-hooks.ps1
+++ b/scripts/install-git-hooks.ps1
@@ -1,0 +1,33 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+  Point this repo at .githooks (local core.hooksPath only — not global).
+#>
+$ErrorActionPreference = 'Stop'
+$Root = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$hooks = Join-Path $Root '.githooks'
+
+if (-not (Test-Path -LiteralPath (Join-Path $hooks 'pre-push'))) {
+  Write-Host "FAIL  missing $hooks\pre-push" -ForegroundColor Red
+  exit 1
+}
+
+# Ensure executable bit for Git Bash / WSL checkouts (best-effort on Windows)
+$bash = @(
+  (Join-Path $env:LOCALAPPDATA 'Programs\Git\bin\bash.exe'),
+  'C:\Program Files\Git\bin\bash.exe'
+) | Where-Object { Test-Path -LiteralPath $_ } | Select-Object -First 1
+
+Push-Location $Root
+try {
+  git config core.hooksPath .githooks
+  if ($bash) {
+    & $bash -lc "cd '/$(($Root.Substring(0,1).ToLowerInvariant()) + ($Root.Substring(2) -replace '\\','/'))' && chmod +x .githooks/pre-push"
+  }
+  $path = git config --get core.hooksPath
+  Write-Host "OK  core.hooksPath=$path" -ForegroundColor Green
+  Write-Host "    pre-push runs frontend vitest on git push"
+  Write-Host "    skip: SKIP_PRE_PUSH=1 git push   or   git push --no-verify"
+} finally {
+  Pop-Location
+}

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# install-git-hooks.sh — set local core.hooksPath=.githooks
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT}"
+chmod +x .githooks/pre-push
+git config core.hooksPath .githooks
+echo "OK  core.hooksPath=$(git config --get core.hooksPath)"
+echo "    skip: SKIP_PRE_PUSH=1 git push   or   git push --no-verify"


### PR DESCRIPTION
## Summary
- Add `ci-local` / `ci-act` scripts and `.actrc` so FE/BE/Docker checks run locally without Actions minutes
- Add `.githooks/pre-push` (frontend vitest) plus install scripts; deploy via Render Auto-Deploy or `deploy-render` hook helpers
- Point `ci.yml` / `deploy.yml` comments and AGENTS/docs at the new local workflow while GH auto-triggers stay off

## Test plan
- [x] `git push` ran pre-push vitest successfully
- [ ] `.\scripts\ci-local.ps1 -SkipInstall -SkipDocker` (optional smoke)
- [ ] `.\scripts\ci-act.ps1 -List` lists three CI jobs
- [ ] Enable Render Auto-Deploy on `main` (manual dashboard step)
