### PR TITLE
chore: Node 24 in Actions and vitest forks by default

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -25,8 +25,7 @@ if [[ ! -d "${FRONTEND}/node_modules" ]]; then
   exit 1
 fi
 
-# forks+maxWorkers: stable on Windows (threads pool can hang / worker-timeout)
-echo "[pre-push] frontend vitest (pool=forks maxWorkers=2) ..."
+echo "[pre-push] frontend vitest (forks pool from vitest.config.js) ..."
 cd "${FRONTEND}"
-npx vitest run --pool=forks --maxWorkers=2 --reporter=dot
+npx vitest run --reporter=dot
 echo "[pre-push] OK"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 
@@ -63,7 +63,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 
@@ -131,7 +131,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
       # กัน database/tidb-init.sql (bootstrap ของ production) drift จาก migration
       # และกัน migration ใหม่ที่ลืม mount ใน docker-compose / ไฟล์นี้
       - name: Validate schema parity

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -14,9 +14,9 @@ export default defineConfig({
   },
   test: {
     environment: 'jsdom',
-    // threads reuse worker threads instead of spawning a Node process per file;
-    // on Windows this roughly halves wall time vs the default forks pool.
-    pool: 'threads',
+    // forks + capped workers: stable on Windows (threads pool can hang / worker-timeout)
+    pool: 'forks',
+    maxWorkers: 2,
     globals: true,
     include: ['src/__tests__/**/*.{test,spec}.{js,ts}'],
     exclude: ['e2e/**', 'node_modules/**', 'dist/**'],

--- a/scripts/ci-local.ps1
+++ b/scripts/ci-local.ps1
@@ -11,7 +11,7 @@
     4) Docker:   build frontend + backend images (no push)
 
   Prerequisites:
-    - Node 20+, npm
+    - Node 24+, npm
     - Docker Desktop (backend + docker-build jobs)
     - Git Bash on PATH as `bash` (for backend/tests/run.sh)
     - Playwright Chromium: cd frontend; npx playwright install chromium
@@ -116,9 +116,9 @@ if (-not $SkipFrontend) {
       Write-Host 'skip npm ci (-SkipInstall)'
     }
 
-    # Windows Vitest: forks+maxWorkers avoids threads pool hang (see session handoff)
-    Write-Host 'npm test (vitest --pool=forks --maxWorkers=2) ...'
-    npx vitest run --pool=forks --maxWorkers=2 --reporter=dot
+    # pool/maxWorkers come from frontend/vitest.config.js (forks + 2 workers)
+    Write-Host 'npm test (vitest) ...'
+    npx vitest run --reporter=dot
     if ($LASTEXITCODE -ne 0) { throw "vitest exited $LASTEXITCODE" }
 
     Write-Host 'npm run build ...'

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -16,7 +16,7 @@
 #   bash scripts/ci-local.sh --skip-backend --skip-docker
 #   bash scripts/ci-local.sh --help
 #
-# Prereqs: Node 20+, Docker, local .env; run `npx playwright install chromium`
+# Prereqs: Node 24+, Docker, local .env; run `npx playwright install chromium`
 # in frontend once. Compose services remain running after the E2E gate.
 # ============================================================================
 set -euo pipefail
@@ -76,9 +76,9 @@ if [[ "${SKIP_FRONTEND}" -eq 0 ]]; then
       echo 'skip npm ci (--skip-install)'
     fi
 
-    # forks+maxWorkers: stable on Windows Git Bash / saturated hosts
-    echo 'npm test (vitest --pool=forks --maxWorkers=2) ...'
-    npx vitest run --pool=forks --maxWorkers=2 --reporter=dot
+    # pool/maxWorkers come from frontend/vitest.config.js (forks + 2 workers)
+    echo 'npm test (vitest) ...'
+    npx vitest run --reporter=dot
 
     echo 'npm run build ...'
     npm run build


### PR DESCRIPTION
## Summary
- Bump GitHub Actions `setup-node` from 20 → 24 (frontend-build, e2e-menus, schema-parity)
- Set `frontend/vitest.config.js` default pool to `forks` with `maxWorkers: 2`
- Point pre-push + local CI scripts at the config defaults; document Node 24+ prereq

## Test plan
- [x] `npx vitest run` → 55 files / 450 tests passed with new config
- [ ] Manual workflow_dispatch CI after merge (Node 24 jobs)