### PR TITLE
Add superadmin role and fail-closed permission overrides

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,7 @@ jobs:
             -v "$PWD/database/23-external-ref.sql:/docker-entrypoint-initdb.d/23-external-ref.sql" \
             -v "$PWD/database/24-drop-dead-tables.sql:/docker-entrypoint-initdb.d/24-drop-dead-tables.sql" \
             -v "$PWD/database/25-ensure-multiplier-tables.sql:/docker-entrypoint-initdb.d/25-ensure-multiplier-tables.sql" \
+            -v "$PWD/database/27-superadmin-permission-overrides.sql:/docker-entrypoint-initdb.d/27-superadmin-permission-overrides.sql" \
             mysql:8.0
 
       - name: Wait for schema init to finish

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -27,7 +27,7 @@
 - **ปีเป็น พ.ศ. เสมอในสิ่งที่ผู้ใช้เห็น** — `received_year` ของเครื่องราชฯ เก็บเป็น พ.ศ. ในฐานข้อมูลด้วย (validate ช่วง 2400–2700) ส่วนคอลัมน์ `DATE`/`TIMESTAMP` อื่นเก็บเป็น ค.ศ. แล้วแปลงตอนแสดงผลด้วย `formatThaiDate()`
 - **การนับวันใช้ฐาน 360 วัน/ปี, 30 วัน/เดือน** ตามระเบียบราชการ ไม่ใช่ปฏิทินจริง
 - **`citizen_id` คือ natural key ของบุคคล** — เป็น PII ห้ามหลุดเข้า log table (`import_log` จึงไม่มีคอลัมน์นี้)
-- **สิทธิ์ตาม role** (`backend/authz.php::checkPermission`): `admin` ทำได้ทุกอย่าง · `operator` อ่าน/สร้าง/แก้ไขได้ แต่ **ลบไม่ได้** และอนุมัติการเทียบตำแหน่งไม่ได้ · `viewer` อ่านอย่างเดียว (career overview: candidates/probation/personnel/dashboard/multiplier/profile) · OCR create และ awards write เป็น admin · UI ต้องซ่อนปุ่มให้ตรงกับ matrix นี้
+- **สิทธิ์ตาม role** (`backend/authz.php::checkPermission`): `superadmin` ทำได้ทุกอย่าง + จัดการเมทริกซ์สิทธิ์ระบบ · `admin` ทำได้ทุกอย่างตาม default (ยกเว้นหน้าตั้งค่าสิทธิ์ระบบ) · `operator` อ่าน/สร้าง/แก้ไขได้ แต่ **ลบไม่ได้** และอนุมัติการเทียบตำแหน่งไม่ได้ · `viewer` อ่านอย่างเดียว (career overview: candidates/probation/personnel/dashboard/multiplier/profile) · ค่า default อยู่ในโค้ด และถูกทับได้ด้วยตาราง `role_permission_overrides` · OCR create และ awards write เป็น admin ตาม default · UI ซ่อนปุ่มให้ตรง matrix; บัญชีตัวเองแก้ username/รหัสผ่านได้ที่ `/settings/account`
 - **วันใกล้เกณฑ์บัญชีรายชื่อ = 90 วัน** — ห้ามให้ FE ใช้ 30 วันสำหรับ candidates; ทดลองใช้ 30 วันได้เมื่อตั้งใจแยกตามศัพท์ด้านบน
 
 ## ขอบเขตที่ยังไม่ทำ (โดยตั้งใจ)

--- a/backend/api.php
+++ b/backend/api.php
@@ -140,6 +140,12 @@ switch ($path[0]) {
         handleAuth($pdo, $method, $path);
         break;
 
+    case 'settings':
+        $pdo = getDB();
+        include __DIR__ . '/routes/settings.php';
+        handleSettings($pdo, $method, $path);
+        break;
+
     case 'users':
         $pdo = getDB();
         include __DIR__ . '/routes/users.php';

--- a/backend/authz.php
+++ b/backend/authz.php
@@ -1,27 +1,45 @@
 <?php
 // ============================================================================
 // authz.php
-// Authorization seam — permission matrix + requirePermission + getAuthenticatedUser
-// (Split from audit.php so audit logging and authz do not share one module.)
+// Authorization seam — permission matrix + DB overrides + requirePermission
 // ============================================================================
 
+/** @var list<string> */
+const AUTHZ_ACTIONS = ['read', 'create', 'update', 'delete'];
+
+/** @var list<string> Roles that can appear in override UI (not superadmin). */
+const AUTHZ_OVERRIDABLE_ROLES = ['admin', 'operator', 'viewer'];
+
 /**
- * ตรวจสอบว่า user มี permission ทำ action นี้หรือไม่
+ * Canonical resource keys used by routes / settings UI.
  *
- * Unknown resource ⇒ deny (must be listed explicitly for non-admin roles).
- *
- * @param string $userRole — admin | operator | viewer
- * @param string $action — read | create | update | delete
- * @param string $resource — see matrix below
+ * @return list<string>
  */
-function checkPermission(string $userRole, string $action, string $resource): bool
+function authzResources(): array
 {
-    // Resources used by routes today (today-vs-matrix):
-    // awards, royal_decorations, import, retirement, analytics, work_results,
-    // ocr, photos, dashboard, sync, audit, users, profile — admin via '*';
-    // viewer read: career overview only (Open Q3 default = deny awards/etc.)
-    // ocr create: admin-only (not in operator create list)
-    $permissions = [
+    return [
+        'multiplier', 'personnel', 'candidates', 'probation',
+        'equivalence', 'equivalence_approval', 'supportive', 'diverse',
+        'photos', 'ocr', 'awards', 'royal_decorations', 'import',
+        'retirement', 'analytics', 'work_results', 'dashboard', 'sync',
+        'audit', 'users', 'profile', 'system_permissions',
+    ];
+}
+
+/**
+ * Hardcoded defaults — DB overrides layer on top when present.
+ *
+ * @return array<string, array<string, list<string>>>
+ */
+function defaultPermissionMatrix(): array
+{
+    return [
+        'superadmin' => [
+            'read' => ['*'],
+            'create' => ['*'],
+            'update' => ['*'],
+            'delete' => ['*'],
+        ],
         'admin' => [
             'read' => ['*'],
             'create' => ['*'],
@@ -38,7 +56,6 @@ function checkPermission(string $userRole, string $action, string $resource): bo
                 'multiplier', 'personnel', 'candidates', 'probation',
                 'equivalence', 'supportive', 'diverse',
             ],
-            // equivalence_approval — admin only
             'delete' => [],
         ],
         'viewer' => [
@@ -51,6 +68,14 @@ function checkPermission(string $userRole, string $action, string $resource): bo
             'delete' => [],
         ],
     ];
+}
+
+/**
+ * Whether the code default allows role/action/resource (no DB).
+ */
+function checkPermissionDefault(string $userRole, string $action, string $resource): bool
+{
+    $permissions = defaultPermissionMatrix();
 
     if (!isset($permissions[$userRole])) {
         return false;
@@ -66,38 +91,174 @@ function checkPermission(string $userRole, string $action, string $resource): bo
 }
 
 /**
- * Middleware: ตรวจสอบ permission ก่อนให้ access endpoint
+ * Generation-based override map so clearPermissionOverrideCache() works.
+ * Successful loads are cached; failures are not (next call retries).
  *
- * @param string $action — read | create | update | delete
- * @param string $resource
+ * @return array<string, bool>|null null only when $pdo is null (unit tests / offline)
+ * @throws RuntimeException when $pdo is provided but the override table cannot be read
+ */
+function getPermissionOverrideMap(?PDO $pdo = null): ?array
+{
+    static $generation = 0;
+    static $cachedGeneration = -1;
+    /** @var array<string, bool>|null */
+    static $cache = null;
+
+    if (!empty($GLOBALS['__authz_overrides_bump'])) {
+        $generation++;
+        unset($GLOBALS['__authz_overrides_bump']);
+    }
+
+    // Without an explicit PDO, do not probe getDB() (keeps unit tests offline).
+    if ($pdo === null) {
+        return null;
+    }
+
+    if ($cachedGeneration === $generation && is_array($cache)) {
+        return $cache;
+    }
+
+    try {
+        $stmt = $pdo->query(
+            'SELECT role, action, resource, allowed FROM role_permission_overrides'
+        );
+        $map = [];
+        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            $key = $row['role'] . '|' . $row['action'] . '|' . $row['resource'];
+            $map[$key] = ((int) $row['allowed']) === 1;
+        }
+        $cachedGeneration = $generation;
+        return $cache = $map;
+    } catch (Throwable $e) {
+        // Note: PDOException extends RuntimeException — always wrap load failures.
+        if ($e instanceof RuntimeException && $e->getMessage() === 'AUTHZ_OVERRIDES_UNAVAILABLE') {
+            throw $e;
+        }
+        error_log('[Authz] Failed to load permission overrides: ' . $e->getMessage());
+        // Do not cache failures — a transient outage must not 503 the worker forever.
+        throw new RuntimeException('AUTHZ_OVERRIDES_UNAVAILABLE', 0, $e);
+    }
+}
+
+function clearPermissionOverrideCache(): void
+{
+    $GLOBALS['__authz_overrides_bump'] = true;
+}
+
+/**
+ * @param PDO|null $pdo Optional PDO (tests / settings write path)
+ * @throws RuntimeException when $pdo provided but overrides cannot be loaded
+ */
+function checkPermission(string $userRole, string $action, string $resource, ?PDO $pdo = null): bool
+{
+    if ($userRole === 'superadmin') {
+        return true;
+    }
+
+    $overrides = getPermissionOverrideMap($pdo);
+    if (is_array($overrides)) {
+        $key = $userRole . '|' . $action . '|' . $resource;
+        if (array_key_exists($key, $overrides)) {
+            return $overrides[$key];
+        }
+    }
+
+    return checkPermissionDefault($userRole, $action, $resource);
+}
+
+/**
+ * Evaluate whether $user may perform $action on $resource.
+ * Fail-closed: any DB / override-store failure ⇒ 503 (do not fall back to defaults).
+ *
+ * @param array{user_id?:int|string, role?:string}|null $user
+ * @return array{status:int, body:array<string,mixed>}|null null = allowed
+ */
+function evaluatePermissionAccess(string $action, string $resource, ?array $user, ?PDO $pdo = null): ?array
+{
+    if (!$user) {
+        return ['status' => 401, 'body' => ['error' => 'Unauthorized']];
+    }
+
+    $role = $user['role'] ?? 'viewer';
+
+    // Superadmin bypasses override store (always allowed).
+    if ($role === 'superadmin') {
+        return null;
+    }
+
+    try {
+        if ($pdo === null) {
+            if (!function_exists('getDB')) {
+                throw new RuntimeException('AUTHZ_OVERRIDES_UNAVAILABLE');
+            }
+            $pdo = getDB();
+        }
+        if (!$pdo instanceof PDO) {
+            throw new RuntimeException('AUTHZ_OVERRIDES_UNAVAILABLE');
+        }
+        if (!checkPermission($role, $action, $resource, $pdo)) {
+            return [
+                'status' => 403,
+                'body' => [
+                    'error' => 'Forbidden',
+                    'message' => 'คุณไม่มีสิทธิ์ในการดำเนินการนี้',
+                    'required_permission' => "{$action}:{$resource}",
+                    'your_role' => $role,
+                ],
+            ];
+        }
+        return null;
+    } catch (Throwable $e) {
+        // getDB() / PDO / override load — treat all as unavailable (fail-closed).
+        error_log('[Authz] Permission check unavailable: ' . $e->getMessage());
+        return [
+            'status' => 503,
+            'body' => [
+                'error' => 'Service Unavailable',
+                'message' => 'ไม่สามารถตรวจสอบสิทธิ์ระบบได้ในขณะนี้ กรุณาลองใหม่ภายหลัง',
+            ],
+        ];
+    }
+}
+
+/**
+ * Middleware: ตรวจสอบ permission ก่อนให้ access endpoint
+ * Fail-closed: if override store / DB is unreachable, deny (503) rather than fall back to defaults.
  */
 function requirePermission(string $action, string $resource): void
 {
-    $user = getAuthenticatedUser();
+    $denied = evaluatePermissionAccess($action, $resource, getAuthenticatedUser());
+    if ($denied === null) {
+        return;
+    }
+    http_response_code($denied['status']);
+    echo json_encode($denied['body']);
+    exit;
+}
 
+/**
+ * @return array{user_id:int|string, role:string, must_change_password?:int|string}
+ */
+function requireSuperAdmin(): array
+{
+    $user = getAuthenticatedUser();
     if (!$user) {
         http_response_code(401);
         echo json_encode(['error' => 'Unauthorized']);
         exit;
     }
-
-    $role = $user['role'] ?? 'viewer';
-
-    if (!checkPermission($role, $action, $resource)) {
+    if (($user['role'] ?? '') !== 'superadmin') {
         http_response_code(403);
         echo json_encode([
             'error' => 'Forbidden',
-            'message' => 'คุณไม่มีสิทธิ์ในการดำเนินการนี้',
-            'required_permission' => "{$action}:{$resource}",
-            'your_role' => $role,
+            'message' => 'เฉพาะซูเปอร์แอดมินเท่านั้นที่จัดการสิทธิ์ระบบได้',
         ]);
         exit;
     }
+    return $user;
 }
 
 /**
- * ดึงข้อมูล authenticated user จาก JWT token
- *
  * @return array|null — ['user_id' => int, 'role' => string, 'must_change_password' => int] หรือ null
  */
 function getAuthenticatedUser(): ?array

--- a/backend/helpers.php
+++ b/backend/helpers.php
@@ -8,6 +8,14 @@
 /** โฟลเดอร์ที่เสิร์ฟรูปผ่านเว็บ — สัมพัทธ์กับ document root ของ backend */
 const PHOTO_WEB_DIR = 'uploads';
 
+/** Username: 3–64 chars, letters/digits/dot/underscore/hyphen */
+const USERNAME_PATTERN = '/^[A-Za-z0-9._-]{3,64}$/';
+
+function isValidUsername(string $username): bool
+{
+    return (bool) preg_match(USERNAME_PATTERN, $username);
+}
+
 /**
  * ตอบ 405 พร้อม JSON body — ใช้กับ route ที่รองรับเฉพาะบาง method
  *

--- a/backend/routes/auth.php
+++ b/backend/routes/auth.php
@@ -5,7 +5,9 @@
 //
 // Endpoints:
 //   POST /auth/login           — ตรวจ username/password กับ DB + rate limit
-//   POST /auth/change-password — เปลี่ยนรหัสผ่านที่ถูกบังคับหลังเข้าสู่ระบบ
+//   POST /auth/change-password — เปลี่ยนรหัสผ่าน (forced หรือ voluntary)
+//   GET  /auth/me              — โปรไฟล์บัญชีตัวเอง
+//   PUT  /auth/me              — แก้ไข username / full_name / email ของตัวเอง
 //
 // Rate limiting (ตาราง login_attempts):
 //   ผิดติดต่อกัน 5 ครั้งภายใน 15 นาที (นับต่อ username) -> 429
@@ -53,8 +55,192 @@ function handleAuth(PDO $pdo, string $method, array $path): void
         return;
     }
 
+    if (($path[1] ?? '') === 'me') {
+        $user = getAuthenticatedUser();
+        if (!$user) {
+            http_response_code(401);
+            echo json_encode(['error' => 'Unauthorized']);
+            return;
+        }
+        if ($method === 'GET') {
+            getAuthMe($pdo, $user);
+            return;
+        }
+        if ($method === 'PUT') {
+            updateAuthMe($pdo, $user);
+            return;
+        }
+        http_response_code(405);
+        echo json_encode(['error' => 'Method not allowed']);
+        return;
+    }
+
     http_response_code(404);
     echo json_encode(['error' => 'ไม่พบ endpoint การยืนยันตัวตน']);
+}
+
+/**
+ * GET /auth/me
+ *
+ * @param array{user_id:int|string} $user
+ */
+function getAuthMe(PDO $pdo, array $user): void
+{
+    $stmt = $pdo->prepare(
+        'SELECT user_id, username, full_name, email, role, must_change_password, last_login_at, created_at
+         FROM users WHERE user_id = ? AND is_active = 1'
+    );
+    $stmt->execute([(int) $user['user_id']]);
+    $row = $stmt->fetch(PDO::FETCH_ASSOC);
+    if (!$row) {
+        http_response_code(404);
+        echo json_encode(['error' => 'ไม่พบบัญชีผู้ใช้']);
+        return;
+    }
+
+    echo json_encode([
+        'success' => true,
+        'data' => [
+            'id' => (int) $row['user_id'],
+            'username' => $row['username'],
+            'name' => $row['full_name'],
+            'full_name' => $row['full_name'],
+            'email' => $row['email'],
+            'role' => $row['role'],
+            'must_change_password' => (bool) $row['must_change_password'],
+            'last_login_at' => $row['last_login_at'],
+            'created_at' => $row['created_at'],
+        ],
+    ]);
+}
+
+/**
+ * PUT /auth/me — แก้ username (ต้องยืนยันรหัสผ่าน) / full_name / email
+ *
+ * @param array{user_id:int|string} $user
+ * @param array<string,mixed>|null $input
+ */
+function updateAuthMe(PDO $pdo, array $user, ?array $input = null): void
+{
+    $data = $input ?? json_decode(file_get_contents('php://input'), true);
+    if (!is_array($data)) {
+        http_response_code(400);
+        echo json_encode(['error' => 'รูปแบบข้อมูลไม่ถูกต้อง']);
+        return;
+    }
+
+    $userId = (int) $user['user_id'];
+    $stmt = $pdo->prepare(
+        'SELECT user_id, username, full_name, email, password_hash, role, must_change_password
+         FROM users WHERE user_id = ? AND is_active = 1'
+    );
+    $stmt->execute([$userId]);
+    $before = $stmt->fetch(PDO::FETCH_ASSOC);
+    if (!$before) {
+        http_response_code(404);
+        echo json_encode(['error' => 'ไม่พบบัญชีผู้ใช้']);
+        return;
+    }
+
+    $sets = [];
+    $params = [];
+    $usernameChanging = false;
+    $newUsername = null;
+
+    if (array_key_exists('username', $data)) {
+        $newUsername = trim((string) $data['username']);
+        if ($newUsername === '' || !isValidUsername($newUsername)) {
+            http_response_code(400);
+            echo json_encode(['error' => 'ชื่อผู้ใช้ต้องเป็น a-z, 0-9, . _ - ความยาว 3–64 ตัวอักษร']);
+            return;
+        }
+        if ($newUsername !== (string) $before['username']) {
+            $usernameChanging = true;
+            $currentPassword = (string) ($data['current_password'] ?? '');
+            if ($currentPassword === '' || !password_verify($currentPassword, (string) $before['password_hash'])) {
+                http_response_code(400);
+                echo json_encode(['error' => 'กรุณายืนยันรหัสผ่านปัจจุบันเพื่อเปลี่ยนชื่อผู้ใช้']);
+                return;
+            }
+            $sets[] = 'username = ?';
+            $params[] = $newUsername;
+        }
+    }
+
+    if (array_key_exists('full_name', $data)) {
+        $fullName = trim((string) $data['full_name']);
+        if ($fullName === '') {
+            http_response_code(400);
+            echo json_encode(['error' => 'ชื่อ-นามสกุลต้องไม่ว่าง']);
+            return;
+        }
+        $sets[] = 'full_name = ?';
+        $params[] = $fullName;
+    }
+
+    if (array_key_exists('email', $data)) {
+        $email = trim((string) $data['email']);
+        $sets[] = 'email = ?';
+        $params[] = $email === '' ? null : $email;
+    }
+
+    if ($sets === []) {
+        http_response_code(400);
+        echo json_encode(['error' => 'ไม่มีข้อมูลที่สามารถอัปเดตได้']);
+        return;
+    }
+
+    $params[] = $userId;
+    try {
+        $pdo->prepare('UPDATE users SET ' . implode(', ', $sets) . ' WHERE user_id = ?')
+            ->execute($params);
+    } catch (PDOException $e) {
+        if ($e->getCode() === '23000') {
+            http_response_code(409);
+            echo json_encode(['error' => 'ชื่อผู้ใช้นี้ถูกใช้งานแล้ว']);
+            return;
+        }
+        throw $e;
+    }
+
+    $afterStmt = $pdo->prepare(
+        'SELECT user_id, username, full_name, email, role, must_change_password
+         FROM users WHERE user_id = ?'
+    );
+    $afterStmt->execute([$userId]);
+    $after = $afterStmt->fetch(PDO::FETCH_ASSOC);
+
+    logAudit(
+        $pdo,
+        $userId,
+        'UPDATE',
+        'users',
+        $userId,
+        [
+            'username' => $before['username'],
+            'full_name' => $before['full_name'],
+            'email' => $before['email'],
+        ],
+        [
+            'username' => $after['username'] ?? null,
+            'full_name' => $after['full_name'] ?? null,
+            'email' => $after['email'] ?? null,
+            'username_changed' => $usernameChanging,
+        ]
+    );
+
+    echo json_encode([
+        'success' => true,
+        'data' => [
+            'id' => (int) ($after['user_id'] ?? $userId),
+            'username' => $after['username'] ?? null,
+            'name' => $after['full_name'] ?? null,
+            'full_name' => $after['full_name'] ?? null,
+            'email' => $after['email'] ?? null,
+            'role' => $after['role'] ?? null,
+            'must_change_password' => (bool) ($after['must_change_password'] ?? false),
+        ],
+    ]);
 }
 
 /**

--- a/backend/routes/settings.php
+++ b/backend/routes/settings.php
@@ -1,0 +1,248 @@
+<?php
+// ============================================================================
+// routes/settings.php
+// System settings — permission matrix overrides (superadmin only)
+//
+// Endpoints:
+//   GET /settings/permissions — matrix with default / effective / override flag
+//   PUT /settings/permissions — upsert override rows, or reset:true to delete override
+// ============================================================================
+
+include_once __DIR__ . '/../helpers.php';
+include_once __DIR__ . '/../audit.php';
+include_once __DIR__ . '/../authz.php';
+
+/**
+ * @param PDO $pdo
+ * @param string $method
+ * @param array $path
+ */
+function handleSettings(PDO $pdo, string $method, array $path): void
+{
+    $section = $path[1] ?? '';
+
+    if ($section === 'permissions') {
+        $auth = requireSuperAdmin();
+        if ($method === 'GET') {
+            getPermissionSettings($pdo);
+            return;
+        }
+        if ($method === 'PUT') {
+            putPermissionSettings($pdo, $auth);
+            return;
+        }
+        http_response_code(405);
+        echo json_encode(['error' => 'Method not allowed']);
+        return;
+    }
+
+    http_response_code(404);
+    echo json_encode(['error' => 'ไม่พบ endpoint การตั้งค่า']);
+}
+
+function getPermissionSettings(PDO $pdo): void
+{
+    clearPermissionOverrideCache();
+    try {
+        $overrides = getPermissionOverrideMap($pdo) ?? [];
+    } catch (RuntimeException $e) {
+        http_response_code(503);
+        echo json_encode([
+            'error' => 'Service Unavailable',
+            'message' => 'ไม่สามารถโหลดเมทริกซ์สิทธิ์ได้ในขณะนี้',
+        ]);
+        return;
+    }
+
+    $roles = AUTHZ_OVERRIDABLE_ROLES;
+    $actions = AUTHZ_ACTIONS;
+    $resources = authzResources();
+
+    $cells = [];
+    foreach ($roles as $role) {
+        foreach ($actions as $action) {
+            foreach ($resources as $resource) {
+                // system_permissions is superadmin-gated via requireSuperAdmin — skip in matrix UI noise
+                if ($resource === 'system_permissions') {
+                    continue;
+                }
+                $key = $role . '|' . $action . '|' . $resource;
+                $defaultAllowed = checkPermissionDefault($role, $action, $resource);
+                $hasOverride = array_key_exists($key, $overrides);
+                $effective = $hasOverride ? $overrides[$key] : $defaultAllowed;
+                $cells[] = [
+                    'role' => $role,
+                    'action' => $action,
+                    'resource' => $resource,
+                    'default_allowed' => $defaultAllowed,
+                    'allowed' => $effective,
+                    'has_override' => $hasOverride,
+                ];
+            }
+        }
+    }
+
+    echo json_encode([
+        'success' => true,
+        'data' => [
+            'roles' => $roles,
+            'actions' => $actions,
+            'resources' => array_values(array_filter(
+                $resources,
+                static fn($r) => $r !== 'system_permissions'
+            )),
+            'cells' => $cells,
+        ],
+    ]);
+}
+
+/**
+ * Validate one override cell identity.
+ *
+ * @return array{0:string,1:string,2:string}|null [role, action, resource] or null + sets HTTP error
+ */
+function validatePermissionCell(array $item, int $index): ?array
+{
+    $role = (string) ($item['role'] ?? '');
+    $action = (string) ($item['action'] ?? '');
+    $resource = (string) ($item['resource'] ?? '');
+
+    if ($role === 'superadmin') {
+        http_response_code(400);
+        echo json_encode(['error' => 'ไม่สามารถกำหนด override ให้บทบาท superadmin ได้']);
+        return null;
+    }
+
+    if (!in_array($role, AUTHZ_OVERRIDABLE_ROLES, true)
+        || !in_array($action, AUTHZ_ACTIONS, true)
+        || !in_array($resource, authzResources(), true)
+        || $resource === 'system_permissions'
+    ) {
+        http_response_code(400);
+        echo json_encode(['error' => "ค่าไม่ถูกต้องที่รายการ #{$index}: {$role}/{$action}/{$resource}"]);
+        return null;
+    }
+
+    return [$role, $action, $resource];
+}
+
+/**
+ * @param array{user_id:int|string} $auth
+ * @param array<string,mixed>|null $input
+ */
+function putPermissionSettings(PDO $pdo, array $auth, ?array $input = null): void
+{
+    $data = $input ?? json_decode(file_get_contents('php://input'), true);
+    if (!is_array($data)) {
+        http_response_code(400);
+        echo json_encode(['error' => 'รูปแบบข้อมูลไม่ถูกต้อง']);
+        return;
+    }
+
+    $items = $data['overrides'] ?? $data;
+    if (!is_array($items)) {
+        http_response_code(400);
+        echo json_encode(['error' => 'ต้องส่งรายการ overrides เป็น array']);
+        return;
+    }
+
+    // Validate all rows first (fail fast, no partial writes).
+    $ops = [];
+    foreach ($items as $index => $item) {
+        if (!is_array($item)) {
+            http_response_code(400);
+            echo json_encode(['error' => "รายการที่ #{$index} ไม่ถูกต้อง"]);
+            return;
+        }
+        $cell = validatePermissionCell($item, (int) $index);
+        if ($cell === null) {
+            return;
+        }
+        [$role, $action, $resource] = $cell;
+        if (!empty($item['reset'])) {
+            $ops[] = ['op' => 'reset', 'role' => $role, 'action' => $action, 'resource' => $resource];
+        } else {
+            if (!array_key_exists('allowed', $item)) {
+                http_response_code(400);
+                echo json_encode(['error' => "รายการที่ #{$index} ต้องมี allowed หรือ reset"]);
+                return;
+            }
+            $ops[] = [
+                'op' => 'upsert',
+                'role' => $role,
+                'action' => $action,
+                'resource' => $resource,
+                'allowed' => !empty($item['allowed']) ? 1 : 0,
+            ];
+        }
+    }
+
+    $find = $pdo->prepare(
+        'SELECT 1 FROM role_permission_overrides
+         WHERE role = ? AND action = ? AND resource = ? LIMIT 1'
+    );
+    $insert = $pdo->prepare(
+        'INSERT INTO role_permission_overrides (role, action, resource, allowed)
+         VALUES (?, ?, ?, ?)'
+    );
+    $update = $pdo->prepare(
+        'UPDATE role_permission_overrides SET allowed = ?
+         WHERE role = ? AND action = ? AND resource = ?'
+    );
+    $delete = $pdo->prepare(
+        'DELETE FROM role_permission_overrides
+         WHERE role = ? AND action = ? AND resource = ?'
+    );
+
+    $applied = [];
+    try {
+        $pdo->beginTransaction();
+        foreach ($ops as $op) {
+            if ($op['op'] === 'reset') {
+                $delete->execute([$op['role'], $op['action'], $op['resource']]);
+                $applied[] = [
+                    'role' => $op['role'],
+                    'action' => $op['action'],
+                    'resource' => $op['resource'],
+                    'reset' => true,
+                ];
+            } else {
+                $find->execute([$op['role'], $op['action'], $op['resource']]);
+                if ($find->fetchColumn()) {
+                    $update->execute([$op['allowed'], $op['role'], $op['action'], $op['resource']]);
+                } else {
+                    $insert->execute([$op['role'], $op['action'], $op['resource'], $op['allowed']]);
+                }
+                $applied[] = [
+                    'role' => $op['role'],
+                    'action' => $op['action'],
+                    'resource' => $op['resource'],
+                    'allowed' => (bool) $op['allowed'],
+                ];
+            }
+        }
+        $pdo->commit();
+    } catch (Throwable $e) {
+        if ($pdo->inTransaction()) {
+            $pdo->rollBack();
+        }
+        error_log('[Settings] putPermissionSettings failed: ' . $e->getMessage());
+        http_response_code(500);
+        echo json_encode(['error' => 'บันทึกสิทธิ์ไม่สำเร็จ']);
+        return;
+    }
+
+    clearPermissionOverrideCache();
+
+    logAudit(
+        $pdo,
+        (int) $auth['user_id'],
+        'UPDATE',
+        'role_permission_overrides',
+        null,
+        null,
+        ['overrides' => $applied]
+    );
+
+    echo json_encode(['success' => true, 'updated' => count($applied)]);
+}

--- a/backend/routes/users.php
+++ b/backend/routes/users.php
@@ -1,7 +1,7 @@
 <?php
 // ============================================================================
 // routes/users.php
-// User Management Route Handler — จัดการบัญชีผู้ใช้ (admin เท่านั้น)
+// User Management Route Handler — admin / superadmin (matrix + assignableRolesFor)
 //
 // Endpoints:
 //   GET  /users          — รายชื่อผู้ใช้ (pagination + search)
@@ -15,10 +15,42 @@ include_once __DIR__ . '/../helpers.php';
 include_once __DIR__ . '/../audit.php';
 
 const PASSWORD_MIN_LENGTH = 8;
-const VALID_ROLES = ['admin', 'operator'];
+/** Roles assignable in principle — further gated by assigner's role. */
+const VALID_ROLES = ['superadmin', 'admin', 'operator', 'viewer'];
 
 // คอลัมน์ที่ส่งออกได้ — ห้ามมี password_hash เด็ดขาด
 const USER_PUBLIC_COLUMNS = 'user_id, username, full_name, email, role, is_active, must_change_password, last_login_at, created_at';
+
+/**
+ * Roles the current actor may assign when creating/updating users.
+ *
+ * @return list<string>
+ */
+function assignableRolesFor(?array $auth): array
+{
+    $role = $auth['role'] ?? '';
+    if ($role === 'superadmin') {
+        return VALID_ROLES;
+    }
+    if ($role === 'admin') {
+        return ['admin', 'operator', 'viewer'];
+    }
+    return [];
+}
+
+/**
+ * @param bool $forUpdate Lock matching rows inside a transaction (MySQL/InnoDB only)
+ */
+function countActiveSuperadmins(PDO $pdo, bool $forUpdate = false): int
+{
+    $sql = "SELECT user_id FROM users WHERE role = 'superadmin' AND is_active = 1";
+    // SQLite rejects FOR UPDATE; production MySQL uses row locks against TOCTOU demotes.
+    if ($forUpdate && $pdo->getAttribute(PDO::ATTR_DRIVER_NAME) === 'mysql') {
+        $sql .= ' FOR UPDATE';
+    }
+    $stmt = $pdo->query($sql);
+    return count($stmt->fetchAll(PDO::FETCH_COLUMN));
+}
 
 /**
  * จัดการ request สำหรับ user management endpoints
@@ -122,9 +154,23 @@ function createUser(PDO $pdo, ?array $auth): void
         return;
     }
 
+    $username = trim((string) $data['username']);
+    if (!isValidUsername($username)) {
+        http_response_code(400);
+        echo json_encode(['error' => 'ชื่อผู้ใช้ต้องเป็น a-z, 0-9, . _ - ความยาว 3–64 ตัวอักษร']);
+        return;
+    }
+
     if (!in_array($data['role'], VALID_ROLES, true)) {
         http_response_code(400);
-        echo json_encode(['error' => 'role ต้องเป็น admin หรือ operator เท่านั้น']);
+        echo json_encode(['error' => 'role ไม่ถูกต้อง']);
+        return;
+    }
+
+    $assignable = assignableRolesFor($auth);
+    if (!in_array($data['role'], $assignable, true)) {
+        http_response_code(403);
+        echo json_encode(['error' => 'คุณไม่มีสิทธิ์กำหนดบทบาทนี้']);
         return;
     }
 
@@ -134,7 +180,7 @@ function createUser(PDO $pdo, ?array $auth): void
              VALUES (?, ?, ?, ?, ?, 1, 1)"
         );
         $stmt->execute([
-            trim($data['username']),
+            $username,
             password_hash($data['password'], PASSWORD_DEFAULT),
             $data['full_name'],
             $data['email'] ?? null,
@@ -161,7 +207,7 @@ function createUser(PDO $pdo, ?array $auth): void
         $newUserId,
         null,
         [
-            'username' => trim($data['username']),
+            'username' => $username,
             'full_name' => $data['full_name'],
             'email' => $data['email'] ?? null,
             'role' => $data['role'],
@@ -177,12 +223,20 @@ function createUser(PDO $pdo, ?array $auth): void
  *
  * - field ที่แก้ได้: full_name, email, role, is_active
  * - ส่ง password มา = reset password (บังคับเปลี่ยนครั้งถัดไป)
- * - username แก้ไม่ได้ (immutable — ผูกกับ audit trail)
- * - กัน admin ลดสิทธิ์/ปิดบัญชีตัวเอง (กัน lock-out)
+ * - username แก้ผ่าน PUT /auth/me ของเจ้าของบัญชี
+ * - กันลดสิทธิ์/ปิดบัญชีตัวเอง (กัน lock-out)
  */
-function updateUser(PDO $pdo, int $id, array $auth): void
+/**
+ * @param array<string,mixed>|null $input Optional body for tests (otherwise php://input)
+ */
+function updateUser(PDO $pdo, int $id, array $auth, ?array $input = null): void
 {
-    $data = json_decode(file_get_contents('php://input'), true);
+    $data = $input ?? json_decode(file_get_contents('php://input'), true);
+    if (!is_array($data)) {
+        http_response_code(400);
+        echo json_encode(['error' => 'รูปแบบข้อมูลไม่ถูกต้อง']);
+        return;
+    }
 
     $stmt = $pdo->prepare("SELECT " . USER_PUBLIC_COLUMNS . " FROM users WHERE user_id = ?");
     $stmt->execute([$id]);
@@ -193,9 +247,13 @@ function updateUser(PDO $pdo, int $id, array $auth): void
         return;
     }
 
-    // Self-guard: ห้ามแก้ role ตัวเองเป็น non-admin หรือปิดบัญชีตัวเอง
-    if ($id === intval($auth['user_id'] ?? 0)) {
-        $demotesSelf = isset($data['role']) && $data['role'] !== 'admin';
+    $actorRole = $auth['role'] ?? '';
+    $selfId = intval($auth['user_id'] ?? 0);
+
+    // Self-guard: ห้ามลดบทบาทตัวเองหรือปิดบัญชีตัวเอง
+    if ($id === $selfId) {
+        $newRole = $data['role'] ?? null;
+        $demotesSelf = isset($newRole) && $newRole !== $beforeRow['role'];
         $deactivatesSelf = isset($data['is_active']) && !((int) (bool) $data['is_active']);
         if ($demotesSelf || $deactivatesSelf) {
             http_response_code(400);
@@ -204,10 +262,25 @@ function updateUser(PDO $pdo, int $id, array $auth): void
         }
     }
 
-    if (isset($data['role']) && !in_array($data['role'], VALID_ROLES, true)) {
-        http_response_code(400);
-        echo json_encode(['error' => 'role ต้องเป็น admin หรือ operator เท่านั้น']);
+    // Non-superadmin cannot modify superadmin accounts
+    if ($beforeRow['role'] === 'superadmin' && $actorRole !== 'superadmin') {
+        http_response_code(403);
+        echo json_encode(['error' => 'ไม่สามารถแก้ไขบัญชีซูเปอร์แอดมินได้']);
         return;
+    }
+
+    if (isset($data['role'])) {
+        if (!in_array($data['role'], VALID_ROLES, true)) {
+            http_response_code(400);
+            echo json_encode(['error' => 'role ไม่ถูกต้อง']);
+            return;
+        }
+        $assignable = assignableRolesFor($auth);
+        if (!in_array($data['role'], $assignable, true)) {
+            http_response_code(403);
+            echo json_encode(['error' => 'คุณไม่มีสิทธิ์กำหนดบทบาทนี้']);
+            return;
+        }
     }
 
     $sets = [];
@@ -243,17 +316,46 @@ function updateUser(PDO $pdo, int $id, array $auth): void
         return;
     }
 
+    $guardLastSuperadmin = $beforeRow['role'] === 'superadmin'
+        && (int) $beforeRow['is_active'] === 1
+        && (
+            (isset($data['role']) && $data['role'] !== 'superadmin')
+            || (isset($data['is_active']) && !((int) (bool) $data['is_active']))
+        );
+
     $params[] = $id;
     $sql = "UPDATE users SET " . implode(', ', $sets) . " WHERE user_id = ?";
-    $stmt = $pdo->prepare($sql);
-    $stmt->execute($params);
 
-    $afterStmt = $pdo->prepare("SELECT " . USER_PUBLIC_COLUMNS . " FROM users WHERE user_id = ?");
-    $afterStmt->execute([$id]);
-    $afterRow = $afterStmt->fetch(PDO::FETCH_ASSOC);
+    try {
+        if ($guardLastSuperadmin) {
+            $pdo->beginTransaction();
+            if (countActiveSuperadmins($pdo, true) <= 1) {
+                $pdo->rollBack();
+                http_response_code(400);
+                echo json_encode(['error' => 'ต้องมีซูเปอร์แอดมินที่ใช้งานได้อย่างน้อย 1 คน']);
+                return;
+            }
+        }
 
-    // Audit log: บันทึกการแก้ไขผู้ใช้ (before/after ไม่มี password_hash อยู่แล้วเพราะไม่อยู่ใน USER_PUBLIC_COLUMNS)
-    logAudit($pdo, $auth['user_id'], 'UPDATE', 'users', $id, $beforeRow, $afterRow);
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute($params);
+
+        $afterStmt = $pdo->prepare("SELECT " . USER_PUBLIC_COLUMNS . " FROM users WHERE user_id = ?");
+        $afterStmt->execute([$id]);
+        $afterRow = $afterStmt->fetch(PDO::FETCH_ASSOC);
+
+        // Audit log: บันทึกการแก้ไขผู้ใช้ (before/after ไม่มี password_hash อยู่แล้วเพราะไม่อยู่ใน USER_PUBLIC_COLUMNS)
+        logAudit($pdo, $auth['user_id'], 'UPDATE', 'users', $id, $beforeRow, $afterRow);
+
+        if ($guardLastSuperadmin && $pdo->inTransaction()) {
+            $pdo->commit();
+        }
+    } catch (Throwable $e) {
+        if ($pdo->inTransaction()) {
+            $pdo->rollBack();
+        }
+        throw $e;
+    }
 
     echo json_encode(['success' => true]);
 }

--- a/backend/tests/Unit/AuditPermissionTest.php
+++ b/backend/tests/Unit/AuditPermissionTest.php
@@ -157,9 +157,17 @@ final class AuditPermissionTest extends TestCase
     }
 
     #[Test]
+    public function superadmin_can_do_anything_on_any_resource(): void
+    {
+        self::assertTrue(checkPermission('superadmin', 'read', 'multiplier'));
+        self::assertTrue(checkPermission('superadmin', 'delete', 'users'));
+        self::assertTrue(checkPermission('superadmin', 'update', 'system_permissions'));
+    }
+
+    #[Test]
     public function unknown_role_is_always_denied(): void
     {
-        self::assertFalse(checkPermission('superadmin', 'read', 'multiplier'));
+        self::assertFalse(checkPermission('no-such-role', 'read', 'multiplier'));
         self::assertFalse(checkPermission('', 'read', 'multiplier'));
     }
 

--- a/backend/tests/Unit/AuthMeUsernameTest.php
+++ b/backend/tests/Unit/AuthMeUsernameTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PDO;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../routes/auth.php';
+
+final class AuthMeUsernameTest extends TestCase
+{
+    #[Test]
+    public function rejects_invalid_username_characters(): void
+    {
+        $pdo = $this->sqliteUsers();
+        if ($pdo === null) {
+            self::markTestSkipped('pdo_sqlite not available');
+        }
+
+        http_response_code(200);
+        ob_start();
+        updateAuthMe($pdo, ['user_id' => 1], [
+            'username' => 'bad name',
+            'full_name' => 'Alice',
+            'email' => '',
+            'current_password' => 'secret-password',
+        ]);
+        $body = json_decode((string) ob_get_clean(), true);
+
+        self::assertSame(400, http_response_code());
+        self::assertStringContainsString('ชื่อผู้ใช้', (string) ($body['error'] ?? ''));
+        self::assertSame('alice', $pdo->query('SELECT username FROM users WHERE user_id = 1')->fetchColumn());
+    }
+
+    #[Test]
+    public function username_change_requires_current_password(): void
+    {
+        $pdo = $this->sqliteUsers();
+        if ($pdo === null) {
+            self::markTestSkipped('pdo_sqlite not available');
+        }
+
+        http_response_code(200);
+        ob_start();
+        updateAuthMe($pdo, ['user_id' => 1], [
+            'username' => 'alice2',
+            'full_name' => 'Alice',
+        ]);
+        $body = json_decode((string) ob_get_clean(), true);
+
+        self::assertSame(400, http_response_code());
+        self::assertStringContainsString('รหัสผ่านปัจจุบัน', (string) ($body['error'] ?? ''));
+        self::assertSame('alice', $pdo->query('SELECT username FROM users WHERE user_id = 1')->fetchColumn());
+    }
+
+    #[Test]
+    public function wrong_current_password_rejects_username_change(): void
+    {
+        $pdo = $this->sqliteUsers();
+        if ($pdo === null) {
+            self::markTestSkipped('pdo_sqlite not available');
+        }
+
+        http_response_code(200);
+        ob_start();
+        updateAuthMe($pdo, ['user_id' => 1], [
+            'username' => 'alice2',
+            'full_name' => 'Alice',
+            'current_password' => 'not-the-password',
+        ]);
+        $body = json_decode((string) ob_get_clean(), true);
+
+        self::assertSame(400, http_response_code());
+        self::assertStringContainsString('รหัสผ่านปัจจุบัน', (string) ($body['error'] ?? ''));
+        self::assertSame('alice', $pdo->query('SELECT username FROM users WHERE user_id = 1')->fetchColumn());
+    }
+
+    #[Test]
+    public function duplicate_username_returns_409(): void
+    {
+        $pdo = $this->sqliteUsers();
+        if ($pdo === null) {
+            self::markTestSkipped('pdo_sqlite not available');
+        }
+
+        http_response_code(200);
+        ob_start();
+        updateAuthMe($pdo, ['user_id' => 1], [
+            'username' => 'bob',
+            'full_name' => 'Alice',
+            'current_password' => 'secret-password',
+        ]);
+        $body = json_decode((string) ob_get_clean(), true);
+
+        self::assertSame(409, http_response_code());
+        self::assertStringContainsString('ถูกใช้งานแล้ว', (string) ($body['error'] ?? ''));
+        self::assertSame('alice', $pdo->query('SELECT username FROM users WHERE user_id = 1')->fetchColumn());
+    }
+
+    #[Test]
+    public function successful_rename_updates_username_and_audits(): void
+    {
+        $pdo = $this->sqliteUsers();
+        if ($pdo === null) {
+            self::markTestSkipped('pdo_sqlite not available');
+        }
+
+        http_response_code(200);
+        ob_start();
+        updateAuthMe($pdo, ['user_id' => 1], [
+            'username' => 'alice_ops',
+            'full_name' => 'Alice Ops',
+            'email' => 'a@example.com',
+            'current_password' => 'secret-password',
+        ]);
+        $body = json_decode((string) ob_get_clean(), true);
+
+        self::assertTrue($body['success'] ?? false, json_encode($body));
+        self::assertSame('alice_ops', $pdo->query('SELECT username FROM users WHERE user_id = 1')->fetchColumn());
+        self::assertSame('Alice Ops', $pdo->query('SELECT full_name FROM users WHERE user_id = 1')->fetchColumn());
+
+        $audit = $pdo->query(
+            "SELECT after_value FROM audit_log WHERE table_name = 'users' AND record_id = 1 ORDER BY audit_id DESC LIMIT 1"
+        )->fetch(PDO::FETCH_ASSOC);
+        self::assertNotFalse($audit);
+        $after = json_decode((string) $audit['after_value'], true);
+        self::assertTrue($after['username_changed'] ?? false);
+        self::assertSame('alice_ops', $after['username'] ?? null);
+    }
+
+    private function sqliteUsers(): ?PDO
+    {
+        if (!in_array('sqlite', PDO::getAvailableDrivers(), true)) {
+            return null;
+        }
+
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec(
+            'CREATE TABLE users (
+                user_id INTEGER PRIMARY KEY,
+                username TEXT NOT NULL UNIQUE,
+                full_name TEXT,
+                email TEXT,
+                password_hash TEXT NOT NULL,
+                role TEXT NOT NULL,
+                is_active INTEGER NOT NULL DEFAULT 1,
+                must_change_password INTEGER NOT NULL DEFAULT 0
+            )'
+        );
+        $pdo->exec(
+            'CREATE TABLE audit_log (
+                audit_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER,
+                action TEXT,
+                table_name TEXT,
+                record_id INTEGER,
+                before_value TEXT,
+                after_value TEXT,
+                ip_address TEXT,
+                user_agent TEXT
+            )'
+        );
+        $hash = password_hash('secret-password', PASSWORD_DEFAULT);
+        $stmt = $pdo->prepare(
+            'INSERT INTO users (user_id, username, full_name, email, password_hash, role, is_active, must_change_password)
+             VALUES (?, ?, ?, ?, ?, ?, 1, 0)'
+        );
+        $stmt->execute([1, 'alice', 'Alice', null, $hash, 'operator']);
+        $stmt->execute([2, 'bob', 'Bob', null, $hash, 'operator']);
+        return $pdo;
+    }
+}

--- a/backend/tests/Unit/PermissionGateHttpTest.php
+++ b/backend/tests/Unit/PermissionGateHttpTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PDO;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../authz.php';
+
+/**
+ * HTTP contract for evaluatePermissionAccess / requirePermission (without exit).
+ */
+final class PermissionGateHttpTest extends TestCase
+{
+    #[Test]
+    public function unauthenticated_is_401(): void
+    {
+        $denied = evaluatePermissionAccess('read', 'users', null);
+        self::assertSame(401, $denied['status'] ?? null);
+        self::assertSame('Unauthorized', $denied['body']['error'] ?? null);
+    }
+
+    #[Test]
+    public function superadmin_allowed_without_pdo(): void
+    {
+        self::assertNull(evaluatePermissionAccess('delete', 'users', [
+            'user_id' => 1,
+            'role' => 'superadmin',
+        ]));
+    }
+
+    #[Test]
+    public function forbidden_when_default_denies(): void
+    {
+        $pdo = $this->sqliteOverrides();
+        if ($pdo === null) {
+            self::markTestSkipped('pdo_sqlite not available');
+        }
+
+        clearPermissionOverrideCache();
+        $denied = evaluatePermissionAccess('delete', 'multiplier', [
+            'user_id' => 2,
+            'role' => 'operator',
+        ], $pdo);
+
+        self::assertSame(403, $denied['status'] ?? null);
+        self::assertSame('Forbidden', $denied['body']['error'] ?? null);
+        self::assertSame('delete:multiplier', $denied['body']['required_permission'] ?? null);
+    }
+
+    #[Test]
+    public function override_store_unavailable_is_503(): void
+    {
+        if (!in_array('sqlite', PDO::getAvailableDrivers(), true)) {
+            self::markTestSkipped('pdo_sqlite not available');
+        }
+
+        // Empty in-memory DB — no role_permission_overrides table
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        clearPermissionOverrideCache();
+
+        $denied = evaluatePermissionAccess('read', 'users', [
+            'user_id' => 3,
+            'role' => 'admin',
+        ], $pdo);
+
+        self::assertSame(503, $denied['status'] ?? null);
+        self::assertSame('Service Unavailable', $denied['body']['error'] ?? null);
+        self::assertNotEmpty($denied['body']['message'] ?? null);
+    }
+
+    #[Test]
+    public function missing_getdb_without_pdo_is_503(): void
+    {
+        if (function_exists('getDB')) {
+            self::markTestSkipped('getDB already defined in this process');
+        }
+
+        clearPermissionOverrideCache();
+        $denied = evaluatePermissionAccess('read', 'users', [
+            'user_id' => 4,
+            'role' => 'admin',
+        ], null);
+
+        self::assertSame(503, $denied['status'] ?? null);
+        self::assertSame('Service Unavailable', $denied['body']['error'] ?? null);
+    }
+
+    private function sqliteOverrides(): ?PDO
+    {
+        if (!in_array('sqlite', PDO::getAvailableDrivers(), true)) {
+            return null;
+        }
+
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec(
+            'CREATE TABLE role_permission_overrides (
+                role TEXT NOT NULL,
+                action TEXT NOT NULL,
+                resource TEXT NOT NULL,
+                allowed INTEGER NOT NULL
+            )'
+        );
+        return $pdo;
+    }
+}

--- a/backend/tests/Unit/PermissionOverrideTest.php
+++ b/backend/tests/Unit/PermissionOverrideTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PDO;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../authz.php';
+
+/**
+ * Override layer on checkPermission — uses an in-memory SQLite stand-in when available,
+ * otherwise verifies default matrix helpers without DB.
+ */
+final class PermissionOverrideTest extends TestCase
+{
+    #[Test]
+    public function default_helper_matches_operator_matrix(): void
+    {
+        self::assertTrue(checkPermissionDefault('operator', 'create', 'multiplier'));
+        self::assertFalse(checkPermissionDefault('operator', 'delete', 'multiplier'));
+        self::assertFalse(checkPermissionDefault('operator', 'update', 'equivalence_approval'));
+    }
+
+    #[Test]
+    public function override_allow_grants_operator_delete_when_map_injected(): void
+    {
+        $pdo = $this->sqliteWithOverrides([
+            ['operator', 'delete', 'multiplier', 1],
+        ]);
+        if ($pdo === null) {
+            self::markTestSkipped('pdo_sqlite not available');
+        }
+
+        clearPermissionOverrideCache();
+        self::assertTrue(checkPermission('operator', 'delete', 'multiplier', $pdo));
+        // Untouched cells still use defaults
+        self::assertFalse(checkPermission('operator', 'delete', 'personnel', $pdo));
+    }
+
+    #[Test]
+    public function override_deny_blocks_admin_read_when_map_injected(): void
+    {
+        $pdo = $this->sqliteWithOverrides([
+            ['admin', 'read', 'audit', 0],
+        ]);
+        if ($pdo === null) {
+            self::markTestSkipped('pdo_sqlite not available');
+        }
+
+        clearPermissionOverrideCache();
+        self::assertFalse(checkPermission('admin', 'read', 'audit', $pdo));
+        self::assertTrue(checkPermission('admin', 'read', 'users', $pdo));
+    }
+
+    #[Test]
+    public function superadmin_ignores_overrides(): void
+    {
+        $pdo = $this->sqliteWithOverrides([
+            ['superadmin', 'read', 'audit', 0],
+        ]);
+        if ($pdo === null) {
+            // Even without DB, superadmin is always true
+            self::assertTrue(checkPermission('superadmin', 'read', 'audit'));
+            return;
+        }
+
+        clearPermissionOverrideCache();
+        self::assertTrue(checkPermission('superadmin', 'read', 'audit', $pdo));
+    }
+
+    #[Test]
+    public function override_load_failure_is_fail_closed(): void
+    {
+        if (!in_array('sqlite', PDO::getAvailableDrivers(), true)) {
+            self::markTestSkipped('pdo_sqlite not available');
+        }
+
+        $pdo = new PDO('sqlite::memory:');
+        // No role_permission_overrides table → load must fail closed
+        clearPermissionOverrideCache();
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('AUTHZ_OVERRIDES_UNAVAILABLE');
+        checkPermission('admin', 'read', 'users', $pdo);
+    }
+
+    #[Test]
+    public function override_load_failure_is_not_sticky_across_retries(): void
+    {
+        if (!in_array('sqlite', PDO::getAvailableDrivers(), true)) {
+            self::markTestSkipped('pdo_sqlite not available');
+        }
+
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        clearPermissionOverrideCache();
+
+        try {
+            checkPermission('admin', 'read', 'users', $pdo);
+            self::fail('expected AUTHZ_OVERRIDES_UNAVAILABLE');
+        } catch (\RuntimeException $e) {
+            self::assertSame('AUTHZ_OVERRIDES_UNAVAILABLE', $e->getMessage());
+        }
+
+        // Recover without clearPermissionOverrideCache() — failures must not stick.
+        $pdo->exec(
+            'CREATE TABLE role_permission_overrides (
+                role TEXT NOT NULL,
+                action TEXT NOT NULL,
+                resource TEXT NOT NULL,
+                allowed INTEGER NOT NULL
+            )'
+        );
+        self::assertTrue(checkPermission('admin', 'read', 'users', $pdo));
+    }
+
+    #[Test]
+    public function null_pdo_keeps_defaults_for_offline_unit_tests(): void
+    {
+        clearPermissionOverrideCache();
+        self::assertTrue(checkPermission('admin', 'read', 'users', null));
+        self::assertFalse(checkPermission('viewer', 'delete', 'users', null));
+    }
+
+    /**
+     * @param list<array{0:string,1:string,2:string,3:int}> $rows
+     */
+    private function sqliteWithOverrides(array $rows): ?PDO
+    {
+        if (!in_array('sqlite', PDO::getAvailableDrivers(), true)) {
+            return null;
+        }
+
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->exec(
+            'CREATE TABLE role_permission_overrides (
+                role TEXT NOT NULL,
+                action TEXT NOT NULL,
+                resource TEXT NOT NULL,
+                allowed INTEGER NOT NULL
+            )'
+        );
+        $stmt = $pdo->prepare(
+            'INSERT INTO role_permission_overrides (role, action, resource, allowed) VALUES (?, ?, ?, ?)'
+        );
+        foreach ($rows as $row) {
+            $stmt->execute($row);
+        }
+        return $pdo;
+    }
+}

--- a/backend/tests/Unit/PermissionSettingsRouteTest.php
+++ b/backend/tests/Unit/PermissionSettingsRouteTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PDO;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../routes/settings.php';
+
+final class PermissionSettingsRouteTest extends TestCase
+{
+    #[Test]
+    public function validate_cell_rejects_superadmin_role(): void
+    {
+        http_response_code(200);
+        ob_start();
+        $result = validatePermissionCell([
+            'role' => 'superadmin',
+            'action' => 'read',
+            'resource' => 'users',
+        ], 0);
+        $body = json_decode((string) ob_get_clean(), true);
+
+        self::assertNull($result);
+        self::assertSame(400, http_response_code());
+        self::assertStringContainsString('superadmin', (string) ($body['error'] ?? ''));
+    }
+
+    #[Test]
+    public function put_rejects_item_without_allowed_or_reset(): void
+    {
+        $pdo = $this->sqliteOverrides();
+        if ($pdo === null) {
+            self::markTestSkipped('pdo_sqlite not available');
+        }
+
+        http_response_code(200);
+        ob_start();
+        putPermissionSettings($pdo, ['user_id' => 1], [
+            'overrides' => [
+                ['role' => 'operator', 'action' => 'delete', 'resource' => 'multiplier'],
+            ],
+        ]);
+        $body = json_decode((string) ob_get_clean(), true);
+
+        self::assertSame(400, http_response_code());
+        self::assertStringContainsString('allowed หรือ reset', (string) ($body['error'] ?? ''));
+    }
+
+    #[Test]
+    public function put_invalid_item_does_not_partially_write(): void
+    {
+        $pdo = $this->sqliteOverrides();
+        if ($pdo === null) {
+            self::markTestSkipped('pdo_sqlite not available');
+        }
+
+        http_response_code(200);
+        ob_start();
+        putPermissionSettings($pdo, ['user_id' => 1], [
+            'overrides' => [
+                [
+                    'role' => 'operator',
+                    'action' => 'delete',
+                    'resource' => 'multiplier',
+                    'allowed' => true,
+                ],
+                [
+                    'role' => 'superadmin',
+                    'action' => 'read',
+                    'resource' => 'users',
+                    'allowed' => false,
+                ],
+            ],
+        ]);
+        ob_get_clean();
+
+        self::assertSame(400, http_response_code());
+        self::assertSame(
+            0,
+            (int) $pdo->query('SELECT COUNT(*) FROM role_permission_overrides')->fetchColumn()
+        );
+    }
+
+    #[Test]
+    public function put_upsert_and_reset_round_trip(): void
+    {
+        $pdo = $this->sqliteOverrides();
+        if ($pdo === null) {
+            self::markTestSkipped('pdo_sqlite not available');
+        }
+
+        http_response_code(200);
+        ob_start();
+        putPermissionSettings($pdo, ['user_id' => 1], [
+            'overrides' => [
+                [
+                    'role' => 'operator',
+                    'action' => 'delete',
+                    'resource' => 'multiplier',
+                    'allowed' => true,
+                ],
+            ],
+        ]);
+        $created = json_decode((string) ob_get_clean(), true);
+        self::assertTrue($created['success'] ?? false);
+
+        self::assertSame(
+            1,
+            (int) $pdo->query('SELECT COUNT(*) FROM role_permission_overrides')->fetchColumn()
+        );
+
+        http_response_code(200);
+        ob_start();
+        putPermissionSettings($pdo, ['user_id' => 1], [
+            'overrides' => [
+                [
+                    'role' => 'operator',
+                    'action' => 'delete',
+                    'resource' => 'multiplier',
+                    'reset' => true,
+                ],
+            ],
+        ]);
+        $reset = json_decode((string) ob_get_clean(), true);
+        self::assertTrue($reset['success'] ?? false);
+        self::assertSame(
+            0,
+            (int) $pdo->query('SELECT COUNT(*) FROM role_permission_overrides')->fetchColumn()
+        );
+    }
+
+    private function sqliteOverrides(): ?PDO
+    {
+        if (!in_array('sqlite', PDO::getAvailableDrivers(), true)) {
+            return null;
+        }
+
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec(
+            'CREATE TABLE role_permission_overrides (
+                role TEXT NOT NULL,
+                action TEXT NOT NULL,
+                resource TEXT NOT NULL,
+                allowed INTEGER NOT NULL,
+                PRIMARY KEY (role, action, resource)
+            )'
+        );
+        $pdo->exec(
+            'CREATE TABLE audit_log (
+                audit_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER,
+                action TEXT,
+                table_name TEXT,
+                record_id INTEGER,
+                before_value TEXT,
+                after_value TEXT,
+                ip_address TEXT,
+                user_agent TEXT
+            )'
+        );
+        return $pdo;
+    }
+}

--- a/backend/tests/Unit/UserManagementGuardTest.php
+++ b/backend/tests/Unit/UserManagementGuardTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PDO;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../routes/users.php';
+
+final class UserManagementGuardTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('usernameProvider')]
+    public function username_validation(string $username, bool $ok): void
+    {
+        self::assertSame($ok, isValidUsername($username));
+    }
+
+    /**
+     * @return list<array{0:string,1:bool}>
+     */
+    public static function usernameProvider(): array
+    {
+        return [
+            ['ab', false],
+            ['abc', true],
+            ['alice.ops', true],
+            ['alice_ops-1', true],
+            ['bad name', false],
+            ['bad@name', false],
+            [str_repeat('a', 64), true],
+            [str_repeat('a', 65), false],
+        ];
+    }
+
+    #[Test]
+    public function admin_cannot_assign_superadmin(): void
+    {
+        self::assertNotContains('superadmin', assignableRolesFor(['role' => 'admin']));
+        self::assertContains('superadmin', assignableRolesFor(['role' => 'superadmin']));
+    }
+
+    #[Test]
+    public function last_active_superadmin_cannot_be_demoted(): void
+    {
+        $pdo = $this->sqliteUsers();
+        if ($pdo === null) {
+            self::markTestSkipped('pdo_sqlite not available');
+        }
+
+        $pdo->exec(
+            "INSERT INTO users (user_id, username, full_name, email, role, is_active, must_change_password)
+             VALUES (1, 'solo', 'Solo', null, 'superadmin', 1, 0)"
+        );
+
+        http_response_code(200);
+        ob_start();
+        updateUser($pdo, 1, ['user_id' => 99, 'role' => 'superadmin'], ['role' => 'admin']);
+        $body = json_decode((string) ob_get_clean(), true);
+
+        self::assertSame(400, http_response_code());
+        self::assertSame('ต้องมีซูเปอร์แอดมินที่ใช้งานได้อย่างน้อย 1 คน', $body['error'] ?? null);
+        self::assertSame('superadmin', $pdo->query('SELECT role FROM users WHERE user_id = 1')->fetchColumn());
+    }
+
+    #[Test]
+    public function last_active_superadmin_cannot_be_deactivated(): void
+    {
+        $pdo = $this->sqliteUsers();
+        if ($pdo === null) {
+            self::markTestSkipped('pdo_sqlite not available');
+        }
+
+        $pdo->exec(
+            "INSERT INTO users (user_id, username, full_name, email, role, is_active, must_change_password)
+             VALUES (1, 'solo', 'Solo', null, 'superadmin', 1, 0)"
+        );
+
+        http_response_code(200);
+        ob_start();
+        updateUser($pdo, 1, ['user_id' => 99, 'role' => 'superadmin'], ['is_active' => 0]);
+        $body = json_decode((string) ob_get_clean(), true);
+
+        self::assertSame(400, http_response_code());
+        self::assertSame('ต้องมีซูเปอร์แอดมินที่ใช้งานได้อย่างน้อย 1 คน', $body['error'] ?? null);
+        self::assertSame(1, (int) $pdo->query('SELECT is_active FROM users WHERE user_id = 1')->fetchColumn());
+    }
+
+    #[Test]
+    public function second_superadmin_can_be_demoted(): void
+    {
+        $pdo = $this->sqliteUsers();
+        if ($pdo === null) {
+            self::markTestSkipped('pdo_sqlite not available');
+        }
+
+        $pdo->exec(
+            "INSERT INTO users (user_id, username, full_name, email, role, is_active, must_change_password) VALUES
+             (1, 'sa1', 'One', null, 'superadmin', 1, 0),
+             (2, 'sa2', 'Two', null, 'superadmin', 1, 0)"
+        );
+
+        http_response_code(200);
+        ob_start();
+        updateUser($pdo, 2, ['user_id' => 1, 'role' => 'superadmin'], ['role' => 'admin']);
+        $body = json_decode((string) ob_get_clean(), true);
+
+        self::assertTrue($body['success'] ?? false, json_encode($body));
+        self::assertSame('admin', $pdo->query('SELECT role FROM users WHERE user_id = 2')->fetchColumn());
+    }
+
+    private function sqliteUsers(): ?PDO
+    {
+        if (!in_array('sqlite', PDO::getAvailableDrivers(), true)) {
+            return null;
+        }
+
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->exec(
+            'CREATE TABLE users (
+                user_id INTEGER PRIMARY KEY,
+                username TEXT NOT NULL,
+                full_name TEXT,
+                email TEXT,
+                role TEXT NOT NULL,
+                is_active INTEGER NOT NULL DEFAULT 1,
+                must_change_password INTEGER NOT NULL DEFAULT 0,
+                last_login_at TEXT,
+                created_at TEXT
+            )'
+        );
+        $pdo->exec(
+            'CREATE TABLE audit_log (
+                audit_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER,
+                action TEXT,
+                table_name TEXT,
+                record_id INTEGER,
+                before_value TEXT,
+                after_value TEXT,
+                ip_address TEXT,
+                user_agent TEXT
+            )'
+        );
+        return $pdo;
+    }
+}

--- a/database/09-auth-users.sql
+++ b/database/09-auth-users.sql
@@ -44,6 +44,6 @@ VALUES ('admin', '$2y$10$Vrl20xAh4dvfwpDt/pWnTOcMuCzjj8353VKy348pb80StKqkENMcm',
 ON DUPLICATE KEY UPDATE
     password_hash = VALUES(password_hash),
     full_name = VALUES(full_name),
-    role = VALUES(role),
+    -- Do not reset role: migration 27 may promote username=admin → superadmin
     is_active = VALUES(is_active),
     must_change_password = VALUES(must_change_password);

--- a/database/27-superadmin-permission-overrides.sql
+++ b/database/27-superadmin-permission-overrides.sql
@@ -1,0 +1,25 @@
+-- บังคับ client charset เป็น utf8mb4 กัน mojibake ตอน docker init
+SET NAMES utf8mb4;
+
+-- ============================================================================
+-- 27-superadmin-permission-overrides.sql
+-- - Promote bootstrap admin → superadmin (once)
+-- - Table role_permission_overrides: runtime overrides on top of authz.php defaults
+-- ============================================================================
+
+-- Promote the seeded bootstrap account to superadmin (idempotent for username=admin)
+UPDATE users
+SET role = 'superadmin'
+WHERE username = 'admin' AND role = 'admin';
+
+CREATE TABLE IF NOT EXISTS role_permission_overrides (
+    override_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    role VARCHAR(20) NOT NULL,
+    action VARCHAR(20) NOT NULL,
+    resource VARCHAR(64) NOT NULL,
+    allowed TINYINT(1) NOT NULL DEFAULT 0,
+    updated_at TIMESTAMP NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_role_action_resource (role, action, resource),
+    KEY idx_rpo_role (role)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/database/tidb-init.sql
+++ b/database/tidb-init.sql
@@ -1276,13 +1276,28 @@ CREATE TABLE login_attempts (
 -- ต้องเปลี่ยนทันทีหลัง deploy production (must_change_password = 1)
 -- ใช้ upsert เผื่อกรณี import ทับ dump เก่าที่ seed แถว (1,'admin') ไว้แล้ว
 INSERT INTO users (username, password_hash, full_name, role, is_active, must_change_password)
-VALUES ('admin', '$2y$10$Vrl20xAh4dvfwpDt/pWnTOcMuCzjj8353VKy348pb80StKqkENMcm', 'ผู้ดูแลระบบ', 'admin', 1, 1)
+VALUES ('admin', '$2y$10$Vrl20xAh4dvfwpDt/pWnTOcMuCzjj8353VKy348pb80StKqkENMcm', 'ผู้ดูแลระบบ', 'superadmin', 1, 1)
 ON DUPLICATE KEY UPDATE
     password_hash = VALUES(password_hash),
     full_name = VALUES(full_name),
-    role = VALUES(role),
+    -- Do not reset role on reimport (matches 09-auth-users.sql)
     is_active = VALUES(is_active),
     must_change_password = VALUES(must_change_password);
+
+-- ============================================
+-- FILE: 27-superadmin-permission-overrides.sql
+-- ============================================
+CREATE TABLE role_permission_overrides (
+    override_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    role VARCHAR(20) NOT NULL,
+    action VARCHAR(20) NOT NULL,
+    resource VARCHAR(64) NOT NULL,
+    allowed TINYINT(1) NOT NULL DEFAULT 0,
+    updated_at TIMESTAMP NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_role_action_resource (role, action, resource),
+    KEY idx_rpo_role (role)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- ============================================
 -- FILE: 10-import-log.sql + 12-import-log-fk.sql

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -81,6 +81,7 @@ services:
       - ./database/23-external-ref.sql:/docker-entrypoint-initdb.d/23-external-ref.sql
       - ./database/24-drop-dead-tables.sql:/docker-entrypoint-initdb.d/24-drop-dead-tables.sql
       - ./database/25-ensure-multiplier-tables.sql:/docker-entrypoint-initdb.d/25-ensure-multiplier-tables.sql
+      - ./database/27-superadmin-permission-overrides.sql:/docker-entrypoint-initdb.d/27-superadmin-permission-overrides.sql
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "--silent"]
       interval: 10s

--- a/docs/adr/0003-superadmin-permission-overrides.md
+++ b/docs/adr/0003-superadmin-permission-overrides.md
@@ -1,0 +1,30 @@
+# ADR-0003: Superadmin role + DB permission overrides
+
+- Status: Accepted
+- Date: 2026-08-04
+
+## Context
+
+Authorization lived only as a hardcoded matrix in `backend/authz.php` (`admin` / `operator` / `viewer`). Self-service account edits were missing, and the topbar “ตั้งค่า” entry pointed at a forced password-change route that redirected voluntary users away.
+
+Operators need to change their own username/password. Operators of the platform also need a **superadmin** who can toggle which roles may perform which actions without a code deploy.
+
+## Decision
+
+1. Add role **`superadmin`** above `admin`. Superadmin always passes `checkPermission` and alone may call `/settings/permissions`.
+2. Keep the PHP matrix as **defaults**. Persist optional rows in `role_permission_overrides` `(role, action, resource, allowed)` that override defaults for `admin` / `operator` / `viewer` only.
+3. Self-service account: `GET|PUT /auth/me` (username change requires current password + uniqueness + audit) and voluntary password change via `/settings/account` (forced flow remains `/change-password`).
+4. Seed: promote bootstrap `admin` username to `superadmin` (migration `27-superadmin-permission-overrides.sql`).
+
+## Consequences
+
+- Empty override table ⇒ behavior matches pre-change defaults (except bootstrap user becomes superadmin).
+- Frontend Phase 1 gates menus with `isAdmin` / `isSuperAdmin`; backend remains source of truth for overrides.
+- Only superadmin may assign the `superadmin` role in user management.
+- Override load is **fail-closed**: if the override store or DB is unreachable, non-superadmin requests get 503 (do not silently fall back to defaults). Failures are not cached so the next request can retry after recovery.
+- PUT `/settings/permissions` is transactional; items may upsert `allowed` or `reset: true` (delete override row → default).
+- At least one active `superadmin` must remain (demote/deactivate of the last one is rejected).
+
+## Release / deploy
+
+**Hard gate:** Apply migration `27-superadmin-permission-overrides.sql` (CREATE `role_permission_overrides` + promote bootstrap `username=admin`) **before or atomically with** backend deploy. Production often has `RUN_MIGRATIONS=0`; shipping authz code without the table 503s every non-superadmin `requirePermission` call. Fresh `tidb-init` already mounts 27.

--- a/frontend/src/__tests__/components/AppSidebar.test.js
+++ b/frontend/src/__tests__/components/AppSidebar.test.js
@@ -7,6 +7,12 @@ let userVal = null
 vi.mock('@/stores/auth.js', () => ({
   useAuthStore: () => ({
     get user() { return userVal },
+    get isAdmin() {
+      return userVal?.role === 'admin' || userVal?.role === 'superadmin'
+    },
+    get isSuperAdmin() {
+      return userVal?.role === 'superadmin'
+    },
   }),
 }))
 
@@ -44,6 +50,15 @@ describe('AppSidebar', () => {
     expect(text).toContain('ภาพรวม')
     expect(text).toContain('MAIN')
     expect(text).toContain('ADMIN')
+  })
+
+  it('renders ADMIN section for superadmin (isAdmin)', () => {
+    userVal = { name: 'sa', role: 'superadmin' }
+    const wrapper = mountSidebar()
+    expect(wrapper.text()).toContain('ADMIN')
+    expect(wrapper.text()).toContain('นำเข้าข้อมูล')
+    expect(wrapper.text()).toContain('จัดการผู้ใช้')
+    expect(wrapper.text()).toContain('Superadmin')
   })
 
   it('shows admin-only items only for admin', () => {

--- a/frontend/src/__tests__/components/AppTopbar.test.js
+++ b/frontend/src/__tests__/components/AppTopbar.test.js
@@ -99,13 +99,13 @@ describe('AppTopbar', () => {
     expect(wrapper.vm.dropdownOpen).toBe(false)
   })
 
-  it('navigates to /change-password when ตั้งค่า clicked', async () => {
+  it('navigates to /settings/account when ตั้งค่า clicked', async () => {
     const wrapper = mountTopbar()
     await wrapper.get('button[aria-label="เมนูผู้ใช้"]').trigger('click')
     const settingsBtn = wrapper.findAll('button').find((b) => b.text().includes('ตั้งค่า'))
     await settingsBtn.trigger('click')
 
-    expect(push).toHaveBeenCalledWith('/change-password')
+    expect(push).toHaveBeenCalledWith('/settings/account')
   })
 
   it('shows ผู้ดูแล menu item only for admin', async () => {

--- a/frontend/src/__tests__/pages/SettingsPage.test.js
+++ b/frontend/src/__tests__/pages/SettingsPage.test.js
@@ -1,0 +1,88 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+const fetchMe = vi.fn()
+const updateMe = vi.fn()
+const changePassword = vi.fn()
+const mockGet = vi.fn()
+const mockPut = vi.fn()
+const confirmSave = vi.fn(async () => true)
+
+const authState = {
+  isSuperAdmin: false,
+  isAdmin: true,
+  fetchMe,
+  updateMe,
+  changePassword,
+  user: { id: 1, username: 'alice', name: 'Alice', role: 'operator' },
+}
+
+vi.mock('@/stores/auth.js', () => ({
+  useAuthStore: () => authState,
+}))
+
+vi.mock('@/stores/ui.js', () => ({
+  useUiStore: () => ({ showToast: vi.fn() }),
+}))
+
+vi.mock('@/composables/useApi.js', () => ({
+  useApi: () => ({ get: mockGet, put: mockPut }),
+}))
+
+vi.mock('@/composables/useConfirm.js', () => ({
+  confirmSave: (...args) => confirmSave(...args),
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ name: 'settings-account', query: {} }),
+  useRouter: () => ({ replace: vi.fn() }),
+}))
+
+const SettingsPage = (await import('@/pages/SettingsPage.vue')).default
+
+describe('SettingsPage', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    authState.isSuperAdmin = false
+    authState.isAdmin = true
+    fetchMe.mockReset()
+    updateMe.mockReset()
+    changePassword.mockReset()
+    mockGet.mockReset()
+    mockPut.mockReset()
+    confirmSave.mockReset()
+    confirmSave.mockResolvedValue(true)
+    fetchMe.mockResolvedValue({
+      username: 'alice',
+      full_name: 'Alice',
+      email: 'a@example.com',
+    })
+  })
+
+  it('loads account fields on mount', async () => {
+    const wrapper = mount(SettingsPage)
+    await flushPromises()
+
+    expect(fetchMe).toHaveBeenCalled()
+    expect(wrapper.find('#settings-username').element.value).toBe('alice')
+    expect(wrapper.find('#settings-fullname').element.value).toBe('Alice')
+  })
+
+  it('saves profile via updateMe after confirm', async () => {
+    updateMe.mockResolvedValue({ username: 'alice', full_name: 'Alice B', email: '' })
+    const wrapper = mount(SettingsPage)
+    await flushPromises()
+
+    await wrapper.find('#settings-fullname').setValue('Alice B')
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(confirmSave).toHaveBeenCalled()
+    expect(updateMe).toHaveBeenCalledWith(expect.objectContaining({
+      full_name: 'Alice B',
+      username: 'alice',
+    }))
+  })
+
+})

--- a/frontend/src/__tests__/router/guards.test.js
+++ b/frontend/src/__tests__/router/guards.test.js
@@ -4,6 +4,12 @@ const mockAuth = {
   isAuthenticated: false,
   mustChangePassword: false,
   user: null,
+  get isAdmin() {
+    return this.user?.role === 'admin' || this.user?.role === 'superadmin'
+  },
+  get isSuperAdmin() {
+    return this.user?.role === 'superadmin'
+  },
 }
 
 vi.mock('@/stores/auth.js', () => ({
@@ -69,12 +75,31 @@ describe('router auth guards', () => {
     expect(router.currentRoute.value.path).toBe('/import')
   })
 
-  it('redirects away from change-password when password change is not required', async () => {
+  it('redirects voluntary change-password visits to settings account', async () => {
     mockAuth.isAuthenticated = true
     mockAuth.mustChangePassword = false
     mockAuth.user = { role: 'operator' }
 
     await router.push('/change-password')
+    expect(router.currentRoute.value.path).toBe('/settings/account')
+  })
+
+  it('allows superadmin into settings permissions', async () => {
+    mockAuth.isAuthenticated = true
+    mockAuth.mustChangePassword = false
+    mockAuth.user = { role: 'superadmin' }
+
+    await router.push('/settings/permissions')
+    expect(router.currentRoute.value.path).toBe('/settings/permissions')
+  })
+
+  it('blocks non-superadmin from settings permissions', async () => {
+    mockAuth.isAuthenticated = true
+    mockAuth.mustChangePassword = false
+    mockAuth.user = { role: 'admin' }
+
+    await router.push('/dashboard')
+    await router.push('/settings/permissions')
     expect(router.currentRoute.value.path).toBe('/dashboard')
   })
 

--- a/frontend/src/__tests__/stores/auth.test.js
+++ b/frontend/src/__tests__/stores/auth.test.js
@@ -116,4 +116,14 @@ describe('auth store', () => {
     expect(localStorage.getItem('user')).toBeNull()
     expect(localStorage.getItem('auth_token')).toBeNull()
   })
+
+  it('treats superadmin as admin for menu gating', () => {
+    const auth = useAuthStore()
+    auth.setAuth({
+      ...authData(),
+      user: { user_id: 1, username: 'root', name: 'Root', role: 'superadmin', must_change_password: false },
+    })
+    expect(auth.isAdmin).toBe(true)
+    expect(auth.isSuperAdmin).toBe(true)
+  })
 })

--- a/frontend/src/__tests__/utils/permissionOverridePending.test.js
+++ b/frontend/src/__tests__/utils/permissionOverridePending.test.js
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { buildPendingOverride } from '@/utils/permissionOverridePending.js'
+
+describe('buildPendingOverride', () => {
+  it('emits reset when value matches default and an override exists', () => {
+    expect(buildPendingOverride('operator', 'delete', 'multiplier', false, false, true)).toEqual({
+      role: 'operator',
+      action: 'delete',
+      resource: 'multiplier',
+      reset: true,
+    })
+  })
+
+  it('returns null when value already matches default with no override', () => {
+    expect(buildPendingOverride('operator', 'delete', 'multiplier', false, false, false)).toBeNull()
+  })
+
+  it('emits upsert when value differs from default', () => {
+    expect(buildPendingOverride('operator', 'delete', 'multiplier', true, false, false)).toEqual({
+      role: 'operator',
+      action: 'delete',
+      resource: 'multiplier',
+      allowed: true,
+    })
+  })
+})

--- a/frontend/src/__tests__/utils/roleLabels.test.js
+++ b/frontend/src/__tests__/utils/roleLabels.test.js
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest'
+import { roleLabel } from '@/utils/roleLabels.js'
+
+describe('roleLabel', () => {
+  it('maps known roles in English and Thai', () => {
+    expect(roleLabel('superadmin')).toBe('Superadmin')
+    expect(roleLabel('admin', 'th')).toBe('ผู้ดูแลระบบ')
+    expect(roleLabel('viewer', 'th')).toBe('ผู้ชม')
+  })
+})

--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -92,7 +92,7 @@
             <div class="flex items-center gap-1.5">
               <p class="text-white text-sm font-medium truncate">{{ auth.user?.name || 'ผู้ใช้' }}</p>
               <span class="text-[10px] px-1.5 py-0.5 bg-blue-500/20 text-blue-300 rounded font-medium shrink-0">
-                {{ auth.user?.role === 'admin' ? 'Admin' : 'Operator' }}
+                {{ roleLabel(auth.user?.role) }}
               </span>
             </div>
             <p class="text-gray-400 text-xs truncate mt-0.5">{{ auth.user?.email || auth.user?.username || '' }}</p>
@@ -108,6 +108,7 @@ import { reactive, computed } from 'vue'
 import { useRoute } from 'vue-router'
 import { RouterLink } from 'vue-router'
 import { useAuthStore } from '@/stores/auth.js'
+import { roleLabel } from '@/utils/roleLabels.js'
 import {
   X, BookOpen, LayoutDashboard, UserCheck, Users, Clock, Award, UserMinus,
   Briefcase, FileText, Trophy, ChevronRight, UserCog, FileUp, FileSearch, Shield, ScanText,
@@ -159,7 +160,7 @@ const menuSections = computed(() => [
       { id: 'awards', label: 'รางวัล/ความดีความชอบ', icon: Trophy, to: '/awards' },
     ],
   },
-  ...(auth.user?.role === 'admin'
+  ...(auth.isAdmin
     ? [{
         id: 'admin',
         label: 'ADMIN',

--- a/frontend/src/components/AppTopbar.vue
+++ b/frontend/src/components/AppTopbar.vue
@@ -51,7 +51,7 @@
               โปรไฟล์
             </button>
             <button
-              @click="navigateTo('/change-password')"
+              @click="navigateTo('/settings/account')"
               class="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 transition-colors cursor-pointer"
             >
               <Settings class="w-4 h-4 text-gray-400" />
@@ -113,6 +113,9 @@ const pageTitles = {
   '/work-results': 'ผลงานและข้อเสนอ',
   '/awards': 'รางวัล/ความดีความชอบ',
   '/profile': 'โปรไฟล์ของฉัน',
+  '/settings/account': 'ตั้งค่า',
+  '/settings/permissions': 'สิทธิ์ระบบ',
+  '/settings/special-areas': 'พื้นที่พิเศษ',
 }
 
 const pageTitle = computed(() => {

--- a/frontend/src/pages/MultiplierPage.vue
+++ b/frontend/src/pages/MultiplierPage.vue
@@ -387,7 +387,7 @@ const api = useApi()
 const { searchPersonnel } = usePersonnelSearch()
 const { fetchList, fetchAreas, create, update, remove } = useMultiplier()
 const auth = useAuthStore()
-const isAdmin = computed(() => auth.user?.role === 'admin')
+const isAdmin = computed(() => auth.isAdmin)
 
 const loading = ref(false)
 const saving = ref(false)

--- a/frontend/src/pages/ProfilePage.vue
+++ b/frontend/src/pages/ProfilePage.vue
@@ -41,7 +41,7 @@
         </div>
         <div>
           <dt class="text-xs text-gray-500">สิทธิ์</dt>
-          <dd class="text-sm text-gray-900">{{ account.role === 'admin' ? 'ผู้ดูแลระบบ' : 'ผู้ปฏิบัติงาน' }}</dd>
+          <dd class="text-sm text-gray-900">{{ roleLabel(account.role, 'th') }}</dd>
         </div>
         <div>
           <dt class="text-xs text-gray-500">สถานะ</dt>
@@ -106,6 +106,7 @@ import { useRoute } from 'vue-router'
 import { useProfile } from '@/composables/useProfile.js'
 import SkeletonLoader from '@/components/SkeletonLoader.vue'
 import EmptyState from '@/components/EmptyState.vue'
+import { roleLabel } from '@/utils/roleLabels.js'
 import { User, AlertCircle } from 'lucide-vue-next'
 
 const route = useRoute()

--- a/frontend/src/pages/SettingsPage.vue
+++ b/frontend/src/pages/SettingsPage.vue
@@ -1,0 +1,426 @@
+<template>
+  <div class="p-4 sm:p-6 space-y-6 max-w-5xl mx-auto">
+    <div>
+      <h1 class="text-2xl font-bold text-gray-900">ตั้งค่า</h1>
+      <p class="text-sm text-gray-500 mt-1">จัดการบัญชีผู้ใช้และการตั้งค่าระบบ</p>
+    </div>
+
+    <div class="flex gap-2 border-b border-gray-200">
+      <button
+        type="button"
+        class="px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors cursor-pointer"
+        :class="tab === 'account' ? 'border-blue-600 text-blue-700' : 'border-transparent text-gray-500 hover:text-gray-700'"
+        @click="openAccountTab"
+      >
+        บัญชีของฉัน
+      </button>
+      <button
+        v-if="auth.isSuperAdmin"
+        type="button"
+        class="px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors cursor-pointer"
+        :class="tab === 'permissions' ? 'border-blue-600 text-blue-700' : 'border-transparent text-gray-500 hover:text-gray-700'"
+        @click="openPermissionsTab"
+      >
+        สิทธิ์ระบบ
+      </button>
+    </div>
+
+    <!-- Account tab -->
+    <section v-if="tab === 'account'" class="space-y-8">
+      <form class="rounded-xl border border-gray-200 bg-white p-6 space-y-4" @submit.prevent="saveProfile">
+        <h2 class="text-lg font-semibold text-gray-900">ข้อมูลบัญชี</h2>
+        <p class="text-sm text-gray-500">เปลี่ยนชื่อผู้ใช้ต้องยืนยันรหัสผ่านปัจจุบัน</p>
+
+        <div>
+          <label class="block text-sm font-medium text-gray-700 mb-1" for="settings-username">ชื่อผู้ใช้</label>
+          <input
+            id="settings-username"
+            v-model="profileForm.username"
+            type="text"
+            required
+            class="block w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+          />
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700 mb-1" for="settings-fullname">ชื่อ-นามสกุล</label>
+          <input
+            id="settings-fullname"
+            v-model="profileForm.full_name"
+            type="text"
+            required
+            class="block w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+          />
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700 mb-1" for="settings-email">อีเมล</label>
+          <input
+            id="settings-email"
+            v-model="profileForm.email"
+            type="email"
+            class="block w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+          />
+        </div>
+        <div v-if="usernameChanged">
+          <label class="block text-sm font-medium text-gray-700 mb-1" for="settings-current-for-username">รหัสผ่านปัจจุบัน (ยืนยันเปลี่ยนชื่อผู้ใช้)</label>
+          <input
+            id="settings-current-for-username"
+            v-model="profileForm.current_password"
+            type="password"
+            autocomplete="current-password"
+            required
+            class="block w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+          />
+        </div>
+
+        <p v-if="profileError" role="alert" class="text-sm text-red-600">{{ profileError }}</p>
+
+        <button
+          type="submit"
+          :disabled="savingProfile"
+          class="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 cursor-pointer"
+        >
+          {{ savingProfile ? 'กำลังบันทึก…' : 'บันทึกข้อมูลบัญชี' }}
+        </button>
+      </form>
+
+      <form class="rounded-xl border border-gray-200 bg-white p-6 space-y-4" @submit.prevent="savePassword">
+        <h2 class="text-lg font-semibold text-gray-900">เปลี่ยนรหัสผ่าน</h2>
+        <div>
+          <label class="block text-sm font-medium text-gray-700 mb-1" for="settings-current-password">รหัสผ่านปัจจุบัน</label>
+          <input
+            id="settings-current-password"
+            v-model="passwordForm.current"
+            type="password"
+            autocomplete="current-password"
+            required
+            class="block w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+          />
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700 mb-1" for="settings-new-password">รหัสผ่านใหม่</label>
+          <input
+            id="settings-new-password"
+            v-model="passwordForm.next"
+            type="password"
+            autocomplete="new-password"
+            minlength="8"
+            required
+            class="block w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+          />
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700 mb-1" for="settings-confirm-password">ยืนยันรหัสผ่านใหม่</label>
+          <input
+            id="settings-confirm-password"
+            v-model="passwordForm.confirm"
+            type="password"
+            autocomplete="new-password"
+            minlength="8"
+            required
+            class="block w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+          />
+        </div>
+        <p v-if="passwordError" role="alert" class="text-sm text-red-600">{{ passwordError }}</p>
+        <button
+          type="submit"
+          :disabled="savingPassword"
+          class="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 cursor-pointer"
+        >
+          {{ savingPassword ? 'กำลังบันทึก…' : 'บันทึกรหัสผ่านใหม่' }}
+        </button>
+      </form>
+    </section>
+
+    <!-- Permissions tab -->
+    <section v-else-if="tab === 'permissions' && auth.isSuperAdmin" class="space-y-4">
+      <div class="rounded-xl border border-gray-200 bg-white p-6 space-y-4">
+        <div class="flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <h2 class="text-lg font-semibold text-gray-900">เมทริกซ์สิทธิ์ตามบทบาท</h2>
+            <p class="text-sm text-gray-500 mt-1">
+              ค่าเริ่มต้นจากโค้ด — เปลี่ยนค่าจะบันทึก override (* = มี override) · คืนค่าเริ่มต้นเมื่อติ๊กกลับให้ตรง default
+            </p>
+          </div>
+          <div class="flex gap-2">
+            <select
+              v-model="selectedRole"
+              class="rounded-lg border border-gray-300 px-3 py-2 text-sm"
+            >
+              <option v-for="role in matrixRoles" :key="role" :value="role">{{ role }}</option>
+            </select>
+            <button
+              type="button"
+              :disabled="savingMatrix || pendingOverrides.length === 0"
+              class="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 cursor-pointer"
+              @click="saveMatrix"
+            >
+              {{ savingMatrix ? 'กำลังบันทึก…' : `บันทึก (${pendingOverrides.length})` }}
+            </button>
+          </div>
+        </div>
+
+        <p v-if="matrixError" role="alert" class="text-sm text-red-600">{{ matrixError }}</p>
+        <p v-if="matrixLoading" class="text-sm text-gray-500">กำลังโหลด…</p>
+
+        <div v-else class="overflow-x-auto">
+          <table class="min-w-full text-sm">
+            <thead>
+              <tr class="border-b border-gray-200 text-left text-gray-500">
+                <th class="py-2 pr-4 font-medium">Resource</th>
+                <th v-for="action in matrixActions" :key="action" class="py-2 px-2 font-medium text-center capitalize">
+                  {{ action }}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="resource in matrixResources"
+                :key="resource"
+                class="border-b border-gray-100"
+              >
+                <td class="py-2 pr-4 font-medium text-gray-800">{{ resource }}</td>
+                <td
+                  v-for="action in matrixActions"
+                  :key="`${resource}-${action}`"
+                  class="py-2 px-2 text-center"
+                >
+                  <input
+                    type="checkbox"
+                    class="h-4 w-4 rounded border-gray-300 text-blue-600 cursor-pointer"
+                    :checked="cellAllowed(selectedRole, action, resource)"
+                    @change="toggleCell(selectedRole, action, resource, $event.target.checked)"
+                  />
+                  <span
+                    v-if="cellHasOverride(selectedRole, action, resource)"
+                    class="ml-1 text-[10px] text-amber-600"
+                    title="มี override"
+                  >*</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup>
+import { computed, onMounted, reactive, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useAuthStore } from '@/stores/auth.js'
+import { useUiStore } from '@/stores/ui.js'
+import { useApi } from '@/composables/useApi.js'
+import { confirmSave } from '@/composables/useConfirm.js'
+import { buildPendingOverride } from '@/utils/permissionOverridePending.js'
+
+const auth = useAuthStore()
+const ui = useUiStore()
+const api = useApi()
+const route = useRoute()
+const router = useRouter()
+
+const tab = ref(
+  route.name === 'settings-permissions' || route.query.tab === 'permissions'
+    ? 'permissions'
+    : 'account'
+)
+
+const originalUsername = ref('')
+const profileForm = reactive({
+  username: '',
+  full_name: '',
+  email: '',
+  current_password: '',
+})
+const profileError = ref('')
+const savingProfile = ref(false)
+
+const passwordForm = reactive({ current: '', next: '', confirm: '' })
+const passwordError = ref('')
+const savingPassword = ref(false)
+
+const matrixLoading = ref(false)
+const matrixError = ref('')
+const savingMatrix = ref(false)
+const matrixRoles = ref([])
+const matrixActions = ref([])
+const matrixResources = ref([])
+const cellMap = ref({})
+const pendingOverrides = ref([])
+const selectedRole = ref('operator')
+
+const usernameChanged = computed(
+  () => profileForm.username.trim() !== originalUsername.value
+)
+
+function cellKey(role, action, resource) {
+  return `${role}|${action}|${resource}`
+}
+
+function cellAllowed(role, action, resource) {
+  return Boolean(cellMap.value[cellKey(role, action, resource)]?.allowed)
+}
+
+function cellHasOverride(role, action, resource) {
+  return Boolean(cellMap.value[cellKey(role, action, resource)]?.has_override)
+}
+
+function toggleCell(role, action, resource, allowed) {
+  const key = cellKey(role, action, resource)
+  const prev = cellMap.value[key] || {}
+  const defaultAllowed = Boolean(prev.default_allowed)
+  const pending = buildPendingOverride(
+    role,
+    action,
+    resource,
+    allowed,
+    defaultAllowed,
+    Boolean(prev.has_override)
+  )
+  cellMap.value = {
+    ...cellMap.value,
+    [key]: {
+      ...prev,
+      allowed,
+      has_override: pending ? !pending.reset : false,
+    },
+  }
+  const rest = pendingOverrides.value.filter(
+    (o) => !(o.role === role && o.action === action && o.resource === resource)
+  )
+  pendingOverrides.value = pending ? [...rest, pending] : rest
+}
+
+async function loadProfile() {
+  const me = await auth.fetchMe()
+  originalUsername.value = me.username || ''
+  profileForm.username = me.username || ''
+  profileForm.full_name = me.full_name || me.name || ''
+  profileForm.email = me.email || ''
+  profileForm.current_password = ''
+}
+
+async function saveProfile() {
+  profileError.value = ''
+  const ok = await confirmSave({ message: 'คุณต้องการบันทึกข้อมูลบัญชีหรือไม่?' })
+  if (!ok) return
+
+  savingProfile.value = true
+  try {
+    const payload = {
+      username: profileForm.username.trim(),
+      full_name: profileForm.full_name.trim(),
+      email: profileForm.email.trim(),
+    }
+    if (usernameChanged.value) {
+      payload.current_password = profileForm.current_password
+    }
+    await auth.updateMe(payload)
+    originalUsername.value = profileForm.username.trim()
+    profileForm.current_password = ''
+    ui.showToast('บันทึกบัญชีสำเร็จ', 'success')
+  } catch (err) {
+    profileError.value = err.message || 'บันทึกไม่สำเร็จ'
+  } finally {
+    savingProfile.value = false
+  }
+}
+
+async function savePassword() {
+  passwordError.value = ''
+  if (passwordForm.next !== passwordForm.confirm) {
+    passwordError.value = 'รหัสผ่านใหม่และการยืนยันไม่ตรงกัน'
+    return
+  }
+  const ok = await confirmSave({ message: 'คุณต้องการเปลี่ยนรหัสผ่านหรือไม่?' })
+  if (!ok) return
+
+  savingPassword.value = true
+  try {
+    await auth.changePassword(passwordForm.current, passwordForm.next)
+    passwordForm.current = ''
+    passwordForm.next = ''
+    passwordForm.confirm = ''
+    ui.showToast('เปลี่ยนรหัสผ่านสำเร็จ', 'success')
+  } catch (err) {
+    passwordError.value = err.message || 'เปลี่ยนรหัสผ่านไม่สำเร็จ'
+  } finally {
+    savingPassword.value = false
+  }
+}
+
+async function loadMatrix() {
+  matrixLoading.value = true
+  matrixError.value = ''
+  pendingOverrides.value = []
+  try {
+    const result = await api.get('/settings/permissions')
+    const data = result.data || result
+    matrixRoles.value = data.roles || []
+    matrixActions.value = data.actions || []
+    matrixResources.value = data.resources || []
+    if (!selectedRole.value || !matrixRoles.value.includes(selectedRole.value)) {
+      selectedRole.value = matrixRoles.value[0] || 'operator'
+    }
+    const next = {}
+    for (const cell of data.cells || []) {
+      next[cellKey(cell.role, cell.action, cell.resource)] = {
+        allowed: Boolean(cell.allowed),
+        has_override: Boolean(cell.has_override),
+        default_allowed: Boolean(cell.default_allowed),
+      }
+    }
+    cellMap.value = next
+  } catch (err) {
+    matrixError.value = err.message || 'โหลดเมทริกซ์ไม่สำเร็จ'
+  } finally {
+    matrixLoading.value = false
+  }
+}
+
+async function openAccountTab() {
+  tab.value = 'account'
+  if (route.name !== 'settings-account') {
+    await router.replace({ name: 'settings-account' })
+  }
+}
+
+async function openPermissionsTab() {
+  tab.value = 'permissions'
+  if (route.name !== 'settings-permissions') {
+    await router.replace({ name: 'settings-permissions' })
+  }
+  if (matrixResources.value.length === 0) {
+    await loadMatrix()
+  }
+}
+
+async function saveMatrix() {
+  if (pendingOverrides.value.length === 0) return
+  const ok = await confirmSave({ message: 'บันทึกการเปลี่ยนแปลงสิทธิ์ระบบหรือไม่?' })
+  if (!ok) return
+  savingMatrix.value = true
+  matrixError.value = ''
+  try {
+    await api.put('/settings/permissions', { overrides: pendingOverrides.value })
+    ui.showToast('บันทึกสิทธิ์ระบบสำเร็จ', 'success')
+    await loadMatrix()
+  } catch (err) {
+    matrixError.value = err.message || 'บันทึกไม่สำเร็จ'
+  } finally {
+    savingMatrix.value = false
+  }
+}
+
+onMounted(async () => {
+  try {
+    await loadProfile()
+  } catch (err) {
+    profileError.value = err.message || 'โหลดบัญชีไม่สำเร็จ'
+  }
+  if (tab.value === 'permissions' && auth.isSuperAdmin) {
+    await loadMatrix()
+  }
+})
+</script>

--- a/frontend/src/pages/UserManagementPage.vue
+++ b/frontend/src/pages/UserManagementPage.vue
@@ -78,9 +78,14 @@
               <td class="px-6 py-4 whitespace-nowrap">
                 <span
                   class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full"
-                  :class="row.role === 'admin' ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 text-gray-600'"
+                  :class="{
+                    'bg-purple-100 text-purple-700': row.role === 'superadmin',
+                    'bg-blue-100 text-blue-700': row.role === 'admin',
+                    'bg-amber-100 text-amber-700': row.role === 'viewer',
+                    'bg-gray-100 text-gray-600': row.role === 'operator',
+                  }"
                 >
-                  {{ row.role === 'admin' ? 'Admin' : 'Operator' }}
+                  {{ roleLabel(row.role) }}
                 </span>
               </td>
               <td class="px-6 py-4 whitespace-nowrap">
@@ -195,8 +200,10 @@
               :disabled="isSelfEditing"
               class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-gray-100 disabled:text-gray-500"
             >
+              <option value="viewer">Viewer — อ่านอย่างเดียว</option>
               <option value="operator">Operator — บันทึกข้อมูล</option>
               <option value="admin">Admin — อนุมัติ + จัดการผู้ใช้</option>
+              <option v-if="auth.isSuperAdmin" value="superadmin">Superadmin — ตั้งค่าระบบ</option>
             </select>
             <p v-if="isSelfEditing" class="text-xs text-gray-400 mt-1">ไม่สามารถแก้ไขสิทธิ์ของตนเองได้</p>
           </div>
@@ -299,6 +306,7 @@ import { ref, computed, onMounted } from 'vue'
 import { useUsers } from '@/composables/useUsers.js'
 import { useAuthStore } from '@/stores/auth.js'
 import { useUiStore } from '@/stores/ui.js'
+import { roleLabel } from '@/utils/roleLabels.js'
 import PaginationBar from '@/components/PaginationBar.vue'
 import EmptyState from '@/components/EmptyState.vue'
 import { Plus, Search, Pencil, KeyRound, Ban, CheckCircle, Users } from 'lucide-vue-next'
@@ -334,6 +342,7 @@ const defaultFormData = () => ({
   role: 'operator',
 })
 const formData = ref(defaultFormData())
+
 
 const isSelfEditing = computed(() => editingUser.value?.userId === auth.user?.id)
 

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -107,6 +107,17 @@ const routes = [
         component: () => import('@/pages/MultiplierPage.vue'),
       },
       {
+        path: 'settings/account',
+        name: 'settings-account',
+        component: () => import('@/pages/SettingsPage.vue'),
+      },
+      {
+        path: 'settings/permissions',
+        name: 'settings-permissions',
+        component: () => import('@/pages/SettingsPage.vue'),
+        meta: { requiresSuperAdmin: true },
+      },
+      {
         // path เดิมก่อนย้ายเข้าเมนูแอดมิน — คง redirect ไว้กัน bookmark เก่าพัง
         path: 'time-multiplier/areas',
         redirect: '/settings/special-areas',
@@ -167,15 +178,19 @@ router.beforeEach(async (to) => {
   }
 
   if (to.path === '/change-password' && auth.isAuthenticated && !auth.mustChangePassword) {
-    return '/dashboard'
+    return '/settings/account'
   }
 
   if (to.path === '/login' && auth.isAuthenticated) {
     return '/dashboard'
   }
 
-  // หน้า admin only — operator เด้งกลับ dashboard
-  if (to.meta.requiresAdmin && auth.user?.role !== 'admin') {
+  // หน้า admin only — operator/viewer เด้งกลับ dashboard (superadmin ผ่านได้)
+  if (to.meta.requiresAdmin && !auth.isAdmin) {
+    return '/dashboard'
+  }
+
+  if (to.meta.requiresSuperAdmin && !auth.isSuperAdmin) {
     return '/dashboard'
   }
 })

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -34,7 +34,8 @@ export const useAuthStore = defineStore('auth', () => {
   const user = ref(readStoredJson('user'))
 
   const isAuthenticated = computed(() => !!token.value && isTokenValid())
-  const isAdmin = computed(() => user.value?.role === 'admin')
+  const isSuperAdmin = computed(() => user.value?.role === 'superadmin')
+  const isAdmin = computed(() => user.value?.role === 'admin' || user.value?.role === 'superadmin')
   const mustChangePassword = computed(() => Boolean(user.value?.must_change_password))
 
   function isTokenValid() {
@@ -125,6 +126,45 @@ export const useAuthStore = defineStore('auth', () => {
     return data
   }
 
+  async function fetchMe() {
+    const { useApi } = await import('@/composables/useApi.js')
+    const api = useApi()
+    const result = await api.get('/auth/me')
+    const me = result.data || result
+    if (user.value) {
+      user.value = {
+        ...user.value,
+        id: me.id ?? user.value.id,
+        username: me.username ?? user.value.username,
+        name: me.name ?? me.full_name ?? user.value.name,
+        email: me.email ?? user.value.email,
+        role: me.role ?? user.value.role,
+        must_change_password: Boolean(me.must_change_password),
+      }
+      localStorage.setItem('user', JSON.stringify(user.value))
+    }
+    return me
+  }
+
+  async function updateMe(payload) {
+    const { useApi } = await import('@/composables/useApi.js')
+    const api = useApi()
+    const result = await api.put('/auth/me', payload)
+    const me = result.data || result
+    if (user.value) {
+      user.value = {
+        ...user.value,
+        id: me.id ?? user.value.id,
+        username: me.username ?? user.value.username,
+        name: me.name ?? me.full_name ?? user.value.name,
+        email: me.email ?? user.value.email,
+        role: me.role ?? user.value.role,
+      }
+      localStorage.setItem('user', JSON.stringify(user.value))
+    }
+    return me
+  }
+
   function logout() {
     // เพิกถอน refresh token ฝั่ง server แบบ best-effort (ไม่รอผล / ไม่โยน error)
     if (refreshToken.value) {
@@ -156,6 +196,7 @@ export const useAuthStore = defineStore('auth', () => {
     user,
     isAuthenticated,
     isAdmin,
+    isSuperAdmin,
     mustChangePassword,
     isTokenValid,
     setAuth,
@@ -163,6 +204,8 @@ export const useAuthStore = defineStore('auth', () => {
     login,
     refresh,
     changePassword,
+    fetchMe,
+    updateMe,
     logout,
   }
 })

--- a/frontend/src/utils/permissionOverridePending.js
+++ b/frontend/src/utils/permissionOverridePending.js
@@ -1,0 +1,24 @@
+/**
+ * Build a pending permission-matrix change for PUT /settings/permissions.
+ * Matching the default clears an existing override (reset); otherwise upserts allowed.
+ * Returns null when the cell already matches the default and has no override (no-op).
+ *
+ * @param {boolean} [hasOverride=true]
+ * @returns {{ role: string, action: string, resource: string, reset?: true, allowed?: boolean } | null}
+ */
+export function buildPendingOverride(
+  role,
+  action,
+  resource,
+  allowed,
+  defaultAllowed,
+  hasOverride = true
+) {
+  if (allowed === Boolean(defaultAllowed)) {
+    if (!hasOverride) {
+      return null
+    }
+    return { role, action, resource, reset: true }
+  }
+  return { role, action, resource, allowed }
+}

--- a/frontend/src/utils/roleLabels.js
+++ b/frontend/src/utils/roleLabels.js
@@ -1,0 +1,22 @@
+const ROLE_LABELS_EN = {
+  superadmin: 'Superadmin',
+  admin: 'Admin',
+  operator: 'Operator',
+  viewer: 'Viewer',
+}
+
+const ROLE_LABELS_TH = {
+  superadmin: 'ซูเปอร์แอดมิน',
+  admin: 'ผู้ดูแลระบบ',
+  operator: 'ผู้ปฏิบัติงาน',
+  viewer: 'ผู้ชม',
+}
+
+/**
+ * @param {string | null | undefined} role
+ * @param {'en' | 'th'} [locale='en']
+ */
+export function roleLabel(role, locale = 'en') {
+  const map = locale === 'th' ? ROLE_LABELS_TH : ROLE_LABELS_EN
+  return map[role] || role || '-'
+}

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -14,9 +14,9 @@ export default defineConfig({
   },
   test: {
     environment: 'jsdom',
-    // forks + capped workers: stable on Windows (threads pool can hang / worker-timeout)
+    // forks + single worker: avoids intermittent pool-runner timeouts on Windows
     pool: 'forks',
-    maxWorkers: 2,
+    maxWorkers: 1,
     globals: true,
     include: ['src/__tests__/**/*.{test,spec}.{js,ts}'],
     exclude: ['e2e/**', 'node_modules/**', 'dist/**'],


### PR DESCRIPTION
## Summary
- Add `superadmin` role, DB `role_permission_overrides`, and Settings UI (account + permissions matrix) with self-service `/auth/me`.
- Fail-closed authz (503 when override store/DB unavailable, non-sticky failures), transactional PUT with reset-to-default, last-superadmin guards, shared username validation.
- FE `isAdmin` gates (sidebar/multiplier), seed demote fix, ADR-0003 deploy note (apply migration 27 before/with backend deploy).

## Test plan
- [x] `.\scripts\ci-local.ps1 -SkipInstall` — schema parity, E2E 21 menus, PHPUnit OK (frontend vitest flaked once on pool timeout; re-run green 61 files / 476 tests; frontend Docker image built)
- [x] Pre-push vitest green (`maxWorkers: 1`)
- [ ] Apply `database/27-superadmin-permission-overrides.sql` on TiDB/prod before or with deploy
- [ ] Smoke: login as promoted bootstrap admin (now superadmin), open Admin nav + Settings → สิทธิ์ระบบ, toggle/reset a cell
- [ ] Confirm non-superadmin cannot open `/settings/permissions`; last superadmin cannot demote/deactivate self via another SA only-one case

EOF

Made with [Cursor](https://cursor.com)