### PR TITLE
debug: expose production blank-content DOM state

### DIFF
--- a/frontend/src/layouts/AppLayout.vue
+++ b/frontend/src/layouts/AppLayout.vue
@@ -22,6 +22,13 @@
       </RouterView>
     </main>
   </div>
+
+  <div
+    v-if="blankDebugEnabled"
+    class="fixed bottom-2 right-2 z-50 max-w-[90vw] rounded bg-black/90 px-3 py-2 font-mono text-[11px] text-lime-300 shadow-lg"
+  >
+    {{ debugSnapshot }}
+  </div>
 </template>
 
 <script setup>
@@ -33,25 +40,64 @@ const instance = getCurrentInstance()
 const mainElement = ref(null)
 const sidebarOpen = ref(window.innerWidth >= 1024)
 const blankDebugEnabled = sessionStorage.getItem('blankDebugSession') === '4975e3'
+const debugSnapshot = ref('debug: waiting for route')
+let mainObserver = null
 
 function handleResize() {
   sidebarOpen.value = window.innerWidth >= 1024
 }
 
-onMounted(() => window.addEventListener('resize', handleResize))
-onUnmounted(() => window.removeEventListener('resize', handleResize))
+function captureMain(reason, path = window.location.pathname) {
+  const main = mainElement.value
+  const style = main ? getComputedStyle(main) : null
+  const centerElement = document.elementFromPoint?.(window.innerWidth / 2, window.innerHeight / 2)
+  const data = {
+    reason,
+    path,
+    mainExists: !!main,
+    textLength: (main?.textContent ?? '').trim().length,
+    childCount: main?.childElementCount ?? -1,
+    display: style?.display ?? null,
+    visibility: style?.visibility ?? null,
+    opacity: style?.opacity ?? null,
+    width: main?.getBoundingClientRect().width ?? -1,
+    height: main?.getBoundingClientRect().height ?? -1,
+    centerTag: centerElement?.tagName ?? null,
+  }
+  debugSnapshot.value = `${path} | text=${data.textLength} child=${data.childCount} | ${data.display}/${data.visibility}/${data.opacity} | center=${data.centerTag ?? '-'}`
+  console.warn('[blankDebug]', data)
+  // #region agent log
+  fetch('http://127.0.0.1:7593/ingest/2c3dac7b-bfe2-4e17-bf18-ee2af8b3d131',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'4975e3'},body:JSON.stringify({sessionId:'4975e3',runId:'blank-v4',hypothesisId:'L,M',location:'AppLayout.vue:captureMain',message:'main content state',data,timestamp:Date.now()})}).catch(()=>{});
+  // #endregion
+}
+
+onMounted(async () => {
+  window.addEventListener('resize', handleResize)
+  if (!blankDebugEnabled) return
+  await nextTick()
+  captureMain('mounted')
+  mainObserver = new MutationObserver(() => {
+    const main = mainElement.value
+    if (!main || main.childElementCount === 0 || !(main.textContent ?? '').trim()) {
+      captureMain('blank-mutation')
+    }
+  })
+  if (mainElement.value) {
+    mainObserver.observe(mainElement.value, { childList: true, subtree: true })
+  }
+})
+
+onUnmounted(() => {
+  window.removeEventListener('resize', handleResize)
+  mainObserver?.disconnect()
+})
 
 watch(
   () => instance?.proxy?.$route?.path ?? window.location.pathname,
   async (path) => {
     if (!blankDebugEnabled) return
     await nextTick()
-    const main = mainElement.value
-    const style = main ? getComputedStyle(main) : null
-    const centerElement = document.elementFromPoint?.(window.innerWidth / 2, window.innerHeight / 2)
-    // #region agent log
-    if (blankDebugEnabled) fetch('http://127.0.0.1:7593/ingest/2c3dac7b-bfe2-4e17-bf18-ee2af8b3d131',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'4975e3'},body:JSON.stringify({sessionId:'4975e3',runId:'blank-v3',hypothesisId:'L,M',location:'AppLayout.vue:routeWatch',message:'main content after route update',data:{path,mainExists:!!main,textLength:(main?.textContent??'').trim().length,childCount:main?.childElementCount??-1,display:style?.display??null,visibility:style?.visibility??null,opacity:style?.opacity??null,width:main?.getBoundingClientRect().width??-1,height:main?.getBoundingClientRect().height??-1,centerTag:centerElement?.tagName??null,centerClass:String(centerElement?.className??'').slice(0,200)},timestamp:Date.now()})}).catch(()=>{});
-    // #endregion
+    captureMain('route', path)
   },
   { immediate: true, flush: 'post' },
 )

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -8,32 +8,8 @@ const requestedDebugSession = new URLSearchParams(window.location.search).get('b
 if (requestedDebugSession === '4975e3') {
   sessionStorage.setItem('blankDebugSession', requestedDebugSession)
 }
-const blankDebugEnabled = sessionStorage.getItem('blankDebugSession') === '4975e3'
 
 const app = createApp(App)
-
-// #region agent log
-if (blankDebugEnabled) fetch('http://127.0.0.1:7593/ingest/2c3dac7b-bfe2-4e17-bf18-ee2af8b3d131',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'4975e3'},body:JSON.stringify({sessionId:'4975e3',runId:'blank-v3',hypothesisId:'N',location:'main.js:startup',message:'application startup',data:{pathname:window.location.pathname,scripts:[...document.scripts].map((script)=>script.src).filter(Boolean),navigationType:performance.getEntriesByType('navigation')[0]?.type??null,hasServiceWorkerController:!!navigator.serviceWorker?.controller},timestamp:Date.now()})}).catch(()=>{});
-// #endregion
-
-// #region agent log
-app.config.errorHandler = (error, instance, info) => {
-  console.error('[Vue error]', info, error)
-  if (blankDebugEnabled) fetch('http://127.0.0.1:7593/ingest/2c3dac7b-bfe2-4e17-bf18-ee2af8b3d131',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'4975e3'},body:JSON.stringify({sessionId:'4975e3',runId:'blank-v3',hypothesisId:'J',location:'main.js:errorHandler',message:'vue application error',data:{pathname:window.location.pathname,component:instance?.$options?.name??instance?.$?.type?.__name??null,info,errorName:error?.name??null,errorMessage:String(error?.message??error).slice(0,500)},timestamp:Date.now()})}).catch(()=>{});
-}
-// #endregion
-
-// #region agent log
-window.addEventListener('error', (event) => {
-  if (blankDebugEnabled) fetch('http://127.0.0.1:7593/ingest/2c3dac7b-bfe2-4e17-bf18-ee2af8b3d131',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'4975e3'},body:JSON.stringify({sessionId:'4975e3',runId:'blank-v3',hypothesisId:'J',location:'main.js:window.error',message:'uncaught window error',data:{pathname:window.location.pathname,errorName:event.error?.name??null,errorMessage:String(event.error?.message??event.message).slice(0,500),source:event.filename?.split('/').pop()??null,line:event.lineno??null},timestamp:Date.now()})}).catch(()=>{});
-})
-// #endregion
-
-// #region agent log
-window.addEventListener('unhandledrejection', (event) => {
-  if (blankDebugEnabled) fetch('http://127.0.0.1:7593/ingest/2c3dac7b-bfe2-4e17-bf18-ee2af8b3d131',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'4975e3'},body:JSON.stringify({sessionId:'4975e3',runId:'blank-v3',hypothesisId:'J',location:'main.js:unhandledrejection',message:'unhandled promise rejection',data:{pathname:window.location.pathname,errorName:event.reason?.name??null,errorMessage:String(event.reason?.message??event.reason).slice(0,500)},timestamp:Date.now()})}).catch(()=>{});
-})
-// #endregion
 
 app.use(createPinia())
 app.use(router)


### PR DESCRIPTION
## Summary
- remove rejected global error/stale-bundle probes after runtime evidence
- add a query-gated on-screen DOM status panel and blank-content observer
- keep normal production users unaffected

## Test plan
- [x] Frontend build passes
- [x] AppLayout tests pass
- [x] Full pre-push suite passes (450 tests)
- [ ] Reproduce production blank state and report the visible debug status