### PR TITLE
fix: restore missing multiplier tables and safe SQL split

### DIFF
--- a/.cursor/rules/thai-simple-explain.mdc
+++ b/.cursor/rules/thai-simple-explain.mdc
@@ -23,6 +23,14 @@ alwaysApply: true
 
 คำสั่งเช็คว่ายังโอเค: `node scripts/validate-schema-parity.mjs` → ต้องได้ `OK ไม่พบ schema drift`
 
+# บั๊กหน้า candidates / multiplier (2026-08-01) — แก้แล้วบน TiDB
+
+- **อาการ:** `/candidates/*` = Internal server error, `/time-multiplier` = เข้าถึงฐานข้อมูลไม่ได้, หลายหน้าว่าง
+- **สาเหตุจริง:** ตาราง `special_area_multiplier` / `multiplier_experience` **ไม่มีบน TiDB** ทั้งที่ migration 13/14 ถูก mark ว่า applied แล้ว (เพราะ baseline ผ่าน 14 โดยไม่รัน SQL) — `QualificationEngine` ต้องใช้ตารางนี้
+- **สาเหตุซ้อน:** migration 24 มี `;` ในคอมเมนต์ ทำให้ `splitSqlStatements` ตัดผิด → backend รีสตาร์ทวนตอน deploy ที่มีไฟล์ 24
+- **แก้:** migration `25-ensure-multiplier-tables.sql` (IF NOT EXISTS) + แก้ตัวแยก SQL ไม่ตัดในคอมเมนต์ — apply 25 บน TiDB แล้ว / API prod กลับ 200
+- **อย่าสับสน:** หน้า awards/retirement ฯลฯ ที่ขึ้น “ไม่พบข้อมูล” = ตารางว่าง ไม่ใช่หน้า “อยู่ระหว่างพัฒนา”
+
 # คำศัพท์ง่ายในโปรเจกต์นี้
 
 - **migration** = สคริปต์อัปเดตโครงสร้างฐานข้อมูลทีละไฟล์ (`database/NN-*.sql`)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,7 @@ jobs:
             -v "$PWD/database/22-unify-person-identity.sql:/docker-entrypoint-initdb.d/22-unify-person-identity.sql" \
             -v "$PWD/database/23-external-ref.sql:/docker-entrypoint-initdb.d/23-external-ref.sql" \
             -v "$PWD/database/24-drop-dead-tables.sql:/docker-entrypoint-initdb.d/24-drop-dead-tables.sql" \
+            -v "$PWD/database/25-ensure-multiplier-tables.sql:/docker-entrypoint-initdb.d/25-ensure-multiplier-tables.sql" \
             mysql:8.0
 
       - name: Wait for schema init to finish

--- a/backend/scripts/migration-lib.php
+++ b/backend/scripts/migration-lib.php
@@ -100,7 +100,11 @@ function migrationDirectory(): string
 }
 
 /**
- * แยก SQL หลายคำสั่งด้วย ";" โดยไม่ตัดในเครื่องหมายคำพูด
+ * แยก SQL หลายคำสั่งด้วย ";" โดยไม่ตัดใน string / คอมเมนต์
+ *
+ * สำคัญ: คอมเมนต์บรรทัด `-- ...` หรือ `# ...` อาจมี ";" อยู่ข้างใน (เช่น อธิบาย FK)
+ * ถ้าตัดที่ ";" ในคอมเมนต์ จะได้เศษข้อความไทยไป execute → SQL syntax error
+ * (เคยพัง migration 24-drop-dead-tables.sql แล้วทำให้ container รีสตาร์ทวน)
  *
  * @return list<string>
  */
@@ -110,11 +114,50 @@ function splitSqlStatements(string $sql): array
     $buffer = '';
     $inSingleQuote = false;
     $inDoubleQuote = false;
+    $inLineComment = false;
+    $inBlockComment = false;
     $length = strlen($sql);
 
     for ($i = 0; $i < $length; $i++) {
         $char = $sql[$i];
+        $next = $i + 1 < $length ? $sql[$i + 1] : '';
         $prev = $i > 0 ? $sql[$i - 1] : '';
+
+        if ($inLineComment) {
+            $buffer .= $char;
+            if ($char === "\n") {
+                $inLineComment = false;
+            }
+            continue;
+        }
+
+        if ($inBlockComment) {
+            $buffer .= $char;
+            if ($char === '*' && $next === '/') {
+                $buffer .= $next;
+                $i++;
+                $inBlockComment = false;
+            }
+            continue;
+        }
+
+        if (!$inSingleQuote && !$inDoubleQuote) {
+            if ($char === '-' && $next === '-') {
+                $inLineComment = true;
+                $buffer .= $char;
+                continue;
+            }
+            if ($char === '#') {
+                $inLineComment = true;
+                $buffer .= $char;
+                continue;
+            }
+            if ($char === '/' && $next === '*') {
+                $inBlockComment = true;
+                $buffer .= $char;
+                continue;
+            }
+        }
 
         if ($char === "'" && !$inDoubleQuote && $prev !== '\\') {
             $inSingleQuote = !$inSingleQuote;
@@ -124,7 +167,8 @@ function splitSqlStatements(string $sql): array
 
         if ($char === ';' && !$inSingleQuote && !$inDoubleQuote) {
             $statement = trim($buffer);
-            if ($statement !== '') {
+            // ข้ามชิ้นที่เป็นแค่คอมเมนต์/ว่าง — ไม่ต้องส่งให้ PDO
+            if ($statement !== '' && !sqlStatementIsCommentOnly($statement)) {
                 $statements[] = $statement;
             }
             $buffer = '';
@@ -135,9 +179,24 @@ function splitSqlStatements(string $sql): array
     }
 
     $tail = trim($buffer);
-    if ($tail !== '') {
+    if ($tail !== '' && !sqlStatementIsCommentOnly($tail)) {
         $statements[] = $tail;
     }
 
     return $statements;
+}
+
+/** true ถ้าข้อความเหลือแต่คอมเมนต์ SQL (ไม่มีคำสั่งจริง) */
+function sqlStatementIsCommentOnly(string $sql): bool
+{
+    $withoutBlock = preg_replace('/\/\*[\s\S]*?\*\//', '', $sql) ?? $sql;
+    $lines = preg_split('/\R/', $withoutBlock) ?: [];
+    foreach ($lines as $line) {
+        $trim = trim($line);
+        if ($trim === '' || str_starts_with($trim, '--') || str_starts_with($trim, '#')) {
+            continue;
+        }
+        return false;
+    }
+    return true;
 }

--- a/backend/tests/Unit/SplitSqlStatementsTest.php
+++ b/backend/tests/Unit/SplitSqlStatementsTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../scripts/migration-lib.php';
+
+final class SplitSqlStatementsTest extends TestCase
+{
+    #[Test]
+    public function does_not_split_on_semicolon_inside_line_comment(): void
+    {
+        $sql = <<<'SQL'
+-- (local MySQL has FK; TiDB does not — keep order for MySQL)
+DROP TABLE IF EXISTS screening_list;
+DROP TABLE IF EXISTS civil_servants;
+SQL;
+
+        $parts = splitSqlStatements($sql);
+
+        self::assertCount(2, $parts);
+        self::assertStringContainsString('DROP TABLE IF EXISTS screening_list', $parts[0]);
+        self::assertStringContainsString('DROP TABLE IF EXISTS civil_servants', $parts[1]);
+        // คอมเมนต์บรรทัดบนอาจติดมากับ statement แรกได้ — สำคัญคือไม่ถูกตัดเป็น statement แยก
+        self::assertDoesNotMatchRegularExpression('/^\s*TiDB\b/m', $parts[0]);
+        self::assertDoesNotMatchRegularExpression('/^\s*TiDB\b/m', $parts[1]);
+    }
+
+    #[Test]
+    public function skips_comment_only_chunks(): void
+    {
+        $sql = "-- only a comment\n\n# also a comment\n";
+        self::assertSame([], splitSqlStatements($sql));
+    }
+
+    #[Test]
+    public function keeps_semicolon_inside_string_literal(): void
+    {
+        $sql = "INSERT INTO t (note) VALUES ('a; b');\nSELECT 1;";
+        $parts = splitSqlStatements($sql);
+        self::assertCount(2, $parts);
+        self::assertStringContainsString("'a; b'", $parts[0]);
+    }
+}

--- a/database/24-drop-dead-tables.sql
+++ b/database/24-drop-dead-tables.sql
@@ -7,8 +7,8 @@
 --   - 1 table advance_notifications (เดิมใช้โดย /forecast ซึ่งถูกถอดออก)
 --   - civil_servants (deprecated ตั้งแต่ ADR-0002, migration 22 ย้ายข้อมูลแล้ว)
 --
--- ลำดับสำคัญ: drop ตารางลูกที่มี FK ชี้ civil_servants ก่อน → แล้วค่อย drop civil_servants
--- (local MySQL มี FK enforcement; TiDB ไม่มี — ลำดับไม่กระทบแต่คงไว้เพื่อ MySQL)
+-- ลำดับสำคัญ: drop ตารางลูกที่มี FK ชี้ civil_servants ก่อน แล้วค่อย drop civil_servants
+-- (local MySQL มี FK enforcement ส่วน TiDB ไม่มี ลำดับไม่กระทบแต่คงไว้เพื่อ MySQL)
 -- ============================================================================
 
 -- Career path (04-career-path.sql) — never queried

--- a/database/25-ensure-multiplier-tables.sql
+++ b/database/25-ensure-multiplier-tables.sql
@@ -1,0 +1,68 @@
+-- บังคับ client charset เป็น utf8mb4 กัน mojibake ตอน docker init (client default อาจเป็น latin1)
+SET NAMES utf8mb4;
+
+-- ============================================================================
+-- 25-ensure-multiplier-tables.sql
+-- ซ่อมตารางทวีคูณที่อาจหายบน production
+--
+-- สาเหตุ: migration 13/14 อยู่ใน baseline (ผ่าน MIGRATION_BASELINE_THROUGH=14)
+-- จึงถูก mark applied โดยไม่รัน SQL ถ้า DB มีอยู่แล้ว แต่ tidb-init รุ่นเก่าไม่มีตารางเหล่านี้
+-- → QualificationEngine / /multiplier พังด้วย "table doesn't exist"
+--
+-- ไฟล์นี้ idempotent (IF NOT EXISTS) — ปลอดภัยทั้ง MySQL local และ TiDB
+-- หมายเหตุ TiDB: ไม่ใส่ FOREIGN KEY (ตาม convention migration 18+)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS special_area_multiplier (
+    area_multiplier_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    province VARCHAR(100) NOT NULL,
+    district VARCHAR(100),
+    district_key VARCHAR(100) GENERATED ALWAYS AS (COALESCE(district, '__ALL__')) VIRTUAL,
+    basis_type VARCHAR(50) NOT NULL,
+    multiplier_ratio DECIMAL(5,2) NOT NULL,
+    effective_start_date DATE NOT NULL,
+    effective_end_date DATE,
+    legal_reference VARCHAR(300),
+    source_reference VARCHAR(500),
+    is_active TINYINT(1) DEFAULT 1,
+    created_by BIGINT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CHECK (multiplier_ratio >= 100.00),
+    CHECK (effective_end_date IS NULL OR effective_end_date >= effective_start_date),
+    KEY idx_area_multiplier_lookup (province, district, is_active, effective_start_date, effective_end_date),
+    UNIQUE KEY uq_area_multiplier_exact_period (province, district_key, basis_type, effective_start_date)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS multiplier_experience (
+    multiplier_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    personnel_id BIGINT NOT NULL,
+    area_multiplier_id BIGINT NOT NULL,
+    province VARCHAR(100) NOT NULL,
+    district VARCHAR(100),
+    basis_type VARCHAR(50) NOT NULL,
+    start_date DATE NOT NULL,
+    end_date DATE NOT NULL,
+    eligible_start_date DATE NOT NULL,
+    eligible_end_date DATE NOT NULL,
+    service_days INT,
+    eligible_days INT,
+    multiplier_ratio DECIMAL(5,2) DEFAULT 200.00,
+    effective_days DECIMAL(10,2),
+    bonus_days DECIMAL(10,2),
+    net_end_date DATE,
+    net_years INT,
+    net_months INT,
+    net_day_remainder INT,
+    proof_reference VARCHAR(500),
+    description TEXT,
+    created_by BIGINT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CHECK (end_date >= start_date),
+    CHECK (eligible_end_date >= eligible_start_date),
+    KEY idx_multiplier_exp_pid (personnel_id),
+    KEY idx_multiplier_exp_area (area_multiplier_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- created_by รวมใน CREATE ด้านบนแล้ว (เทียบเท่า migration 14) — ไม่ ALTER ซ้ำ

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -80,6 +80,7 @@ services:
       - ./database/22-unify-person-identity.sql:/docker-entrypoint-initdb.d/22-unify-person-identity.sql
       - ./database/23-external-ref.sql:/docker-entrypoint-initdb.d/23-external-ref.sql
       - ./database/24-drop-dead-tables.sql:/docker-entrypoint-initdb.d/24-drop-dead-tables.sql
+      - ./database/25-ensure-multiplier-tables.sql:/docker-entrypoint-initdb.d/25-ensure-multiplier-tables.sql
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "--silent"]
       interval: 10s


### PR DESCRIPTION
## Summary
- Add idempotent migration `25-ensure-multiplier-tables.sql` so production recovers when baseline skipped creating multiplier tables (candidates / time-multiplier 500).
- Fix `splitSqlStatements` so semicolons inside `--` comments do not break migration 24 and crash the backend restart loop.
- Mount migration 25 in compose/CI; add unit tests for SQL splitting.

## Test plan
- [x] `node scripts/validate-schema-parity.mjs` → OK
- [x] PHPUnit `SplitSqlStatementsTest` → 3 passed
- [x] Pre-push vitest → passed
- [x] Applied migration 25 on TiDB; prod API candidates/multiplier returned 200
- [ ] After deploy: `GET /api/` shows updated `migrations_available`; smoke candidates + time-multiplier in UI