### PR TITLE
feat: sync transform layer (ADR-0001) + drop dead tables

### DIFF
--- a/backend/SyncTransformService.php
+++ b/backend/SyncTransformService.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/sync/SourceAdapterInterface.php';
+require_once __DIR__ . '/sync/CrosswalkService.php';
+require_once __DIR__ . '/sync/TransformHelpers.php';
+require_once __DIR__ . '/sync/Transformers/PrefixTransformer.php';
+require_once __DIR__ . '/sync/Transformers/OrgTransformer.php';
+require_once __DIR__ . '/sync/Transformers/PositionTransformer.php';
+require_once __DIR__ . '/sync/Transformers/PersonTransformer.php';
+require_once __DIR__ . '/sync/Transformers/PositionHistoryTransformer.php';
+require_once __DIR__ . '/sync/Transformers/DecorationTransformer.php';
+require_once __DIR__ . '/sync/Transformers/TrainingTransformer.php';
+
+class SyncTransformService
+{
+    private const DOMAIN_ORDER = ['D4', 'D2', 'D3', 'D1', 'D5', 'D6', 'D7'];
+
+    private const DOMAIN_TABLES = [
+        'D4' => 'per_prename',
+        'D2' => 'per_org',
+        'D3' => 'per_position',
+        'D1' => 'per_personal',
+        'D5' => 'per_positionhis',
+        'D6' => 'per_decoratehis',
+        'D7' => 'per_training',
+    ];
+
+    private PDO $target;
+    private SourceAdapterInterface $source;
+    private CrosswalkService $crosswalk;
+
+    public function __construct(PDO $target, SourceAdapterInterface $source)
+    {
+        $this->target = $target;
+        $this->source = $source;
+        $this->crosswalk = new CrosswalkService($target);
+    }
+
+    public function syncDomain(string $domain, bool $full = false): array
+    {
+        $domain = strtoupper($domain);
+
+        if (!isset(self::DOMAIN_TABLES[$domain])) {
+            return ['domain' => $domain, 'created' => 0, 'updated' => 0, 'skipped' => 0, 'errors' => ["Unknown domain: {$domain}"]];
+        }
+
+        $transformer = $this->createTransformer($domain);
+
+        return $transformer->transform($full);
+    }
+
+    public function syncAll(bool $full = false): array
+    {
+        $results = [];
+        $totalErrors = 0;
+
+        foreach (self::DOMAIN_ORDER as $domain) {
+            $result = $this->syncDomain($domain, $full);
+            $results[] = $result;
+            $totalErrors += count($result['errors']);
+
+            if ($totalErrors > 100) {
+                $results[] = ['domain' => 'ABORT', 'created' => 0, 'updated' => 0, 'skipped' => 0, 'errors' => ['Aborted: >100 cumulative errors']];
+                break;
+            }
+        }
+
+        return $results;
+    }
+
+    public function getStatus(): array
+    {
+        $status = [];
+        foreach (self::DOMAIN_TABLES as $domain => $table) {
+            $status[$domain] = [
+                'source_table' => $table,
+                'last_sync' => $this->crosswalk->lastSyncTime($table),
+            ];
+        }
+
+        return $status;
+    }
+
+    public static function domainOrder(): array
+    {
+        return self::DOMAIN_ORDER;
+    }
+
+    private function createTransformer(string $domain): object
+    {
+        return match ($domain) {
+            'D4' => new PrefixTransformer($this->target, $this->source, $this->crosswalk),
+            'D2' => new OrgTransformer($this->target, $this->source, $this->crosswalk),
+            'D3' => new PositionTransformer($this->target, $this->source, $this->crosswalk),
+            'D1' => new PersonTransformer($this->target, $this->source, $this->crosswalk),
+            'D5' => new PositionHistoryTransformer($this->target, $this->source, $this->crosswalk),
+            'D6' => new DecorationTransformer($this->target, $this->source, $this->crosswalk),
+            'D7' => new TrainingTransformer($this->target, $this->source, $this->crosswalk),
+        };
+    }
+}

--- a/backend/api.php
+++ b/backend/api.php
@@ -305,22 +305,6 @@ switch ($path[0]) {
         }
         break;
 
-    case 'forecast':
-        // อ่านอย่างเดียวจาก advance_notifications ซึ่งยังไม่มีตัวเติมข้อมูล — ปกติจึงคืน []
-        // เดิมเรียก stored procedure sp_calculate_promotion_eligibility ก่อน query แต่ procedure
-        // นั้นไม่เคยถูกสร้างในไฟล์ migration ใดเลย (ตกค้างจาก design เดิม) จึงเป็น no-op ที่เสีย
-        // query ไป information_schema ทุก request — ถอดออก
-        // การคำนวณคุณสมบัติจริงอยู่ที่ QualificationEngine (/candidates) แล้ว
-        if ($method == 'GET') {
-            $pdo = getDB();
-            $stmt = $pdo->query("SELECT * FROM advance_notifications");
-            $forecasts = $stmt->fetchAll(PDO::FETCH_ASSOC);
-            echo json_encode($forecasts);
-        } else {
-            respondMethodNotAllowed();
-        }
-        break;
-
     case 'civil-servants':
         if ($method == 'GET') {
             $pdo = getDB();
@@ -631,6 +615,12 @@ switch ($path[0]) {
         $pdo = getDB();
         include __DIR__ . '/routes/ocr.php';
         handleOcr($pdo, $method, $path);
+        break;
+
+    case 'sync':
+        $pdo = getDB();
+        include __DIR__ . '/routes/sync.php';
+        handleSync($pdo, $method, $path);
         break;
 
     default:

--- a/backend/routes/sync.php
+++ b/backend/routes/sync.php
@@ -1,0 +1,137 @@
+<?php
+// ============================================================================
+// routes/sync.php
+// Sync Transform Layer — legacy HR → Smart Port (ADR-0001)
+//
+// Endpoints:
+//   POST /sync/{domain}  — trigger sync for one domain (admin-only)
+//   POST /sync           — trigger sync all domains (admin-only)
+//   GET  /sync/status    — last sync timestamps per domain
+// ============================================================================
+
+include_once __DIR__ . '/../helpers.php';
+include_once __DIR__ . '/../audit.php';
+include_once __DIR__ . '/../SyncTransformService.php';
+include_once __DIR__ . '/../sync/StagingPdoAdapter.php';
+include_once __DIR__ . '/../sync/CsvFileAdapter.php';
+
+function handleSync(PDO $pdo, string $method, array $path): void
+{
+    $user = getAuthenticatedUser();
+    if (!$user) {
+        http_response_code(401);
+        echo json_encode(['error' => 'Unauthorized']);
+        return;
+    }
+
+    if (($user['role'] ?? '') !== 'admin') {
+        http_response_code(403);
+        echo json_encode(['error' => 'เฉพาะผู้ดูแลระบบเท่านั้นที่สามารถสั่ง sync ได้']);
+        return;
+    }
+
+    $sub = $path[1] ?? '';
+
+    try {
+        switch ($method) {
+            case 'GET':
+                if ($sub === 'status') {
+                    handleSyncStatus($pdo);
+                } else {
+                    http_response_code(404);
+                    echo json_encode(['error' => 'Not found']);
+                }
+                break;
+
+            case 'POST':
+                handleSyncTrigger($pdo, $sub);
+                break;
+
+            default:
+                http_response_code(405);
+                echo json_encode(['error' => 'Method not allowed']);
+        }
+    } catch (PDOException $e) {
+        error_log('[sync] DB error: ' . $e->getMessage());
+        http_response_code(500);
+        echo json_encode(['error' => 'เกิดข้อผิดพลาดในการเข้าถึงฐานข้อมูล'], JSON_UNESCAPED_UNICODE);
+    }
+}
+
+function handleSyncStatus(PDO $pdo): void
+{
+    $dummySource = new class implements SourceAdapterInterface {
+        public function fetchRows(string $table, array $columns = [], ?string $sinceColumn = null, ?string $sinceValue = null): iterable { return []; }
+        public function fetchLookup(string $table, string $keyColumn, string $valueColumn): array { return []; }
+        public function hasTable(string $table): bool { return false; }
+    };
+
+    $service = new SyncTransformService($pdo, $dummySource);
+    $status = $service->getStatus();
+
+    echo json_encode(['success' => true, 'data' => $status], JSON_UNESCAPED_UNICODE);
+}
+
+function handleSyncTrigger(PDO $pdo, string $domain): void
+{
+    $body = json_decode(file_get_contents('php://input'), true) ?? [];
+    $sourceType = $body['source'] ?? 'staging';
+    $full = (bool) ($body['full'] ?? false);
+
+    if ($sourceType === 'staging') {
+        $host = getenv('SYNC_STAGING_HOST') ?: '';
+        $dbname = getenv('SYNC_STAGING_DATABASE') ?: '';
+        $user = getenv('SYNC_STAGING_USER') ?: '';
+
+        if ($host === '' || $dbname === '' || $user === '') {
+            http_response_code(503);
+            echo json_encode(['error' => 'Staging database not configured (SYNC_STAGING_* env vars missing)'], JSON_UNESCAPED_UNICODE);
+            return;
+        }
+
+        $port = getenv('SYNC_STAGING_PORT') ?: '3306';
+        $pass = getenv('SYNC_STAGING_PASSWORD') ?: '';
+        $dsn = "mysql:host={$host};port={$port};dbname={$dbname};charset=utf8mb4";
+
+        $stagingPdo = new PDO($dsn, $user, $pass, [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+            PDO::ATTR_EMULATE_PREPARES => false,
+        ]);
+
+        $source = new StagingPdoAdapter($stagingPdo);
+    } elseif ($sourceType === 'csv') {
+        $csvDir = getenv('SYNC_CSV_DIR') ?: '';
+        if ($csvDir === '' || !is_dir($csvDir)) {
+            http_response_code(503);
+            echo json_encode(['error' => 'CSV directory not configured or not found (SYNC_CSV_DIR)'], JSON_UNESCAPED_UNICODE);
+            return;
+        }
+        $source = new CsvFileAdapter($csvDir);
+    } else {
+        http_response_code(400);
+        echo json_encode(['error' => 'source ต้องเป็น staging หรือ csv เท่านั้น'], JSON_UNESCAPED_UNICODE);
+        return;
+    }
+
+    $service = new SyncTransformService($pdo, $source);
+
+    if ($domain === '' || $domain === 'all') {
+        $results = $service->syncAll($full);
+        echo json_encode(['success' => true, 'data' => $results], JSON_UNESCAPED_UNICODE);
+    } else {
+        $domain = strtoupper($domain);
+        $validDomains = ['D1', 'D2', 'D3', 'D4', 'D5', 'D6', 'D7'];
+        if (!in_array($domain, $validDomains, true)) {
+            http_response_code(400);
+            echo json_encode(['error' => "domain ไม่ถูกต้อง — ใช้ได้: " . implode(', ', $validDomains) . ', all'], JSON_UNESCAPED_UNICODE);
+            return;
+        }
+
+        $result = $service->syncDomain($domain, $full);
+        $hasErrors = count($result['errors']) > 0;
+        echo json_encode(['success' => !$hasErrors, 'data' => $result], JSON_UNESCAPED_UNICODE);
+    }
+
+    logAudit($pdo, (int) ($user['user_id'] ?? 0), 'sync', 'external_ref', null, null, ['domain' => $domain ?: 'all', 'source' => $sourceType, 'full' => $full]);
+}

--- a/backend/scripts/run-sync.php
+++ b/backend/scripts/run-sync.php
@@ -1,0 +1,172 @@
+#!/usr/bin/env php
+<?php
+/**
+ * CLI runner for legacy HR → Smart Port sync transform (ADR-0001).
+ *
+ * Usage:
+ *   php scripts/run-sync.php --domain=all --source=staging
+ *   php scripts/run-sync.php --domain=D1 --source=csv --csv-dir=/data/export
+ *   php scripts/run-sync.php --domain=D2 --full --dry-run
+ *
+ * Env vars (staging source):
+ *   SYNC_STAGING_HOST, SYNC_STAGING_PORT, SYNC_STAGING_DATABASE,
+ *   SYNC_STAGING_USER, SYNC_STAGING_PASSWORD
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../SyncTransformService.php';
+require_once __DIR__ . '/../sync/StagingPdoAdapter.php';
+require_once __DIR__ . '/../sync/CsvFileAdapter.php';
+
+function syncEnv(string $key, string $default = ''): string
+{
+    $val = getenv($key);
+    if ($val !== false && $val !== '') {
+        return $val;
+    }
+    if (isset($_ENV[$key]) && $_ENV[$key] !== '') {
+        return $_ENV[$key];
+    }
+
+    return $default;
+}
+
+function targetPdo(): PDO
+{
+    $host = syncEnv('MYSQL_HOST', 'db');
+    $port = syncEnv('MYSQL_PORT', '3306');
+    $dbname = syncEnv('MYSQL_DATABASE', 'civil_service_mgmt');
+    $user = syncEnv('MYSQL_USER', 'root');
+    $pass = syncEnv('MYSQL_PASSWORD', 'rootpassword');
+
+    $dsn = "mysql:host={$host};port={$port};dbname={$dbname};charset=utf8mb4";
+
+    return new PDO($dsn, $user, $pass, [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        PDO::ATTR_EMULATE_PREPARES => false,
+    ]);
+}
+
+function stagingPdo(): PDO
+{
+    $host = syncEnv('SYNC_STAGING_HOST', '');
+    $port = syncEnv('SYNC_STAGING_PORT', '3306');
+    $dbname = syncEnv('SYNC_STAGING_DATABASE', '');
+    $user = syncEnv('SYNC_STAGING_USER', '');
+    $pass = syncEnv('SYNC_STAGING_PASSWORD', '');
+
+    if ($host === '' || $dbname === '' || $user === '') {
+        fwrite(STDERR, "Error: SYNC_STAGING_HOST, SYNC_STAGING_DATABASE, SYNC_STAGING_USER are required for staging source.\n");
+        exit(1);
+    }
+
+    $dsn = "mysql:host={$host};port={$port};dbname={$dbname};charset=utf8mb4";
+
+    return new PDO($dsn, $user, $pass, [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        PDO::ATTR_EMULATE_PREPARES => false,
+    ]);
+}
+
+// --- Parse arguments ---
+$options = getopt('', ['domain:', 'source:', 'csv-dir:', 'full', 'dry-run', 'help']);
+
+if (isset($options['help'])) {
+    fwrite(STDOUT, "Usage: php scripts/run-sync.php [options]\n");
+    fwrite(STDOUT, "  --domain=D1|D2|D3|D4|D5|D6|D7|all   (default: all)\n");
+    fwrite(STDOUT, "  --source=staging|csv                  (default: staging)\n");
+    fwrite(STDOUT, "  --csv-dir=/path/to/csv                (required if source=csv)\n");
+    fwrite(STDOUT, "  --full                                (ignore delta, re-sync everything)\n");
+    fwrite(STDOUT, "  --dry-run                             (validate only, no writes)\n");
+    exit(0);
+}
+
+$domain = strtoupper($options['domain'] ?? 'all');
+$sourceType = $options['source'] ?? 'staging';
+$csvDir = $options['csv-dir'] ?? '';
+$full = isset($options['full']);
+$dryRun = isset($options['dry-run']);
+
+if ($sourceType === 'csv' && $csvDir === '') {
+    fwrite(STDERR, "Error: --csv-dir is required when --source=csv\n");
+    exit(1);
+}
+
+if ($sourceType === 'csv' && !is_dir($csvDir)) {
+    fwrite(STDERR, "Error: CSV directory not found: {$csvDir}\n");
+    exit(1);
+}
+
+// --- Build source adapter ---
+$source = $sourceType === 'csv'
+    ? new CsvFileAdapter($csvDir)
+    : new StagingPdoAdapter(stagingPdo());
+
+// --- Run ---
+try {
+    $target = targetPdo();
+    $service = new SyncTransformService($target, $source);
+
+    if ($dryRun) {
+        fwrite(STDOUT, "[DRY RUN] No writes will be performed.\n\n");
+    }
+
+    fwrite(STDOUT, "Sync Transform — source: {$sourceType}, domain: {$domain}, mode: " . ($full ? 'full' : 'delta') . "\n");
+    fwrite(STDOUT, str_repeat('-', 60) . "\n");
+
+    if ($domain === 'ALL') {
+        $results = $dryRun ? [] : $service->syncAll($full);
+        if ($dryRun) {
+            foreach (SyncTransformService::domainOrder() as $d) {
+                fwrite(STDOUT, "  {$d}: would sync (dry-run)\n");
+            }
+        }
+    } else {
+        $results = $dryRun ? [] : [$service->syncDomain($domain, $full)];
+        if ($dryRun) {
+            fwrite(STDOUT, "  {$domain}: would sync (dry-run)\n");
+        }
+    }
+
+    if (!$dryRun) {
+        $totalCreated = 0;
+        $totalUpdated = 0;
+        $totalErrors = 0;
+
+        foreach ($results as $r) {
+            $errCount = count($r['errors']);
+            $totalCreated += $r['created'];
+            $totalUpdated += $r['updated'];
+            $totalErrors += $errCount;
+
+            fwrite(STDOUT, sprintf(
+                "  %s: +%d created, ~%d updated, %d skipped, %d errors\n",
+                $r['domain'],
+                $r['created'],
+                $r['updated'],
+                $r['skipped'],
+                $errCount
+            ));
+
+            foreach (array_slice($r['errors'], 0, 5) as $err) {
+                fwrite(STDERR, "    ERROR: {$err}\n");
+            }
+            if ($errCount > 5) {
+                fwrite(STDERR, "    ... and " . ($errCount - 5) . " more errors\n");
+            }
+        }
+
+        fwrite(STDOUT, str_repeat('-', 60) . "\n");
+        fwrite(STDOUT, "Total: +{$totalCreated} created, ~{$totalUpdated} updated, {$totalErrors} errors\n");
+
+        exit($totalErrors > 0 ? 2 : 0);
+    }
+
+    exit(0);
+} catch (Throwable $e) {
+    fwrite(STDERR, 'Sync failed: ' . $e->getMessage() . "\n");
+    exit(1);
+}

--- a/backend/sync/CrosswalkService.php
+++ b/backend/sync/CrosswalkService.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+class CrosswalkService
+{
+    private const SOURCE_SYSTEM = 'legacy-hr';
+
+    private PDO $pdo;
+
+    public function __construct(PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    public function resolve(string $sourceTable, string $sourceId, string $internalTable): ?int
+    {
+        $stmt = $this->pdo->prepare(
+            'SELECT internal_id FROM external_ref
+             WHERE source_system = ? AND source_table = ? AND source_id = ? AND internal_table = ?
+             LIMIT 1'
+        );
+        $stmt->execute([self::SOURCE_SYSTEM, $sourceTable, $sourceId, $internalTable]);
+        $val = $stmt->fetchColumn();
+
+        return $val !== false ? (int) $val : null;
+    }
+
+    public function resolveByNaturalKey(string $internalTable, string $column, string $value): ?int
+    {
+        $allowed = ['personnel', 'organization', 'position', 'prefixes', 'training_course', 'royal_decorations', 'personnel_position_history'];
+        if (!in_array($internalTable, $allowed, true)) {
+            throw new InvalidArgumentException("Table not allowed: {$internalTable}");
+        }
+        $allowedCols = ['citizen_id', 'org_code', 'position_code', 'prefix_code', 'course_name'];
+        if (!in_array($column, $allowedCols, true)) {
+            throw new InvalidArgumentException("Column not allowed: {$column}");
+        }
+
+        $stmt = $this->pdo->prepare(
+            "SELECT {$this->pkColumn($internalTable)} FROM `{$internalTable}` WHERE `{$column}` = ? LIMIT 1"
+        );
+        $stmt->execute([$value]);
+        $val = $stmt->fetchColumn();
+
+        return $val !== false ? (int) $val : null;
+    }
+
+    public function record(string $sourceTable, string $sourceId, string $internalTable, int $internalId): void
+    {
+        $stmt = $this->pdo->prepare(
+            'INSERT INTO external_ref (source_system, source_table, source_id, internal_table, internal_id)
+             VALUES (?, ?, ?, ?, ?)
+             ON DUPLICATE KEY UPDATE internal_id = VALUES(internal_id), synced_at = CURRENT_TIMESTAMP'
+        );
+        $stmt->execute([self::SOURCE_SYSTEM, $sourceTable, $sourceId, $internalTable, $internalId]);
+    }
+
+    /**
+     * Build a full source_id → internal_id map for a table pair.
+     * @return array<string, int>
+     */
+    public function buildMap(string $sourceTable, string $internalTable): array
+    {
+        $stmt = $this->pdo->prepare(
+            'SELECT source_id, internal_id FROM external_ref
+             WHERE source_system = ? AND source_table = ? AND internal_table = ?'
+        );
+        $stmt->execute([self::SOURCE_SYSTEM, $sourceTable, $internalTable]);
+
+        $map = [];
+        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            $map[$row['source_id']] = (int) $row['internal_id'];
+        }
+
+        return $map;
+    }
+
+    public function lastSyncTime(string $sourceTable): ?string
+    {
+        $stmt = $this->pdo->prepare(
+            'SELECT MAX(synced_at) FROM external_ref
+             WHERE source_system = ? AND source_table = ?'
+        );
+        $stmt->execute([self::SOURCE_SYSTEM, $sourceTable]);
+        $val = $stmt->fetchColumn();
+
+        return $val !== false && $val !== null ? (string) $val : null;
+    }
+
+    private function pkColumn(string $table): string
+    {
+        return match ($table) {
+            'personnel' => 'personnel_id',
+            'organization' => 'org_id',
+            'position' => 'position_id',
+            'prefixes' => 'prefix_id',
+            'training_course' => 'course_id',
+            'royal_decorations' => 'decoration_id',
+            'personnel_position_history' => 'history_id',
+            default => 'id',
+        };
+    }
+}

--- a/backend/sync/CsvFileAdapter.php
+++ b/backend/sync/CsvFileAdapter.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/SourceAdapterInterface.php';
+
+class CsvFileAdapter implements SourceAdapterInterface
+{
+    public function __construct(private string $csvDir) {}
+
+    public function fetchRows(string $table, array $columns = [], ?string $sinceColumn = null, ?string $sinceValue = null): iterable
+    {
+        $file = $this->resolveFile($table);
+
+        if (!is_file($file)) {
+            return;
+        }
+
+        $handle = fopen($file, 'r');
+        if ($handle === false) {
+            throw new RuntimeException("Cannot open CSV file: {$file}");
+        }
+
+        try {
+            $headers = fgetcsv($handle);
+            if ($headers === false) {
+                return;
+            }
+
+            $headers = array_map('trim', $headers);
+            $sinceIndex = ($sinceColumn !== null) ? array_search($sinceColumn, $headers, true) : false;
+
+            while (($row = fgetcsv($handle)) !== false) {
+                if (count($row) !== count($headers)) {
+                    continue;
+                }
+
+                $assoc = array_combine($headers, $row);
+
+                if ($sinceIndex !== false && $sinceValue !== null) {
+                    $cellVal = $assoc[$sinceColumn] ?? '';
+                    if ($cellVal <= $sinceValue) {
+                        continue;
+                    }
+                }
+
+                if ($columns !== []) {
+                    $assoc = array_intersect_key($assoc, array_flip($columns));
+                }
+
+                yield $assoc;
+            }
+        } finally {
+            fclose($handle);
+        }
+    }
+
+    public function fetchLookup(string $table, string $keyColumn, string $valueColumn): array
+    {
+        $map = [];
+        foreach ($this->fetchRows($table, [$keyColumn, $valueColumn]) as $row) {
+            $key = (string) ($row[$keyColumn] ?? '');
+            if ($key !== '') {
+                $map[$key] = (string) ($row[$valueColumn] ?? '');
+            }
+        }
+
+        return $map;
+    }
+
+    public function hasTable(string $table): bool
+    {
+        return is_file($this->resolveFile($table));
+    }
+
+    private function resolveFile(string $table): string
+    {
+        if (!preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*$/', $table)) {
+            throw new InvalidArgumentException("Invalid table name: {$table}");
+        }
+
+        $file = rtrim($this->csvDir, '/\\') . DIRECTORY_SEPARATOR . $table . '.csv';
+
+        return $file;
+    }
+}

--- a/backend/sync/SourceAdapterInterface.php
+++ b/backend/sync/SourceAdapterInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+interface SourceAdapterInterface
+{
+    /**
+     * Fetch rows from a source table.
+     *
+     * @param string $table Source table name (e.g. 'per_personal')
+     * @param array $columns Column names to select (empty = all)
+     * @param string|null $sinceColumn Column for delta detection (e.g. 'update_date')
+     * @param string|null $sinceValue Only return rows where sinceColumn > this value
+     * @return iterable<array<string, mixed>>
+     */
+    public function fetchRows(string $table, array $columns = [], ?string $sinceColumn = null, ?string $sinceValue = null): iterable;
+
+    /**
+     * Build a lookup map from a source table.
+     *
+     * @param string $table Source table name (e.g. 'per_line')
+     * @param string $keyColumn Column to use as key (e.g. 'pl_code')
+     * @param string $valueColumn Column to use as value (e.g. 'pl_name')
+     * @return array<string, string> key => value map
+     */
+    public function fetchLookup(string $table, string $keyColumn, string $valueColumn): array;
+
+    /**
+     * Check if a source table exists / is accessible.
+     */
+    public function hasTable(string $table): bool;
+}

--- a/backend/sync/StagingPdoAdapter.php
+++ b/backend/sync/StagingPdoAdapter.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/SourceAdapterInterface.php';
+
+class StagingPdoAdapter implements SourceAdapterInterface
+{
+    public function __construct(private PDO $pdo) {}
+
+    public function fetchRows(string $table, array $columns = [], ?string $sinceColumn = null, ?string $sinceValue = null): iterable
+    {
+        $this->validateIdentifier($table);
+        $select = $columns !== []
+            ? implode(', ', array_map([$this, 'quoteIdentifier'], $columns))
+            : '*';
+
+        $sql = "SELECT {$select} FROM `{$table}`";
+        $params = [];
+
+        if ($sinceColumn !== null && $sinceValue !== null) {
+            $this->validateIdentifier($sinceColumn);
+            $sql .= " WHERE `{$sinceColumn}` > ?";
+            $params[] = $sinceValue;
+        }
+
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute($params);
+
+        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            yield $row;
+        }
+    }
+
+    public function fetchLookup(string $table, string $keyColumn, string $valueColumn): array
+    {
+        $this->validateIdentifier($table);
+        $this->validateIdentifier($keyColumn);
+        $this->validateIdentifier($valueColumn);
+
+        $sql = "SELECT `{$keyColumn}`, `{$valueColumn}` FROM `{$table}`";
+        $stmt = $this->pdo->query($sql);
+
+        $map = [];
+        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            $key = (string) $row[$keyColumn];
+            $map[$key] = $row[$valueColumn] !== null ? (string) $row[$valueColumn] : '';
+        }
+
+        return $map;
+    }
+
+    public function hasTable(string $table): bool
+    {
+        $this->validateIdentifier($table);
+        $stmt = $this->pdo->prepare(
+            'SELECT 1 FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = ? LIMIT 1'
+        );
+        $stmt->execute([$table]);
+
+        return (bool) $stmt->fetchColumn();
+    }
+
+    private function validateIdentifier(string $identifier): void
+    {
+        if (!preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*$/', $identifier)) {
+            throw new InvalidArgumentException("Invalid SQL identifier: {$identifier}");
+        }
+    }
+
+    private function quoteIdentifier(string $identifier): string
+    {
+        $this->validateIdentifier($identifier);
+
+        return "`{$identifier}`";
+    }
+}

--- a/backend/sync/TransformHelpers.php
+++ b/backend/sync/TransformHelpers.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pure transform functions for legacy HR → Smart Port sync (date/year/level conversion).
+ */
+class TransformHelpers
+{
+    private const BE_OFFSET = 543;
+    private const BE_THRESHOLD = 2400;
+
+    private const LEVEL_MAP = [
+        '01' => 'K1', '02' => 'K2', '03' => 'K3', '04' => 'K4', '05' => 'K5',
+        '06' => 'M1', '07' => 'M2',
+        '08' => 'S1', '09' => 'S2',
+        '10' => 'O1', '11' => 'O2', '12' => 'O3',
+    ];
+
+    /**
+     * G1: Convert Buddhist Era datetime string to CE date.
+     * Source: CHAR(19) 'YYYY-MM-DD HH:MM:SS' (BE) → Target: 'YYYY-MM-DD' (CE DATE)
+     */
+    public static function beDateToCe(?string $raw): ?string
+    {
+        if ($raw === null || trim($raw) === '') {
+            return null;
+        }
+
+        $raw = trim($raw);
+        $datePart = substr($raw, 0, 10);
+        $parts = explode('-', $datePart);
+
+        if (count($parts) !== 3) {
+            return null;
+        }
+
+        $year = (int) $parts[0];
+        $month = (int) $parts[1];
+        $day = (int) $parts[2];
+
+        if ($year > self::BE_THRESHOLD) {
+            $year -= self::BE_OFFSET;
+        }
+
+        if ($month < 1 || $month > 12 || $day < 1 || $day > 31) {
+            return null;
+        }
+
+        return sprintf('%04d-%02d-%02d', $year, $month, $day);
+    }
+
+    /**
+     * G2: Convert Buddhist Era year to CE.
+     * Source: CHAR(4) 'YYYY' (BE) → Target: int (CE year)
+     */
+    public static function beYearToCe(?string $raw): ?int
+    {
+        if ($raw === null || trim($raw) === '') {
+            return null;
+        }
+
+        $year = (int) trim($raw);
+
+        if ($year === 0) {
+            return null;
+        }
+
+        if ($year > self::BE_THRESHOLD) {
+            $year -= self::BE_OFFSET;
+        }
+
+        return $year;
+    }
+
+    /**
+     * D1/D5 level crosswalk: source level_no CHAR(2) → Smart Port level code.
+     * '01'→'K1', '02'→'K2', ..., '12'→'O3' (ระบบแท่ง ก.พ.)
+     */
+    public static function levelCrosswalk(?string $levelNo): ?string
+    {
+        if ($levelNo === null || trim($levelNo) === '') {
+            return null;
+        }
+
+        $key = str_pad(trim($levelNo), 2, '0', STR_PAD_LEFT);
+
+        return self::LEVEL_MAP[$key] ?? null;
+    }
+
+    /**
+     * G4: Trim whitespace; return null if empty.
+     */
+    public static function trimOrNull(?string $val): ?string
+    {
+        if ($val === null) {
+            return null;
+        }
+
+        $trimmed = trim($val);
+
+        return $trimmed === '' ? null : $trimmed;
+    }
+
+    /**
+     * G1 variant: return full DATETIME string (CE) when source has time component.
+     */
+    public static function beDatetimeToCe(?string $raw): ?string
+    {
+        if ($raw === null || trim($raw) === '') {
+            return null;
+        }
+
+        $raw = trim($raw);
+        $datePart = self::beDateToCe($raw);
+
+        if ($datePart === null) {
+            return null;
+        }
+
+        if (strlen($raw) >= 19) {
+            $timePart = substr($raw, 11, 8);
+            return $datePart . ' ' . $timePart;
+        }
+
+        return $datePart;
+    }
+}

--- a/backend/sync/Transformers/DecorationTransformer.php
+++ b/backend/sync/Transformers/DecorationTransformer.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../TransformHelpers.php';
+require_once __DIR__ . '/../CrosswalkService.php';
+require_once __DIR__ . '/../SourceAdapterInterface.php';
+
+/**
+ * D6: per_decoratehis (+ per_decoration lookup) → royal_decorations
+ * Natural key: servant_id + decoration_name + received_year
+ * received_year stores Buddhist Era (validation 2400-2700) — NO CE conversion
+ */
+class DecorationTransformer
+{
+    public function __construct(
+        private PDO $target,
+        private SourceAdapterInterface $source,
+        private CrosswalkService $crosswalk,
+    ) {}
+
+    public function transform(bool $full = false): array
+    {
+        $result = ['domain' => 'D6', 'created' => 0, 'updated' => 0, 'skipped' => 0, 'errors' => []];
+
+        $since = null;
+        if (!$full) {
+            $since = $this->crosswalk->lastSyncTime('per_decoratehis');
+        }
+
+        $personMap = $this->crosswalk->buildMap('per_personal', 'personnel');
+        $decorationMap = $this->source->fetchLookup('per_decoration', 'dc_code', 'dc_name');
+        $classMap = $this->source->fetchLookup('per_decoration', 'dc_code', 'dc_shortname');
+
+        $checkStmt = $this->target->prepare(
+            'SELECT decoration_id FROM royal_decorations
+             WHERE servant_id = ? AND decoration_name = ? AND received_year = ?
+             LIMIT 1'
+        );
+
+        $insertStmt = $this->target->prepare(
+            'INSERT INTO royal_decorations (servant_id, decoration_name, decoration_class, received_year, gazette_ref)
+             VALUES (?, ?, ?, ?, ?)'
+        );
+
+        foreach ($this->source->fetchRows('per_decoratehis', [
+            'deh_id', 'per_id', 'per_cardno', 'dc_code', 'deh_date', 'deh_gazette',
+        ], 'update_date', $since) as $row) {
+            try {
+                $sourceId = (string) ($row['deh_id'] ?? '');
+                $perSourceId = (string) ($row['per_id'] ?? '');
+
+                $personnelId = $personMap[$perSourceId] ?? null;
+                if ($personnelId === null) {
+                    $citizenId = TransformHelpers::trimOrNull($row['per_cardno'] ?? null);
+                    if ($citizenId !== null) {
+                        $personnelId = $this->crosswalk->resolveByNaturalKey('personnel', 'citizen_id', $citizenId);
+                    }
+                }
+
+                if ($personnelId === null) {
+                    $result['skipped']++;
+                    continue;
+                }
+
+                $dcCode = TransformHelpers::trimOrNull($row['dc_code'] ?? null);
+                $decorationName = $dcCode !== null ? ($decorationMap[$dcCode] ?? $dcCode) : null;
+
+                if ($decorationName === null) {
+                    $result['skipped']++;
+                    continue;
+                }
+
+                // D6 exception: received_year stores Buddhist Era directly (no -543)
+                $receivedYear = null;
+                $rawYear = TransformHelpers::trimOrNull($row['deh_date'] ?? null);
+                if ($rawYear !== null) {
+                    $yearVal = (int) substr($rawYear, 0, 4);
+                    if ($yearVal >= 2400 && $yearVal <= 2700) {
+                        $receivedYear = $yearVal;
+                    } else {
+                        $result['errors'][] = "per_decoratehis [{$sourceId}]: year {$yearVal} outside BE range 2400-2700";
+                        $result['skipped']++;
+                        continue;
+                    }
+                }
+
+                $decorationClass = $dcCode !== null ? ($classMap[$dcCode] ?? null) : null;
+                $gazetteRef = TransformHelpers::trimOrNull($row['deh_gazette'] ?? null);
+
+                $checkStmt->execute([$personnelId, $decorationName, $receivedYear]);
+                $existingId = $checkStmt->fetchColumn();
+
+                if ($existingId !== false) {
+                    $this->crosswalk->record('per_decoratehis', $sourceId, 'royal_decorations', (int) $existingId);
+                    $result['skipped']++;
+                } else {
+                    $insertStmt->execute([$personnelId, $decorationName, $decorationClass, $receivedYear, $gazetteRef]);
+                    $newId = (int) $this->target->lastInsertId();
+                    $this->crosswalk->record('per_decoratehis', $sourceId, 'royal_decorations', $newId);
+                    $result['created']++;
+                }
+            } catch (Throwable $e) {
+                $result['errors'][] = 'per_decoratehis [' . ($row['deh_id'] ?? '?') . ']: ' . $e->getMessage();
+            }
+        }
+
+        return $result;
+    }
+}

--- a/backend/sync/Transformers/OrgTransformer.php
+++ b/backend/sync/Transformers/OrgTransformer.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../TransformHelpers.php';
+require_once __DIR__ . '/../CrosswalkService.php';
+require_once __DIR__ . '/../SourceAdapterInterface.php';
+
+/**
+ * D2: per_org → organization (import only org_active = 1)
+ */
+class OrgTransformer
+{
+    public function __construct(
+        private PDO $target,
+        private SourceAdapterInterface $source,
+        private CrosswalkService $crosswalk,
+    ) {}
+
+    public function transform(bool $full = false): array
+    {
+        $result = ['domain' => 'D2', 'created' => 0, 'updated' => 0, 'skipped' => 0, 'errors' => []];
+
+        $since = null;
+        if (!$full) {
+            $since = $this->crosswalk->lastSyncTime('per_org');
+        }
+
+        foreach ($this->source->fetchRows('per_org', ['org_id', 'org_code', 'org_name', 'org_active'], 'update_date', $since) as $row) {
+            try {
+                if ((int) ($row['org_active'] ?? 0) !== 1) {
+                    $result['skipped']++;
+                    continue;
+                }
+
+                $orgCode = TransformHelpers::trimOrNull($row['org_code'] ?? null);
+                $orgName = TransformHelpers::trimOrNull($row['org_name'] ?? null);
+                $sourceId = (string) ($row['org_id'] ?? '');
+
+                if ($orgCode === null || $orgName === null || $sourceId === '') {
+                    $result['skipped']++;
+                    continue;
+                }
+
+                $existingId = $this->crosswalk->resolveByNaturalKey('organization', 'org_code', $orgCode);
+
+                if ($existingId !== null) {
+                    $upd = $this->target->prepare('UPDATE organization SET org_name = ? WHERE org_id = ?');
+                    $upd->execute([$orgName, $existingId]);
+                    $this->crosswalk->record('per_org', $sourceId, 'organization', $existingId);
+                    $result['updated']++;
+                } else {
+                    $ins = $this->target->prepare('INSERT INTO organization (org_name, org_code) VALUES (?, ?)');
+                    $ins->execute([$orgName, $orgCode]);
+                    $newId = (int) $this->target->lastInsertId();
+                    $this->crosswalk->record('per_org', $sourceId, 'organization', $newId);
+                    $result['created']++;
+                }
+            } catch (Throwable $e) {
+                $result['errors'][] = 'per_org [' . ($row['org_id'] ?? '?') . ']: ' . $e->getMessage();
+            }
+        }
+
+        return $result;
+    }
+}

--- a/backend/sync/Transformers/PersonTransformer.php
+++ b/backend/sync/Transformers/PersonTransformer.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../TransformHelpers.php';
+require_once __DIR__ . '/../CrosswalkService.php';
+require_once __DIR__ . '/../SourceAdapterInterface.php';
+
+/**
+ * D1: per_personal → personnel
+ * Natural key: per_cardno = citizen_id (13-digit)
+ * Depends on: D2 (org crosswalk), D3 (position crosswalk), D4 (prefix crosswalk)
+ */
+class PersonTransformer
+{
+    public function __construct(
+        private PDO $target,
+        private SourceAdapterInterface $source,
+        private CrosswalkService $crosswalk,
+    ) {}
+
+    public function transform(bool $full = false): array
+    {
+        $result = ['domain' => 'D1', 'created' => 0, 'updated' => 0, 'skipped' => 0, 'errors' => []];
+
+        $since = null;
+        if (!$full) {
+            $since = $this->crosswalk->lastSyncTime('per_personal');
+        }
+
+        $orgMap = $this->crosswalk->buildMap('per_org', 'organization');
+        $posMap = $this->crosswalk->buildMap('per_position', 'position');
+        $prefixMap = $this->crosswalk->buildMap('per_prename', 'prefixes');
+
+        $upsert = $this->target->prepare(
+            'INSERT INTO personnel (citizen_id, first_name, last_name, prefix_id, hire_date,
+                current_position_id, current_org_id, current_level_code, is_active)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+             ON DUPLICATE KEY UPDATE
+                first_name = VALUES(first_name),
+                last_name = VALUES(last_name),
+                prefix_id = VALUES(prefix_id),
+                hire_date = VALUES(hire_date),
+                current_position_id = VALUES(current_position_id),
+                current_org_id = VALUES(current_org_id),
+                current_level_code = VALUES(current_level_code),
+                is_active = VALUES(is_active)'
+        );
+
+        foreach ($this->source->fetchRows('per_personal', [
+            'per_id', 'per_cardno', 'per_name', 'per_surname', 'per_startdate',
+            'pos_id', 'org_id', 'level_no', 'per_status', 'pn_code',
+        ], 'update_date', $since) as $row) {
+            try {
+                $citizenId = TransformHelpers::trimOrNull($row['per_cardno'] ?? null);
+                $firstName = TransformHelpers::trimOrNull($row['per_name'] ?? null);
+                $lastName = TransformHelpers::trimOrNull($row['per_surname'] ?? null);
+                $sourceId = (string) ($row['per_id'] ?? '');
+
+                if ($citizenId === null || $firstName === null || $lastName === null) {
+                    $result['skipped']++;
+                    continue;
+                }
+
+                if (!preg_match('/^\d{13}$/', $citizenId)) {
+                    $result['errors'][] = "per_personal [{$sourceId}]: invalid citizen_id format '{$citizenId}'";
+                    $result['skipped']++;
+                    continue;
+                }
+
+                $hireDate = TransformHelpers::beDateToCe($row['per_startdate'] ?? null);
+                $levelCode = TransformHelpers::levelCrosswalk($row['level_no'] ?? null);
+                $isActive = (int) ($row['per_status'] ?? 0) === 1 ? 1 : 0;
+
+                $prefixId = null;
+                $pnCode = TransformHelpers::trimOrNull($row['pn_code'] ?? null);
+                if ($pnCode !== null && isset($prefixMap[$pnCode])) {
+                    $prefixId = $prefixMap[$pnCode];
+                }
+
+                $positionId = null;
+                $posSourceId = (string) ($row['pos_id'] ?? '');
+                if ($posSourceId !== '' && $posSourceId !== '0' && isset($posMap[$posSourceId])) {
+                    $positionId = $posMap[$posSourceId];
+                }
+
+                $orgId = null;
+                $orgSourceId = (string) ($row['org_id'] ?? '');
+                if ($orgSourceId !== '' && $orgSourceId !== '0' && isset($orgMap[$orgSourceId])) {
+                    $orgId = $orgMap[$orgSourceId];
+                }
+
+                $existed = $this->crosswalk->resolveByNaturalKey('personnel', 'citizen_id', $citizenId);
+                $upsert->execute([$citizenId, $firstName, $lastName, $prefixId, $hireDate, $positionId, $orgId, $levelCode, $isActive]);
+
+                $personnelId = $this->crosswalk->resolveByNaturalKey('personnel', 'citizen_id', $citizenId);
+                if ($personnelId !== null) {
+                    $this->crosswalk->record('per_personal', $sourceId, 'personnel', $personnelId);
+                }
+
+                if ($existed !== null) {
+                    $result['updated']++;
+                } else {
+                    $result['created']++;
+                }
+            } catch (Throwable $e) {
+                $result['errors'][] = 'per_personal [' . ($row['per_id'] ?? '?') . ']: ' . $e->getMessage();
+            }
+        }
+
+        return $result;
+    }
+}

--- a/backend/sync/Transformers/PositionHistoryTransformer.php
+++ b/backend/sync/Transformers/PositionHistoryTransformer.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../TransformHelpers.php';
+require_once __DIR__ . '/../CrosswalkService.php';
+require_once __DIR__ . '/../SourceAdapterInterface.php';
+
+/**
+ * D5: per_positionhis → personnel_position_history
+ * Composite natural key: personnel_id + effective_date + position_name
+ * Depends on: D1 (person crosswalk), D2 (org crosswalk), D3 (position crosswalk)
+ */
+class PositionHistoryTransformer
+{
+    public function __construct(
+        private PDO $target,
+        private SourceAdapterInterface $source,
+        private CrosswalkService $crosswalk,
+    ) {}
+
+    public function transform(bool $full = false): array
+    {
+        $result = ['domain' => 'D5', 'created' => 0, 'updated' => 0, 'skipped' => 0, 'errors' => []];
+
+        $since = null;
+        if (!$full) {
+            $since = $this->crosswalk->lastSyncTime('per_positionhis');
+        }
+
+        $personMap = $this->crosswalk->buildMap('per_personal', 'personnel');
+        $orgMap = $this->crosswalk->buildMap('per_org', 'organization');
+        $posMap = $this->crosswalk->buildMap('per_position', 'position');
+        $lineMap = $this->source->fetchLookup('per_line', 'pl_code', 'pl_name');
+        $provinceMap = $this->source->fetchLookup('per_province', 'pv_code', 'pv_name');
+
+        $checkStmt = $this->target->prepare(
+            'SELECT history_id FROM personnel_position_history
+             WHERE personnel_id = ? AND effective_date = ? AND position_name = ?
+             LIMIT 1'
+        );
+
+        $insertStmt = $this->target->prepare(
+            'INSERT INTO personnel_position_history
+                (personnel_id, position_id, org_id, position_name, position_level, effective_date, end_date, order_number, order_date, job_series_name, province)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+        );
+
+        $updateStmt = $this->target->prepare(
+            'UPDATE personnel_position_history
+             SET position_id = ?, org_id = ?, position_level = ?, end_date = ?, order_number = ?, order_date = ?, job_series_name = ?, province = ?
+             WHERE history_id = ?'
+        );
+
+        foreach ($this->source->fetchRows('per_positionhis', [
+            'poh_id', 'per_id', 'poh_effectivedate', 'poh_enddate', 'poh_pos_no',
+            'org_id_3', 'level_no', 'poh_docno', 'poh_docdate', 'pl_code', 'pv_code',
+        ], 'update_date', $since) as $row) {
+            try {
+                $sourceId = (string) ($row['poh_id'] ?? '');
+                $perSourceId = (string) ($row['per_id'] ?? '');
+
+                $personnelId = $personMap[$perSourceId] ?? null;
+                if ($personnelId === null) {
+                    $result['skipped']++;
+                    continue;
+                }
+
+                $effectiveDate = TransformHelpers::beDateToCe($row['poh_effectivedate'] ?? null);
+                if ($effectiveDate === null) {
+                    $result['skipped']++;
+                    continue;
+                }
+
+                $posNo = TransformHelpers::trimOrNull($row['poh_pos_no'] ?? null);
+                $plCode = TransformHelpers::trimOrNull($row['pl_code'] ?? null);
+                $jobSeriesName = $plCode !== null ? ($lineMap[$plCode] ?? $plCode) : null;
+                $positionName = $jobSeriesName ?? $posNo ?? 'ไม่ระบุ';
+
+                $positionId = null;
+                if ($posNo !== null && isset($posMap[$posNo])) {
+                    $positionId = $posMap[$posNo];
+                }
+
+                $orgId = null;
+                $orgSourceId = (string) ($row['org_id_3'] ?? '');
+                if ($orgSourceId !== '' && $orgSourceId !== '0' && isset($orgMap[$orgSourceId])) {
+                    $orgId = $orgMap[$orgSourceId];
+                }
+
+                $level = TransformHelpers::levelCrosswalk($row['level_no'] ?? null);
+                $endDate = TransformHelpers::beDateToCe($row['poh_enddate'] ?? null);
+                $orderNumber = TransformHelpers::trimOrNull($row['poh_docno'] ?? null);
+                $orderDate = TransformHelpers::beDateToCe($row['poh_docdate'] ?? null);
+
+                $pvCode = TransformHelpers::trimOrNull($row['pv_code'] ?? null);
+                $province = $pvCode !== null ? ($provinceMap[$pvCode] ?? $pvCode) : null;
+
+                $checkStmt->execute([$personnelId, $effectiveDate, $positionName]);
+                $existingId = $checkStmt->fetchColumn();
+
+                if ($existingId !== false) {
+                    $updateStmt->execute([$positionId, $orgId, $level, $endDate, $orderNumber, $orderDate, $jobSeriesName, $province, (int) $existingId]);
+                    $this->crosswalk->record('per_positionhis', $sourceId, 'personnel_position_history', (int) $existingId);
+                    $result['updated']++;
+                } else {
+                    $insertStmt->execute([$personnelId, $positionId, $orgId, $positionName, $level, $effectiveDate, $endDate, $orderNumber, $orderDate, $jobSeriesName, $province]);
+                    $newId = (int) $this->target->lastInsertId();
+                    $this->crosswalk->record('per_positionhis', $sourceId, 'personnel_position_history', $newId);
+                    $result['created']++;
+                }
+            } catch (Throwable $e) {
+                $result['errors'][] = 'per_positionhis [' . ($row['poh_id'] ?? '?') . ']: ' . $e->getMessage();
+            }
+        }
+
+        return $result;
+    }
+}

--- a/backend/sync/Transformers/PositionTransformer.php
+++ b/backend/sync/Transformers/PositionTransformer.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../TransformHelpers.php';
+require_once __DIR__ . '/../CrosswalkService.php';
+require_once __DIR__ . '/../SourceAdapterInterface.php';
+
+/**
+ * D3: per_position → position (import only pos_status = 1, lookup per_line for name)
+ */
+class PositionTransformer
+{
+    public function __construct(
+        private PDO $target,
+        private SourceAdapterInterface $source,
+        private CrosswalkService $crosswalk,
+    ) {}
+
+    public function transform(bool $full = false): array
+    {
+        $result = ['domain' => 'D3', 'created' => 0, 'updated' => 0, 'skipped' => 0, 'errors' => []];
+
+        $since = null;
+        if (!$full) {
+            $since = $this->crosswalk->lastSyncTime('per_position');
+        }
+
+        $lineMap = $this->source->fetchLookup('per_line', 'pl_code', 'pl_name');
+
+        foreach ($this->source->fetchRows('per_position', ['pos_id', 'pos_no', 'pl_code', 'pos_status'], 'update_date', $since) as $row) {
+            try {
+                if ((int) ($row['pos_status'] ?? 0) !== 1) {
+                    $result['skipped']++;
+                    continue;
+                }
+
+                $posNo = TransformHelpers::trimOrNull($row['pos_no'] ?? null);
+                $sourceId = (string) ($row['pos_id'] ?? '');
+
+                if ($posNo === null || $sourceId === '') {
+                    $result['skipped']++;
+                    continue;
+                }
+
+                $plCode = TransformHelpers::trimOrNull($row['pl_code'] ?? null);
+                $positionName = $plCode !== null ? ($lineMap[$plCode] ?? $plCode) : $posNo;
+
+                $existingId = $this->crosswalk->resolveByNaturalKey('position', 'position_code', $posNo);
+
+                if ($existingId !== null) {
+                    $upd = $this->target->prepare('UPDATE `position` SET position_name = ? WHERE position_id = ?');
+                    $upd->execute([$positionName, $existingId]);
+                    $this->crosswalk->record('per_position', $sourceId, 'position', $existingId);
+                    $result['updated']++;
+                } else {
+                    $ins = $this->target->prepare('INSERT INTO `position` (position_name, position_code) VALUES (?, ?)');
+                    $ins->execute([$positionName, $posNo]);
+                    $newId = (int) $this->target->lastInsertId();
+                    $this->crosswalk->record('per_position', $sourceId, 'position', $newId);
+                    $result['created']++;
+                }
+            } catch (Throwable $e) {
+                $result['errors'][] = 'per_position [' . ($row['pos_id'] ?? '?') . ']: ' . $e->getMessage();
+            }
+        }
+
+        return $result;
+    }
+}

--- a/backend/sync/Transformers/PrefixTransformer.php
+++ b/backend/sync/Transformers/PrefixTransformer.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../TransformHelpers.php';
+require_once __DIR__ . '/../CrosswalkService.php';
+require_once __DIR__ . '/../SourceAdapterInterface.php';
+
+/**
+ * D4: per_prename → prefixes
+ */
+class PrefixTransformer
+{
+    public function __construct(
+        private PDO $target,
+        private SourceAdapterInterface $source,
+        private CrosswalkService $crosswalk,
+    ) {}
+
+    public function transform(bool $full = false): array
+    {
+        $result = ['domain' => 'D4', 'created' => 0, 'updated' => 0, 'skipped' => 0, 'errors' => []];
+
+        $since = null;
+        if (!$full) {
+            $since = $this->crosswalk->lastSyncTime('per_prename');
+        }
+
+        $stmt = $this->target->prepare(
+            'INSERT INTO prefixes (prefix_code, prefix_name_th, prefix_name_en, prefix_short, is_active)
+             VALUES (?, ?, ?, ?, ?)
+             ON DUPLICATE KEY UPDATE
+                prefix_name_th = VALUES(prefix_name_th),
+                prefix_name_en = VALUES(prefix_name_en),
+                prefix_short = VALUES(prefix_short),
+                is_active = VALUES(is_active)'
+        );
+
+        foreach ($this->source->fetchRows('per_prename', ['pn_code', 'pn_name', 'pn_eng_name', 'pn_shortname', 'pn_active'], 'update_date', $since) as $row) {
+            try {
+                $code = TransformHelpers::trimOrNull($row['pn_code'] ?? null);
+                $nameTh = TransformHelpers::trimOrNull($row['pn_name'] ?? null);
+
+                if ($code === null || $nameTh === null) {
+                    $result['skipped']++;
+                    continue;
+                }
+
+                $nameEn = TransformHelpers::trimOrNull($row['pn_eng_name'] ?? null);
+                $short = TransformHelpers::trimOrNull($row['pn_shortname'] ?? null);
+                $active = (int) ($row['pn_active'] ?? 1) === 1 ? 1 : 0;
+
+                $stmt->execute([$code, mb_substr($nameTh, 0, 50), $nameEn !== null ? mb_substr($nameEn, 0, 50) : null, $short !== null ? mb_substr($short, 0, 20) : null, $active]);
+
+                $prefixId = $this->resolvePrefixId($code);
+                if ($prefixId !== null) {
+                    $this->crosswalk->record('per_prename', $code, 'prefixes', $prefixId);
+                }
+
+                if ($stmt->rowCount() === 1) {
+                    $result['created']++;
+                } else {
+                    $result['updated']++;
+                }
+            } catch (Throwable $e) {
+                $result['errors'][] = 'per_prename [' . ($row['pn_code'] ?? '?') . ']: ' . $e->getMessage();
+            }
+        }
+
+        return $result;
+    }
+
+    private function resolvePrefixId(string $code): ?int
+    {
+        $stmt = $this->target->prepare('SELECT prefix_id FROM prefixes WHERE prefix_code = ? LIMIT 1');
+        $stmt->execute([$code]);
+        $val = $stmt->fetchColumn();
+
+        return $val !== false ? (int) $val : null;
+    }
+}

--- a/backend/sync/Transformers/TrainingTransformer.php
+++ b/backend/sync/Transformers/TrainingTransformer.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../TransformHelpers.php';
+require_once __DIR__ . '/../CrosswalkService.php';
+require_once __DIR__ . '/../SourceAdapterInterface.php';
+
+/**
+ * D7: per_training (+ per_train lookup) → training_course
+ * Only course names imported (no enrollment records this phase).
+ * Dedup by course_name.
+ */
+class TrainingTransformer
+{
+    public function __construct(
+        private PDO $target,
+        private SourceAdapterInterface $source,
+        private CrosswalkService $crosswalk,
+    ) {}
+
+    public function transform(bool $full = false): array
+    {
+        $result = ['domain' => 'D7', 'created' => 0, 'updated' => 0, 'skipped' => 0, 'errors' => []];
+
+        $since = null;
+        if (!$full) {
+            $since = $this->crosswalk->lastSyncTime('per_training');
+        }
+
+        $trainMap = $this->source->fetchLookup('per_train', 'tr_code', 'tr_name');
+
+        $checkStmt = $this->target->prepare('SELECT course_id FROM training_course WHERE course_name = ? LIMIT 1');
+        $insertStmt = $this->target->prepare('INSERT INTO training_course (course_name) VALUES (?)');
+
+        $seen = [];
+
+        foreach ($this->source->fetchRows('per_training', ['trn_id', 'tr_code'], 'update_date', $since) as $row) {
+            try {
+                $sourceId = (string) ($row['trn_id'] ?? '');
+                $trCode = TransformHelpers::trimOrNull($row['tr_code'] ?? null);
+
+                if ($trCode === null) {
+                    $result['skipped']++;
+                    continue;
+                }
+
+                $courseName = $trainMap[$trCode] ?? null;
+                if ($courseName === null || trim($courseName) === '') {
+                    $result['skipped']++;
+                    continue;
+                }
+
+                $courseName = TransformHelpers::trimOrNull($courseName);
+
+                if (isset($seen[$courseName])) {
+                    $this->crosswalk->record('per_training', $sourceId, 'training_course', $seen[$courseName]);
+                    $result['skipped']++;
+                    continue;
+                }
+
+                $checkStmt->execute([$courseName]);
+                $existingId = $checkStmt->fetchColumn();
+
+                if ($existingId !== false) {
+                    $courseId = (int) $existingId;
+                    $seen[$courseName] = $courseId;
+                    $this->crosswalk->record('per_training', $sourceId, 'training_course', $courseId);
+                    $result['skipped']++;
+                } else {
+                    $insertStmt->execute([$courseName]);
+                    $courseId = (int) $this->target->lastInsertId();
+                    $seen[$courseName] = $courseId;
+                    $this->crosswalk->record('per_training', $sourceId, 'training_course', $courseId);
+                    $result['created']++;
+                }
+            } catch (Throwable $e) {
+                $result['errors'][] = 'per_training [' . ($row['trn_id'] ?? '?') . ']: ' . $e->getMessage();
+            }
+        }
+
+        return $result;
+    }
+}

--- a/backend/tests/Integration/SyncTransformServiceTest.php
+++ b/backend/tests/Integration/SyncTransformServiceTest.php
@@ -1,0 +1,319 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration;
+
+use CrosswalkService;
+use PDO;
+use PDOException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use SyncTransformService;
+use Throwable;
+
+require_once __DIR__ . '/../../sync/CrosswalkService.php';
+require_once __DIR__ . '/../../sync/SourceAdapterInterface.php';
+require_once __DIR__ . '/../../sync/StagingPdoAdapter.php';
+require_once __DIR__ . '/../../sync/CsvFileAdapter.php';
+require_once __DIR__ . '/../../sync/TransformHelpers.php';
+require_once __DIR__ . '/../../sync/Transformers/PrefixTransformer.php';
+require_once __DIR__ . '/../../sync/Transformers/OrgTransformer.php';
+require_once __DIR__ . '/../../sync/Transformers/PositionTransformer.php';
+require_once __DIR__ . '/../../sync/Transformers/PersonTransformer.php';
+require_once __DIR__ . '/../../sync/Transformers/PositionHistoryTransformer.php';
+require_once __DIR__ . '/../../sync/Transformers/DecorationTransformer.php';
+require_once __DIR__ . '/../../sync/Transformers/TrainingTransformer.php';
+require_once __DIR__ . '/../../SyncTransformService.php';
+
+/**
+ * In-memory source adapter for testing — no staging DB required.
+ */
+class ArraySourceAdapter implements \SourceAdapterInterface
+{
+    private array $tables = [];
+    private array $lookups = [];
+
+    public function setRows(string $table, array $rows): void
+    {
+        $this->tables[$table] = $rows;
+    }
+
+    public function setLookup(string $table, string $keyCol, string $valCol, array $map): void
+    {
+        $this->lookups["{$table}.{$keyCol}.{$valCol}"] = $map;
+    }
+
+    public function fetchRows(string $table, array $columns = [], ?string $sinceColumn = null, ?string $sinceValue = null): iterable
+    {
+        $rows = $this->tables[$table] ?? [];
+
+        if ($sinceColumn !== null && $sinceValue !== null) {
+            $rows = array_filter($rows, fn($r) => ($r[$sinceColumn] ?? '') > $sinceValue);
+        }
+
+        foreach ($rows as $row) {
+            if ($columns !== []) {
+                yield array_intersect_key($row, array_flip($columns));
+            } else {
+                yield $row;
+            }
+        }
+    }
+
+    public function fetchLookup(string $table, string $keyColumn, string $valueColumn): array
+    {
+        return $this->lookups["{$table}.{$keyColumn}.{$valueColumn}"] ?? [];
+    }
+
+    public function hasTable(string $table): bool
+    {
+        return isset($this->tables[$table]);
+    }
+}
+
+final class SyncTransformServiceTest extends TestCase
+{
+    private static ?PDO $pdo = null;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$pdo = testPdo();
+    }
+
+    protected function setUp(): void
+    {
+        if (self::$pdo === null) {
+            self::markTestSkipped('ต่อ MySQL ไม่ได้ — รัน: docker compose up -d db แล้วใช้ tests/run.sh');
+        }
+        if (!self::$pdo->query("SHOW TABLES LIKE 'external_ref'")->fetchColumn()) {
+            self::markTestSkipped('ไม่พบตาราง external_ref — รัน migration 23-external-ref.sql');
+        }
+        $this->cleanup();
+    }
+
+    protected function tearDown(): void
+    {
+        if (self::$pdo !== null) {
+            $this->cleanup();
+        }
+    }
+
+    #[Test]
+    public function it_syncs_prefixes_d4(): void
+    {
+        $source = new ArraySourceAdapter();
+        $source->setRows('per_prename', [
+            ['pn_code' => '001', 'pn_name' => 'นาย', 'pn_eng_name' => 'Mr.', 'pn_shortname' => 'นาย', 'pn_active' => '1'],
+            ['pn_code' => '002', 'pn_name' => 'นาง', 'pn_eng_name' => 'Mrs.', 'pn_shortname' => 'นาง', 'pn_active' => '1'],
+            ['pn_code' => '003', 'pn_name' => 'นางสาว', 'pn_eng_name' => 'Miss', 'pn_shortname' => 'น.ส.', 'pn_active' => '1'],
+        ]);
+
+        $service = new SyncTransformService(self::$pdo, $source);
+        $result = $service->syncDomain('D4', true);
+
+        self::assertSame(3, $result['created'], 'ต้องสร้าง prefix 3 แถว: ' . json_encode($result));
+        self::assertSame(0, count($result['errors']));
+
+        $stmt = self::$pdo->query("SELECT COUNT(*) FROM prefixes WHERE prefix_code IN ('001','002','003')");
+        self::assertSame(3, (int) $stmt->fetchColumn());
+
+        $refCount = self::$pdo->query("SELECT COUNT(*) FROM external_ref WHERE source_table = 'per_prename' AND source_system = 'legacy-hr'")->fetchColumn();
+        self::assertSame(3, (int) $refCount);
+    }
+
+    #[Test]
+    public function it_syncs_organizations_d2(): void
+    {
+        $source = new ArraySourceAdapter();
+        $source->setRows('per_org', [
+            ['org_id' => '901', 'org_code' => 'TEST000000001', 'org_name' => 'กองทดสอบระบบ sync', 'org_active' => '1'],
+            ['org_id' => '902', 'org_code' => 'TEST000000002', 'org_name' => 'ฝ่ายทดสอบ inactive', 'org_active' => '0'],
+        ]);
+
+        $service = new SyncTransformService(self::$pdo, $source);
+        $result = $service->syncDomain('D2', true);
+
+        self::assertSame(1, $result['created']);
+        self::assertSame(1, $result['skipped'], 'org_active=0 ต้องถูก skip');
+
+        $stmt = self::$pdo->prepare("SELECT org_id FROM organization WHERE org_code = 'TEST000000001'");
+        $stmt->execute();
+        self::assertNotFalse($stmt->fetchColumn());
+    }
+
+    #[Test]
+    public function it_syncs_positions_d3(): void
+    {
+        $source = new ArraySourceAdapter();
+        $source->setRows('per_position', [
+            ['pos_id' => '801', 'pos_no' => 'TEST-POS-001', 'pl_code' => 'PL01', 'pos_status' => '1'],
+            ['pos_id' => '802', 'pos_no' => 'TEST-POS-002', 'pl_code' => 'PL02', 'pos_status' => '2'],
+        ]);
+        $source->setLookup('per_line', 'pl_code', 'pl_name', [
+            'PL01' => 'นักวิเคราะห์นโยบายและแผน',
+            'PL02' => 'นักทรัพยากรบุคคล',
+        ]);
+
+        $service = new SyncTransformService(self::$pdo, $source);
+        $result = $service->syncDomain('D3', true);
+
+        self::assertSame(1, $result['created']);
+        self::assertSame(1, $result['skipped'], 'pos_status=2 ต้องถูก skip');
+
+        $stmt = self::$pdo->prepare("SELECT position_name FROM `position` WHERE position_code = 'TEST-POS-001'");
+        $stmt->execute();
+        self::assertSame('นักวิเคราะห์นโยบายและแผน', $stmt->fetchColumn());
+    }
+
+    #[Test]
+    public function it_syncs_persons_d1_with_crosswalk(): void
+    {
+        // Seed crosswalks for org/position/prefix
+        $this->seedCrosswalkDependencies();
+
+        $source = new ArraySourceAdapter();
+        $source->setRows('per_personal', [
+            [
+                'per_id' => '9001', 'per_cardno' => '1999900000001', 'per_name' => 'ทดสอบ',
+                'per_surname' => 'ซิงก์', 'per_startdate' => '2560-04-01 00:00:00',
+                'pos_id' => '801', 'org_id' => '901', 'level_no' => '03', 'per_status' => '1', 'pn_code' => '001',
+            ],
+        ]);
+
+        $service = new SyncTransformService(self::$pdo, $source);
+        $result = $service->syncDomain('D1', true);
+
+        self::assertSame(1, $result['created'], json_encode($result));
+        self::assertSame(0, count($result['errors']));
+
+        $stmt = self::$pdo->prepare("SELECT * FROM personnel WHERE citizen_id = '1999900000001'");
+        $stmt->execute();
+        $person = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        self::assertNotFalse($person);
+        self::assertSame('ทดสอบ', $person['first_name']);
+        self::assertSame('ซิงก์', $person['last_name']);
+        self::assertSame('2017-04-01', $person['hire_date'], 'G1: BE 2560 → CE 2017');
+        self::assertSame('K3', $person['current_level_code'], 'level 03 → K3');
+        self::assertSame(1, (int) $person['is_active']);
+    }
+
+    #[Test]
+    public function it_is_idempotent_on_rerun(): void
+    {
+        $source = new ArraySourceAdapter();
+        $source->setRows('per_prename', [
+            ['pn_code' => '001', 'pn_name' => 'นาย', 'pn_eng_name' => 'Mr.', 'pn_shortname' => 'นาย', 'pn_active' => '1'],
+        ]);
+
+        $service = new SyncTransformService(self::$pdo, $source);
+        $service->syncDomain('D4', true);
+        $result2 = $service->syncDomain('D4', true);
+
+        self::assertSame(0, $result2['created'], 'รันซ้ำต้องไม่สร้างใหม่');
+        self::assertSame(1, $result2['updated']);
+
+        $count = self::$pdo->query("SELECT COUNT(*) FROM prefixes WHERE prefix_code = '001'")->fetchColumn();
+        self::assertSame(1, (int) $count, 'ต้องมีแถวเดียว');
+    }
+
+    #[Test]
+    public function it_syncs_training_d7_dedup_by_name(): void
+    {
+        $source = new ArraySourceAdapter();
+        $source->setRows('per_training', [
+            ['trn_id' => '701', 'tr_code' => 'TR01'],
+            ['trn_id' => '702', 'tr_code' => 'TR01'],
+            ['trn_id' => '703', 'tr_code' => 'TR02'],
+        ]);
+        $source->setLookup('per_train', 'tr_code', 'tr_name', [
+            'TR01' => 'หลักสูตรนักบริหารระดับสูง',
+            'TR02' => 'หลักสูตรภาษาอังกฤษ',
+        ]);
+
+        $service = new SyncTransformService(self::$pdo, $source);
+        $result = $service->syncDomain('D7', true);
+
+        self::assertSame(2, $result['created'], 'สร้าง 2 courses (dedup TR01)');
+        self::assertSame(1, $result['skipped']);
+    }
+
+    #[Test]
+    public function it_syncs_decorations_d6_with_be_year(): void
+    {
+        // Seed person crosswalk
+        self::$pdo->exec("INSERT INTO personnel (citizen_id, first_name, last_name) VALUES ('1999900000002', 'ประดับ', 'เครื่องราช')");
+        $personnelId = (int) self::$pdo->lastInsertId();
+        $crosswalk = new CrosswalkService(self::$pdo);
+        $crosswalk->record('per_personal', '9002', 'personnel', $personnelId);
+
+        $source = new ArraySourceAdapter();
+        $source->setRows('per_decoratehis', [
+            ['deh_id' => '601', 'per_id' => '9002', 'per_cardno' => '1999900000002', 'dc_code' => 'DC', 'deh_date' => '2565-01-01', 'deh_gazette' => 'ราชกิจจาฯ เล่ม 139'],
+        ]);
+        $source->setLookup('per_decoration', 'dc_code', 'dc_name', ['DC' => 'ทวีติยาภรณ์ช้างเผือก']);
+        $source->setLookup('per_decoration', 'dc_code', 'dc_shortname', ['DC' => 'ท.ช.']);
+
+        $service = new SyncTransformService(self::$pdo, $source);
+        $result = $service->syncDomain('D6', true);
+
+        self::assertSame(1, $result['created'], json_encode($result));
+
+        $stmt = self::$pdo->prepare('SELECT * FROM royal_decorations WHERE servant_id = ?');
+        $stmt->execute([$personnelId]);
+        $dec = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        self::assertNotFalse($dec);
+        self::assertSame('ทวีติยาภรณ์ช้างเผือก', $dec['decoration_name']);
+        self::assertSame(2565, (int) $dec['received_year'], 'D6: เก็บ พ.ศ. ตรง ไม่ลบ 543');
+    }
+
+    #[Test]
+    public function it_returns_status_per_domain(): void
+    {
+        $source = new ArraySourceAdapter();
+        $service = new SyncTransformService(self::$pdo, $source);
+        $status = $service->getStatus();
+
+        self::assertArrayHasKey('D1', $status);
+        self::assertArrayHasKey('D7', $status);
+        self::assertSame('per_personal', $status['D1']['source_table']);
+    }
+
+    private function seedCrosswalkDependencies(): void
+    {
+        // Org
+        self::$pdo->exec("INSERT INTO organization (org_name, org_code) VALUES ('กองทดสอบระบบ sync', 'TEST000000001')");
+        $orgId = (int) self::$pdo->lastInsertId();
+
+        // Position
+        self::$pdo->exec("INSERT INTO `position` (position_name, position_code) VALUES ('นักวิเคราะห์นโยบายและแผน', 'TEST-POS-001')");
+        $posId = (int) self::$pdo->lastInsertId();
+
+        // Prefix
+        self::$pdo->exec("INSERT INTO prefixes (prefix_code, prefix_name_th) VALUES ('001', 'นาย')");
+        $prefixId = (int) self::$pdo->lastInsertId();
+
+        $crosswalk = new CrosswalkService(self::$pdo);
+        $crosswalk->record('per_org', '901', 'organization', $orgId);
+        $crosswalk->record('per_position', '801', 'position', $posId);
+        $crosswalk->record('per_prename', '001', 'prefixes', $prefixId);
+    }
+
+    private function cleanup(): void
+    {
+        try {
+            self::$pdo->exec("DELETE FROM external_ref WHERE source_system = 'legacy-hr'");
+            self::$pdo->exec("DELETE FROM personnel_position_history WHERE personnel_id IN (SELECT personnel_id FROM personnel WHERE citizen_id LIKE '19999%')");
+            self::$pdo->exec("DELETE FROM royal_decorations WHERE servant_id IN (SELECT personnel_id FROM personnel WHERE citizen_id LIKE '19999%')");
+            self::$pdo->exec("DELETE FROM personnel WHERE citizen_id LIKE '19999%'");
+            self::$pdo->exec("DELETE FROM organization WHERE org_code LIKE 'TEST%'");
+            self::$pdo->exec("DELETE FROM `position` WHERE position_code LIKE 'TEST%'");
+            self::$pdo->exec("DELETE FROM prefixes WHERE prefix_code IN ('001','002','003')");
+            self::$pdo->exec("DELETE FROM training_course WHERE course_name LIKE 'หลักสูตร%'");
+        } catch (Throwable $e) {
+            // tables may not exist in some schemas
+        }
+    }
+}

--- a/backend/tests/Unit/CsvFileAdapterTest.php
+++ b/backend/tests/Unit/CsvFileAdapterTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use CsvFileAdapter;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../sync/CsvFileAdapter.php';
+
+final class CsvFileAdapterTest extends TestCase
+{
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/sync_test_' . getmypid();
+        if (!is_dir($this->tmpDir)) {
+            mkdir($this->tmpDir, 0777, true);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        $files = glob($this->tmpDir . '/*');
+        foreach ($files as $f) {
+            unlink($f);
+        }
+        rmdir($this->tmpDir);
+    }
+
+    #[Test]
+    public function it_reads_csv_with_headers(): void
+    {
+        file_put_contents($this->tmpDir . '/per_prename.csv', "pn_code,pn_name,pn_active\n001,นาย,1\n002,นาง,1\n");
+
+        $adapter = new CsvFileAdapter($this->tmpDir);
+        $rows = iterator_to_array($adapter->fetchRows('per_prename'));
+
+        self::assertCount(2, $rows);
+        self::assertSame('001', $rows[0]['pn_code']);
+        self::assertSame('นาย', $rows[0]['pn_name']);
+    }
+
+    #[Test]
+    public function it_filters_by_since_column(): void
+    {
+        file_put_contents($this->tmpDir . '/per_org.csv', "org_id,org_name,update_date\n1,A,2026-01-01\n2,B,2026-06-01\n3,C,2026-03-01\n");
+
+        $adapter = new CsvFileAdapter($this->tmpDir);
+        $rows = iterator_to_array($adapter->fetchRows('per_org', [], 'update_date', '2026-02-01'));
+
+        self::assertCount(2, $rows);
+        self::assertSame('2', $rows[0]['org_id']);
+        self::assertSame('3', $rows[1]['org_id']);
+    }
+
+    #[Test]
+    public function it_selects_specific_columns(): void
+    {
+        file_put_contents($this->tmpDir . '/per_line.csv', "pl_code,pl_name,pl_type\nPL01,นักวิเคราะห์,1\n");
+
+        $adapter = new CsvFileAdapter($this->tmpDir);
+        $rows = iterator_to_array($adapter->fetchRows('per_line', ['pl_code', 'pl_name']));
+
+        self::assertCount(1, $rows);
+        self::assertArrayHasKey('pl_code', $rows[0]);
+        self::assertArrayHasKey('pl_name', $rows[0]);
+        self::assertArrayNotHasKey('pl_type', $rows[0]);
+    }
+
+    #[Test]
+    public function it_builds_lookup_map(): void
+    {
+        file_put_contents($this->tmpDir . '/per_line.csv', "pl_code,pl_name\nPL01,นักวิเคราะห์\nPL02,นักทรัพยากร\n");
+
+        $adapter = new CsvFileAdapter($this->tmpDir);
+        $map = $adapter->fetchLookup('per_line', 'pl_code', 'pl_name');
+
+        self::assertSame(['PL01' => 'นักวิเคราะห์', 'PL02' => 'นักทรัพยากร'], $map);
+    }
+
+    #[Test]
+    public function it_returns_empty_for_missing_file(): void
+    {
+        $adapter = new CsvFileAdapter($this->tmpDir);
+        $rows = iterator_to_array($adapter->fetchRows('nonexistent'));
+
+        self::assertCount(0, $rows);
+    }
+
+    #[Test]
+    public function it_reports_table_existence(): void
+    {
+        file_put_contents($this->tmpDir . '/per_org.csv', "org_id\n1\n");
+
+        $adapter = new CsvFileAdapter($this->tmpDir);
+        self::assertTrue($adapter->hasTable('per_org'));
+        self::assertFalse($adapter->hasTable('per_missing'));
+    }
+
+    #[Test]
+    public function it_rejects_invalid_table_names(): void
+    {
+        $adapter = new CsvFileAdapter($this->tmpDir);
+
+        $this->expectException(InvalidArgumentException::class);
+        iterator_to_array($adapter->fetchRows('../../etc/passwd'));
+    }
+
+    #[Test]
+    public function it_handles_empty_csv(): void
+    {
+        file_put_contents($this->tmpDir . '/empty.csv', '');
+
+        $adapter = new CsvFileAdapter($this->tmpDir);
+        $rows = iterator_to_array($adapter->fetchRows('empty'));
+
+        self::assertCount(0, $rows);
+    }
+}

--- a/backend/tests/Unit/TransformHelpersTest.php
+++ b/backend/tests/Unit/TransformHelpersTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use TransformHelpers;
+
+require_once __DIR__ . '/../../sync/TransformHelpers.php';
+
+final class TransformHelpersTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('beDateProvider')]
+    public function it_converts_be_date_to_ce(?string $input, ?string $expected): void
+    {
+        self::assertSame($expected, TransformHelpers::beDateToCe($input));
+    }
+
+    public static function beDateProvider(): array
+    {
+        return [
+            'standard BE datetime' => ['2565-03-15 00:00:00', '2022-03-15'],
+            'BE date with time' => ['2566-12-01 14:30:00', '2023-12-01'],
+            'CE date passthrough' => ['2022-03-15 00:00:00', '2022-03-15'],
+            'boundary 2401 is BE' => ['2401-01-01 00:00:00', '1858-01-01'],
+            'boundary 2400 is CE' => ['2400-06-15 00:00:00', '2400-06-15'],
+            'null input' => [null, null],
+            'empty string' => ['', null],
+            'whitespace only' => ['   ', null],
+            'date only 10 chars' => ['2565-03-15', '2022-03-15'],
+            'invalid month' => ['2565-13-01 00:00:00', null],
+            'invalid day' => ['2565-01-32 00:00:00', null],
+            'garbage' => ['not-a-date', null],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('beYearProvider')]
+    public function it_converts_be_year_to_ce(?string $input, ?int $expected): void
+    {
+        self::assertSame($expected, TransformHelpers::beYearToCe($input));
+    }
+
+    public static function beYearProvider(): array
+    {
+        return [
+            'standard BE year' => ['2565', 2022],
+            'BE year 2566' => ['2566', 2023],
+            'CE year passthrough' => ['2022', 2022],
+            'boundary 2401' => ['2401', 1858],
+            'boundary 2400' => ['2400', 2400],
+            'null' => [null, null],
+            'empty' => ['', null],
+            'zero' => ['0', null],
+            'with spaces' => [' 2565 ', 2022],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('levelProvider')]
+    public function it_crosswalks_level_codes(?string $input, ?string $expected): void
+    {
+        self::assertSame($expected, TransformHelpers::levelCrosswalk($input));
+    }
+
+    public static function levelProvider(): array
+    {
+        return [
+            'K1' => ['01', 'K1'],
+            'K2' => ['02', 'K2'],
+            'K3' => ['03', 'K3'],
+            'K4' => ['04', 'K4'],
+            'K5' => ['05', 'K5'],
+            'M1' => ['06', 'M1'],
+            'M2' => ['07', 'M2'],
+            'S1' => ['08', 'S1'],
+            'S2' => ['09', 'S2'],
+            'O1' => ['10', 'O1'],
+            'O2' => ['11', 'O2'],
+            'O3' => ['12', 'O3'],
+            'single digit padded' => ['1', 'K1'],
+            'null' => [null, null],
+            'empty' => ['', null],
+            'unknown code' => ['99', null],
+            'alpha' => ['AB', null],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('trimProvider')]
+    public function it_trims_or_returns_null(?string $input, ?string $expected): void
+    {
+        self::assertSame($expected, TransformHelpers::trimOrNull($input));
+    }
+
+    public static function trimProvider(): array
+    {
+        return [
+            'normal' => ['hello', 'hello'],
+            'padded' => ['  hello  ', 'hello'],
+            'null' => [null, null],
+            'empty' => ['', null],
+            'whitespace' => ['   ', null],
+        ];
+    }
+
+    #[Test]
+    public function it_converts_be_datetime_with_time_component(): void
+    {
+        self::assertSame('2022-03-15 14:30:00', TransformHelpers::beDatetimeToCe('2565-03-15 14:30:00'));
+    }
+
+    #[Test]
+    public function it_converts_be_datetime_date_only(): void
+    {
+        self::assertSame('2022-03-15', TransformHelpers::beDatetimeToCe('2565-03-15'));
+    }
+
+    #[Test]
+    public function it_returns_null_datetime_for_null(): void
+    {
+        self::assertNull(TransformHelpers::beDatetimeToCe(null));
+    }
+}

--- a/backend/tests/bootstrap.php
+++ b/backend/tests/bootstrap.php
@@ -14,6 +14,7 @@ require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../helpers.php';
 require_once __DIR__ . '/../QualificationEngine.php';
 require_once __DIR__ . '/../ImportService.php';
+require_once __DIR__ . '/../SyncTransformService.php';
 
 /**
  * สร้าง PDO สำหรับ integration test — อ่าน env เดียวกับ config.php::getDB()

--- a/database/23-external-ref.sql
+++ b/database/23-external-ref.sql
@@ -1,0 +1,25 @@
+-- บังคับ client charset เป็น utf8mb4 กัน mojibake ตอน docker init (client default อาจเป็น latin1)
+SET NAMES utf8mb4;
+
+-- ============================================================================
+-- 23-external-ref.sql
+-- Crosswalk อ้างอิง record ต้นทางจากระบบภายนอก (ADR-0001: Anti-Corruption Layer)
+--   - ID ระบบเดิมเป็น running number ที่ระบบเขา generate — ห้ามใช้เป็น PK ภายใน
+--   - source_id เป็น VARCHAR เพราะรหัสระบบเดิมมีทั้งตัวเลขและ CHAR code
+--   - PII: source_id อาจเป็น citizen_id (กรณี Excel import) → สถานะเดียวกับ
+--     ตาราง personnel ห้าม expose ผ่าน API endpoint
+-- หมายเหตุ TiDB: ไม่ใช้ FOREIGN KEY / TRIGGER / DEFINER (validate ฝั่ง PHP)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS external_ref (
+    ref_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    source_system VARCHAR(50) NOT NULL,
+    source_table VARCHAR(100) NOT NULL,
+    source_id VARCHAR(100) NOT NULL,
+    internal_table VARCHAR(100) NOT NULL,
+    internal_id BIGINT NOT NULL,
+    synced_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_external_ref_source (source_system, source_table, source_id, internal_table),
+    KEY idx_external_ref_internal (internal_table, internal_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/database/24-drop-dead-tables.sql
+++ b/database/24-drop-dead-tables.sql
@@ -1,0 +1,37 @@
+-- ============================================================================
+-- 24-drop-dead-tables.sql
+-- ลบตารางที่ไม่มี consumer ใดใน backend/frontend (ผลตรวจ 2026-07-29)
+--   - 5 tables จาก 04-career-path.sql (partial implementation, ไม่เคยถูก query)
+--   - 2 tables จาก 05-probation.sql (elearning — ไม่เคย wire เข้า route)
+--   - 6 tables จาก export/tidb-init (legacy/speculative schema)
+--   - 1 table advance_notifications (เดิมใช้โดย /forecast ซึ่งถูกถอดออก)
+--   - civil_servants (deprecated ตั้งแต่ ADR-0002, migration 22 ย้ายข้อมูลแล้ว)
+--
+-- ลำดับสำคัญ: drop ตารางลูกที่มี FK ชี้ civil_servants ก่อน → แล้วค่อย drop civil_servants
+-- (local MySQL มี FK enforcement; TiDB ไม่มี — ลำดับไม่กระทบแต่คงไว้เพื่อ MySQL)
+-- ============================================================================
+
+-- Career path (04-career-path.sql) — never queried
+DROP TABLE IF EXISTS screening_list;
+DROP TABLE IF EXISTS rotation_assignment;
+DROP TABLE IF EXISTS promotion_evaluation;
+DROP TABLE IF EXISTS promotion_required_training;
+DROP TABLE IF EXISTS professional_license;
+
+-- Probation e-learning (05-probation.sql) — never wired
+DROP TABLE IF EXISTS elearning_enrollment;
+DROP TABLE IF EXISTS elearning_course;
+
+-- Legacy/speculative — มี FK ชี้ civil_servants (ต้อง drop ก่อน)
+DROP TABLE IF EXISTS candidate_list_members;
+DROP TABLE IF EXISTS candidate_lists;
+DROP TABLE IF EXISTS career_paths;
+DROP TABLE IF EXISTS ml_predictions;
+DROP TABLE IF EXISTS network_connections;
+DROP TABLE IF EXISTS task_assignments;
+
+-- Forecast placeholder (removed endpoint /forecast 2026-07-29)
+DROP TABLE IF EXISTS advance_notifications;
+
+-- Deprecated person table (ADR-0002: merged into personnel since migration 22)
+DROP TABLE IF EXISTS civil_servants;


### PR DESCRIPTION
## Summary
- Implement Anti-Corruption Layer sync pipeline per ADR-0001: 7 domain transformers (D4 prefixes → D2 orgs → D3 positions → D1 persons → D5 history → D6 decorations → D7 training)
- Source adapters: staging PDO + CSV files (adapter pattern)
- Trigger: CLI (`scripts/run-sync.php`) + admin-only API (`POST /sync/{domain}`)
- Add `external_ref` crosswalk table (migration 23)
- Drop 15 dead tables incl. deprecated `civil_servants` (migration 24)
- Remove `/forecast` endpoint (always returned `[]`, real logic in `/candidates`)

## Schema notes
- Migration 23: `external_ref` — crosswalk (source_system, source_table, source_id) ↔ (internal_table, internal_id)
- Migration 24: DROP 15 tables (5 career-path stubs, 2 elearning, 6 legacy/speculative, 1 forecast, 1 civil_servants)
- TiDB-compatible: no FK, no TRIGGER, no DEFINER

## Verification
- PHPUnit: 255 tests, 659 assertions — OK
- New tests: TransformHelpersTest (unit), CsvFileAdapterTest (unit), SyncTransformServiceTest (integration, 8 tests)
- Migrations 23-24 applied + verified on local Docker DB
- Secret scan: clean (no PII, no credentials, no MAPPING-SPEC content)

## Test plan
- [x] `bash backend/tests/run.sh` — full suite passes
- [x] Migration 23-24 applied to local DB without errors
- [x] Idempotency verified (re-run sync, no duplicates)
- [ ] Deploy to Render → run migrations on TiDB prod
- [ ] Verify `/sync/status` returns domain list (no staging configured yet → 503 on POST)