### PR TITLE
test: guard every sidebar page against blank content

### DIFF
--- a/frontend/e2e/features/all-menu-content.spec.js
+++ b/frontend/e2e/features/all-menu-content.spec.js
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test'
+import { loginAsAdmin } from '../helpers/auth.js'
+
+test('all sidebar menu destinations keep the content area rendered', async ({ page }) => {
+  const pageErrors = []
+  page.on('pageerror', (error) => pageErrors.push(String(error)))
+
+  await loginAsAdmin(page)
+  await page.setViewportSize({ width: 1440, height: 900 })
+
+  for (const label of ['Candidate Lists', 'การนับเวลาเพิ่มเติม']) {
+    await page.getByRole('button', { name: label }).click()
+  }
+
+  const destinations = await page.locator('nav a[href]').evaluateAll((links) => (
+    links.map((link) => ({
+      href: link.getAttribute('href'),
+      label: link.textContent?.trim() || link.getAttribute('href'),
+    }))
+  ))
+
+  expect(destinations.length).toBeGreaterThan(15)
+
+  for (const { href, label } of destinations) {
+    await test.step(`${label} (${href})`, async () => {
+      await page.locator(`nav a[href="${href}"]`).click()
+      await expect(page).toHaveURL(new RegExp(`${href.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`))
+      await expect.poll(
+        async () => (await page.locator('main').innerText()).trim().length,
+        { message: `${href} content area must not be blank` },
+      ).toBeGreaterThan(5)
+    })
+  }
+
+  expect(pageErrors, `unexpected page errors:\n${pageErrors.join('\n')}`).toEqual([])
+})

--- a/frontend/src/layouts/AppLayout.vue
+++ b/frontend/src/layouts/AppLayout.vue
@@ -9,7 +9,7 @@
 
   <div class="lg:ml-64 transition-all duration-300">
     <AppTopbar @toggle-sidebar="sidebarOpen = !sidebarOpen" />
-    <main ref="mainElement" class="min-h-[calc(100vh-4rem)] bg-gray-50">
+    <main class="min-h-[calc(100vh-4rem)] bg-gray-50">
       <!-- แสดง loading แทนพื้นที่ว่างเมื่อ RouterView ยังไม่มี component; ไม่ใช้ out-in -->
       <RouterView v-slot="{ Component }">
         <component :is="Component" v-if="Component" :key="$route.path" />
@@ -22,83 +22,19 @@
       </RouterView>
     </main>
   </div>
-
-  <div
-    v-if="blankDebugEnabled"
-    class="fixed bottom-2 right-2 z-50 max-w-[90vw] rounded bg-black/90 px-3 py-2 font-mono text-[11px] text-lime-300 shadow-lg"
-  >
-    {{ debugSnapshot }}
-  </div>
 </template>
 
 <script setup>
-import { getCurrentInstance, nextTick, ref, onMounted, onUnmounted, watch } from 'vue'
+import { ref, onMounted, onUnmounted } from 'vue'
 import AppSidebar from '@/components/AppSidebar.vue'
 import AppTopbar from '@/components/AppTopbar.vue'
 
-const instance = getCurrentInstance()
-const mainElement = ref(null)
 const sidebarOpen = ref(window.innerWidth >= 1024)
-const blankDebugEnabled = sessionStorage.getItem('blankDebugSession') === '4975e3'
-const debugSnapshot = ref('debug: waiting for route')
-let mainObserver = null
 
 function handleResize() {
   sidebarOpen.value = window.innerWidth >= 1024
 }
 
-function captureMain(reason, path = window.location.pathname) {
-  const main = mainElement.value
-  const style = main ? getComputedStyle(main) : null
-  const centerElement = document.elementFromPoint?.(window.innerWidth / 2, window.innerHeight / 2)
-  const data = {
-    reason,
-    path,
-    mainExists: !!main,
-    textLength: (main?.textContent ?? '').trim().length,
-    childCount: main?.childElementCount ?? -1,
-    display: style?.display ?? null,
-    visibility: style?.visibility ?? null,
-    opacity: style?.opacity ?? null,
-    width: main?.getBoundingClientRect().width ?? -1,
-    height: main?.getBoundingClientRect().height ?? -1,
-    centerTag: centerElement?.tagName ?? null,
-  }
-  debugSnapshot.value = `${path} | text=${data.textLength} child=${data.childCount} | ${data.display}/${data.visibility}/${data.opacity} | center=${data.centerTag ?? '-'}`
-  console.warn('[blankDebug]', data)
-  // #region agent log
-  fetch('http://127.0.0.1:7593/ingest/2c3dac7b-bfe2-4e17-bf18-ee2af8b3d131',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'4975e3'},body:JSON.stringify({sessionId:'4975e3',runId:'blank-v4',hypothesisId:'L,M',location:'AppLayout.vue:captureMain',message:'main content state',data,timestamp:Date.now()})}).catch(()=>{});
-  // #endregion
-}
-
-onMounted(async () => {
-  window.addEventListener('resize', handleResize)
-  if (!blankDebugEnabled) return
-  await nextTick()
-  captureMain('mounted')
-  mainObserver = new MutationObserver(() => {
-    const main = mainElement.value
-    if (!main || main.childElementCount === 0 || !(main.textContent ?? '').trim()) {
-      captureMain('blank-mutation')
-    }
-  })
-  if (mainElement.value) {
-    mainObserver.observe(mainElement.value, { childList: true, subtree: true })
-  }
-})
-
-onUnmounted(() => {
-  window.removeEventListener('resize', handleResize)
-  mainObserver?.disconnect()
-})
-
-watch(
-  () => instance?.proxy?.$route?.path ?? window.location.pathname,
-  async (path) => {
-    if (!blankDebugEnabled) return
-    await nextTick()
-    captureMain('route', path)
-  },
-  { immediate: true, flush: 'post' },
-)
+onMounted(() => window.addEventListener('resize', handleResize))
+onUnmounted(() => window.removeEventListener('resize', handleResize))
 </script>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -4,11 +4,6 @@ import App from './App.vue'
 import router from './router'
 import './style.css'
 
-const requestedDebugSession = new URLSearchParams(window.location.search).get('blankDebug')
-if (requestedDebugSession === '4975e3') {
-  sessionStorage.setItem('blankDebugSession', requestedDebugSession)
-}
-
 const app = createApp(App)
 
 app.use(createPinia())

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -2,11 +2,6 @@ import { createRouter, createWebHistory } from 'vue-router'
 import { isChunkLoadError, resolveChunkRecoveryTarget } from '@/utils/chunkGuard.js'
 import { useNavProgress } from '@/composables/useNavProgress.js'
 
-const blankDebugEnabled = (
-  sessionStorage.getItem('blankDebugSession') === '4975e3'
-  || new URLSearchParams(window.location.search).get('blankDebug') === '4975e3'
-)
-
 const routes = [
   {
     path: '/login',
@@ -160,10 +155,6 @@ const { isNavigating } = useNavProgress()
 router.beforeEach(async (to) => {
   isNavigating.value = true
 
-  // #region agent log
-  if (blankDebugEnabled) fetch('http://127.0.0.1:7593/ingest/2c3dac7b-bfe2-4e17-bf18-ee2af8b3d131',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'4975e3'},body:JSON.stringify({sessionId:'4975e3',runId:'blank-v3',hypothesisId:'K',location:'router/index.js:beforeEach',message:'navigation guard entered',data:{toPath:to.path,matchedNames:to.matched.map((record)=>String(record.name??record.path)),requiresAuth:to.meta.requiresAuth!==false,requiresAdmin:!!to.meta.requiresAdmin},timestamp:Date.now()})}).catch(()=>{});
-  // #endregion
-
   const { useAuthStore } = await import('@/stores/auth.js')
   const auth = useAuthStore()
 
@@ -189,12 +180,8 @@ router.beforeEach(async (to) => {
   }
 })
 
-router.afterEach((to, from, failure) => {
+router.afterEach(() => {
   isNavigating.value = false
-
-  // #region agent log
-  if (blankDebugEnabled) fetch('http://127.0.0.1:7593/ingest/2c3dac7b-bfe2-4e17-bf18-ee2af8b3d131',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'4975e3'},body:JSON.stringify({sessionId:'4975e3',runId:'blank-v3',hypothesisId:'K',location:'router/index.js:afterEach',message:'navigation completed',data:{toPath:to.path,fromPath:from.path,failureType:failure?.type??null,failureMessage:failure?String(failure.message).slice(0,300):null,matchedNames:to.matched.map((record)=>String(record.name??record.path))},timestamp:Date.now()})}).catch(()=>{});
-  // #endregion
 })
 
 // chunk เก่าหายหลัง deploy ใหม่ → dynamic import พังและ navigation ถูกยกเลิกเงียบๆ
@@ -213,10 +200,6 @@ export function onRouterError(
 ) {
   isNavigating.value = false
   const target = to?.fullPath ?? getPathname()
-
-  // #region agent log
-  if (blankDebugEnabled) fetch('http://127.0.0.1:7593/ingest/2c3dac7b-bfe2-4e17-bf18-ee2af8b3d131',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'4975e3'},body:JSON.stringify({sessionId:'4975e3',runId:'blank-v3',hypothesisId:isChunkLoadError(error)?'K':'J',location:'router/index.js:onRouterError',message:'router error',data:{target,chunk:isChunkLoadError(error),errorName:error?.name??null,errorMessage:String(error?.message??error).slice(0,500)},timestamp:Date.now()})}).catch(()=>{});
-  // #endregion
 
   if (isChunkLoadError(error)) {
     const recovery = resolveChunkRecoveryTarget(target, storage, now, fallbackPath)


### PR DESCRIPTION
## Summary
- remove all temporary production blank-screen diagnostics after user verification
- add a Playwright regression that clicks all 21 admin sidebar destinations
- assert every destination keeps non-empty main content and emits no page errors

## Test plan
- [x] Full all-menu + blank-contagion E2E suite: 4 passed
- [x] Focused recovery unit tests: 27 passed
- [x] Production build passes
- [x] Full pre-push suite: 450 passed