### PR TITLE
fix: baseline init-mounted migrations through 25

### DIFF
--- a/backend/scripts/migration-lib.php
+++ b/backend/scripts/migration-lib.php
@@ -9,8 +9,12 @@
 
 declare(strict_types=1);
 
-/** Last migration assumed already applied on existing production DBs */
-const MIGRATION_BASELINE_THROUGH = '14-multiplier-area-admin.sql';
+/**
+ * Last migration assumed already applied when the DB was provisioned by
+ * docker-compose init mounts or tidb-init (both include through 25).
+ * Fresh volumes must not re-run non-idempotent files such as 22.
+ */
+const MIGRATION_BASELINE_THROUGH = '25-ensure-multiplier-tables.sql';
 
 function migrationEnv(string $key, string $default = ''): string
 {

--- a/backend/scripts/run-migrations.php
+++ b/backend/scripts/run-migrations.php
@@ -3,10 +3,10 @@
 /**
  * Apply ordered SQL migrations from database/ and record them in schema_migrations.
  *
- * Safety for existing TiDB/prod:
+ * Safety for existing TiDB/prod / fresh docker-compose volumes:
  * - If schema_migrations is empty but core tables already exist, seed a baseline
- *   for migrations through 14-* (already applied manually / via init scripts)
- *   and only execute newer files (e.g. 15-api-rate-limit-hits.sql).
+ *   for migrations through 25-* (already applied via init mounts / tidb-init)
+ *   and only execute newer files. test-seed files are never baselined.
  * - DDL is not wrapped in a multi-statement transaction (TiDB/MySQL auto-commit DDL).
  * - Uses GET_LOCK when available to reduce multi-instance races.
  *
@@ -95,6 +95,10 @@ function seedBaselineIfNeeded(PDO $pdo, array $files): array
     $seeded = [];
     foreach ($files as $file) {
         $name = basename($file);
+        // test-seed ต้องรอ APPLY_TEST_SEED_MIGRATIONS — อย่า baseline ข้าม
+        if (str_contains($name, 'test-seed')) {
+            continue;
+        }
         if (strnatcasecmp($name, MIGRATION_BASELINE_THROUGH) > 0) {
             continue;
         }

--- a/backend/tests/Unit/MigrationBaselineTest.php
+++ b/backend/tests/Unit/MigrationBaselineTest.php
@@ -10,12 +10,12 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/../../scripts/migration-lib.php';
 
 /**
- * Guards the production baseline cut-off used by scripts/run-migrations.php.
- * Existing TiDB DBs already have migrations through 14; only 15+ should execute.
+ * Guards the baseline cut-off used by scripts/run-migrations.php.
+ * docker-compose init + tidb-init already apply through 25; only newer files execute.
  */
 final class MigrationBaselineTest extends TestCase
 {
-    private const BASELINE_THROUGH = '14-multiplier-area-admin.sql';
+    private const BASELINE_THROUGH = '25-ensure-multiplier-tables.sql';
 
     #[Test]
     public function baseline_cut_off_matches_runner_constant(): void
@@ -24,22 +24,24 @@ final class MigrationBaselineTest extends TestCase
     }
 
     #[Test]
-    public function net_new_rate_limit_migration_is_after_baseline(): void
+    public function next_migration_after_baseline_would_execute(): void
     {
         self::assertGreaterThan(
             0,
-            strnatcasecmp('15-api-rate-limit-hits.sql', self::BASELINE_THROUGH)
+            strnatcasecmp('26-placeholder-next.sql', self::BASELINE_THROUGH)
         );
     }
 
     #[Test]
-    public function historical_migrations_are_at_or_before_baseline(): void
+    public function init_mounted_migrations_are_at_or_before_baseline(): void
     {
         $historical = [
             '03-personnel-stubs.sql',
             '09-auth-users.sql',
-            '13-multiplier-time-counting.sql',
             '14-multiplier-area-admin.sql',
+            '15-api-rate-limit-hits.sql',
+            '22-unify-person-identity.sql',
+            '25-ensure-multiplier-tables.sql',
         ];
 
         foreach ($historical as $name) {
@@ -49,5 +51,11 @@ final class MigrationBaselineTest extends TestCase
                 "{$name} should be covered by baseline"
             );
         }
+    }
+
+    #[Test]
+    public function test_seed_filename_is_detectable_for_baseline_skip(): void
+    {
+        self::assertStringContainsString('test-seed', '16-multiplier-test-seed-expand.sql');
     }
 }


### PR DESCRIPTION
## Summary
- Raise migration baseline to `25-ensure-multiplier-tables.sql` so fresh docker-compose / tidb-init volumes do not re-run non-idempotent SQL (fixes E2E CI crash on missing `civil_servants`)
- Never baseline `test-seed` files so `APPLY_TEST_SEED_MIGRATIONS=1` still applies them
- Update `MigrationBaselineTest` to match

## Test plan
- [x] `bash backend/tests/run.sh --filter MigrationBaselineTest`
- [ ] Re-run manual CI workflow `e2e-menus` job after merge