### PR TITLE
debug: capture production blank-content runtime state

### DIFF
--- a/frontend/src/layouts/AppLayout.vue
+++ b/frontend/src/layouts/AppLayout.vue
@@ -44,6 +44,7 @@ onUnmounted(() => window.removeEventListener('resize', handleResize))
 watch(
   () => instance?.proxy?.$route?.path ?? window.location.pathname,
   async (path) => {
+    if (!blankDebugEnabled) return
     await nextTick()
     const main = mainElement.value
     const style = main ? getComputedStyle(main) : null

--- a/frontend/src/layouts/AppLayout.vue
+++ b/frontend/src/layouts/AppLayout.vue
@@ -25,14 +25,14 @@
 </template>
 
 <script setup>
-import { nextTick, ref, onMounted, onUnmounted, watch } from 'vue'
-import { useRoute } from 'vue-router'
+import { getCurrentInstance, nextTick, ref, onMounted, onUnmounted, watch } from 'vue'
 import AppSidebar from '@/components/AppSidebar.vue'
 import AppTopbar from '@/components/AppTopbar.vue'
 
-const route = useRoute()
+const instance = getCurrentInstance()
 const mainElement = ref(null)
 const sidebarOpen = ref(window.innerWidth >= 1024)
+const blankDebugEnabled = sessionStorage.getItem('blankDebugSession') === '4975e3'
 
 function handleResize() {
   sidebarOpen.value = window.innerWidth >= 1024
@@ -42,14 +42,14 @@ onMounted(() => window.addEventListener('resize', handleResize))
 onUnmounted(() => window.removeEventListener('resize', handleResize))
 
 watch(
-  () => route.path,
+  () => instance?.proxy?.$route?.path ?? window.location.pathname,
   async (path) => {
     await nextTick()
     const main = mainElement.value
     const style = main ? getComputedStyle(main) : null
     const centerElement = document.elementFromPoint?.(window.innerWidth / 2, window.innerHeight / 2)
     // #region agent log
-    fetch('http://127.0.0.1:7593/ingest/2c3dac7b-bfe2-4e17-bf18-ee2af8b3d131',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'4975e3'},body:JSON.stringify({sessionId:'4975e3',runId:'blank-v3',hypothesisId:'L,M',location:'AppLayout.vue:routeWatch',message:'main content after route update',data:{path,mainExists:!!main,textLength:(main?.textContent??'').trim().length,childCount:main?.childElementCount??-1,display:style?.display??null,visibility:style?.visibility??null,opacity:style?.opacity??null,width:main?.getBoundingClientRect().width??-1,height:main?.getBoundingClientRect().height??-1,centerTag:centerElement?.tagName??null,centerClass:String(centerElement?.className??'').slice(0,200)},timestamp:Date.now()})}).catch(()=>{});
+    if (blankDebugEnabled) fetch('http://127.0.0.1:7593/ingest/2c3dac7b-bfe2-4e17-bf18-ee2af8b3d131',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'4975e3'},body:JSON.stringify({sessionId:'4975e3',runId:'blank-v3',hypothesisId:'L,M',location:'AppLayout.vue:routeWatch',message:'main content after route update',data:{path,mainExists:!!main,textLength:(main?.textContent??'').trim().length,childCount:main?.childElementCount??-1,display:style?.display??null,visibility:style?.visibility??null,opacity:style?.opacity??null,width:main?.getBoundingClientRect().width??-1,height:main?.getBoundingClientRect().height??-1,centerTag:centerElement?.tagName??null,centerClass:String(centerElement?.className??'').slice(0,200)},timestamp:Date.now()})}).catch(()=>{});
     // #endregion
   },
   { immediate: true, flush: 'post' },

--- a/frontend/src/layouts/AppLayout.vue
+++ b/frontend/src/layouts/AppLayout.vue
@@ -9,7 +9,7 @@
 
   <div class="lg:ml-64 transition-all duration-300">
     <AppTopbar @toggle-sidebar="sidebarOpen = !sidebarOpen" />
-    <main class="min-h-[calc(100vh-4rem)] bg-gray-50">
+    <main ref="mainElement" class="min-h-[calc(100vh-4rem)] bg-gray-50">
       <!-- แสดง loading แทนพื้นที่ว่างเมื่อ RouterView ยังไม่มี component; ไม่ใช้ out-in -->
       <RouterView v-slot="{ Component }">
         <component :is="Component" v-if="Component" :key="$route.path" />
@@ -25,10 +25,13 @@
 </template>
 
 <script setup>
-import { ref, onMounted, onUnmounted } from 'vue'
+import { nextTick, ref, onMounted, onUnmounted, watch } from 'vue'
+import { useRoute } from 'vue-router'
 import AppSidebar from '@/components/AppSidebar.vue'
 import AppTopbar from '@/components/AppTopbar.vue'
 
+const route = useRoute()
+const mainElement = ref(null)
 const sidebarOpen = ref(window.innerWidth >= 1024)
 
 function handleResize() {
@@ -37,4 +40,18 @@ function handleResize() {
 
 onMounted(() => window.addEventListener('resize', handleResize))
 onUnmounted(() => window.removeEventListener('resize', handleResize))
+
+watch(
+  () => route.path,
+  async (path) => {
+    await nextTick()
+    const main = mainElement.value
+    const style = main ? getComputedStyle(main) : null
+    const centerElement = document.elementFromPoint?.(window.innerWidth / 2, window.innerHeight / 2)
+    // #region agent log
+    fetch('http://127.0.0.1:7593/ingest/2c3dac7b-bfe2-4e17-bf18-ee2af8b3d131',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'4975e3'},body:JSON.stringify({sessionId:'4975e3',runId:'blank-v3',hypothesisId:'L,M',location:'AppLayout.vue:routeWatch',message:'main content after route update',data:{path,mainExists:!!main,textLength:(main?.textContent??'').trim().length,childCount:main?.childElementCount??-1,display:style?.display??null,visibility:style?.visibility??null,opacity:style?.opacity??null,width:main?.getBoundingClientRect().width??-1,height:main?.getBoundingClientRect().height??-1,centerTag:centerElement?.tagName??null,centerClass:String(centerElement?.className??'').slice(0,200)},timestamp:Date.now()})}).catch(()=>{});
+    // #endregion
+  },
+  { immediate: true, flush: 'post' },
+)
 </script>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -4,28 +4,34 @@ import App from './App.vue'
 import router from './router'
 import './style.css'
 
+const requestedDebugSession = new URLSearchParams(window.location.search).get('blankDebug')
+if (requestedDebugSession === '4975e3') {
+  sessionStorage.setItem('blankDebugSession', requestedDebugSession)
+}
+const blankDebugEnabled = sessionStorage.getItem('blankDebugSession') === '4975e3'
+
 const app = createApp(App)
 
 // #region agent log
-fetch('http://127.0.0.1:7593/ingest/2c3dac7b-bfe2-4e17-bf18-ee2af8b3d131',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'4975e3'},body:JSON.stringify({sessionId:'4975e3',runId:'blank-v3',hypothesisId:'N',location:'main.js:startup',message:'application startup',data:{pathname:window.location.pathname,scripts:[...document.scripts].map((script)=>script.src).filter(Boolean),navigationType:performance.getEntriesByType('navigation')[0]?.type??null,hasServiceWorkerController:!!navigator.serviceWorker?.controller},timestamp:Date.now()})}).catch(()=>{});
+if (blankDebugEnabled) fetch('http://127.0.0.1:7593/ingest/2c3dac7b-bfe2-4e17-bf18-ee2af8b3d131',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'4975e3'},body:JSON.stringify({sessionId:'4975e3',runId:'blank-v3',hypothesisId:'N',location:'main.js:startup',message:'application startup',data:{pathname:window.location.pathname,scripts:[...document.scripts].map((script)=>script.src).filter(Boolean),navigationType:performance.getEntriesByType('navigation')[0]?.type??null,hasServiceWorkerController:!!navigator.serviceWorker?.controller},timestamp:Date.now()})}).catch(()=>{});
 // #endregion
 
 // #region agent log
 app.config.errorHandler = (error, instance, info) => {
   console.error('[Vue error]', info, error)
-  fetch('http://127.0.0.1:7593/ingest/2c3dac7b-bfe2-4e17-bf18-ee2af8b3d131',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'4975e3'},body:JSON.stringify({sessionId:'4975e3',runId:'blank-v3',hypothesisId:'J',location:'main.js:errorHandler',message:'vue application error',data:{pathname:window.location.pathname,component:instance?.$options?.name??instance?.$?.type?.__name??null,info,errorName:error?.name??null,errorMessage:String(error?.message??error).slice(0,500)},timestamp:Date.now()})}).catch(()=>{});
+  if (blankDebugEnabled) fetch('http://127.0.0.1:7593/ingest/2c3dac7b-bfe2-4e17-bf18-ee2af8b3d131',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'4975e3'},body:JSON.stringify({sessionId:'4975e3',runId:'blank-v3',hypothesisId:'J',location:'main.js:errorHandler',message:'vue application error',data:{pathname:window.location.pathname,component:instance?.$options?.name??instance?.$?.type?.__name??null,info,errorName:error?.name??null,errorMessage:String(error?.message??error).slice(0,500)},timestamp:Date.now()})}).catch(()=>{});
 }
 // #endregion
 
 // #region agent log
 window.addEventListener('error', (event) => {
-  fetch('http://127.0.0.1:7593/ingest/2c3dac7b-bfe2-4e17-bf18-ee2af8b3d131',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'4975e3'},body:JSON.stringify({sessionId:'4975e3',runId:'blank-v3',hypothesisId:'J',location:'main.js:window.error',message:'uncaught window error',data:{pathname:window.location.pathname,errorName:event.error?.name??null,errorMessage:String(event.error?.message??event.message).slice(0,500),source:event.filename?.split('/').pop()??null,line:event.lineno??null},timestamp:Date.now()})}).catch(()=>{});
+  if (blankDebugEnabled) fetch('http://127.0.0.1:7593/ingest/2c3dac7b-bfe2-4e17-bf18-ee2af8b3d131',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'4975e3'},body:JSON.stringify({sessionId:'4975e3',runId:'blank-v3',hypothesisId:'J',location:'main.js:window.error',message:'uncaught window error',data:{pathname:window.location.pathname,errorName:event.error?.name??null,errorMessage:String(event.error?.message??event.message).slice(0,500),source:event.filename?.split('/').pop()??null,line:event.lineno??null},timestamp:Date.now()})}).catch(()=>{});
 })
 // #endregion
 
 // #region agent log
 window.addEventListener('unhandledrejection', (event) => {
-  fetch('http://127.0.0.1:7593/ingest/2c3dac7b-bfe2-4e17-bf18-ee2af8b3d131',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'4975e3'},body:JSON.stringify({sessionId:'4975e3',runId:'blank-v3',hypothesisId:'J',location:'main.js:unhandledrejection',message:'unhandled promise rejection',data:{pathname:window.location.pathname,errorName:event.reason?.name??null,errorMessage:String(event.reason?.message??event.reason).slice(0,500)},timestamp:Date.now()})}).catch(()=>{});
+  if (blankDebugEnabled) fetch('http://127.0.0.1:7593/ingest/2c3dac7b-bfe2-4e17-bf18-ee2af8b3d131',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'4975e3'},body:JSON.stringify({sessionId:'4975e3',runId:'blank-v3',hypothesisId:'J',location:'main.js:unhandledrejection',message:'unhandled promise rejection',data:{pathname:window.location.pathname,errorName:event.reason?.name??null,errorMessage:String(event.reason?.message??event.reason).slice(0,500)},timestamp:Date.now()})}).catch(()=>{});
 })
 // #endregion
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -5,6 +5,30 @@ import router from './router'
 import './style.css'
 
 const app = createApp(App)
+
+// #region agent log
+fetch('http://127.0.0.1:7593/ingest/2c3dac7b-bfe2-4e17-bf18-ee2af8b3d131',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'4975e3'},body:JSON.stringify({sessionId:'4975e3',runId:'blank-v3',hypothesisId:'N',location:'main.js:startup',message:'application startup',data:{pathname:window.location.pathname,scripts:[...document.scripts].map((script)=>script.src).filter(Boolean),navigationType:performance.getEntriesByType('navigation')[0]?.type??null,hasServiceWorkerController:!!navigator.serviceWorker?.controller},timestamp:Date.now()})}).catch(()=>{});
+// #endregion
+
+// #region agent log
+app.config.errorHandler = (error, instance, info) => {
+  console.error('[Vue error]', info, error)
+  fetch('http://127.0.0.1:7593/ingest/2c3dac7b-bfe2-4e17-bf18-ee2af8b3d131',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'4975e3'},body:JSON.stringify({sessionId:'4975e3',runId:'blank-v3',hypothesisId:'J',location:'main.js:errorHandler',message:'vue application error',data:{pathname:window.location.pathname,component:instance?.$options?.name??instance?.$?.type?.__name??null,info,errorName:error?.name??null,errorMessage:String(error?.message??error).slice(0,500)},timestamp:Date.now()})}).catch(()=>{});
+}
+// #endregion
+
+// #region agent log
+window.addEventListener('error', (event) => {
+  fetch('http://127.0.0.1:7593/ingest/2c3dac7b-bfe2-4e17-bf18-ee2af8b3d131',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'4975e3'},body:JSON.stringify({sessionId:'4975e3',runId:'blank-v3',hypothesisId:'J',location:'main.js:window.error',message:'uncaught window error',data:{pathname:window.location.pathname,errorName:event.error?.name??null,errorMessage:String(event.error?.message??event.message).slice(0,500),source:event.filename?.split('/').pop()??null,line:event.lineno??null},timestamp:Date.now()})}).catch(()=>{});
+})
+// #endregion
+
+// #region agent log
+window.addEventListener('unhandledrejection', (event) => {
+  fetch('http://127.0.0.1:7593/ingest/2c3dac7b-bfe2-4e17-bf18-ee2af8b3d131',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'4975e3'},body:JSON.stringify({sessionId:'4975e3',runId:'blank-v3',hypothesisId:'J',location:'main.js:unhandledrejection',message:'unhandled promise rejection',data:{pathname:window.location.pathname,errorName:event.reason?.name??null,errorMessage:String(event.reason?.message??event.reason).slice(0,500)},timestamp:Date.now()})}).catch(()=>{});
+})
+// #endregion
+
 app.use(createPinia())
 app.use(router)
 app.mount('#app')

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -155,6 +155,10 @@ const { isNavigating } = useNavProgress()
 router.beforeEach(async (to) => {
   isNavigating.value = true
 
+  // #region agent log
+  fetch('http://127.0.0.1:7593/ingest/2c3dac7b-bfe2-4e17-bf18-ee2af8b3d131',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'4975e3'},body:JSON.stringify({sessionId:'4975e3',runId:'blank-v3',hypothesisId:'K',location:'router/index.js:beforeEach',message:'navigation guard entered',data:{toPath:to.path,matchedNames:to.matched.map((record)=>String(record.name??record.path)),requiresAuth:to.meta.requiresAuth!==false,requiresAdmin:!!to.meta.requiresAdmin},timestamp:Date.now()})}).catch(()=>{});
+  // #endregion
+
   const { useAuthStore } = await import('@/stores/auth.js')
   const auth = useAuthStore()
 
@@ -180,8 +184,12 @@ router.beforeEach(async (to) => {
   }
 })
 
-router.afterEach(() => {
+router.afterEach((to, from, failure) => {
   isNavigating.value = false
+
+  // #region agent log
+  fetch('http://127.0.0.1:7593/ingest/2c3dac7b-bfe2-4e17-bf18-ee2af8b3d131',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'4975e3'},body:JSON.stringify({sessionId:'4975e3',runId:'blank-v3',hypothesisId:'K',location:'router/index.js:afterEach',message:'navigation completed',data:{toPath:to.path,fromPath:from.path,failureType:failure?.type??null,failureMessage:failure?String(failure.message).slice(0,300):null,matchedNames:to.matched.map((record)=>String(record.name??record.path))},timestamp:Date.now()})}).catch(()=>{});
+  // #endregion
 })
 
 // chunk เก่าหายหลัง deploy ใหม่ → dynamic import พังและ navigation ถูกยกเลิกเงียบๆ
@@ -200,6 +208,10 @@ export function onRouterError(
 ) {
   isNavigating.value = false
   const target = to?.fullPath ?? getPathname()
+
+  // #region agent log
+  fetch('http://127.0.0.1:7593/ingest/2c3dac7b-bfe2-4e17-bf18-ee2af8b3d131',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'4975e3'},body:JSON.stringify({sessionId:'4975e3',runId:'blank-v3',hypothesisId:isChunkLoadError(error)?'K':'J',location:'router/index.js:onRouterError',message:'router error',data:{target,chunk:isChunkLoadError(error),errorName:error?.name??null,errorMessage:String(error?.message??error).slice(0,500)},timestamp:Date.now()})}).catch(()=>{});
+  // #endregion
 
   if (isChunkLoadError(error)) {
     const recovery = resolveChunkRecoveryTarget(target, storage, now, fallbackPath)

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -2,6 +2,11 @@ import { createRouter, createWebHistory } from 'vue-router'
 import { isChunkLoadError, resolveChunkRecoveryTarget } from '@/utils/chunkGuard.js'
 import { useNavProgress } from '@/composables/useNavProgress.js'
 
+const blankDebugEnabled = (
+  sessionStorage.getItem('blankDebugSession') === '4975e3'
+  || new URLSearchParams(window.location.search).get('blankDebug') === '4975e3'
+)
+
 const routes = [
   {
     path: '/login',
@@ -156,7 +161,7 @@ router.beforeEach(async (to) => {
   isNavigating.value = true
 
   // #region agent log
-  fetch('http://127.0.0.1:7593/ingest/2c3dac7b-bfe2-4e17-bf18-ee2af8b3d131',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'4975e3'},body:JSON.stringify({sessionId:'4975e3',runId:'blank-v3',hypothesisId:'K',location:'router/index.js:beforeEach',message:'navigation guard entered',data:{toPath:to.path,matchedNames:to.matched.map((record)=>String(record.name??record.path)),requiresAuth:to.meta.requiresAuth!==false,requiresAdmin:!!to.meta.requiresAdmin},timestamp:Date.now()})}).catch(()=>{});
+  if (blankDebugEnabled) fetch('http://127.0.0.1:7593/ingest/2c3dac7b-bfe2-4e17-bf18-ee2af8b3d131',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'4975e3'},body:JSON.stringify({sessionId:'4975e3',runId:'blank-v3',hypothesisId:'K',location:'router/index.js:beforeEach',message:'navigation guard entered',data:{toPath:to.path,matchedNames:to.matched.map((record)=>String(record.name??record.path)),requiresAuth:to.meta.requiresAuth!==false,requiresAdmin:!!to.meta.requiresAdmin},timestamp:Date.now()})}).catch(()=>{});
   // #endregion
 
   const { useAuthStore } = await import('@/stores/auth.js')
@@ -188,7 +193,7 @@ router.afterEach((to, from, failure) => {
   isNavigating.value = false
 
   // #region agent log
-  fetch('http://127.0.0.1:7593/ingest/2c3dac7b-bfe2-4e17-bf18-ee2af8b3d131',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'4975e3'},body:JSON.stringify({sessionId:'4975e3',runId:'blank-v3',hypothesisId:'K',location:'router/index.js:afterEach',message:'navigation completed',data:{toPath:to.path,fromPath:from.path,failureType:failure?.type??null,failureMessage:failure?String(failure.message).slice(0,300):null,matchedNames:to.matched.map((record)=>String(record.name??record.path))},timestamp:Date.now()})}).catch(()=>{});
+  if (blankDebugEnabled) fetch('http://127.0.0.1:7593/ingest/2c3dac7b-bfe2-4e17-bf18-ee2af8b3d131',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'4975e3'},body:JSON.stringify({sessionId:'4975e3',runId:'blank-v3',hypothesisId:'K',location:'router/index.js:afterEach',message:'navigation completed',data:{toPath:to.path,fromPath:from.path,failureType:failure?.type??null,failureMessage:failure?String(failure.message).slice(0,300):null,matchedNames:to.matched.map((record)=>String(record.name??record.path))},timestamp:Date.now()})}).catch(()=>{});
   // #endregion
 })
 
@@ -210,7 +215,7 @@ export function onRouterError(
   const target = to?.fullPath ?? getPathname()
 
   // #region agent log
-  fetch('http://127.0.0.1:7593/ingest/2c3dac7b-bfe2-4e17-bf18-ee2af8b3d131',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'4975e3'},body:JSON.stringify({sessionId:'4975e3',runId:'blank-v3',hypothesisId:isChunkLoadError(error)?'K':'J',location:'router/index.js:onRouterError',message:'router error',data:{target,chunk:isChunkLoadError(error),errorName:error?.name??null,errorMessage:String(error?.message??error).slice(0,500)},timestamp:Date.now()})}).catch(()=>{});
+  if (blankDebugEnabled) fetch('http://127.0.0.1:7593/ingest/2c3dac7b-bfe2-4e17-bf18-ee2af8b3d131',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'4975e3'},body:JSON.stringify({sessionId:'4975e3',runId:'blank-v3',hypothesisId:isChunkLoadError(error)?'K':'J',location:'router/index.js:onRouterError',message:'router error',data:{target,chunk:isChunkLoadError(error),errorName:error?.name??null,errorMessage:String(error?.message??error).slice(0,500)},timestamp:Date.now()})}).catch(()=>{});
   // #endregion
 
   if (isChunkLoadError(error)) {


### PR DESCRIPTION
## Summary
- add temporary production runtime probes for Vue, router, and rendered main-content state
- gate all telemetry behind `?blankDebug=4975e3` so normal users are unaffected
- capture only technical state; no tokens, credentials, or personnel data

## Test plan
- [x] Frontend build passes
- [x] Focused layout/router tests pass
- [x] Full pre-push suite passes (450 tests)
- [ ] Reproduce the blank-content issue in production with the debug query
- [ ] Remove telemetry after evidence-based fix verification