### PR TITLE
test: add all-menu E2E gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,76 @@ jobs:
           path: frontend/dist
           retention-days: 7
 
+  e2e-menus:
+    name: E2E All Menus
+    runs-on: ubuntu-latest
+    needs: frontend-build
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        working-directory: frontend
+        run: npx playwright install --with-deps chromium
+
+      - name: Create non-production test environment
+        run: |
+          cat > .env <<'EOF'
+          MYSQL_ROOT_PASSWORD=rootpassword
+          MYSQL_DATABASE=civil_service_mgmt
+          MYSQL_USER=root
+          MYSQL_PASSWORD=rootpassword
+          JWT_SECRET=ci-only-not-for-production
+          EOF
+
+      - name: Start database and backend
+        run: docker compose up -d --build db backend
+
+      - name: Wait for schema and backend
+        run: |
+          for i in $(seq 1 60); do
+            if docker compose exec -T db sh -c \
+                'MYSQL_PWD="$MYSQL_ROOT_PASSWORD" mysql -uroot --silent -e "SELECT 1 FROM personnel LIMIT 1" "$MYSQL_DATABASE"' \
+                >/dev/null 2>&1 \
+              && curl --fail --silent http://127.0.0.1:8000/ >/dev/null; then
+              echo "schema and backend ready"; exit 0
+            fi
+            sleep 5
+          done
+          echo "schema/backend startup timed out"
+          docker compose logs db backend
+          exit 1
+
+      - name: Run all-menu E2E gate
+        working-directory: frontend
+        run: npm run test:e2e:menus
+
+      - name: Upload Playwright failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-menu-failure-${{ github.run_id }}
+          path: |
+            frontend/playwright-report
+            frontend/test-results
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Stop test stack
+        if: always()
+        run: |
+          docker compose down -v
+          rm -f .env
+
   schema-parity:
     name: Schema Parity Gate
     runs-on: ubuntu-latest

--- a/backend/scripts/run-migrations.php
+++ b/backend/scripts/run-migrations.php
@@ -34,6 +34,7 @@ function migrationPdo(): PDO
         PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
         PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
         PDO::ATTR_EMULATE_PREPARES => false,
+        PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => true,
     ];
 
     if ($useSSL === 'true' || $useSSL === '1') {

--- a/backend/scripts/run-migrations.php
+++ b/backend/scripts/run-migrations.php
@@ -34,7 +34,6 @@ function migrationPdo(): PDO
         PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
         PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
         PDO::ATTR_EMULATE_PREPARES => false,
-        PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => true,
     ];
 
     if ($useSSL === 'true' || $useSSL === '1') {

--- a/database/22-unify-person-identity.sql
+++ b/database/22-unify-person-identity.sql
@@ -24,7 +24,7 @@ SET @db := DATABASE();
 SET @sql := (
   SELECT IF(COUNT(*) = 0,
     'ALTER TABLE personnel ADD COLUMN prefix_id INT NULL AFTER last_name',
-    'SELECT 1')
+    'DO 1')
   FROM information_schema.COLUMNS
   WHERE TABLE_SCHEMA = @db AND TABLE_NAME = 'personnel' AND COLUMN_NAME = 'prefix_id'
 );
@@ -33,7 +33,7 @@ PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 SET @sql := (
   SELECT IF(COUNT(*) = 0,
     'ALTER TABLE personnel ADD COLUMN employee_id VARCHAR(20) NULL AFTER prefix_id',
-    'SELECT 1')
+    'DO 1')
   FROM information_schema.COLUMNS
   WHERE TABLE_SCHEMA = @db AND TABLE_NAME = 'personnel' AND COLUMN_NAME = 'employee_id'
 );
@@ -42,7 +42,7 @@ PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 SET @sql := (
   SELECT IF(COUNT(*) = 0,
     'ALTER TABLE personnel ADD COLUMN birth_date DATE NULL AFTER employee_id',
-    'SELECT 1')
+    'DO 1')
   FROM information_schema.COLUMNS
   WHERE TABLE_SCHEMA = @db AND TABLE_NAME = 'personnel' AND COLUMN_NAME = 'birth_date'
 );
@@ -51,7 +51,7 @@ PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 SET @sql := (
   SELECT IF(COUNT(*) = 0,
     'ALTER TABLE personnel ADD COLUMN appointment_date DATE NULL AFTER birth_date',
-    'SELECT 1')
+    'DO 1')
   FROM information_schema.COLUMNS
   WHERE TABLE_SCHEMA = @db AND TABLE_NAME = 'personnel' AND COLUMN_NAME = 'appointment_date'
 );
@@ -60,7 +60,7 @@ PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 SET @sql := (
   SELECT IF(COUNT(*) = 0,
     'ALTER TABLE personnel ADD COLUMN retirement_date DATE NULL AFTER appointment_date',
-    'SELECT 1')
+    'DO 1')
   FROM information_schema.COLUMNS
   WHERE TABLE_SCHEMA = @db AND TABLE_NAME = 'personnel' AND COLUMN_NAME = 'retirement_date'
 );
@@ -69,7 +69,7 @@ PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 SET @sql := (
   SELECT IF(COUNT(*) = 0,
     'ALTER TABLE personnel ADD COLUMN servant_status VARCHAR(20) DEFAULT ''active'' AFTER retirement_date',
-    'SELECT 1')
+    'DO 1')
   FROM information_schema.COLUMNS
   WHERE TABLE_SCHEMA = @db AND TABLE_NAME = 'personnel' AND COLUMN_NAME = 'servant_status'
 );
@@ -78,7 +78,7 @@ PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 SET @sql := (
   SELECT IF(COUNT(*) = 0,
     'ALTER TABLE personnel ADD UNIQUE KEY uq_personnel_employee_id (employee_id)',
-    'SELECT 1')
+    'DO 1')
   FROM information_schema.STATISTICS
   WHERE TABLE_SCHEMA = @db AND TABLE_NAME = 'personnel' AND INDEX_NAME = 'uq_personnel_employee_id'
 );
@@ -87,7 +87,7 @@ PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 SET @sql := (
   SELECT IF(COUNT(*) = 0,
     'ALTER TABLE personnel ADD KEY idx_personnel_prefix (prefix_id)',
-    'SELECT 1')
+    'DO 1')
   FROM information_schema.STATISTICS
   WHERE TABLE_SCHEMA = @db AND TABLE_NAME = 'personnel' AND INDEX_NAME = 'idx_personnel_prefix'
 );
@@ -96,7 +96,7 @@ PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 SET @sql := (
   SELECT IF(COUNT(*) = 0,
     'ALTER TABLE personnel ADD KEY idx_personnel_retirement (retirement_date)',
-    'SELECT 1')
+    'DO 1')
   FROM information_schema.STATISTICS
   WHERE TABLE_SCHEMA = @db AND TABLE_NAME = 'personnel' AND INDEX_NAME = 'idx_personnel_retirement'
 );

--- a/frontend/e2e/features/all-menu-content.spec.js
+++ b/frontend/e2e/features/all-menu-content.spec.js
@@ -1,9 +1,33 @@
 import { test, expect } from '@playwright/test'
 import { loginAsAdmin } from '../helpers/auth.js'
 
+const expectedMenuPaths = [
+  '/dashboard',
+  '/probation-end',
+  '/candidates/overview',
+  '/candidates/general',
+  '/candidates/academic',
+  '/candidates/support',
+  '/candidates/management',
+  '/time-counting',
+  '/time-multiplier',
+  '/time-difference',
+  '/position-compare',
+  '/royal-decorations',
+  '/retirement-report',
+  '/admin',
+  '/work-results',
+  '/awards',
+  '/import',
+  '/ocr',
+  '/users',
+  '/audit',
+  '/settings/special-areas',
+]
+
 test('all sidebar menu destinations keep the content area rendered', async ({ page }) => {
   const pageErrors = []
-  page.on('pageerror', (error) => pageErrors.push(String(error)))
+  page.on('pageerror', (error) => pageErrors.push(`${page.url()}: ${String(error)}`))
 
   await loginAsAdmin(page)
   await page.setViewportSize({ width: 1440, height: 900 })
@@ -19,14 +43,21 @@ test('all sidebar menu destinations keep the content area rendered', async ({ pa
     }))
   ))
 
-  expect(destinations.length).toBeGreaterThan(15)
+  expect(destinations).toHaveLength(21)
+  expect(destinations.map(({ href }) => href).sort()).toEqual([...expectedMenuPaths].sort())
 
   for (const { href, label } of destinations) {
     await test.step(`${label} (${href})`, async () => {
       await page.locator(`nav a[href="${href}"]`).click()
-      await expect(page).toHaveURL(new RegExp(`${href.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`))
+      await expect.poll(() => new URL(page.url()).pathname).toBe(href)
+      const main = page.locator('main')
+      await expect(main).toBeVisible()
+      await expect(
+        main,
+        `${href} must not remain on the route loading fallback`,
+      ).not.toContainText('กำลังโหลดหน้า...')
       await expect.poll(
-        async () => (await page.locator('main').innerText()).trim().length,
+        async () => (await main.innerText()).trim().length,
         { message: `${href} content area must not be blank` },
       ).toBeGreaterThan(5)
     })

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "playwright test",
+    "test:e2e:menus": "playwright test e2e/features/all-menu-content.spec.js",
     "test:e2e:ui": "playwright test --ui",
     "test:coverage": "vitest run --coverage"
   },

--- a/scripts/ci-local.ps1
+++ b/scripts/ci-local.ps1
@@ -6,24 +6,28 @@
 .DESCRIPTION
   Jobs (same as ci.yml):
     1) Frontend: npm ci (optional) + npm test + npm run build
-    2) Backend:  bash backend/tests/run.sh  (Docker PHPUnit; needs Git Bash)
-    3) Docker:   build frontend + backend images (no push)
+    2) E2E:      Playwright Chromium checks all 21 menus (Docker db + backend)
+    3) Backend:  bash backend/tests/run.sh  (Docker PHPUnit; needs Git Bash)
+    4) Docker:   build frontend + backend images (no push)
 
   Prerequisites:
     - Node 20+, npm
     - Docker Desktop (backend + docker-build jobs)
     - Git Bash on PATH as `bash` (for backend/tests/run.sh)
-    - For backend integration: docker compose up -d db
+    - Playwright Chromium: cd frontend; npx playwright install chromium
+    - A local .env with the Docker Compose development values
 
 .EXAMPLE
   .\scripts\ci-local.ps1
   .\scripts\ci-local.ps1 -SkipInstall
+  .\scripts\ci-local.ps1 -SkipE2E
   .\scripts\ci-local.ps1 -SkipDocker
   .\scripts\ci-local.ps1 -SkipBackend -SkipDocker
 #>
 param(
   [switch]$SkipInstall,
   [switch]$SkipFrontend,
+  [switch]$SkipE2E,
   [switch]$SkipBackend,
   [switch]$SkipDocker,
   [switch]$Help
@@ -49,16 +53,21 @@ function Write-Fail([string]$Msg) {
 
 if ($Help) {
   @"
-Usage: .\scripts\ci-local.ps1 [-SkipInstall] [-SkipFrontend] [-SkipBackend] [-SkipDocker] [-Help]
+Usage: .\scripts\ci-local.ps1 [-SkipInstall] [-SkipFrontend] [-SkipE2E] [-SkipBackend] [-SkipDocker] [-Help]
 
 Mirrors .github/workflows/ci.yml locally (no GitHub Actions minutes):
   1) Frontend  npm ci + vitest (forks/2) + build
-  2) Backend   bash backend/tests/run.sh
-  3) Docker    build frontend + backend images
+  2) E2E       Docker db/backend + Playwright Chromium (21 menus)
+  3) Backend   bash backend/tests/run.sh
+  4) Docker    build frontend + backend images
+
+E2E prerequisites: Docker Desktop, frontend dependencies, Playwright Chromium,
+and a local .env file. The Compose services remain running after the gate.
 
 Examples:
   .\scripts\ci-local.ps1
   .\scripts\ci-local.ps1 -SkipInstall
+  .\scripts\ci-local.ps1 -SkipE2E
   .\scripts\ci-local.ps1 -SkipDocker
   .\scripts\ci-local.ps1 -SkipBackend -SkipDocker
 "@
@@ -66,7 +75,7 @@ Examples:
 }
 
 Write-Host "smart-port local CI  (root: $Root)"
-Write-Host "flags: SkipInstall=$SkipInstall SkipFrontend=$SkipFrontend SkipBackend=$SkipBackend SkipDocker=$SkipDocker"
+Write-Host "flags: SkipInstall=$SkipInstall SkipFrontend=$SkipFrontend SkipE2E=$SkipE2E SkipBackend=$SkipBackend SkipDocker=$SkipDocker"
 
 function Resolve-GitBash {
   $candidates = @(
@@ -87,7 +96,12 @@ function Resolve-GitBash {
 # ---- 0) Schema parity (เร็ว รันก่อนเสมอ — fail เร็วดีกว่ารอ docker build) -----
 Write-Step 'Schema Parity Gate'
 & node (Join-Path $Root 'scripts\validate-schema-parity.mjs')
-if ($LASTEXITCODE -eq 0) { Write-Ok 'schema parity' } else { Write-Fail 'schema parity' }
+if ($LASTEXITCODE -eq 0) {
+  Write-Ok 'schema parity'
+} else {
+  Write-Fail 'schema parity'
+  $failed += 'schema-parity'
+}
 
 # ---- 1) Frontend Build & Test ----------------------------------------------
 if (-not $SkipFrontend) {
@@ -122,7 +136,50 @@ if (-not $SkipFrontend) {
   Write-Host 'skip frontend (-SkipFrontend)'
 }
 
-# ---- 2) Backend PHPUnit ----------------------------------------------------
+# ---- 2) Playwright E2E: all 21 menus --------------------------------------
+if (-not $SkipE2E) {
+  Write-Step 'E2E All Menus (Docker + Playwright Chromium)'
+  if (-not (Test-Path -LiteralPath (Join-Path $Root '.env'))) {
+    Write-Fail 'E2E requires a local .env file for Docker Compose'
+    $failed += 'e2e'
+  } else {
+    try {
+      docker compose --project-directory $Root up -d db backend
+      if ($LASTEXITCODE -ne 0) { throw "docker compose up exited $LASTEXITCODE" }
+
+      $backendReady = $false
+      for ($attempt = 1; $attempt -le 60; $attempt++) {
+        docker compose --project-directory $Root exec -T db sh -c 'MYSQL_PWD="$MYSQL_ROOT_PASSWORD" mysql -uroot --silent -e ''SELECT 1 FROM personnel LIMIT 1'' "$MYSQL_DATABASE"' *> $null
+        $schemaReady = $LASTEXITCODE -eq 0
+        try {
+          $response = Invoke-WebRequest -UseBasicParsing -Uri 'http://127.0.0.1:8000/' -TimeoutSec 2
+          if ($schemaReady -and $response.StatusCode -ge 200 -and $response.StatusCode -lt 500) {
+            $backendReady = $true
+            break
+          }
+        } catch {}
+        Start-Sleep -Seconds 5
+      }
+      if (-not $backendReady) { throw 'backend did not become ready within 5 minutes' }
+
+      Push-Location (Join-Path $Root 'frontend')
+      try {
+        npm run test:e2e:menus
+        if ($LASTEXITCODE -ne 0) { throw "Playwright exited $LASTEXITCODE" }
+      } finally {
+        Pop-Location
+      }
+      Write-Ok 'all 21 menu destinations rendered'
+    } catch {
+      Write-Fail $_.Exception.Message
+      $failed += 'e2e'
+    }
+  }
+} else {
+  Write-Host 'skip E2E (-SkipE2E)'
+}
+
+# ---- 3) Backend PHPUnit ----------------------------------------------------
 if (-not $SkipBackend) {
   Write-Step 'Backend PHPUnit (via backend/tests/run.sh)'
   $bashExe = Resolve-GitBash
@@ -146,7 +203,7 @@ if (-not $SkipBackend) {
   Write-Host 'skip backend (-SkipBackend)'
 }
 
-# ---- 3) Docker Build Check -------------------------------------------------
+# ---- 4) Docker Build Check -------------------------------------------------
 if (-not $SkipDocker) {
   Write-Step 'Docker Build Check'
   $docker = Get-Command docker -ErrorAction SilentlyContinue

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -4,23 +4,27 @@
 #
 # Jobs:
 #   1) Frontend: npm ci (optional) + vitest + build
-#   2) Backend:  bash backend/tests/run.sh
-#   3) Docker:   build frontend + backend images (no push)
+#   2) E2E:      Playwright Chromium checks all 21 menus (Docker db + backend)
+#   3) Backend:  bash backend/tests/run.sh
+#   4) Docker:   build frontend + backend images (no push)
 #
 # Usage:
 #   bash scripts/ci-local.sh
 #   bash scripts/ci-local.sh --skip-install
+#   bash scripts/ci-local.sh --skip-e2e
 #   bash scripts/ci-local.sh --skip-docker
 #   bash scripts/ci-local.sh --skip-backend --skip-docker
 #   bash scripts/ci-local.sh --help
 #
-# Prereqs: Node 20+, Docker; for backend integration: docker compose up -d db
+# Prereqs: Node 20+, Docker, local .env; run `npx playwright install chromium`
+# in frontend once. Compose services remain running after the E2E gate.
 # ============================================================================
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SKIP_INSTALL=0
 SKIP_FRONTEND=0
+SKIP_E2E=0
 SKIP_BACKEND=0
 SKIP_DOCKER=0
 FAILED=()
@@ -35,6 +39,7 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --skip-install)  SKIP_INSTALL=1 ;;
     --skip-frontend) SKIP_FRONTEND=1 ;;
+    --skip-e2e)      SKIP_E2E=1 ;;
     --skip-backend)  SKIP_BACKEND=1 ;;
     --skip-docker)   SKIP_DOCKER=1 ;;
     -h|--help)       usage ;;
@@ -48,7 +53,7 @@ ok()   { printf 'OK  %s\n' "$1"; }
 fail() { printf 'FAIL  %s\n' "$1"; FAILED+=("$1"); }
 
 echo "smart-port local CI  (root: ${ROOT})"
-echo "flags: skip-install=${SKIP_INSTALL} skip-frontend=${SKIP_FRONTEND} skip-backend=${SKIP_BACKEND} skip-docker=${SKIP_DOCKER}"
+echo "flags: skip-install=${SKIP_INSTALL} skip-frontend=${SKIP_FRONTEND} skip-e2e=${SKIP_E2E} skip-backend=${SKIP_BACKEND} skip-docker=${SKIP_DOCKER}"
 
 # ---- 0) Schema parity (เร็ว รันก่อนเสมอ — fail เร็วดีกว่ารอ docker build) -----
 step 'Schema Parity Gate'
@@ -82,7 +87,43 @@ else
   echo 'skip frontend (--skip-frontend)'
 fi
 
-# ---- 2) Backend ------------------------------------------------------------
+# ---- 2) Playwright E2E: all 21 menus --------------------------------------
+if [[ "${SKIP_E2E}" -eq 0 ]]; then
+  step 'E2E All Menus (Docker + Playwright Chromium)'
+  if [[ ! -f "${ROOT}/.env" ]]; then
+    fail 'e2e (local .env is required for Docker Compose)'
+  elif (
+    set -e
+    cd "${ROOT}"
+    docker compose up -d db backend
+    backend_ready=0
+    for _ in $(seq 1 60); do
+      if docker compose exec -T db sh -c \
+          'MYSQL_PWD="$MYSQL_ROOT_PASSWORD" mysql -uroot --silent -e "SELECT 1 FROM personnel LIMIT 1" "$MYSQL_DATABASE"' \
+          >/dev/null 2>&1 \
+        && curl --fail --silent http://127.0.0.1:8000/ >/dev/null; then
+        backend_ready=1
+        break
+      fi
+      sleep 5
+    done
+    if [[ "${backend_ready}" -ne 1 ]]; then
+      echo 'backend did not become ready within 5 minutes'
+      docker compose logs db backend
+      exit 1
+    fi
+    cd frontend
+    npm run test:e2e:menus
+  ); then
+    ok 'all 21 menu destinations rendered'
+  else
+    fail 'e2e'
+  fi
+else
+  echo 'skip E2E (--skip-e2e)'
+fi
+
+# ---- 3) Backend ------------------------------------------------------------
 if [[ "${SKIP_BACKEND}" -eq 0 ]]; then
   step 'Backend PHPUnit (via backend/tests/run.sh)'
   if bash "${ROOT}/backend/tests/run.sh"; then
@@ -94,7 +135,7 @@ else
   echo 'skip backend (--skip-backend)'
 fi
 
-# ---- 3) Docker -------------------------------------------------------------
+# ---- 4) Docker -------------------------------------------------------------
 if [[ "${SKIP_DOCKER}" -eq 0 ]]; then
   step 'Docker Build Check'
   if ! command -v docker >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- enforce exact coverage for all 21 sidebar destinations and reject blank or stuck-loading content
- add a manual GitHub Actions E2E job with an isolated test environment and failure artifacts
- add the same menu gate and skip flags to PowerShell and Bash local CI

## Test plan
- [x] Run all-menu Playwright spec locally
- [x] Run PowerShell local CI E2E phase
- [x] Run frontend unit tests and production build
- [x] Validate workflow YAML and Bash syntax
- [ ] Run the manual GitHub Actions workflow on this branch