### PR TITLE
docs: record multiplier technical UAT readiness for #23

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -25,7 +25,8 @@ if [[ ! -d "${FRONTEND}/node_modules" ]]; then
   exit 1
 fi
 
-echo "[pre-push] frontend vitest (threads pool, from vitest.config.js) ..."
+# forks+maxWorkers: stable on Windows (threads pool can hang / worker-timeout)
+echo "[pre-push] frontend vitest (pool=forks maxWorkers=2) ..."
 cd "${FRONTEND}"
-npx vitest run --reporter=dot
+npx vitest run --pool=forks --maxWorkers=2 --reporter=dot
 echo "[pre-push] OK"

--- a/docs/multiplier_phase0_hr_request.md
+++ b/docs/multiplier_phase0_hr_request.md
@@ -43,19 +43,32 @@
 - `docs/multiplier_phase0_master_data_template.csv`
 - `docs/multiplier_phase0_uat_cases_template.csv`
 
+## สถานะหลัง technical UAT (2026-08-02)
+
+ทีมพัฒนาตรวจแล้วบน Docker local:
+
+| Gate | Result |
+|------|--------|
+| `node scripts/validate-multiplier-phase0.mjs` | **12/12 PASS** (TEST_SEED) |
+| `node scripts/uat-multiplier-live-api.mjs` | **10/10 PASS** (TC-001..TC-010) |
+| DB data-quality queries | **PASS** (0 bad rows) |
+| Director readiness | **NO** — รอ HR แทนที่ TEST_SEED |
+
+รายละเอียด: `docs/multiplier_phase0_validation_pack.md`, `frontend/docs/multiplier_verification_report.md`
+
 ## ช่องว่างที่ต้องปิดก่อน production (สถานะ gate)
 
-- **Dev/test gate:** `node scripts/validate-multiplier-phase0.mjs` ผ่าน **12/12** แล้วด้วย `TEST_SEED` (ไม่ใช่ HR sign-off)
-- **Production gate:** ยังต้องให้ HR กรอก workbook จริงแล้วแทนที่ `TEST_SEED` ทุกแถว
+- **Dev/test gate:** ผ่านแล้วด้วย `TEST_SEED` (ไม่ใช่ HR sign-off)
+- **Production / director gate:** ยังต้องให้ HR กรอก workbook จริงแล้วแทนที่ `TEST_SEED` ทุกแถว
 
-| # | สิ่งที่ HR ต้องยืนยันแทน TEST_SEED |
-|---|-------------------------------------|
-| 1 | สตูล 4 อำเภอที่มีสิทธิจริง (ตอนนี้ provisional: ควนโดน/ควนกาหลง/ท่าแพ/มะนัง) |
-| 2 | `legal_reference` จากมติ/ประกาศ/หนังสือเวียนจริง |
-| 3 | `source_reference` (ไฟล์/หน้า/ลิงก์หลักฐาน) |
-| 4 | ช่วง พ.ร.ก.ฉุกเฉินหลังปี 2548 (ตอนนี้ provisional start `2005-07-20`) |
-| 5 | UAT ≥ 10 เคสจาก Excel เดิม (ตอนนี้เป็น synthetic) |
-| 6 | `verified_by` / `verified_date` ของ HR จริง |
+| # | สิ่งที่ HR ต้องยืนยันแทน TEST_SEED | Checklist |
+|---|-------------------------------------|-----------|
+| 1 | สตูล 4 อำเภอที่มีสิทธิจริง (ตอนนี้ provisional: ควนโดน/ควนกาหลง/ท่าแพ/มะนัง) | [ ] |
+| 2 | `legal_reference` จากมติ/ประกาศ/หนังสือเวียนจริง | [ ] |
+| 3 | `source_reference` (ไฟล์/หน้า/ลิงก์หลักฐาน) | [ ] |
+| 4 | ช่วง พ.ร.ก.ฉุกเฉินหลังปี 2548 (ตอนนี้ provisional start `2005-07-20`) | [ ] |
+| 5 | UAT ≥ 10 เคสจาก Excel เดิม (ตอนนี้เป็น synthetic) | [ ] |
+| 6 | `verified_by` / `verified_date` ของ HR จริง | [ ] |
 
 ## จุดที่ต้องยืนยันเป็นพิเศษ
 
@@ -85,7 +98,8 @@ Phase 0 ผ่านเมื่อ:
 
 1. วางไฟล์ xlsx ที่กรอกแล้วทับ `docs/multiplier_phase0_hr_workbook.xlsx` (หรือระบุ path อื่น)
 2. `python scripts/sync-multiplier-phase0-from-xlsx.py` → อัปเดต CSV
-3. `node scripts/validate-multiplier-phase0.mjs` → ต้อง 12/12
-4. อัปเดต `docs/multiplier_phase0_validation_pack.md` + sign-off
-5. อัปเดต seed `database/13-multiplier-time-counting.sql`
-6. ปิด GitHub issues #18 / #19 แล้วเดิน UAT #23
+3. `node scripts/validate-multiplier-phase0.mjs` → ต้อง 12/12 บนข้อมูลจริง
+4. `node scripts/uat-multiplier-live-api.mjs` → ต้อง 10/10 กับ expected จาก Excel
+5. อัปเดต `docs/multiplier_phase0_validation_pack.md` + Sign-Off เป็น approve
+6. อัปเดต production seed / `tidb-init` ตาม ADR-0002 (ห้ามใช้ TEST_SEED)
+7. ปิด GitHub issue #23 เมื่อ director package พร้อม

--- a/docs/multiplier_phase0_validation_pack.md
+++ b/docs/multiplier_phase0_validation_pack.md
@@ -1,61 +1,61 @@
 # Phase 0 Validation Pack — การนับทวีคูณ
 
-เอกสารนี้ใช้สำหรับยืนยัน master data ก่อนเริ่มพัฒนา/ทำ migration ฟีเจอร์ "การนับเวลาราชการเป็นทวีคูณ" ใน Smart Port
+เอกสารนี้ใช้สำหรับยืนยัน master data และ UAT readiness ของฟีเจอร์ "การนับเวลาราชการเป็นทวีคูณ" ใน Smart Port
 
-สถานะ: `test-seed` — validator 2026-07-13: **12/12 PASS** ด้วย `TEST_SEED` (ยังไม่ใช่ HR sign-off จริง; ห้ามถือว่า production-ready จนกว่า HR ยืนยัน)
+สถานะ (อัปเดต 2026-08-02): `test-seed-technical-uat-pass`
+
+- Offline validator: **12/12 PASS** (`node scripts/validate-multiplier-phase0.mjs`)
+- Live API UAT: **10/10 PASS** (`node scripts/uat-multiplier-live-api.mjs`, TC-001..TC-010)
+- DB data-quality: **PASS** (ไม่มีสตูลทั้งจังหวัด / ไม่มี TODO refs / ไม่มี duplicate หรือ overlap)
+- **ยังไม่ใช่ HR sign-off จริง — ห้ามถือว่า production/director-ready**
+
+Source of truth ของ fixtures:
+
+- `docs/multiplier_phase0_master_data_template.csv` (14 แถว: M-001..M-011, E-001..E-003)
+- `docs/multiplier_phase0_uat_cases_template.csv` (10 เคส: TC-001..TC-010)
 
 ## เป้าหมาย Phase 0
 
-ก่อนเริ่มเขียน migration หรือ backend calculation ต้องยืนยันข้อมูล 4 ชุดนี้ให้ครบ:
+ก่อน seed production ต้องยืนยันข้อมูล 4 ชุดนี้ให้ครบ:
 
 1. พื้นที่ที่นับทวีคูณได้: จังหวัด/อำเภอ
 2. ช่วงวันที่มีผลบังคับใช้ของแต่ละพื้นที่
 3. ฐานประกาศ/เอกสารอ้างอิงที่ HR ใช้จริง
 4. ตัวอย่างผลคำนวณจาก Excel/วิธีเดิมสำหรับ UAT
 
-ห้ามนำข้อมูล mockup ไปใช้เป็น production seed จนกว่า checklist นี้จะผ่าน sign-off
+ห้ามนำ `TEST_SEED` ไปใช้เป็น production seed จนกว่า checklist นี้จะผ่าน sign-off จาก HR
 
 ## Blocking Decisions
 
 | # | Decision | Required answer | Status | Owner | Notes |
 |---|----------|-----------------|--------|-------|-------|
 | 1 | อัตราทวีคูณ MVP | `200% fixed` | confirmed | Product/HR | PRD ปิด open question แล้ว |
-| 2 | ช่วง martial-law initial period | `2004-01-26` ถึง `2004-09-30` | needs HR/source confirmation | HR | Reviewer ระบุให้แก้จาก draft เดิม |
-| 3 | สตูล scope | เฉพาะ 4 อำเภอ ไม่ใช่ทั้งจังหวัด | needs HR/source confirmation | HR | ต้องระบุชื่ออำเภอจริงก่อน seed |
-| 4 | ช่วงหลังปี 2548 | ต้องมี coverage ตาม พ.ร.ก.ฉุกเฉิน ถ้าใช้ใน Excel เดิม | needs HR/source confirmation | HR | ระบุ start/end และพื้นที่ให้ครบ |
+| 2 | ช่วง martial-law initial period | `2004-01-26` ถึง `2004-09-30` | TEST_SEED only | HR | ต้องยืนยันด้วยเอกสารจริง |
+| 3 | สตูล scope | เฉพาะ 4 อำเภอ ไม่ใช่ทั้งจังหวัด | TEST_SEED only | HR | provisional: ควนโดน/ควนกาหลง/ท่าแพ/มะนัง |
+| 4 | ช่วงหลังปี 2548 | พ.ร.ก.ฉุกเฉิน open-ended จาก `2005-07-20` | TEST_SEED only | HR | ต้องยืนยัน start/end และพื้นที่ |
 | 5 | Self-view | ไม่อยู่ใน MVP | confirmed | Product/Tech | รอ auth ownership ใน roadmap |
 
-## Master Data Template
+## Master Data (CSV)
 
-กรอก 1 แถวต่อ 1 พื้นที่/ช่วงเวลา/ฐานประกาศ หากพื้นที่เดียวมีหลายช่วง ให้แยกหลายแถว
+กรอก/ตรวจใน `docs/multiplier_phase0_master_data_template.csv` — สรุปสถานะปัจจุบัน:
 
-| Row ID | Province | District | Whole province? | Basis type | Ratio | Effective start | Effective end | Legal reference | Source reference | HR confirmed? | Notes |
-|--------|----------|----------|-----------------|------------|-------|-----------------|---------------|-----------------|------------------|---------------|-------|
-| M-001 | ยะลา | `NULL` | yes/no | `MARTIAL_LAW` | 200.00 | 2004-01-26 | 2004-09-30 | TODO | TODO | no | Confirm whole-province coverage |
-| M-002 | ปัตตานี | `NULL` | yes/no | `MARTIAL_LAW` | 200.00 | 2004-01-26 | 2004-09-30 | TODO | TODO | no | Confirm whole-province coverage |
-| M-003 | นราธิวาส | `NULL` | yes/no | `MARTIAL_LAW` | 200.00 | 2004-01-26 | 2004-09-30 | TODO | TODO | no | Confirm whole-province coverage |
-| M-004 | สงขลา | เทพา | no | `MARTIAL_LAW` | 200.00 | 2004-01-26 | 2004-09-30 | TODO | TODO | no | Confirm district list |
-| M-005 | สงขลา | สะบ้าย้อย | no | `MARTIAL_LAW` | 200.00 | 2004-01-26 | 2004-09-30 | TODO | TODO | no | Confirm district list |
-| M-006 | สงขลา | นาทวี | no | `MARTIAL_LAW` | 200.00 | 2004-01-26 | 2004-09-30 | TODO | TODO | no | Confirm district list |
-| M-007 | สงขลา | จะนะ | no | `MARTIAL_LAW` | 200.00 | 2004-01-26 | 2004-09-30 | TODO | TODO | no | Confirm district list |
-| M-008 | สตูล | TODO อำเภอ 1 | no | `MARTIAL_LAW` | 200.00 | 2004-01-26 | 2004-09-30 | TODO | TODO | no | Must be one of confirmed 4 districts |
-| M-009 | สตูล | TODO อำเภอ 2 | no | `MARTIAL_LAW` | 200.00 | 2004-01-26 | 2004-09-30 | TODO | TODO | no | Must be one of confirmed 4 districts |
-| M-010 | สตูล | TODO อำเภอ 3 | no | `MARTIAL_LAW` | 200.00 | 2004-01-26 | 2004-09-30 | TODO | TODO | no | Must be one of confirmed 4 districts |
-| M-011 | สตูล | TODO อำเภอ 4 | no | `MARTIAL_LAW` | 200.00 | 2004-01-26 | 2004-09-30 | TODO | TODO | no | Must be one of confirmed 4 districts |
-| E-001 | ยะลา | `NULL` | yes/no | `EMERGENCY_DECREE` | 200.00 | TODO | TODO/NULL | TODO | TODO | no | Post-2548 coverage |
-| E-002 | ปัตตานี | `NULL` | yes/no | `EMERGENCY_DECREE` | 200.00 | TODO | TODO/NULL | TODO | TODO | no | Post-2548 coverage |
-| E-003 | นราธิวาส | `NULL` | yes/no | `EMERGENCY_DECREE` | 200.00 | TODO | TODO/NULL | TODO | TODO | no | Post-2548 coverage |
+| Row IDs | Coverage | Ratio | Period | Verified by |
+|---------|----------|-------|--------|-------------|
+| M-001..M-003 | ยะลา/ปัตตานี/นราธิวาส ทั้งจังหวัด | 200% | 2004-01-26..2004-09-30 MARTIAL_LAW | TEST_SEED |
+| M-004..M-007 | สงขลา 4 อำเภอ | 200% | same | TEST_SEED |
+| M-008..M-011 | สตูล 4 อำเภอ | 200% | same | TEST_SEED |
+| E-001..E-003 | ยะลา/ปัตตานี/นราธิวาส | 200% | 2005-07-20..NULL EMERGENCY_DECREE | TEST_SEED |
+
+ทุกแถวยังใช้ `legal_reference` / `source_reference` แบบ `TEST_SEED: ... (not HR-confirmed)`
 
 ## Source Evidence Checklist
 
-แนบหรืออ้างอิงเอกสารสำหรับทุกแถวใน master data
-
 | Evidence ID | Document name | Issuer | Date issued | Covers rows | File/path/link | Verified by | Verified date | Notes |
 |-------------|---------------|--------|-------------|-------------|----------------|-------------|---------------|-------|
-| EV-001 | TODO | TODO | TODO | M-001..M-011 | TODO | TODO | TODO | Initial period |
-| EV-002 | TODO | TODO | TODO | E-001..E-003 | TODO | TODO | TODO | Emergency decree period |
+| EV-001 | pending HR | pending | pending | M-001..M-011 | pending | — | — | Initial martial-law period |
+| EV-002 | pending HR | pending | pending | E-001..E-003 | pending | — | — | Emergency decree period |
 
-ดู source research notes และช่องทางค้นเอกสารที่ `docs/multiplier_phase0_source_research.md`
+ดู source research notes ที่ `docs/multiplier_phase0_source_research.md`
 
 ไฟล์สำหรับส่งให้ HR กรอก:
 
@@ -63,9 +63,7 @@
 - `docs/multiplier_phase0_master_data_template.csv`
 - `docs/multiplier_phase0_uat_cases_template.csv`
 
-## UAT Expected Cases
-
-ต้องมีอย่างน้อย 10 รายการจริงจาก Excel/วิธีเดิม และต้องมี case คร่อมวันเริ่ม/สิ้นสุดประกาศ
+## UAT Expected Cases (CSV)
 
 Calculation rules ที่ต้องเทียบ:
 
@@ -77,50 +75,65 @@ Calculation rules ที่ต้องเทียบ:
 - `bonus_days`: `eligible_days * (200 - 100) / 100`
 - `net_years/net_months/net_day_remainder`: 360-day breakdown จาก `effective_days`
 
-| Case ID | Personnel/example | Province | District | Service start | Service end | Expected eligible start | Expected eligible end | Expected eligible days | Expected effective days | Expected bonus days | Expected net Y/M/D | Excel/source ref | HR confirmed? | Notes |
-|---------|-------------------|----------|----------|---------------|-------------|-------------------------|-----------------------|------------------------|-------------------------|--------------------|------------------|------------------|---------------|-------|
-| TC-001 | Example clamp start | ยะลา | `NULL` | 2004-01-01 | 2004-02-10 | 2004-01-26 | 2004-02-10 | 16 | 32 | 16 | 0/1/2 | TODO | no | Starts before effective period |
-| TC-002 | Example clamp end | ยะลา | `NULL` | 2004-08-01 | 2004-10-15 | 2004-08-01 | 2004-09-30 | 61 | 122 | 61 | 0/4/2 | TODO | no | Ends after effective period |
-| TC-003 | TODO real case | TODO | TODO | TODO | TODO | TODO | TODO | TODO | TODO | TODO | TODO | TODO | no | HR Excel case |
-| TC-004 | TODO real case | TODO | TODO | TODO | TODO | TODO | TODO | TODO | TODO | TODO | TODO | TODO | no | HR Excel case |
-| TC-005 | TODO real case | TODO | TODO | TODO | TODO | TODO | TODO | TODO | TODO | TODO | TODO | TODO | no | HR Excel case |
-| TC-006 | TODO real case | TODO | TODO | TODO | TODO | TODO | TODO | TODO | TODO | TODO | TODO | TODO | no | HR Excel case |
-| TC-007 | TODO real case | TODO | TODO | TODO | TODO | TODO | TODO | TODO | TODO | TODO | TODO | TODO | no | HR Excel case |
-| TC-008 | TODO real case | TODO | TODO | TODO | TODO | TODO | TODO | TODO | TODO | TODO | TODO | TODO | no | HR Excel case |
-| TC-009 | TODO real case | TODO | TODO | TODO | TODO | TODO | TODO | TODO | TODO | TODO | TODO | TODO | no | HR Excel case |
-| TC-010 | TODO real case | TODO | TODO | TODO | TODO | TODO | TODO | TODO | TODO | TODO | TODO | TODO | no | HR Excel case |
+เคสปัจจุบัน (synthetic TEST_SEED) อยู่ใน CSV:
 
-## Data Quality Checks Before Migration
+| Case ID | Focus | Live API (2026-08-02) |
+|---------|-------|------------------------|
+| TC-001 | Clamp start (ยะลา) | PASS |
+| TC-002 | Clamp end (ยะลา) | PASS |
+| TC-003 | Full month inside martial | PASS |
+| TC-004 | สงขลา เทพา | PASS |
+| TC-005 | สตูล ควนโดน | PASS |
+| TC-006 | Clamp start district | PASS |
+| TC-007 | Clamp end province | PASS |
+| TC-008 | Emergency decree period | PASS |
+| TC-009 | นราธิวาส inside martial | PASS |
+| TC-010 | สงขลา สะบ้าย้อย | PASS |
 
-ต้องผ่านทุกข้อก่อนสร้าง `database/13-multiplier-time-counting.sql`
+Mismatch log: **ไม่มี** (0 FAIL)
 
-| Check | Pass criteria | Status | Notes |
-|-------|---------------|--------|-------|
-| No whole-province Satun row | ไม่มี row `province = 'สตูล' AND district IS NULL` | pending | สตูลต้องเป็น 4 อำเภอเท่านั้น |
-| No missing legal reference | ทุก row มี `legal_reference` | pending | ห้ามเป็น TODO ใน final seed |
-| No missing source reference | ทุก row มี `source_reference` | pending | ระบุไฟล์/หน้า/ลิงก์ |
-| No ambiguous active overlap | province+district+basis_type ไม่มีช่วงซ้อนที่ทำให้ lookup ไม่ deterministic | pending | ใช้ helper query จาก `docs/multiplier_seed_data_mockup.sql` |
-| District precedence reviewed | district-level row ไม่ถูก province-level row กลบผลผิด | pending | ตรวจ case สงขลา/สตูล |
-| Emergency decree coverage reviewed | ช่วงหลังปี 2548 ครบตาม Excel เดิม | pending | ถ้าไม่มี ต้องระบุเหตุผล |
-| UAT cases complete | มีอย่างน้อย 10 cases และ HR confirm expected output | pending | รวม clamp start/end |
+## Data Quality Checks
+
+| Check | Pass criteria | Status (CSV) | Status (DB local 2026-08-02) | Notes |
+|-------|---------------|--------------|------------------------------|-------|
+| No whole-province Satun row | ไม่มี `province='สตูล' AND district IS NULL` | PASS | PASS (0) | สตูลเป็น 4 อำเภอ |
+| No missing legal reference | ทุก row มี `legal_reference` | PASS (TEST_SEED text) | PASS (0 empty/TODO) | ยังไม่ใช่เอกสาร HR |
+| No missing source reference | ทุก row มี `source_reference` | PASS (TEST_SEED text) | PASS (0 empty/TODO) | ยังไม่ใช่เอกสาร HR |
+| No duplicate exact periods | ไม่มี period ซ้ำ exact | PASS | PASS (0) | |
+| No ambiguous active overlap | ไม่มีช่วงซ้อนคลุมเครือ | PASS | PASS (0) | |
+| District precedence reviewed | สงขลา/สตูลเป็น district-level | PASS | PASS (8 district rows) | |
+| Emergency decree coverage reviewed | มี E-001..E-003 | PASS (TEST_SEED) | PASS (3 rows) | รอ HR confirm วันที่ |
+| UAT cases complete | ≥ 10 cases + clamp | PASS | Live 10/10 PASS | synthetic เท่านั้น |
+
+Local DB snapshot: 14 areas (ยะลา 2, ปัตตานี 2, นราธิวาส 2, สงขลา 4, สตูล 4)
 
 ## Sign-Off
 
 | Role | Name | Decision | Date | Notes |
 |------|------|----------|------|-------|
-| HR owner | TODO | approve/reject | TODO | Master data |
-| Product owner | TODO | approve/reject | TODO | MVP scope |
-| Technical owner | TODO | approve/reject | TODO | Migration readiness |
+| HR owner | pending | reject / pending | — | ยังไม่มี Excel/เอกสารจริง |
+| Product owner | pending | pending | — | รอ HR |
+| Technical owner | engineering | conditional approve (TEST_SEED only) | 2026-08-02 | Technical UAT ผ่าน; **NOT ready for director review** |
 
-## Output After Sign-Off
+### Director readiness verdict
 
-เมื่อ Phase 0 ผ่าน ให้สร้างงานต่อไปนี้:
+**NOT ready for director review.**
 
-1. `database/13-multiplier-time-counting.sql`
-2. Backend calculation tests จาก UAT expected cases
-3. `backend/routes/multiplier.php`
-4. `frontend/src/composables/useMultiplier.js`
-5. `frontend/src/pages/MultiplierPage.vue`
-6. Sidebar/router wiring
+เหตุผล:
 
-อ้างอิง mock seed: `docs/multiplier_seed_data_mockup.sql`
+1. Master data และ UAT expected ยังเป็น `TEST_SEED` ไม่ใช่เคสจาก Excel ของ HR
+2. `legal_reference` / `source_reference` ยังเป็น placeholder
+3. Acceptance ของ issue #23 ต้องการเทียบ HR expected 100% — รอบนี้พิสูจน์ได้แค่ engine/API ตรงกับ synthetic fixtures
+
+เมื่อ HR ส่ง workbook กลับ: sync CSV → รัน validator + live UAT ซ้ำ → อัปเดตตาราง Sign-Off เป็น approve ก่อนนำเสนอ director
+
+## Output After Sign-Off (HR)
+
+เมื่อ Phase 0 ผ่าน HR จริง:
+
+1. แทนที่ `TEST_SEED` ใน CSV / workbook
+2. อัปเดต production seed / `tidb-init` ตาม ADR-0002 (หลัง validator ผ่านบนข้อมูลจริง)
+3. ปิด gate production ใน `docs/multiplier_phase0_hr_request.md`
+4. ปิด GitHub issue #23 เมื่อ director package พร้อม
+
+อ้างอิงรายงานเทคนิค: `frontend/docs/multiplier_verification_report.md`

--- a/frontend/docs/multiplier_verification_report.md
+++ b/frontend/docs/multiplier_verification_report.md
@@ -113,12 +113,70 @@ curl -X POST http://localhost:8000/multiplier \
 
 ---
 
-## 🔍 Known Issues
+## UAT / Director readiness (#23) — 2026-08-02
 
-1. **Mock Data Only** — ห้ามใช้ production จนกว่าจะได้ข้อมูลจริงจาก HR (Issue #18)
-2. **Satun Province Missing** — ยังไม่มีใน seed เพราะรอยืนยันอำเภอทั้ง 4
-3. **POST /multiplier/areas** — ยังไม่ได้ทดสอบ validation (legal_reference, date range)
-4. **Frontend Warning UI** — ควรตรวจสอบว่า MOCK DATA warning แสดงชัดเจนในหน้า UI
+### Commands run
+
+```bash
+node scripts/validate-multiplier-phase0.mjs
+# → 12/12 PASS (TEST_SEED fixtures)
+
+docker compose up -d db backend   # APPLY_TEST_SEED_MIGRATIONS=1
+node scripts/uat-multiplier-live-api.mjs
+# → 10/10 PASS, 0 FAIL
+```
+
+### Offline validator (12 checks)
+
+All PASS against `docs/multiplier_phase0_master_data_template.csv` + `docs/multiplier_phase0_uat_cases_template.csv`.
+
+Note: check “All rows verified by HR” passes because `verified_by=TEST_SEED` is non-TODO text — **not** a real HR signature.
+
+### Live API UAT (TC-001..TC-010)
+
+| Case | Result | Notes |
+|------|--------|-------|
+| TC-001 | PASS | clamp start, area 1 MARTIAL_LAW, eligible=16 bonus=16 |
+| TC-002 | PASS | clamp end, eligible=61 bonus=61 |
+| TC-003 | PASS | full month inside martial |
+| TC-004 | PASS | สงขลา เทพา |
+| TC-005 | PASS | สตูล ควนโดน (TEST_SEED district) |
+| TC-006 | PASS | clamp start district |
+| TC-007 | PASS | clamp end province |
+| TC-008 | PASS | EMERGENCY_DECREE area 12 |
+| TC-009 | PASS | นราธิวาส |
+| TC-010 | PASS | สงขลา สะบ้าย้อย |
+
+Mismatches: **none**. Severity/owner/resolution: N/A.
+
+### DB data-quality (local Docker)
+
+| Check | bad_count |
+|-------|-----------|
+| whole-province Satun | 0 |
+| missing legal_reference | 0 |
+| missing source_reference | 0 |
+| duplicate exact periods | 0 |
+| ambiguous active overlaps | 0 |
+
+Areas loaded: **14** (รวมสตูล 4 อำเภอ + emergency 3 แถวจาก test-seed expand)
+
+### Director readiness verdict
+
+**NOT ready for director review.**
+
+- Technical engine/API matches synthetic TEST_SEED expected values 100%
+- HR Excel / signed legal references still missing → production seed and director package remain blocked
+- Full pack: `docs/multiplier_phase0_validation_pack.md`
+
+---
+
+## Known Issues
+
+1. **TEST_SEED / Mock Data Only** — ห้ามใช้ production จนกว่าจะได้ข้อมูลจริงจาก HR (Issue #18 / #23 director gate)
+2. **Satun districts are provisional** — มีใน TEST_SEED (ควนโดน/ควนกาหลง/ท่าแพ/มะนัง) แต่ยังไม่ใช่ HR confirm
+3. **POST /multiplier/areas** — ยังไม่ได้ทดสอบ validation เชิงลึกในรายงานนี้
+4. **Frontend Warning UI** — ควรตรวจสอบว่า SOURCE_PENDING / TEST_SEED warning แสดงชัดเจนในหน้า UI
 
 ---
 
@@ -155,21 +213,22 @@ EOF
 
 ---
 
-## ✅ Next Steps
+## Next Steps
 
-1. **Visual UI Testing** — เปิด browser ทดสอบ `/time-multiplier` และ `/time-multiplier/areas`
-2. **Period Clamping Edge Cases** — ทดสอบ record ที่คร่อมขอบเขต effective period
-3. **Validation Testing** — ทดสอบ POST /multiplier/areas ด้วยข้อมูลผิด
-4. **Integration Testing** — ทดสอบ QualificationEngine integration (Issue #22)
-5. **UAT Preparation** — รอข้อมูลจาก HR (Issue #18) แล้วทำ UAT (Issue #23)
+1. **HR workbook** — กรอก `docs/multiplier_phase0_hr_workbook.xlsx` (หรือ CSV เทียบเท่า) แทนทุก `TEST_SEED`
+2. **Re-run gates on real data** — `sync-multiplier-phase0-from-xlsx.py` → `validate-multiplier-phase0.mjs` → `uat-multiplier-live-api.mjs`
+3. **Production seed** — อัปเดต seed / tidb-init หลัง HR sign-off เท่านั้น (ADR-0002)
+4. **Close #23 director gate** — เมื่อ expected จาก Excel จริงผ่าน 100% และ Sign-Off ใน validation pack เป็น approve
 
 ---
 
-## 🎯 Issue #19 Status: ✅ COMPLETE
+## Issue status snapshot
 
-**Backend API** — Fully functional with mock data  
-**Frontend UI** — Components ready, build successful  
-**Testing** — Core CRUD endpoints verified  
-**Documentation** — This report + inline comments
+| Issue | Status | Notes |
+|-------|--------|-------|
+| #19 feature shell | implemented (TEST_SEED) | page + lookup + areas |
+| #21 edit/delete | closed | safe edit/delete |
+| #22 bonus-days qualification | closed | engine uses bonus only |
+| #23 UAT / readiness | technical PASS / director NO | this section |
 
-**Ready for:** Visual UI testing + Integration with QualificationEngine (Issue #22)
+**Ready for:** HR confirmation package — **not** director review yet


### PR DESCRIPTION
## Summary
- Document Phase 0 validator (12/12), live API UAT (10/10), and DB data-quality results for multiplier #23
- Sync validation pack / HR request / verification report with TEST_SEED fixtures
- Explicitly mark **NOT ready for director review** until HR replaces TEST_SEED
- Stabilize Windows pre-push by using vitest `forks` pool (same as local CI)

## Test plan
- [x] `node scripts/validate-multiplier-phase0.mjs` → 12/12
- [x] `node scripts/uat-multiplier-live-api.mjs` → 10/10
- [ ] Docs-only review of handoff wording

Closes nothing on #23 (director gate still open; technical package only).