### PR TITLE
fix: include Thai name prefixes in personnel full_name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,7 @@ jobs:
             -v "$PWD/database/24-drop-dead-tables.sql:/docker-entrypoint-initdb.d/24-drop-dead-tables.sql" \
             -v "$PWD/database/25-ensure-multiplier-tables.sql:/docker-entrypoint-initdb.d/25-ensure-multiplier-tables.sql" \
             -v "$PWD/database/27-superadmin-permission-overrides.sql:/docker-entrypoint-initdb.d/27-superadmin-permission-overrides.sql" \
+            -v "$PWD/database/28-prefix-in-probation-view.sql:/docker-entrypoint-initdb.d/28-prefix-in-probation-view.sql" \
             mysql:8.0
 
       - name: Wait for schema init to finish

--- a/backend/QualificationEngine.php
+++ b/backend/QualificationEngine.php
@@ -62,7 +62,7 @@ class QualificationEngine
         $baseSelect = "
             SELECT
                 p.personnel_id,
-                CONCAT(p.first_name, ' ', p.last_name) AS full_name,
+                CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name,
                 pos.position_name AS current_position,
                 p.current_level_code,
                 p.current_level_start_date,
@@ -103,6 +103,7 @@ class QualificationEngine
                     ELSE 'not_yet'
                 END AS status
             FROM personnel p
+            LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id
             LEFT JOIN position pos ON p.current_position_id = pos.position_id
             LEFT JOIN organization o ON p.current_org_id = o.org_id
             LEFT JOIN promotion_criteria pc
@@ -328,7 +329,7 @@ class QualificationEngine
         $sql = "
             SELECT
                 p.personnel_id,
-                CONCAT(p.first_name, ' ', p.last_name) AS full_name,
+                CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name,
                 pos.position_name AS current_position,
                 p.current_level_code,
                 p.current_level_start_date,
@@ -347,6 +348,7 @@ class QualificationEngine
                     ELSE 'not_yet'
                 END AS status
             FROM personnel p
+            LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id
             LEFT JOIN position pos ON p.current_position_id = pos.position_id
             LEFT JOIN organization o ON p.current_org_id = o.org_id
             LEFT JOIN (
@@ -698,7 +700,7 @@ class QualificationEngine
             SELECT
                 p.personnel_id,
                 p.citizen_id,
-                CONCAT(p.first_name, ' ', p.last_name) AS full_name,
+                CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name,
                 p.first_name,
                 p.last_name,
                 p.hire_date,
@@ -743,6 +745,7 @@ class QualificationEngine
                     ELSE 'not_yet'
                 END AS status
             FROM personnel p
+            LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id
             LEFT JOIN position pos ON p.current_position_id = pos.position_id
             LEFT JOIN organization o ON p.current_org_id = o.org_id
             LEFT JOIN promotion_criteria pc

--- a/backend/api.php
+++ b/backend/api.php
@@ -167,7 +167,7 @@ switch ($path[0]) {
                 "SELECT p.personnel_id AS servant_id, p.employee_id, p.first_name, p.last_name,
                         p.birth_date, p.appointment_date, p.retirement_date,
                         p.servant_status,
-                        CONCAT(COALESCE(px.prefix_name_th, ''), p.first_name, ' ', p.last_name) AS full_name,
+                        CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name,
                         csp.file_path AS photo_path
                  FROM personnel p
                  LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id
@@ -338,7 +338,7 @@ switch ($path[0]) {
                     p.personnel_id AS servant_id,
                     p.employee_id,
                     p.citizen_id,
-                    CONCAT(COALESCE(px.prefix_name_th, ''), p.first_name, ' ', p.last_name) as full_name,
+                    CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) as full_name,
                     p.first_name,
                     p.last_name,
                     p.birth_date,
@@ -512,11 +512,12 @@ switch ($path[0]) {
             $searchTerm = "%{$search}%";
             $stmt = $pdo->prepare("
                 SELECT p.personnel_id, p.citizen_id,
-                       CONCAT(p.first_name, ' ', p.last_name) AS full_name,
+                       CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name,
                        p.first_name, p.last_name,
                        pos.position_name AS current_position,
                        o.org_name AS department
                 FROM personnel p
+                LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id
                 LEFT JOIN `position` pos ON p.current_position_id = pos.position_id
                 LEFT JOIN organization o ON p.current_org_id = o.org_id
                 WHERE p.is_active = 1

--- a/backend/routes/awards.php
+++ b/backend/routes/awards.php
@@ -65,7 +65,7 @@ function handleAwards(PDO $pdo, string $method, array $path): void
 
 const AWARD_SELECT = "a.award_id, a.servant_id, a.award_name, a.award_type,
                       a.award_level, a.awarded_date, a.description, a.created_at,
-                      CONCAT(COALESCE(px.prefix_name_th, ''), p.first_name, ' ', p.last_name) AS servant_name";
+                      CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS servant_name";
 
 function awardBaseQuery(): string
 {

--- a/backend/routes/decorations.php
+++ b/backend/routes/decorations.php
@@ -62,7 +62,7 @@ function handleDecorations(PDO $pdo, string $method, array $path): void
 
 const DECORATION_SELECT = "d.decoration_id, d.servant_id, d.decoration_name, d.decoration_class,
                            d.received_year, d.gazette_ref, d.description, d.created_at,
-                           CONCAT(COALESCE(px.prefix_name_th, ''), p.first_name, ' ', p.last_name) AS servant_name";
+                           CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS servant_name";
 
 function decorationBaseQuery(): string
 {

--- a/backend/routes/diverse.php
+++ b/backend/routes/diverse.php
@@ -87,13 +87,15 @@ function getDiverseList(PDO $pdo): void
     $limit = max(1, min(intval($_GET['limit'] ?? 20), 200));
     $offset = max(0, intval($_GET['offset'] ?? 0));
 
-    $baseQuery = "SELECT de.*, CONCAT(p.first_name, ' ', p.last_name) AS full_name
+    $baseQuery = "SELECT de.*, CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name
                   FROM diverse_experience de
-                  LEFT JOIN personnel p ON de.personnel_id = p.personnel_id";
+                  LEFT JOIN personnel p ON de.personnel_id = p.personnel_id
+                  LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id";
 
     $countQuery = "SELECT COUNT(*) AS total
                    FROM diverse_experience de
-                   LEFT JOIN personnel p ON de.personnel_id = p.personnel_id";
+                   LEFT JOIN personnel p ON de.personnel_id = p.personnel_id
+                   LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id";
 
     $conditions = [];
     $params = [];
@@ -105,7 +107,7 @@ function getDiverseList(PDO $pdo): void
 
     if ($search !== '') {
         $conditions[] = "(p.first_name LIKE ? OR p.last_name LIKE ?
-                          OR CONCAT(p.first_name, ' ', p.last_name) LIKE ?
+                          OR CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) LIKE ?
                           OR de.from_job_series LIKE ? OR de.to_job_series LIKE ?
                           OR de.from_division LIKE ? OR de.to_division LIKE ?)";
         $term = "%{$search}%";
@@ -165,9 +167,10 @@ function getDiverseList(PDO $pdo): void
  */
 function getDiverseDetail(PDO $pdo, int $id): void
 {
-    $sql = "SELECT de.*, CONCAT(p.first_name, ' ', p.last_name) AS full_name
+    $sql = "SELECT de.*, CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name
             FROM diverse_experience de
             LEFT JOIN personnel p ON de.personnel_id = p.personnel_id
+            LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id
             WHERE de.experience_id = ?";
 
     $stmt = $pdo->prepare($sql);

--- a/backend/routes/equivalence.php
+++ b/backend/routes/equivalence.php
@@ -80,16 +80,18 @@ function getEquivalenceList(PDO $pdo): void
     $offset = max(0, intval($_GET['offset'] ?? 0));
 
     $baseQuery = "SELECT pe.*,
-                         CONCAT(p.first_name, ' ', p.last_name) AS full_name,
+                         CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name,
                          u.username AS approved_by_name
                   FROM position_equivalence pe
                   LEFT JOIN personnel p ON pe.personnel_id = p.personnel_id
+                  LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id
                   LEFT JOIN users u ON pe.approved_by = u.user_id";
 
-    // count ต้อง join personnel ด้วย เพราะเงื่อนไข search อ้างคอลัมน์ฝั่ง personnel
+    // count ต้อง join personnel + prefixes ด้วย เพราะเงื่อนไข search อ้างคอลัมน์ฝั่งชื่อเต็ม
     $countQuery = "SELECT COUNT(*) AS total
                    FROM position_equivalence pe
-                   LEFT JOIN personnel p ON pe.personnel_id = p.personnel_id";
+                   LEFT JOIN personnel p ON pe.personnel_id = p.personnel_id
+                   LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id";
 
     $conditions = [];
     $params = [];
@@ -101,7 +103,7 @@ function getEquivalenceList(PDO $pdo): void
 
     if ($search !== '') {
         $conditions[] = "(p.first_name LIKE ? OR p.last_name LIKE ?
-                          OR CONCAT(p.first_name, ' ', p.last_name) LIKE ?
+                          OR CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) LIKE ?
                           OR pe.actual_position LIKE ? OR pe.equivalent_type LIKE ?
                           OR pe.approval_order_ref LIKE ?)";
         $term = "%{$search}%";
@@ -168,10 +170,11 @@ function getEquivalenceList(PDO $pdo): void
 function getEquivalenceDetail(PDO $pdo, int $id): void
 {
     $sql = "SELECT pe.*,
-                   CONCAT(p.first_name, ' ', p.last_name) AS full_name,
+                   CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name,
                    u.username AS approved_by_name
             FROM position_equivalence pe
             LEFT JOIN personnel p ON pe.personnel_id = p.personnel_id
+            LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id
             LEFT JOIN users u ON pe.approved_by = u.user_id
             WHERE pe.equivalence_id = ?";
 

--- a/backend/routes/multiplier.php
+++ b/backend/routes/multiplier.php
@@ -167,11 +167,12 @@ function getMultiplierById(PDO $pdo, int $multiplierId): void
     $stmt = $pdo->prepare("
         SELECT
             me.*,
-            CONCAT(p.first_name, ' ', p.last_name) AS full_name,
+            CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name,
             sam.legal_reference,
             sam.source_reference
         FROM multiplier_experience me
         LEFT JOIN personnel p ON me.personnel_id = p.personnel_id
+        LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id
         LEFT JOIN special_area_multiplier sam ON me.area_multiplier_id = sam.area_multiplier_id
         WHERE me.multiplier_id = ?
     ");
@@ -212,6 +213,7 @@ function getMultiplierList(PDO $pdo): void
     $baseQuery = "
         FROM multiplier_experience me
         LEFT JOIN personnel p ON me.personnel_id = p.personnel_id
+        LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id
         LEFT JOIN special_area_multiplier sam ON me.area_multiplier_id = sam.area_multiplier_id
         {$whereSql}
     ";
@@ -219,7 +221,7 @@ function getMultiplierList(PDO $pdo): void
     $sql = "
         SELECT
             me.*,
-            CONCAT(p.first_name, ' ', p.last_name) AS full_name,
+            CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name,
             sam.legal_reference,
             sam.source_reference
         {$baseQuery}
@@ -645,11 +647,12 @@ function updateMultiplier(PDO $pdo, int $multiplierId, array $user, ?array $inpu
     $updatedStmt = $pdo->prepare("
         SELECT
             me.*,
-            CONCAT(p.first_name, ' ', p.last_name) AS full_name,
+            CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name,
             sam.legal_reference,
             sam.source_reference
         FROM multiplier_experience me
         LEFT JOIN personnel p ON me.personnel_id = p.personnel_id
+        LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id
         LEFT JOIN special_area_multiplier sam ON me.area_multiplier_id = sam.area_multiplier_id
         WHERE me.multiplier_id = ?
     ");

--- a/backend/routes/probation.php
+++ b/backend/routes/probation.php
@@ -106,7 +106,7 @@ function getProbationList(PDO $pdo): void
     } catch (PDOException $e) {
         // Fallback: query จาก base tables โดยตรง (ไม่มี task_progress / stakeholder subqueries)
         $baseQuery = "SELECT pe.enrollment_id, pe.personnel_id,
-                             CONCAT(p.first_name, ' ', p.last_name) AS full_name,
+                             CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name,
                              pos.position_name, o.org_name AS department,
                              pe.start_date, pe.end_date,
                              DATEDIFF(pe.end_date, CURDATE()) AS remaining_days,
@@ -114,15 +114,23 @@ function getProbationList(PDO $pdo): void
                              0 AS total_tasks, 0 AS completed_tasks
                       FROM probation_enrollment pe
                       JOIN personnel p ON pe.personnel_id = p.personnel_id
+                      LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id
                       LEFT JOIN organization o ON p.current_org_id = o.org_id
                       LEFT JOIN position pos ON p.current_position_id = pos.position_id
                       WHERE pe.overall_status = 'IN_PROGRESS'";
-        $countQuery = "SELECT COUNT(*) AS total FROM probation_enrollment WHERE overall_status = 'IN_PROGRESS'";
+        // count ต้อง JOIN ชุดเดียวกับ list — ไม่งั้น search ที่อ้าง px/pos/o จะพังแล้วตก catch นับแค่หน้าปัจจุบัน
+        $countQuery = "SELECT COUNT(*) AS total
+                       FROM probation_enrollment pe
+                       JOIN personnel p ON pe.personnel_id = p.personnel_id
+                       LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id
+                       LEFT JOIN organization o ON p.current_org_id = o.org_id
+                       LEFT JOIN position pos ON p.current_position_id = pos.position_id
+                       WHERE pe.overall_status = 'IN_PROGRESS'";
 
         $where = '';
         $params = [];
         if (!empty($search)) {
-            $where = " AND (CONCAT(p.first_name, ' ', p.last_name) LIKE ? OR pos.position_name LIKE ? OR o.org_name LIKE ?)";
+            $where = " AND (CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) LIKE ? OR pos.position_name LIKE ? OR o.org_name LIKE ?)";
             $searchTerm = "%{$search}%";
             $params = [$searchTerm, $searchTerm, $searchTerm];
         }
@@ -202,7 +210,7 @@ function getProbationList(PDO $pdo): void
 function getProbationDetail(PDO $pdo, int $enrollmentId): void
 {
     $sql = "SELECT pe.enrollment_id, pe.personnel_id,
-                   CONCAT(p.first_name, ' ', p.last_name) AS full_name,
+                   CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name,
                    pos.position_name, o.org_name AS department,
                    pe.start_date, pe.end_date,
                    DATEDIFF(pe.end_date, CURDATE()) AS remaining_days,
@@ -212,6 +220,7 @@ function getProbationDetail(PDO $pdo, int $enrollmentId): void
                    pe.order_number, pe.order_date
             FROM probation_enrollment pe
             JOIN personnel p ON pe.personnel_id = p.personnel_id
+            LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id
             LEFT JOIN organization o ON p.current_org_id = o.org_id
             LEFT JOIN position pos ON p.current_position_id = pos.position_id
             WHERE pe.enrollment_id = ?";

--- a/backend/routes/retirement.php
+++ b/backend/routes/retirement.php
@@ -46,7 +46,7 @@ function getRetirementList(PDO $pdo): void
 
     $select = "p.personnel_id AS servant_id, p.employee_id, p.retirement_date, p.servant_status,
                DATEDIFF(p.retirement_date, CURDATE()) AS remaining_days,
-               CONCAT(COALESCE(px.prefix_name_th, ''), p.first_name, ' ', p.last_name) AS full_name";
+               CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name";
     $base = "FROM personnel p LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id";
 
     $sql = "SELECT {$select} {$base}{$where}

--- a/backend/routes/supportive.php
+++ b/backend/routes/supportive.php
@@ -87,13 +87,15 @@ function getSupportiveList(PDO $pdo): void
     $limit = max(1, min(intval($_GET['limit'] ?? 20), 200));
     $offset = max(0, intval($_GET['offset'] ?? 0));
 
-    $baseQuery = "SELECT se.*, CONCAT(p.first_name, ' ', p.last_name) AS full_name
+    $baseQuery = "SELECT se.*, CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name
                   FROM supportive_experience se
-                  LEFT JOIN personnel p ON se.personnel_id = p.personnel_id";
+                  LEFT JOIN personnel p ON se.personnel_id = p.personnel_id
+                  LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id";
 
     $countQuery = "SELECT COUNT(*) AS total
                    FROM supportive_experience se
-                   LEFT JOIN personnel p ON se.personnel_id = p.personnel_id";
+                   LEFT JOIN personnel p ON se.personnel_id = p.personnel_id
+                   LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id";
 
     $conditions = [];
     $params = [];
@@ -105,7 +107,7 @@ function getSupportiveList(PDO $pdo): void
 
     if ($search !== '') {
         $conditions[] = "(p.first_name LIKE ? OR p.last_name LIKE ?
-                          OR CONCAT(p.first_name, ' ', p.last_name) LIKE ?
+                          OR CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) LIKE ?
                           OR se.job_series_name LIKE ?)";
         $term = "%{$search}%";
         array_push($params, $term, $term, $term, $term);
@@ -161,9 +163,10 @@ function getSupportiveList(PDO $pdo): void
  */
 function getSupportiveDetail(PDO $pdo, int $id): void
 {
-    $sql = "SELECT se.*, CONCAT(p.first_name, ' ', p.last_name) AS full_name
+    $sql = "SELECT se.*, CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name
             FROM supportive_experience se
             LEFT JOIN personnel p ON se.personnel_id = p.personnel_id
+            LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id
             WHERE se.supportive_id = ?";
 
     $stmt = $pdo->prepare($sql);

--- a/backend/routes/work_results.php
+++ b/backend/routes/work_results.php
@@ -33,7 +33,7 @@ const WORK_RESULT_SELECT = "pp.proposal_id, pp.servant_id, pp.proposal_type, pp.
                             pp.description, pp.impact_description, pp.quantitative_result,
                             pp.result_unit, pp.submission_date, pp.evaluation_score,
                             pp.status, pp.approval_level, pp.created_at,
-                            CONCAT(COALESCE(px.prefix_name_th, ''), p.first_name, ' ', p.last_name) AS servant_name";
+                            CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS servant_name";
 
 function workResultBaseQuery(): string
 {

--- a/backend/tests/Integration/PersonnelFullNamePrefixTest.php
+++ b/backend/tests/Integration/PersonnelFullNamePrefixTest.php
@@ -1,0 +1,144 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Integration;
+
+use PDO;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Throwable;
+
+putenv('JWT_SECRET=integration-test-secret');
+
+require_once __DIR__ . '/../../config.php';
+require_once __DIR__ . '/../../routes/supportive.php';
+
+/**
+ * Regression: ชื่อบุคลากรต้องรวมคำนำหน้าเมื่อมี prefix_id
+ * (รูปแบบเดียวกับ /civil-servants และ GET /personnel)
+ */
+final class PersonnelFullNamePrefixTest extends TestCase
+{
+    private static ?PDO $pdo = null;
+    private int $personnelId = 0;
+    private int $prefixId = 0;
+    private string $prefixCode = '';
+    private string $firstName = '';
+    private string $lastName = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$pdo = testPdo();
+    }
+
+    protected function setUp(): void
+    {
+        if (self::$pdo === null) {
+            self::markTestSkipped('ต่อ MySQL ไม่ได้ — รัน: docker compose up -d db แล้วใช้ tests/run.sh');
+        }
+        foreach (['personnel', 'prefixes', 'supportive_experience'] as $table) {
+            if (!self::$pdo->query("SHOW TABLES LIKE '{$table}'")->fetchColumn()) {
+                self::markTestSkipped("ไม่พบตาราง {$table}");
+            }
+        }
+
+        $suffix = bin2hex(random_bytes(3));
+        $this->prefixCode = 'T' . $suffix;
+        $this->firstName = 'NamePF' . $suffix;
+        $this->lastName = 'LastPF' . $suffix;
+
+        self::$pdo->prepare(
+            'INSERT INTO prefixes (prefix_code, prefix_name_th) VALUES (?, ?)'
+        )->execute([$this->prefixCode, 'นาย']);
+        $this->prefixId = (int) self::$pdo->lastInsertId();
+
+        self::$pdo->prepare(
+            'INSERT INTO personnel (first_name, last_name, prefix_id, is_active) VALUES (?, ?, ?, 1)'
+        )->execute([$this->firstName, $this->lastName, $this->prefixId]);
+        $this->personnelId = (int) self::$pdo->lastInsertId();
+
+        $_GET = [];
+        http_response_code(200);
+    }
+
+    protected function tearDown(): void
+    {
+        if (self::$pdo === null) {
+            return;
+        }
+        if ($this->personnelId) {
+            self::$pdo->prepare('DELETE FROM supportive_experience WHERE personnel_id = ?')
+                ->execute([$this->personnelId]);
+            self::$pdo->prepare('DELETE FROM personnel WHERE personnel_id = ?')
+                ->execute([$this->personnelId]);
+        }
+        if ($this->prefixId) {
+            self::$pdo->prepare('DELETE FROM prefixes WHERE prefix_id = ?')
+                ->execute([$this->prefixId]);
+        }
+        $_GET = [];
+    }
+
+    private function expectedFullName(): string
+    {
+        return 'นาย' . $this->firstName . ' ' . $this->lastName;
+    }
+
+    #[Test]
+    public function personnel_search_sql_includes_thai_prefix(): void
+    {
+        $stmt = self::$pdo->prepare(
+            "SELECT CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name
+             FROM personnel p
+             LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id
+             WHERE p.personnel_id = ?"
+        );
+        $stmt->execute([$this->personnelId]);
+        $fullName = $stmt->fetchColumn();
+
+        self::assertSame($this->expectedFullName(), $fullName);
+    }
+
+    #[Test]
+    public function supportive_list_full_name_includes_thai_prefix(): void
+    {
+        self::$pdo->prepare(
+            'INSERT INTO supportive_experience (personnel_id, job_series_name, start_date, end_date)
+             VALUES (?, ?, ?, ?)'
+        )->execute([$this->personnelId, 'HR-series', '2020-01-01', '2021-01-01']);
+
+        $_GET = ['search' => $this->firstName, 'limit' => 50, 'offset' => 0];
+        ob_start();
+        try {
+            getSupportiveList(self::$pdo);
+            $response = json_decode((string) ob_get_clean(), true) ?? [];
+        } catch (Throwable $e) {
+            if (ob_get_level() > 0) {
+                ob_end_clean();
+            }
+            throw $e;
+        }
+
+        self::assertTrue($response['success'] ?? false);
+        self::assertGreaterThanOrEqual(1, (int) ($response['pagination']['total'] ?? 0));
+        self::assertSame($this->expectedFullName(), $response['data'][0]['full_name'] ?? null);
+    }
+
+    #[Test]
+    public function null_prefix_still_returns_name_without_null_concat(): void
+    {
+        self::$pdo->prepare('UPDATE personnel SET prefix_id = NULL WHERE personnel_id = ?')
+            ->execute([$this->personnelId]);
+
+        $stmt = self::$pdo->prepare(
+            "SELECT CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name
+             FROM personnel p
+             LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id
+             WHERE p.personnel_id = ?"
+        );
+        $stmt->execute([$this->personnelId]);
+        $fullName = $stmt->fetchColumn();
+
+        self::assertSame($this->firstName . ' ' . $this->lastName, $fullName);
+    }
+}

--- a/backend/tests/Integration/ProbationDashboardViewTest.php
+++ b/backend/tests/Integration/ProbationDashboardViewTest.php
@@ -65,6 +65,23 @@ final class ProbationDashboardViewTest extends TestCase
     }
 
     #[Test]
+    public function it_joins_prefixes_for_full_name(): void
+    {
+        try {
+            $ddl = self::$pdo->query('SHOW CREATE VIEW vw_probation_dashboard')->fetch(PDO::FETCH_ASSOC);
+        } catch (Throwable $e) {
+            self::markTestSkipped('vw_probation_dashboard ไม่พร้อม: ' . $e->getMessage());
+        }
+
+        $create = (string) ($ddl['Create View'] ?? '');
+        self::assertStringContainsString(
+            'prefix_name_th',
+            $create,
+            'view ต้อง JOIN prefixes (migration 28) — มิฉะนั้นรายชื่อทดลองงานไม่มีคำนำหน้า'
+        );
+    }
+
+    #[Test]
     public function it_matches_task_aggregates_from_base_tables(): void
     {
         try {

--- a/database/05-probation.sql
+++ b/database/05-probation.sql
@@ -241,6 +241,8 @@ CREATE TABLE probation_committee_member (
 -- PART 9: DASHBOARD VIEW
 -- ############################################################################
 
+-- หมายเหตุ: full_name ใน view นี้ยังไม่มีคำนำหน้า — personnel.prefix_id มาทีหลังใน 22
+-- migration 28 จะ recreate view ให้รวมคำนำหน้า (อย่าใส่ JOIN prefixes ที่นี่ — จะพังตอน docker init)
 DROP VIEW IF EXISTS vw_probation_dashboard;
 CREATE VIEW vw_probation_dashboard AS
 SELECT

--- a/database/28-prefix-in-probation-view.sql
+++ b/database/28-prefix-in-probation-view.sql
@@ -1,13 +1,12 @@
 -- ============================================================================
--- 17-probation-dashboard-view.sql
--- Rewrite vw_probation_dashboard: replace 6 correlated subqueries with JOINs
--- (task aggregates + stakeholder names) — same column contract for API/FE.
---
--- หมายเหตุ: ยังไม่ JOIN prefixes ที่นี่ — personnel.prefix_id มาใน migration 22
--- นิยามสุดท้ายที่มีคำนำหน้าอยู่ที่ 28-prefix-in-probation-view.sql / tidb-init.sql
+-- 28-prefix-in-probation-view.sql
+-- รวมคำนำหน้า (prefixes) ใน vw_probation_dashboard.full_name
+-- และชื่อ mentor / supervisor / director
 --
 -- Apply: docker compose exec backend php scripts/run-migrations.php
--- Fresh Docker also gets the same definition via updated 05-probation.sql.
+-- Fresh Docker: mount ไฟล์นี้หลัง migration 22 (มี personnel.prefix_id แล้ว)
+-- Production bootstrap: นิยามเดียวกันอยู่ใน tidb-init.sql
+-- (อย่าใส่ JOIN prefixes ใน 05/17 — รันก่อน 22 จะพังตอน docker init)
 -- ============================================================================
 
 SET NAMES utf8mb4;
@@ -18,7 +17,8 @@ SELECT
     pe.enrollment_id,
     p.personnel_id,
     p.citizen_id,
-    CONCAT(p.first_name, ' ', p.last_name) AS full_name,
+    -- COLLATE: prefixes เป็น utf8mb4_0900_ai_ci ส่วน personnel เป็น unicode_ci — MAX/CONCAT ต้องบังคับ collation
+    CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name,
     p.hire_date,
     pe.start_date AS probation_start,
     pe.end_date AS probation_end,
@@ -34,6 +34,7 @@ SELECT
     pos.position_name
 FROM probation_enrollment pe
 JOIN personnel p ON pe.personnel_id = p.personnel_id
+LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id
 LEFT JOIN organization o ON p.current_org_id = o.org_id
 LEFT JOIN position pos ON p.current_position_id = pos.position_id
 LEFT JOIN (
@@ -48,11 +49,12 @@ LEFT JOIN (
 LEFT JOIN (
     SELECT
         ps.enrollment_id,
-        MAX(CASE WHEN ps.role_type = 'MENTOR' THEN CONCAT(p2.first_name, ' ', p2.last_name) END) AS mentor_name,
-        MAX(CASE WHEN ps.role_type = 'SUPERVISOR' THEN CONCAT(p2.first_name, ' ', p2.last_name) END) AS supervisor_name,
-        MAX(CASE WHEN ps.role_type = 'DIRECTOR' THEN CONCAT(p2.first_name, ' ', p2.last_name) END) AS director_name
+        MAX(CASE WHEN ps.role_type = 'MENTOR' THEN CONCAT(COALESCE(px2.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p2.first_name, ' ', p2.last_name) END) AS mentor_name,
+        MAX(CASE WHEN ps.role_type = 'SUPERVISOR' THEN CONCAT(COALESCE(px2.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p2.first_name, ' ', p2.last_name) END) AS supervisor_name,
+        MAX(CASE WHEN ps.role_type = 'DIRECTOR' THEN CONCAT(COALESCE(px2.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p2.first_name, ' ', p2.last_name) END) AS director_name
     FROM probation_stakeholder ps
     JOIN personnel p2 ON ps.personnel_id = p2.personnel_id
+    LEFT JOIN prefixes px2 ON p2.prefix_id = px2.prefix_id
     WHERE ps.is_active = 1
       AND ps.role_type IN ('MENTOR', 'SUPERVISOR', 'DIRECTOR')
     GROUP BY ps.enrollment_id

--- a/database/tidb-init.sql
+++ b/database/tidb-init.sql
@@ -995,7 +995,7 @@ SELECT
     pe.enrollment_id,
     p.personnel_id,
     p.citizen_id,
-    CONCAT(p.first_name, ' ', p.last_name) AS full_name,
+    CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name,
     p.hire_date,
     pe.start_date AS probation_start,
     pe.end_date AS probation_end,
@@ -1011,6 +1011,7 @@ SELECT
     pos.position_name
 FROM probation_enrollment pe
 JOIN personnel p ON pe.personnel_id = p.personnel_id
+LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id
 LEFT JOIN organization o ON p.current_org_id = o.org_id
 LEFT JOIN position pos ON p.current_position_id = pos.position_id
 LEFT JOIN (
@@ -1025,16 +1026,18 @@ LEFT JOIN (
 LEFT JOIN (
     SELECT
         ps.enrollment_id,
-        MAX(CASE WHEN ps.role_type = 'MENTOR' THEN CONCAT(p2.first_name, ' ', p2.last_name) END) AS mentor_name,
-        MAX(CASE WHEN ps.role_type = 'SUPERVISOR' THEN CONCAT(p2.first_name, ' ', p2.last_name) END) AS supervisor_name,
-        MAX(CASE WHEN ps.role_type = 'DIRECTOR' THEN CONCAT(p2.first_name, ' ', p2.last_name) END) AS director_name
+        MAX(CASE WHEN ps.role_type = 'MENTOR' THEN CONCAT(COALESCE(px2.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p2.first_name, ' ', p2.last_name) END) AS mentor_name,
+        MAX(CASE WHEN ps.role_type = 'SUPERVISOR' THEN CONCAT(COALESCE(px2.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p2.first_name, ' ', p2.last_name) END) AS supervisor_name,
+        MAX(CASE WHEN ps.role_type = 'DIRECTOR' THEN CONCAT(COALESCE(px2.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p2.first_name, ' ', p2.last_name) END) AS director_name
     FROM probation_stakeholder ps
     JOIN personnel p2 ON ps.personnel_id = p2.personnel_id
+    LEFT JOIN prefixes px2 ON p2.prefix_id = px2.prefix_id
     WHERE ps.is_active = 1
       AND ps.role_type IN ('MENTOR', 'SUPERVISOR', 'DIRECTOR')
     GROUP BY ps.enrollment_id
 ) sh ON sh.enrollment_id = pe.enrollment_id
 WHERE pe.overall_status = 'IN_PROGRESS';
+
 
 -- ============================================
 -- FILE: 06-seed-data.sql

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -82,6 +82,7 @@ services:
       - ./database/24-drop-dead-tables.sql:/docker-entrypoint-initdb.d/24-drop-dead-tables.sql
       - ./database/25-ensure-multiplier-tables.sql:/docker-entrypoint-initdb.d/25-ensure-multiplier-tables.sql
       - ./database/27-superadmin-permission-overrides.sql:/docker-entrypoint-initdb.d/27-superadmin-permission-overrides.sql
+      - ./database/28-prefix-in-probation-view.sql:/docker-entrypoint-initdb.d/28-prefix-in-probation-view.sql
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "--silent"]
       interval: 10s


### PR DESCRIPTION
## Summary
- Include Thai name prefixes (คํานําหน้า) in ull_name across personnel list/search APIs, QualificationEngine, and related HR routes.
- Add migration 28 to recreate w_probation_dashboard with prefix joins; keep schema parity (tidb-init, docker-compose, CI).
- Add collation-safe CONCAT and regression tests for prefix display / probation view.

## Test plan
- [x] 
ode scripts/validate-schema-parity.mjs
- [x] PHPUnit prefix + probation view integration tests
- [x] Pre-push frontend vitest
- [ ] After deploy: spot-check /personnel, candidates, probation list show prefix + first + last name
