### PR TITLE
feat(ui): standardize table row actions across admin pages

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -221,6 +221,35 @@ All buttons: `rounded-md text-sm font-medium transition-colors`, focus ring `rin
 - Cells: `px-4 py-3 text-sm`
 - Striped (optional): `odd:bg-white even:bg-government-50`
 
+### Table row actions (`จัดการ`)
+
+Use shared component `TableRowActions` for row action columns. Do not invent per-page icon styles.
+
+**Column rules**
+
+- Header label: always `จัดการ` (never `การดำเนินการ`, `ดู`, or `รายละเอียด` as the action column title)
+- Align the actions column **right** (`text-right` + `justify-end`)
+- Icon order (when present): ดู → แก้ไข → specialty actions → ลบ
+- Show only actions that match the page job and the user’s role — do **not** force Eye + Edit + Delete on every table
+- Delete always requires confirmation
+
+**When to show which actions**
+
+| Page type | Typical actions |
+|-----------|-----------------|
+| Read-only / computed lists (candidates, probation, work results, audit) | ดู |
+| Master-data CRUD (awards, decorations, multiplier, diverse, supportive) | แก้ไข + ลบ (omit ดู if edit form already shows full detail) |
+| Separate view vs edit modes | ดู + แก้ไข (+ ลบ if permitted) |
+| Admin specialty (users, approval) | Specialty icons; move into `⋮` when total visible actions ≥ 4 |
+
+**Presentation**
+
+- **1–3 actions:** inline Lucide icon buttons with Thai `title`
+- **≥ 4 actions:** vertical kebab `⋮` (`MoreVertical`) + dropdown menu; order same as above; put destructive items last with a separator
+- Do **not** use hamburger `☰` for row actions
+- Do **not** use horizontal ellipsis `⋯` as the default row-action trigger
+- Default icon style: `text-government-400`; hover view/edit = `text-primary-600`; delete = `text-red-600`
+
 ### Status Badge
 
 ```html
@@ -318,7 +347,9 @@ Do not implement full dark mode — only the sidebar is dark.
 | Use Thai labels for user-facing text | Use English labels for domain concepts |
 | Use `rounded-md` / `rounded-lg` | Use `rounded-full` on buttons or cards |
 | Use subtle shadows (elevation-1) | Use heavy drop shadows |
-| Left-align all table content | Center-align table cells (except stat numbers) |
+| Left-align table content; right-align the `จัดการ` column | Center-align table cells (except stat numbers) |
+| Use `TableRowActions` for row icons / `⋮` menus | Mix Eye-only / Edit-Delete styles or hamburger menus per page |
+| Show only role-appropriate row actions | Show disabled actions the user cannot perform |
 
 ## File Conventions
 

--- a/frontend/src/__tests__/components/TableRowActions.test.js
+++ b/frontend/src/__tests__/components/TableRowActions.test.js
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { Eye, Pencil, Trash2, KeyRound, Ban } from 'lucide-vue-next'
+import TableRowActions from '@/components/TableRowActions.vue'
+
+describe('TableRowActions', () => {
+  it('renders inline icon buttons when actions ≤ maxInline', () => {
+    const wrapper = mount(TableRowActions, {
+      props: {
+        actions: [
+          { key: 'edit', label: 'แก้ไข', onClick: vi.fn() },
+          { key: 'delete', label: 'ลบ', variant: 'danger', onClick: vi.fn() },
+        ],
+      },
+    })
+    expect(wrapper.findAll('button')).toHaveLength(2)
+    expect(wrapper.find('button[title="แก้ไข"]').exists()).toBe(true)
+    expect(wrapper.find('button[title="ลบ"]').exists()).toBe(true)
+    expect(wrapper.find('button[title="จัดการ"]').exists()).toBe(false)
+  })
+
+  it('uses default icons for view/edit/delete keys', () => {
+    const wrapper = mount(TableRowActions, {
+      props: {
+        actions: [
+          { key: 'view', label: 'ดูรายละเอียด' },
+          { key: 'edit', label: 'แก้ไข' },
+          { key: 'delete', label: 'ลบ', variant: 'danger' },
+        ],
+      },
+    })
+    expect(wrapper.findComponent(Eye).exists()).toBe(true)
+    expect(wrapper.findComponent(Pencil).exists()).toBe(true)
+    expect(wrapper.findComponent(Trash2).exists()).toBe(true)
+  })
+
+  it('calls onClick and emits action key', async () => {
+    const onClick = vi.fn()
+    const wrapper = mount(TableRowActions, {
+      props: {
+        actions: [{ key: 'view', label: 'ดูรายละเอียด', onClick }],
+      },
+    })
+    await wrapper.find('button[title="ดูรายละเอียด"]').trigger('click')
+    expect(onClick).toHaveBeenCalledTimes(1)
+    expect(wrapper.emitted('action')).toEqual([['view']])
+  })
+
+  it('switches to MoreVertical menu when actions exceed maxInline', async () => {
+    const wrapper = mount(TableRowActions, {
+      props: {
+        maxInline: 3,
+        actions: [
+          { key: 'view', label: 'ดูรายละเอียด' },
+          { key: 'edit', label: 'แก้ไข' },
+          { key: 'reset', label: 'รีเซ็ตรหัสผ่าน', icon: KeyRound, variant: 'warning' },
+          { key: 'ban', label: 'ปิดบัญชี', icon: Ban, variant: 'danger' },
+        ],
+      },
+      attachTo: document.body,
+    })
+    expect(wrapper.find('button[title="จัดการ"]').exists()).toBe(true)
+    expect(wrapper.find('button[title="แก้ไข"]').exists()).toBe(false)
+
+    await wrapper.find('button[title="จัดการ"]').trigger('click')
+    expect(wrapper.find('[role="menu"]').exists()).toBe(true)
+    expect(wrapper.text()).toContain('ดูรายละเอียด')
+    expect(wrapper.text()).toContain('ปิดบัญชี')
+    expect(wrapper.find('[role="separator"]').exists()).toBe(true)
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('[role="menu"]').exists()).toBe(false)
+
+    wrapper.unmount()
+  })
+
+  it('exposes aria-label on inline icon buttons', () => {
+    const wrapper = mount(TableRowActions, {
+      props: {
+        actions: [{ key: 'edit', label: 'แก้ไข' }],
+      },
+    })
+    expect(wrapper.find('button[aria-label="แก้ไข"]').exists()).toBe(true)
+  })
+})

--- a/frontend/src/components/TableRowActions.vue
+++ b/frontend/src/components/TableRowActions.vue
@@ -1,0 +1,167 @@
+<template>
+  <div ref="rootEl" class="relative inline-flex items-center justify-end gap-1" data-table-row-actions>
+    <template v-if="useMenu">
+      <button
+        type="button"
+        class="p-1 text-government-400 hover:text-primary-600 transition-colors cursor-pointer rounded"
+        title="จัดการ"
+        aria-label="จัดการ"
+        aria-haspopup="menu"
+        :aria-expanded="menuOpen"
+        @click.stop="toggleMenu"
+      >
+        <MoreVertical class="w-4 h-4" aria-hidden="true" />
+      </button>
+      <div
+        v-if="menuOpen"
+        role="menu"
+        class="absolute right-0 top-full z-20 mt-1 min-w-40 rounded-md border border-government-200 bg-white py-1 elevation-2"
+      >
+        <template v-for="(action, index) in visibleActions" :key="action.key">
+          <div
+            v-if="showSeparatorBefore(action, index)"
+            class="my-1 border-t border-government-100"
+            role="separator"
+          />
+          <button
+            type="button"
+            role="menuitem"
+            class="flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors cursor-pointer disabled:opacity-50 disabled:pointer-events-none"
+            :class="menuItemClass(action)"
+            :title="action.label"
+            :disabled="action.disabled"
+            @click.stop="runAction(action)"
+          >
+            <component :is="resolveIcon(action)" class="w-4 h-4 shrink-0" />
+            <span>{{ action.label }}</span>
+          </button>
+        </template>
+      </div>
+    </template>
+    <template v-else>
+      <button
+        v-for="action in visibleActions"
+        :key="action.key"
+        type="button"
+        class="p-1 transition-colors cursor-pointer rounded disabled:opacity-50 disabled:pointer-events-none"
+        :class="iconButtonClass(action)"
+        :title="action.label"
+        :aria-label="action.label"
+        :disabled="action.disabled"
+        @click.stop="runAction(action)"
+      >
+        <component :is="resolveIcon(action)" class="w-4 h-4" aria-hidden="true" />
+      </button>
+    </template>
+  </div>
+</template>
+
+<script setup>
+import { computed, onBeforeUnmount, ref, watch } from 'vue'
+import { Eye, Pencil, Trash2, MoreVertical } from 'lucide-vue-next'
+
+const DEFAULT_ICONS = {
+  view: Eye,
+  edit: Pencil,
+  delete: Trash2,
+}
+
+const props = defineProps({
+  /** @type {{ key: string, label: string, icon?: object|Function, variant?: string, disabled?: boolean, onClick?: Function }[]} */
+  actions: { type: Array, default: () => [] },
+  /** Inline icons when visible count ≤ this; otherwise MoreVertical menu */
+  maxInline: { type: Number, default: 3 },
+})
+
+const emit = defineEmits(['action'])
+
+const rootEl = ref(null)
+const menuOpen = ref(false)
+
+const visibleActions = computed(() =>
+  (props.actions || []).filter((action) => action && action.key && action.label)
+)
+
+const useMenu = computed(() => visibleActions.value.length > props.maxInline)
+
+function resolveIcon(action) {
+  return action.icon || DEFAULT_ICONS[action.key] || Eye
+}
+
+function iconButtonClass(action) {
+  const variant = action.variant || (action.key === 'delete' ? 'danger' : 'default')
+  if (variant === 'danger') return 'text-government-400 hover:text-red-600'
+  if (variant === 'success') return 'text-government-400 hover:text-green-600'
+  if (variant === 'warning') return 'text-government-400 hover:text-amber-600'
+  return 'text-government-400 hover:text-primary-600'
+}
+
+function menuItemClass(action) {
+  const variant = action.variant || (action.key === 'delete' ? 'danger' : 'default')
+  if (variant === 'danger') return 'text-red-600 hover:bg-red-50'
+  if (variant === 'success') return 'text-green-700 hover:bg-green-50'
+  if (variant === 'warning') return 'text-amber-700 hover:bg-amber-50'
+  return 'text-government-700 hover:bg-primary-50'
+}
+
+function showSeparatorBefore(action, index) {
+  if (index === 0) return false
+  const variant = action.variant || (action.key === 'delete' ? 'danger' : 'default')
+  return variant === 'danger'
+}
+
+function runAction(action) {
+  if (action.disabled) return
+  closeMenu()
+  if (typeof action.onClick === 'function') {
+    action.onClick()
+  }
+  emit('action', action.key)
+}
+
+function onDocumentClick(event) {
+  if (!menuOpen.value || !rootEl.value) return
+  if (!rootEl.value.contains(event.target)) {
+    closeMenu()
+  }
+}
+
+function onKeydown(event) {
+  if (event.key === 'Escape') closeMenu()
+}
+
+function bindMenuListeners() {
+  document.addEventListener('click', onDocumentClick)
+  document.addEventListener('keydown', onKeydown)
+}
+
+function unbindMenuListeners() {
+  document.removeEventListener('click', onDocumentClick)
+  document.removeEventListener('keydown', onKeydown)
+}
+
+function openMenu() {
+  if (menuOpen.value) return
+  menuOpen.value = true
+  bindMenuListeners()
+}
+
+function closeMenu() {
+  if (!menuOpen.value) return
+  menuOpen.value = false
+  unbindMenuListeners()
+}
+
+function toggleMenu() {
+  if (menuOpen.value) closeMenu()
+  else openMenu()
+}
+
+watch(useMenu, (menu) => {
+  if (!menu) closeMenu()
+})
+
+onBeforeUnmount(() => {
+  unbindMenuListeners()
+})
+</script>

--- a/frontend/src/pages/AuditLogPage.vue
+++ b/frontend/src/pages/AuditLogPage.vue
@@ -106,7 +106,7 @@
               <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">การกระทำ</th>
               <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ตาราง</th>
               <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Record ID</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">รายละเอียด</th>
+              <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">จัดการ</th>
             </tr>
           </thead>
           <tbody>
@@ -130,13 +130,10 @@
               </td>
               <td class="px-6 py-3 text-sm text-gray-700">{{ tableName(row.table_name) }}</td>
               <td class="px-6 py-3 text-sm text-gray-500">{{ row.record_id || '-' }}</td>
-              <td class="px-6 py-3 text-sm">
-                <button
-                  class="text-blue-600 hover:text-blue-800 text-xs font-medium"
-                  @click="showDetail(row)"
-                >
-                  ดูรายละเอียด
-                </button>
+              <td class="px-6 py-3 text-sm text-right">
+                <TableRowActions
+                  :actions="[{ key: 'view', label: 'ดูรายละเอียด', onClick: () => showDetail(row) }]"
+                />
               </td>
             </tr>
             <tr v-if="rows.length === 0">
@@ -215,6 +212,7 @@ import { Home, RefreshCw, AlertCircle, X } from 'lucide-vue-next'
 import SkeletonLoader from '@/components/SkeletonLoader.vue'
 import EmptyState from '@/components/EmptyState.vue'
 import PaginationBar from '@/components/PaginationBar.vue'
+import TableRowActions from '@/components/TableRowActions.vue'
 import { useApi } from '@/composables/useApi.js'
 
 const api = useApi()

--- a/frontend/src/pages/AwardsPage.vue
+++ b/frontend/src/pages/AwardsPage.vue
@@ -73,14 +73,12 @@
               <td class="px-6 py-3 text-sm text-gray-700">{{ awardLevelLabel(row.awardLevel) }}</td>
               <td class="px-6 py-3 text-sm text-gray-700">{{ row.awardedDate || '-' }}</td>
               <td v-if="isAdmin" class="px-6 py-3 text-right">
-                <div class="flex items-center justify-end gap-1">
-                  <button @click="openEdit(row)" class="p-1 text-gray-400 hover:text-blue-600 transition-colors" title="แก้ไข">
-                    <Pencil class="w-4 h-4" />
-                  </button>
-                  <button @click="openDelete(row)" class="p-1 text-gray-400 hover:text-red-600 transition-colors" title="ลบ">
-                    <Trash2 class="w-4 h-4" />
-                  </button>
-                </div>
+                <TableRowActions
+                  :actions="[
+                    { key: 'edit', label: 'แก้ไข', onClick: () => openEdit(row) },
+                    { key: 'delete', label: 'ลบ', variant: 'danger', onClick: () => openDelete(row) },
+                  ]"
+                />
               </td>
             </tr>
             <tr v-if="rows.length === 0 && !loading">
@@ -173,7 +171,8 @@ import SkeletonLoader from '@/components/SkeletonLoader.vue'
 import EmptyState from '@/components/EmptyState.vue'
 import PaginationBar from '@/components/PaginationBar.vue'
 import ThaiDatePicker from '@/components/ThaiDatePicker.vue'
-import { Plus, Search, Pencil, Trash2, AlertCircle } from 'lucide-vue-next'
+import TableRowActions from '@/components/TableRowActions.vue'
+import { Plus, Search, AlertCircle } from 'lucide-vue-next'
 
 const { fetchList, create, update, remove } = useAwards()
 const auth = useAuthStore()

--- a/frontend/src/pages/CandidateListsPage.vue
+++ b/frontend/src/pages/CandidateListsPage.vue
@@ -236,7 +236,7 @@
                 <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">วันเทียบ ตน.</th>
                 <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">จำนวนวันที่เหลือ</th>
                 <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">สถานะ</th>
-                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">การดำเนินการ</th>
+                <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">จัดการ</th>
               </tr>
             </thead>
             <tbody class="divide-y divide-gray-200">
@@ -267,14 +267,10 @@
                 <td class="px-6 py-3">
                   <StatusBadge :status="row.status" />
                 </td>
-                <td class="px-6 py-3">
-                  <button
-                    @click="openView(row)"
-                    class="p-1 text-blue-500 hover:text-blue-700 hover:bg-blue-50 rounded"
-                    title="ดูรายละเอียด"
-                  >
-                    <Eye class="w-4 h-4" />
-                  </button>
+                <td class="px-6 py-3 text-right">
+                  <TableRowActions
+                    :actions="[{ key: 'view', label: 'ดูรายละเอียด', onClick: () => openView(row) }]"
+                  />
                 </td>
               </tr>
               <tr v-if="rows.length === 0">
@@ -381,9 +377,10 @@ import StatusBadge from '@/components/StatusBadge.vue'
 import SkeletonLoader from '@/components/SkeletonLoader.vue'
 import EmptyState from '@/components/EmptyState.vue'
 import PaginationBar from '@/components/PaginationBar.vue'
+import TableRowActions from '@/components/TableRowActions.vue'
 import {
   Users, UserCheck, AlertCircle, Clock, Timer, Loader, Home,
-  Eye, Briefcase, Building2
+  Briefcase, Building2
 } from 'lucide-vue-next'
 
 const props = defineProps({

--- a/frontend/src/pages/DashboardPage.vue
+++ b/frontend/src/pages/DashboardPage.vue
@@ -87,7 +87,7 @@
                 <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">รายการ</th>
                 <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">จำนวน</th>
                 <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ความสำคัญ</th>
-                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">การดำเนินการ</th>
+                <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">จัดการ</th>
               </tr>
             </thead>
             <tbody class="bg-white divide-y divide-gray-200">
@@ -104,8 +104,8 @@
                     {{ task.priority }}
                   </span>
                 </td>
-                <td class="px-6 py-4 whitespace-nowrap">
-                  <RouterLink :to="task.route" class="text-blue-600 hover:text-blue-800 text-sm font-medium">
+                <td class="px-6 py-4 whitespace-nowrap text-right">
+                  <RouterLink :to="task.route" class="text-primary-600 hover:text-primary-700 text-sm font-medium">
                     ดูรายละเอียด
                   </RouterLink>
                 </td>

--- a/frontend/src/pages/DiversePage.vue
+++ b/frontend/src/pages/DiversePage.vue
@@ -90,7 +90,7 @@
               <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ไป</th>
               <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">จำนวนต่าง</th>
               <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">วันครบ 3 ต่าง</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">จัดการ</th>
+              <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">จัดการ</th>
             </tr>
           </thead>
           <tbody>
@@ -113,25 +113,8 @@
                 </template>
               </td>
               <td class="px-6 py-3 text-sm text-gray-700">{{ row.qualifiedDateThai || '-' }}</td>
-              <td class="px-6 py-3 text-sm">
-                <div class="flex items-center gap-2">
-                  <button
-                    @click="openEditModal(row)"
-                    class="p-1 text-gray-400 hover:text-blue-600 transition-colors"
-                    title="แก้ไข"
-                  >
-                    <Pencil class="w-4 h-4" />
-                  </button>
-                  <!-- ลบได้เฉพาะ admin (backend: checkPermission delete => [] สำหรับ operator) -->
-                  <button
-                    v-if="isAdmin"
-                    @click="confirmDelete(row)"
-                    class="p-1 text-gray-400 hover:text-red-600 transition-colors"
-                    title="ลบ"
-                  >
-                    <Trash2 class="w-4 h-4" />
-                  </button>
-                </div>
+              <td class="px-6 py-3 text-sm text-right">
+                <TableRowActions :actions="rowActions(row)" />
               </td>
             </tr>
             <tr v-if="rows.length === 0 && !loading">
@@ -355,9 +338,10 @@ import StatusBadge from '@/components/StatusBadge.vue'
 import PaginationBar from '@/components/PaginationBar.vue'
 import SkeletonLoader from '@/components/SkeletonLoader.vue'
 import EmptyState from '@/components/EmptyState.vue'
+import TableRowActions from '@/components/TableRowActions.vue'
 import {
   Home, Plus, Search, FileText, CheckCircle, AlertTriangle,
-  AlertCircle, Pencil, Trash2, X
+  AlertCircle, X
 } from 'lucide-vue-next'
 
 const { fetchList, create, update, remove } = useDiverse()
@@ -368,6 +352,21 @@ const ui = useUiStore()
 
 // operator สร้าง/แก้ไขได้ แต่ลบไม่ได้ — ซ่อนปุ่มลบไม่ให้กดแล้วเจอ 403
 const isAdmin = computed(() => auth.isAdmin)
+
+function rowActions(row) {
+  const actions = [
+    { key: 'edit', label: 'แก้ไข', onClick: () => openEditModal(row) },
+  ]
+  if (isAdmin.value) {
+    actions.push({
+      key: 'delete',
+      label: 'ลบ',
+      variant: 'danger',
+      onClick: () => confirmDelete(row),
+    })
+  }
+  return actions
+}
 
 // List state
 const loading = ref(false)

--- a/frontend/src/pages/EquivalencePage.vue
+++ b/frontend/src/pages/EquivalencePage.vue
@@ -103,7 +103,7 @@
               <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">วันที่ขอ</th>
               <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">สถานะ</th>
               <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">วันที่อนุมัติ</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">จัดการ</th>
+              <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">จัดการ</th>
             </tr>
           </thead>
           <tbody>
@@ -130,28 +130,8 @@
                 </template>
                 <template v-else>-</template>
               </td>
-              <td class="px-6 py-3 text-sm">
-                <div class="flex items-center gap-1">
-                  <!-- PENDING: edit + approve + reject buttons -->
-                  <template v-if="row.approvalStatus === 'PENDING'">
-                    <button @click="openEdit(row)" class="p-1 text-gray-400 hover:text-blue-600 transition-colors" title="แก้ไข">
-                      <Pencil class="w-4 h-4" />
-                    </button>
-                    <!-- อนุมัติ/ไม่อนุมัติ — admin เท่านั้น (backend เช็ค role ซ้ำอีกชั้น) -->
-                    <button v-if="auth.isAdmin" @click="openApprove(row)" class="p-1 text-gray-400 hover:text-green-600 transition-colors" title="อนุมัติ">
-                      <Check class="w-4 h-4" />
-                    </button>
-                    <button v-if="auth.isAdmin" @click="confirmReject(row.equivalenceId)" class="p-1 text-gray-400 hover:text-red-600 transition-colors" title="ไม่อนุมัติ">
-                      <X class="w-4 h-4" />
-                    </button>
-                  </template>
-                  <!-- APPROVED/REJECTED: view only -->
-                  <template v-else>
-                    <button @click="openView(row)" class="p-1 text-gray-400 hover:text-blue-600 transition-colors" title="ดูรายละเอียด">
-                      <Eye class="w-4 h-4" />
-                    </button>
-                  </template>
-                </div>
+              <td class="px-6 py-3 text-sm text-right">
+                <TableRowActions :actions="rowActions(row)" />
               </td>
             </tr>
             <tr v-if="rows.length === 0 && !loading">
@@ -435,9 +415,10 @@ import StatusBadge from '@/components/StatusBadge.vue'
 import SkeletonLoader from '@/components/SkeletonLoader.vue'
 import EmptyState from '@/components/EmptyState.vue'
 import PaginationBar from '@/components/PaginationBar.vue'
+import TableRowActions from '@/components/TableRowActions.vue'
 import {
   Home, Plus, Search, FileText, Clock, CheckCircle, XCircle,
-  AlertCircle, Eye, Pencil, Check, X
+  AlertCircle, Check, X
 } from 'lucide-vue-next'
 
 const { fetchList, create, update, approve, reject } = useEquivalence()
@@ -445,6 +426,23 @@ const api = useApi()
 const { searchPersonnel } = usePersonnelSearch()
 const ui = useUiStore()
 const auth = useAuthStore()
+
+function rowActions(row) {
+  if (row.approvalStatus === 'PENDING') {
+    const actions = [
+      { key: 'edit', label: 'แก้ไข', onClick: () => openEdit(row) },
+    ]
+    // อนุมัติ/ไม่อนุมัติ — admin เท่านั้น (backend เช็ค role ซ้ำอีกชั้น)
+    if (auth.isAdmin) {
+      actions.push(
+        { key: 'approve', label: 'อนุมัติ', icon: Check, variant: 'success', onClick: () => openApprove(row) },
+        { key: 'reject', label: 'ไม่อนุมัติ', icon: X, variant: 'danger', onClick: () => confirmReject(row.equivalenceId) },
+      )
+    }
+    return actions
+  }
+  return [{ key: 'view', label: 'ดูรายละเอียด', onClick: () => openView(row) }]
+}
 
 // Data state
 const loading = ref(false)

--- a/frontend/src/pages/MultiplierAreasPage.vue
+++ b/frontend/src/pages/MultiplierAreasPage.vue
@@ -89,7 +89,7 @@
               <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ช่วงมีผล</th>
               <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">อ้างอิง</th>
               <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">สถานะ</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">จัดการ</th>
+              <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">จัดการ</th>
             </tr>
           </thead>
           <tbody>
@@ -121,17 +121,19 @@
                   {{ area.isActive ? 'ใช้งาน' : 'ปิดใช้งาน' }}
                 </span>
               </td>
-              <td class="px-6 py-3 text-sm">
-                <button
-                  class="px-3 py-1 rounded-md border text-xs transition-colors disabled:opacity-50"
-                  :class="area.isActive
-                    ? 'border-red-200 text-red-600 hover:bg-red-50'
-                    : 'border-green-200 text-green-600 hover:bg-green-50'"
-                  :disabled="togglingId === area.areaMultiplierId"
-                  @click="toggleStatus(area)"
-                >
-                  {{ togglingId === area.areaMultiplierId ? 'กำลังบันทึก...' : area.isActive ? 'ปิดใช้งาน' : 'เปิดใช้งาน' }}
-                </button>
+              <td class="px-6 py-3 text-sm text-right">
+                <TableRowActions
+                  :actions="[{
+                    key: 'toggle',
+                    label: togglingId === area.areaMultiplierId
+                      ? 'กำลังบันทึก...'
+                      : (area.isActive ? 'ปิดใช้งาน' : 'เปิดใช้งาน'),
+                    icon: area.isActive ? Ban : CheckCircle,
+                    variant: area.isActive ? 'danger' : 'success',
+                    disabled: togglingId === area.areaMultiplierId,
+                    onClick: () => toggleStatus(area),
+                  }]"
+                />
               </td>
             </tr>
             <tr v-if="areas.length === 0">
@@ -304,9 +306,12 @@ import StatCard from '@/components/StatCard.vue'
 import SkeletonLoader from '@/components/SkeletonLoader.vue'
 import EmptyState from '@/components/EmptyState.vue'
 import ThaiDatePicker from '@/components/ThaiDatePicker.vue'
+import TableRowActions from '@/components/TableRowActions.vue'
 import {
   AlertCircle,
   AlertTriangle,
+  Ban,
+  CheckCircle,
   CheckCircle2,
   Home,
   MapPinned,

--- a/frontend/src/pages/MultiplierPage.vue
+++ b/frontend/src/pages/MultiplierPage.vue
@@ -112,7 +112,7 @@
                 <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">วันจริง</th>
                 <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">วันทวีคูณ</th>
                 <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">สุทธิ</th>
-                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">จัดการ</th>
+                <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">จัดการ</th>
               </tr>
             </thead>
             <tbody>
@@ -131,23 +131,13 @@
                 <td class="px-6 py-3 text-sm text-gray-700">
                   {{ row.netYears }} ปี {{ row.netMonths }} เดือน {{ row.netDayRemainder }} วัน
                 </td>
-                <td class="px-6 py-3 text-sm">
-                  <div class="flex items-center gap-2">
-                    <button
-                      class="p-1.5 text-blue-600 hover:bg-blue-50 rounded transition-colors"
-                      @click="openEditModal(row)"
-                      title="แก้ไข"
-                    >
-                      <Pencil class="w-4 h-4" />
-                    </button>
-                    <button
-                      class="p-1.5 text-red-600 hover:bg-red-50 rounded transition-colors"
-                      @click="openDeleteConfirm(row)"
-                      title="ลบ"
-                    >
-                      <Trash2 class="w-4 h-4" />
-                    </button>
-                  </div>
+                <td class="px-6 py-3 text-sm text-right">
+                  <TableRowActions
+                    :actions="[
+                      { key: 'edit', label: 'แก้ไข', onClick: () => openEditModal(row) },
+                      { key: 'delete', label: 'ลบ', variant: 'danger', onClick: () => openDeleteConfirm(row) },
+                    ]"
+                  />
                 </td>
               </tr>
               <tr v-if="rows.length === 0">
@@ -369,17 +359,16 @@ import SkeletonLoader from '@/components/SkeletonLoader.vue'
 import EmptyState from '@/components/EmptyState.vue'
 import PaginationBar from '@/components/PaginationBar.vue'
 import ThaiDatePicker from '@/components/ThaiDatePicker.vue'
+import TableRowActions from '@/components/TableRowActions.vue'
 import {
   AlertCircle,
   Clock,
   FileText,
   Home,
   MapPinned,
-  Pencil,
   Plus,
   RefreshCw,
   Search,
-  Trash2,
   X,
 } from 'lucide-vue-next'
 

--- a/frontend/src/pages/ProbationEndPage.vue
+++ b/frontend/src/pages/ProbationEndPage.vue
@@ -94,7 +94,7 @@
               <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">วันครบกำหนด</th>
               <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">วันคงเหลือ</th>
               <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">สถานะ</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">การดำเนินการ</th>
+              <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">จัดการ</th>
             </tr>
           </thead>
           <tbody>
@@ -117,14 +117,10 @@
               <td class="px-6 py-3 text-sm">
                 <StatusBadge :status="row.status" />
               </td>
-              <td class="px-6 py-3 text-sm">
-                <button
-                  @click="openView(row)"
-                  class="p-1 text-gray-400 hover:text-blue-600 transition-colors"
-                  title="ดูรายละเอียด"
-                >
-                  <Eye class="w-4 h-4" />
-                </button>
+              <td class="px-6 py-3 text-sm text-right">
+                <TableRowActions
+                  :actions="[{ key: 'view', label: 'ดูรายละเอียด', onClick: () => openView(row) }]"
+                />
               </td>
             </tr>
             <tr v-if="rows.length === 0 && !loading">
@@ -220,7 +216,8 @@ import StatusBadge from '@/components/StatusBadge.vue'
 import SkeletonLoader from '@/components/SkeletonLoader.vue'
 import EmptyState from '@/components/EmptyState.vue'
 import PaginationBar from '@/components/PaginationBar.vue'
-import { Users, UserCheck, Clock, AlertTriangle, AlertCircle, Home, Eye, Search } from 'lucide-vue-next'
+import TableRowActions from '@/components/TableRowActions.vue'
+import { Users, UserCheck, Clock, AlertTriangle, AlertCircle, Home, Search } from 'lucide-vue-next'
 
 const { fetchList } = useProbation()
 

--- a/frontend/src/pages/RoyalDecorationsPage.vue
+++ b/frontend/src/pages/RoyalDecorationsPage.vue
@@ -71,14 +71,12 @@
               <td class="px-6 py-3 text-sm text-gray-700">{{ row.receivedYear || '-' }}</td>
               <td class="px-6 py-3 text-sm text-gray-700">{{ row.gazetteRef || '-' }}</td>
               <td v-if="isAdmin" class="px-6 py-3 text-right">
-                <div class="flex items-center justify-end gap-1">
-                  <button @click="openEdit(row)" class="p-1 text-gray-400 hover:text-blue-600 transition-colors" title="แก้ไข">
-                    <Pencil class="w-4 h-4" />
-                  </button>
-                  <button @click="openDelete(row)" class="p-1 text-gray-400 hover:text-red-600 transition-colors" title="ลบ">
-                    <Trash2 class="w-4 h-4" />
-                  </button>
-                </div>
+                <TableRowActions
+                  :actions="[
+                    { key: 'edit', label: 'แก้ไข', onClick: () => openEdit(row) },
+                    { key: 'delete', label: 'ลบ', variant: 'danger', onClick: () => openDelete(row) },
+                  ]"
+                />
               </td>
             </tr>
             <tr v-if="rows.length === 0 && !loading">
@@ -157,7 +155,8 @@ import { confirmDelete as confirmDeleteAction, confirmSave } from '@/composables
 import SkeletonLoader from '@/components/SkeletonLoader.vue'
 import EmptyState from '@/components/EmptyState.vue'
 import PaginationBar from '@/components/PaginationBar.vue'
-import { Plus, Search, Pencil, Trash2, AlertCircle } from 'lucide-vue-next'
+import TableRowActions from '@/components/TableRowActions.vue'
+import { Plus, Search, AlertCircle } from 'lucide-vue-next'
 
 const { fetchList, create, update, remove } = useDecorations()
 const auth = useAuthStore()

--- a/frontend/src/pages/SupportivePage.vue
+++ b/frontend/src/pages/SupportivePage.vue
@@ -98,7 +98,7 @@
               <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">จำนวนวัน</th>
               <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">อัตราลดทอน</th>
               <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">วันที่ได้</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">จัดการ</th>
+              <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">จัดการ</th>
             </tr>
           </thead>
           <tbody>
@@ -115,25 +115,8 @@
               <td class="px-6 py-3 text-sm text-gray-700">{{ row.totalDays }}</td>
               <td class="px-6 py-3 text-sm text-gray-700">{{ row.ratioPercent }}%</td>
               <td class="px-6 py-3 text-sm text-gray-700">{{ row.effectiveDays }}</td>
-              <td class="px-6 py-3 text-sm">
-                <div class="flex items-center gap-2">
-                  <button
-                    class="p-1 text-gray-400 hover:text-blue-600 transition-colors"
-                    title="แก้ไข"
-                    @click="openEdit(row)"
-                  >
-                    <Pencil class="w-4 h-4" />
-                  </button>
-                  <!-- ลบได้เฉพาะ admin (backend: checkPermission delete => [] สำหรับ operator) -->
-                  <button
-                    v-if="isAdmin"
-                    class="p-1 text-gray-400 hover:text-red-600 transition-colors"
-                    title="ลบ"
-                    @click="confirmDelete(row.supportiveId)"
-                  >
-                    <Trash2 class="w-4 h-4" />
-                  </button>
-                </div>
+              <td class="px-6 py-3 text-sm text-right">
+                <TableRowActions :actions="rowActions(row)" />
               </td>
             </tr>
             <tr v-if="rows.length === 0 && !loading">
@@ -295,7 +278,8 @@ import { ymdToDate } from '@/utils/thaiDate.js'
 import SkeletonLoader from '@/components/SkeletonLoader.vue'
 import EmptyState from '@/components/EmptyState.vue'
 import PaginationBar from '@/components/PaginationBar.vue'
-import { Home, Plus, Search, FileText, Users, Clock, AlertCircle, Pencil, Trash2 } from 'lucide-vue-next'
+import TableRowActions from '@/components/TableRowActions.vue'
+import { Home, Plus, Search, FileText, Users, Clock, AlertCircle } from 'lucide-vue-next'
 
 const { fetchList, create, update, remove } = useSupportive()
 const api = useApi()
@@ -305,6 +289,21 @@ const ui = useUiStore()
 
 // operator สร้าง/แก้ไขได้ แต่ลบไม่ได้ — ซ่อนปุ่มลบไม่ให้กดแล้วเจอ 403
 const isAdmin = computed(() => auth.isAdmin)
+
+function rowActions(row) {
+  const actions = [
+    { key: 'edit', label: 'แก้ไข', onClick: () => openEdit(row) },
+  ]
+  if (isAdmin.value) {
+    actions.push({
+      key: 'delete',
+      label: 'ลบ',
+      variant: 'danger',
+      onClick: () => confirmDelete(row.supportiveId),
+    })
+  }
+  return actions
+}
 
 // Data state
 const loading = ref(false)

--- a/frontend/src/pages/UserManagementPage.vue
+++ b/frontend/src/pages/UserManagementPage.vue
@@ -98,24 +98,7 @@
               </td>
               <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ formatDateTime(row.lastLoginAt) }}</td>
               <td class="px-6 py-4 whitespace-nowrap text-right">
-                <div class="flex items-center justify-end gap-1">
-                  <button @click="openEdit(row)" class="p-1 text-gray-400 hover:text-blue-600 transition-colors cursor-pointer" title="แก้ไข">
-                    <Pencil class="w-4 h-4" />
-                  </button>
-                  <button @click="openResetPassword(row)" class="p-1 text-gray-400 hover:text-amber-600 transition-colors cursor-pointer" title="รีเซ็ตรหัสผ่าน">
-                    <KeyRound class="w-4 h-4" />
-                  </button>
-                  <!-- Self-guard: ไม่แสดงปุ่มปิดบัญชีของตัวเอง -->
-                  <button
-                    v-if="row.userId !== auth.user?.id"
-                    @click="openToggleActive(row)"
-                    class="p-1 text-gray-400 transition-colors cursor-pointer"
-                    :class="row.isActive ? 'hover:text-red-600' : 'hover:text-green-600'"
-                    :title="row.isActive ? 'ปิดบัญชี' : 'เปิดใช้งานบัญชี'"
-                  >
-                    <component :is="row.isActive ? Ban : CheckCircle" class="w-4 h-4" />
-                  </button>
-                </div>
+                <TableRowActions :actions="rowActions(row)" />
               </td>
             </tr>
           </tbody>
@@ -309,13 +292,38 @@ import { useUiStore } from '@/stores/ui.js'
 import { roleLabel } from '@/utils/roleLabels.js'
 import PaginationBar from '@/components/PaginationBar.vue'
 import EmptyState from '@/components/EmptyState.vue'
-import { Plus, Search, Pencil, KeyRound, Ban, CheckCircle, Users } from 'lucide-vue-next'
+import TableRowActions from '@/components/TableRowActions.vue'
+import { Plus, Search, KeyRound, Ban, CheckCircle, Users } from 'lucide-vue-next'
 
 const PASSWORD_MIN_LENGTH = 8
 
 const { fetchList, create, update } = useUsers()
 const auth = useAuthStore()
 const ui = useUiStore()
+
+function rowActions(row) {
+  const actions = [
+    { key: 'edit', label: 'แก้ไข', onClick: () => openEdit(row) },
+    {
+      key: 'reset',
+      label: 'รีเซ็ตรหัสผ่าน',
+      icon: KeyRound,
+      variant: 'warning',
+      onClick: () => openResetPassword(row),
+    },
+  ]
+  // Self-guard: ไม่แสดงปุ่มปิดบัญชีของตัวเอง
+  if (row.userId !== auth.user?.id) {
+    actions.push({
+      key: 'toggle',
+      label: row.isActive ? 'ปิดบัญชี' : 'เปิดใช้งานบัญชี',
+      icon: row.isActive ? Ban : CheckCircle,
+      variant: row.isActive ? 'danger' : 'success',
+      onClick: () => openToggleActive(row),
+    })
+  }
+  return actions
+}
 
 // Data state
 const loading = ref(false)

--- a/frontend/src/pages/WorkResultsPage.vue
+++ b/frontend/src/pages/WorkResultsPage.vue
@@ -60,7 +60,7 @@
               <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ประเภท</th>
               <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">วันที่ส่ง</th>
               <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">สถานะ</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ดู</th>
+              <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">จัดการ</th>
             </tr>
           </thead>
           <tbody>
@@ -77,14 +77,10 @@
               <td class="px-6 py-3 text-sm">
                 <StatusBadge :status="row.status || 'draft'" />
               </td>
-              <td class="px-6 py-3 text-sm">
-                <button
-                  @click="openView(row)"
-                  class="p-1 text-gray-400 hover:text-blue-600 transition-colors"
-                  title="ดูรายละเอียด"
-                >
-                  <Eye class="w-4 h-4" />
-                </button>
+              <td class="px-6 py-3 text-sm text-right">
+                <TableRowActions
+                  :actions="[{ key: 'view', label: 'ดูรายละเอียด', onClick: () => openView(row) }]"
+                />
               </td>
             </tr>
             <tr v-if="rows.length === 0 && !loading">
@@ -181,7 +177,8 @@ import StatusBadge from '@/components/StatusBadge.vue'
 import SkeletonLoader from '@/components/SkeletonLoader.vue'
 import EmptyState from '@/components/EmptyState.vue'
 import PaginationBar from '@/components/PaginationBar.vue'
-import { AlertCircle, Eye, Search } from 'lucide-vue-next'
+import TableRowActions from '@/components/TableRowActions.vue'
+import { AlertCircle, Search } from 'lucide-vue-next'
 
 const { fetchList } = useWorkResults()
 


### PR DESCRIPTION
## Summary
- Add shared `TableRowActions` for consistent admin table action columns (`จัดการ`)
- Document row-action UX rules in DESIGN.md (inline icons 1–3, MoreVertical when ≥4)
- Migrate list pages to the shared component while keeping page-specific action sets and role gates

## Test plan
- [x] `vitest` TableRowActions + affected page suites
- [x] Pre-push full frontend suite (481 tests)
- [ ] Spot-check Awards / Candidates / User Management action icons in browser