### PR TITLE
fix: recover from blank content after failed lazy chunk load

### DIFF
--- a/frontend/e2e/features/blank-contagion.spec.js
+++ b/frontend/e2e/features/blank-contagion.spec.js
@@ -1,0 +1,111 @@
+import { test, expect } from '@playwright/test'
+import { loginAsAdmin } from '../helpers/auth.js'
+
+/**
+ * Reproduce: visit /time-difference or /position-compare → content blank,
+ * then other menu pages also blank (contagious).
+ */
+test.describe('content blank contagion', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page)
+  })
+
+  test('time-difference then dashboard still shows content', async ({ page }) => {
+    const pageErrors = []
+    const consoleErrors = []
+    page.on('pageerror', (err) => pageErrors.push(String(err)))
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text())
+    })
+
+    await page.goto('/time-difference')
+    await page.waitForTimeout(1500)
+
+    const mainTextAfterDiverse = (await page.locator('main').innerText()).trim()
+    const diverseHeading = await page.getByRole('heading', { name: 'การนับแตกต่าง' }).count()
+
+    await page.goto('/dashboard')
+    await page.waitForTimeout(1500)
+    const dashHeading = await page.getByRole('heading', { name: 'ภาพรวมระบบสมุดพก' }).count()
+    const mainTextAfterDash = (await page.locator('main').innerText()).trim()
+
+    // Attach diagnostics on failure
+    expect(
+      {
+        diverseHeading,
+        dashHeading,
+        mainTextAfterDiverseLen: mainTextAfterDiverse.length,
+        mainTextAfterDashLen: mainTextAfterDash.length,
+        pageErrors,
+        consoleErrors: consoleErrors.slice(0, 10),
+      },
+      'content should not go blank after time-difference',
+    ).toMatchObject({
+      diverseHeading: 1,
+      dashHeading: 1,
+    })
+    expect(mainTextAfterDiverse.length).toBeGreaterThan(20)
+    expect(mainTextAfterDash.length).toBeGreaterThan(20)
+  })
+
+  test('position-compare then candidates still shows content', async ({ page }) => {
+    const pageErrors = []
+    page.on('pageerror', (err) => pageErrors.push(String(err)))
+
+    await page.goto('/position-compare')
+    await page.waitForTimeout(1500)
+
+    const eqHeading = await page.getByRole('heading', { name: 'การเทียบตำแหน่ง' }).count()
+    const mainEq = (await page.locator('main').innerText()).trim()
+
+    await page.goto('/candidates/overview')
+    await page.waitForTimeout(2000)
+    const mainCand = (await page.locator('main').innerText()).trim()
+
+    expect({ eqHeading, mainEqLen: mainEq.length, mainCandLen: mainCand.length, pageErrors }).toMatchObject({
+      eqHeading: 1,
+    })
+    expect(mainEq.length).toBeGreaterThan(20)
+    expect(mainCand.length).toBeGreaterThan(20)
+  })
+
+  test('failed DiversePage chunk + SPA nav: content must not stay blank', async ({ page }) => {
+    const pageErrors = []
+    const consoleErrors = []
+    page.on('pageerror', (err) => pageErrors.push(String(err)))
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text())
+    })
+
+    await page.goto('/dashboard')
+    await expect(page.getByRole('heading', { name: 'ภาพรวมระบบสมุดพก' })).toBeVisible()
+
+    // Break lazy chunk (stale deploy) — SPA click, not full reload
+    await page.route('**/assets/DiversePage*.js', (route) => route.fulfill({ status: 404, body: 'missing' }))
+    await page.route('**/src/pages/DiversePage.vue*', (route) => route.fulfill({ status: 404, body: 'missing' }))
+    await page.route('**/DiversePage*', (route) => {
+      if (route.request().resourceType() === 'script' || route.request().url().includes('DiversePage')) {
+        return route.fulfill({ status: 404, body: 'missing' })
+      }
+      return route.continue()
+    })
+
+    // Submenu is collapsed by default
+    await page.getByRole('button', { name: 'การนับเวลาเพิ่มเติม' }).click()
+    await page.getByRole('link', { name: 'การนับแตกต่าง' }).click()
+
+    // Expect: first chunk fail reloads target, second fail falls back to /dashboard
+    await expect(page).toHaveURL(/\/dashboard/, { timeout: 20_000 })
+    await expect(page.getByRole('heading', { name: 'ภาพรวมระบบสมุดพก' })).toBeVisible({
+      timeout: 15_000,
+    })
+
+    const mainText = (await page.locator('main').innerText()).trim()
+    expect({
+      mainLen: mainText.length,
+      pageErrors: pageErrors.slice(0, 8),
+      consoleErrors: consoleErrors.slice(0, 8),
+    }).toMatchObject({})
+    expect(mainText.length).toBeGreaterThan(20)
+  })
+})

--- a/frontend/src/__tests__/router/onError.test.js
+++ b/frontend/src/__tests__/router/onError.test.js
@@ -67,7 +67,26 @@ describe('onRouterError chunk reload', () => {
     expect(mockShouldReload).not.toHaveBeenCalled()
   })
 
-  it('does not assign when reload window blocks a chunk error', () => {
+  it('falls back to dashboard when reload window blocks the target path', () => {
+    mockIsChunkLoadError.mockReturnValue(true)
+    mockShouldReload
+      .mockReturnValueOnce(false) // target /x blocked
+      .mockReturnValueOnce(true) // fallback:/dashboard allowed
+
+    onRouterError(new Error('Failed to fetch dynamically imported module'), { fullPath: '/x' }, { assign })
+
+    expect(isNavigating.value).toBe(false)
+    expect(mockShouldReload).toHaveBeenNthCalledWith(1, '/x', expect.anything(), expect.any(Number))
+    expect(mockShouldReload).toHaveBeenNthCalledWith(
+      2,
+      'fallback:/dashboard',
+      expect.anything(),
+      expect.any(Number),
+    )
+    expect(assign).toHaveBeenCalledWith('/dashboard')
+  })
+
+  it('does not assign when both target and fallback reload windows are blocked', () => {
     mockIsChunkLoadError.mockReturnValue(true)
     mockShouldReload.mockReturnValue(false)
 
@@ -75,5 +94,19 @@ describe('onRouterError chunk reload', () => {
 
     expect(isNavigating.value).toBe(false)
     expect(assign).not.toHaveBeenCalled()
+  })
+
+  it('does not fallback-loop when the failed target is already dashboard', () => {
+    mockIsChunkLoadError.mockReturnValue(true)
+    mockShouldReload.mockReturnValue(false)
+
+    onRouterError(
+      new Error('Failed to fetch dynamically imported module'),
+      { fullPath: '/dashboard' },
+      { assign },
+    )
+
+    expect(assign).not.toHaveBeenCalled()
+    expect(mockShouldReload).toHaveBeenCalledTimes(1)
   })
 })

--- a/frontend/src/layouts/AppLayout.vue
+++ b/frontend/src/layouts/AppLayout.vue
@@ -11,9 +11,9 @@
     <AppTopbar @toggle-sidebar="sidebarOpen = !sidebarOpen" />
     <main class="min-h-[calc(100vh-4rem)] bg-gray-50">
       <!-- ไม่ใช้ mode="out-in": ถ้า child lazy import พังหลัง leave จะเหลือจอว่างติดตาย -->
-      <RouterView v-slot="{ Component, route }">
+      <RouterView v-slot="{ Component }">
         <Transition name="page">
-          <component :is="Component" v-if="Component" :key="route.path" />
+          <component :is="Component" v-if="Component" :key="$route.path" />
         </Transition>
       </RouterView>
     </main>

--- a/frontend/src/layouts/AppLayout.vue
+++ b/frontend/src/layouts/AppLayout.vue
@@ -10,9 +10,10 @@
   <div class="lg:ml-64 transition-all duration-300">
     <AppTopbar @toggle-sidebar="sidebarOpen = !sidebarOpen" />
     <main class="min-h-[calc(100vh-4rem)] bg-gray-50">
-      <RouterView v-slot="{ Component }">
-        <Transition name="page" mode="out-in">
-          <component :is="Component" :key="$route.path" />
+      <!-- ไม่ใช้ mode="out-in": ถ้า child lazy import พังหลัง leave จะเหลือจอว่างติดตาย -->
+      <RouterView v-slot="{ Component, route }">
+        <Transition name="page">
+          <component :is="Component" v-if="Component" :key="route.path" />
         </Transition>
       </RouterView>
     </main>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -195,12 +195,28 @@ export function onRouterError(
     getPathname = () => window.location.pathname,
     now = Date.now(),
     storage = typeof sessionStorage !== 'undefined' ? sessionStorage : null,
+    fallbackPath = '/dashboard',
   } = {},
 ) {
   isNavigating.value = false
   const target = to?.fullPath ?? getPathname()
-  if (isChunkLoadError(error) && shouldReloadForChunkError(target, storage, now)) {
+  if (!isChunkLoadError(error)) {
+    return
+  }
+
+  // หลัง deploy: hard reload หน้าเป้าหมายเพื่อดึง index/asset ชุดใหม่
+  if (shouldReloadForChunkError(target, storage, now)) {
     assign(target)
+    return
+  }
+
+  // reload หน้าเดิมถูกบล็อก (กันวนลูป) — ถอยไป dashboard ครั้งเดียว
+  // กันจอขาวติดตายหลัง lazy page (เช่น /time-difference) โหลด chunk ไม่ได้ซ้ำ
+  if (
+    target !== fallbackPath
+    && shouldReloadForChunkError(`fallback:${fallbackPath}`, storage, now)
+  ) {
+    assign(fallbackPath)
   }
 }
 


### PR DESCRIPTION
## Summary
- After a lazy route chunk fails to load (common after deploy with a stale tab), hard-reload the target once; if that path is still blocked by the reload window, fall back to `/dashboard` so the app does not stay on a white screen.
- Remove `Transition mode=out-in` in `AppLayout` so a failed child navigation cannot leave RouterView empty and hang all later menus.
- Add unit coverage for the fallback path and a Playwright blank-contagion suite (including forced DiversePage 404).

## Test plan
- [x] `npx vitest run src/__tests__/router/onError.test.js`
- [x] `npx vitest run src/__tests__/layouts/AppLayout.test.js`
- [x] `npx playwright test e2e/features/blank-contagion.spec.js`
- [x] Pre-push full frontend vitest (55 files)
- [ ] After merge/deploy: open `/time-difference` and `/position-compare`, then navigate other menus — content must not stay blank
- [ ] Optional: keep an old tab open across a deploy and hit a rarely used lazy page — should recover to dashboard instead of white screen