### PR TITLE
feat: full row actions on candidates and probation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,7 @@ jobs:
             -v "$PWD/database/25-ensure-multiplier-tables.sql:/docker-entrypoint-initdb.d/25-ensure-multiplier-tables.sql" \
             -v "$PWD/database/27-superadmin-permission-overrides.sql:/docker-entrypoint-initdb.d/27-superadmin-permission-overrides.sql" \
             -v "$PWD/database/28-prefix-in-probation-view.sql:/docker-entrypoint-initdb.d/28-prefix-in-probation-view.sql" \
+            -v "$PWD/database/29-ensure-probation-view-prefixes.sql:/docker-entrypoint-initdb.d/29-ensure-probation-view-prefixes.sql" \
             mysql:8.0
 
       - name: Wait for schema init to finish

--- a/backend/QualificationEngine.php
+++ b/backend/QualificationEngine.php
@@ -42,6 +42,12 @@ class QualificationEngine
         $this->pdo = $pdo;
     }
 
+    /** SQL: คำนำหน้า + ชื่อ + นามสกุล (ต้อง LEFT JOIN prefixes px) */
+    private function fullNameSql(): string
+    {
+        return sqlPersonnelFullName('p', 'px');
+    }
+
     /**
      * สร้าง base SELECT query + parameters สำหรับ target level ที่กำหนด
      * แชร์ระหว่าง computeForLevel และ computeOverview เพื่อไม่ให้ SQL ซ้ำสองก๊อปปี้
@@ -62,7 +68,7 @@ class QualificationEngine
         $baseSelect = "
             SELECT
                 p.personnel_id,
-                CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name,
+                {$this->fullNameSql()} AS full_name,
                 pos.position_name AS current_position,
                 p.current_level_code,
                 p.current_level_start_date,
@@ -329,7 +335,7 @@ class QualificationEngine
         $sql = "
             SELECT
                 p.personnel_id,
-                CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name,
+                {$this->fullNameSql()} AS full_name,
                 pos.position_name AS current_position,
                 p.current_level_code,
                 p.current_level_start_date,
@@ -426,11 +432,13 @@ class QualificationEngine
         $baseSelect = $base['sql'];
         $params = $base['params'];
 
-        // Step 3: Apply search filter
+        // Step 3: Apply search filter (รวมคำนำหน้าในชื่อเต็ม)
         $searchClause = '';
         if (!empty($search)) {
-            $searchClause = ' AND (p.first_name LIKE ? OR p.last_name LIKE ? OR pos.position_name LIKE ?)';
+            $fullNameExpr = $this->fullNameSql();
+            $searchClause = " AND ({$fullNameExpr} LIKE ? OR p.first_name LIKE ? OR p.last_name LIKE ? OR pos.position_name LIKE ?)";
             $searchTerm = "%{$search}%";
+            $params[] = $searchTerm;
             $params[] = $searchTerm;
             $params[] = $searchTerm;
             $params[] = $searchTerm;
@@ -700,7 +708,7 @@ class QualificationEngine
             SELECT
                 p.personnel_id,
                 p.citizen_id,
-                CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name,
+                {$this->fullNameSql()} AS full_name,
                 p.first_name,
                 p.last_name,
                 p.hire_date,

--- a/backend/api.php
+++ b/backend/api.php
@@ -314,9 +314,11 @@ switch ($path[0]) {
         break;
 
     case 'civil-servants':
+        $pdo = getDB();
+        $servantId = isset($path[1]) ? intval($path[1]) : 0;
+
         if ($method == 'GET') {
             requirePermission('read', 'personnel');
-            $pdo = getDB();
             $search = $_GET['search'] ?? '';
             $limit = intval($_GET['limit'] ?? 20);
             $offset = intval($_GET['offset'] ?? 0);
@@ -373,6 +375,24 @@ switch ($path[0]) {
                     'has_more' => ($offset + $limit) < $total
                 ]
             ]);
+        } elseif ($method === 'DELETE' && $servantId > 0) {
+            // Soft-delete: ปิดใช้งานบุคลากร (ออกจากรายชื่อ candidates ที่กรอง is_active=1)
+            requirePermission('delete', 'personnel');
+            $stmt = $pdo->prepare(
+                'UPDATE personnel SET is_active = 0 WHERE personnel_id = ? AND is_active = 1'
+            );
+            $stmt->execute([$servantId]);
+            if ($stmt->rowCount() === 0) {
+                $check = $pdo->prepare('SELECT is_active FROM personnel WHERE personnel_id = ?');
+                $check->execute([$servantId]);
+                $active = $check->fetchColumn();
+                if ($active === false) {
+                    http_response_code(404);
+                    echo json_encode(['error' => 'Not found']);
+                    break;
+                }
+            }
+            echo json_encode(['success' => true]);
         } else {
             respondMethodNotAllowed();
         }

--- a/backend/helpers.php
+++ b/backend/helpers.php
@@ -193,3 +193,13 @@ function personnelExists(PDO $pdo, int $personnelId): bool
     $stmt->execute([$personnelId]);
     return (bool) $stmt->fetchColumn();
 }
+
+/**
+ * SQL expression: คำนำหน้า + ชื่อ + นามสกุล (NULL-safe)
+ * ใช้คู่กับ LEFT JOIN prefixes — COLLATE บังคับเพราะ prefixes / personnel คนละ collation
+ */
+function sqlPersonnelFullName(string $personnelAlias = 'p', string $prefixAlias = 'px'): string
+{
+    return "CONCAT(COALESCE({$prefixAlias}.prefix_name_th COLLATE utf8mb4_unicode_ci, ''),"
+        . " {$personnelAlias}.first_name, ' ', {$personnelAlias}.last_name)";
+}

--- a/backend/routes/probation.php
+++ b/backend/routes/probation.php
@@ -5,10 +5,11 @@
 // จัดการเส้นทาง API สำหรับติดตามทดลองปฏิบัติราชการ
 //
 // Endpoints:
-//   GET  /probation                     — รายชื่อผู้ทดลองปฏิบัติราชการ (จาก view)
-//   GET  /probation/{enrollmentId}      — รายละเอียดการทดลองปฏิบัติราชการรายบุคคล
-//   POST /probation                     — สร้างการลงทะเบียนทดลองใหม่
-//   PUT  /probation/{enrollmentId}      — อัปเดตข้อมูลการทดลอง
+//   GET    /probation                     — รายชื่อผู้ทดลองปฏิบัติราชการ (จาก view)
+//   GET    /probation/{enrollmentId}      — รายละเอียดการทดลองปฏิบัติราชการรายบุคคล
+//   POST   /probation                     — สร้างการลงทะเบียนทดลองใหม่
+//   PUT    /probation/{enrollmentId}      — อัปเดตข้อมูลการทดลอง
+//   DELETE /probation/{enrollmentId}      — ถอดออกจากรายการติดตาม (CANCELLED)
 // ============================================================================
 
 include_once __DIR__ . '/../helpers.php';
@@ -64,6 +65,16 @@ function handleProbation(PDO $pdo, string $method, array $path): void
             updateProbationEnrollment($pdo, intval($enrollmentId));
             break;
 
+        case 'DELETE':
+            $enrollmentId = $path[1] ?? null;
+            if ($enrollmentId === null) {
+                http_response_code(400);
+                echo json_encode(['error' => 'Enrollment ID is required']);
+                return;
+            }
+            deleteProbationEnrollment($pdo, intval($enrollmentId));
+            break;
+
         default:
             http_response_code(405);
             echo json_encode(['error' => 'Method not allowed']);
@@ -83,35 +94,46 @@ function getProbationList(PDO $pdo): void
     $where = '';
     $params = [];
 
-    // ลองใช้ view ก่อน ถ้าพัง (TiDB definer issue) ใช้ fallback query จาก base tables
+    // ใช้ view สำหรับ task aggregates แต่คำนวณ full_name จาก personnel+prefixes เสมอ
+    // (view บน TiDB อาจค้างรุ่นก่อน migration 28 — อย่าเชื่อ v.full_name)
+    $fullNameExpr = sqlPersonnelFullName('p', 'px');
     try {
-        $baseQuery = "SELECT enrollment_id, personnel_id, full_name, position_name,
-                             department, probation_start AS start_date, probation_end AS end_date,
-                             remaining_days, overall_status AS status,
-                             total_tasks, completed_tasks
-                      FROM vw_probation_dashboard";
-        $countQuery = "SELECT COUNT(*) AS total FROM vw_probation_dashboard";
+        $baseQuery = "SELECT v.enrollment_id, v.personnel_id,
+                             {$fullNameExpr} AS full_name,
+                             v.position_name,
+                             v.department, v.probation_start AS start_date, v.probation_end AS end_date,
+                             v.remaining_days, v.overall_status AS status,
+                             v.total_tasks, v.completed_tasks,
+                             pe.remarks
+                      FROM vw_probation_dashboard v
+                      JOIN personnel p ON v.personnel_id = p.personnel_id
+                      LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id
+                      JOIN probation_enrollment pe ON v.enrollment_id = pe.enrollment_id";
+        $countQuery = "SELECT COUNT(*) AS total
+                       FROM vw_probation_dashboard v
+                       JOIN personnel p ON v.personnel_id = p.personnel_id
+                       LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id";
 
         if (!empty($search)) {
-            $where = " WHERE (full_name LIKE ? OR position_name LIKE ? OR department LIKE ?)";
+            $where = " WHERE ({$fullNameExpr} LIKE ? OR v.position_name LIKE ? OR v.department LIKE ?)";
             $searchTerm = "%{$search}%";
             $params = [$searchTerm, $searchTerm, $searchTerm];
         }
 
-        // Test the view first
-        $sql = $baseQuery . $where . " ORDER BY remaining_days ASC LIMIT {$limit} OFFSET {$offset}";
+        $sql = $baseQuery . $where . " ORDER BY v.remaining_days ASC LIMIT {$limit} OFFSET {$offset}";
         $stmt = $pdo->prepare($sql);
         $stmt->execute($params);
         $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
     } catch (PDOException $e) {
         // Fallback: query จาก base tables โดยตรง (ไม่มี task_progress / stakeholder subqueries)
         $baseQuery = "SELECT pe.enrollment_id, pe.personnel_id,
-                             CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name,
+                             {$fullNameExpr} AS full_name,
                              pos.position_name, o.org_name AS department,
                              pe.start_date, pe.end_date,
                              DATEDIFF(pe.end_date, CURDATE()) AS remaining_days,
                              pe.overall_status AS status,
-                             0 AS total_tasks, 0 AS completed_tasks
+                             0 AS total_tasks, 0 AS completed_tasks,
+                             pe.remarks
                       FROM probation_enrollment pe
                       JOIN personnel p ON pe.personnel_id = p.personnel_id
                       LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id
@@ -130,7 +152,7 @@ function getProbationList(PDO $pdo): void
         $where = '';
         $params = [];
         if (!empty($search)) {
-            $where = " AND (CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) LIKE ? OR pos.position_name LIKE ? OR o.org_name LIKE ?)";
+            $where = " AND ({$fullNameExpr} LIKE ? OR pos.position_name LIKE ? OR o.org_name LIKE ?)";
             $searchTerm = "%{$search}%";
             $params = [$searchTerm, $searchTerm, $searchTerm];
         }
@@ -209,8 +231,9 @@ function getProbationList(PDO $pdo): void
  */
 function getProbationDetail(PDO $pdo, int $enrollmentId): void
 {
+    $fullNameExpr = sqlPersonnelFullName('p', 'px');
     $sql = "SELECT pe.enrollment_id, pe.personnel_id,
-                   CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name,
+                   {$fullNameExpr} AS full_name,
                    pos.position_name, o.org_name AS department,
                    pe.start_date, pe.end_date,
                    DATEDIFF(pe.end_date, CURDATE()) AS remaining_days,
@@ -288,14 +311,23 @@ function updateProbationEnrollment(PDO $pdo, int $enrollmentId): void
 {
     $data = json_decode(file_get_contents('php://input'), true);
 
-    $allowed = ['overall_status', 'final_result', 'final_result_date', 'extension_end_date', 'extension_reason', 'remarks'];
+    $allowed = [
+        'start_date',
+        'end_date',
+        'overall_status',
+        'final_result',
+        'final_result_date',
+        'extension_end_date',
+        'extension_reason',
+        'remarks',
+    ];
     $sets = [];
     $params = [];
 
     foreach ($allowed as $field) {
-        if (isset($data[$field])) {
+        if (array_key_exists($field, $data)) {
             $sets[] = "{$field} = ?";
-            $params[] = $data[$field];
+            $params[] = $data[$field] === '' ? null : $data[$field];
         }
     }
 
@@ -312,9 +344,43 @@ function updateProbationEnrollment(PDO $pdo, int $enrollmentId): void
     $stmt->execute($params);
 
     if ($stmt->rowCount() === 0) {
-        http_response_code(404);
-        echo json_encode(['error' => 'Enrollment not found']);
-        return;
+        // แถวอาจมีอยู่แต่ค่าไม่เปลี่ยน — แยก 404 จริง
+        $check = $pdo->prepare('SELECT 1 FROM probation_enrollment WHERE enrollment_id = ?');
+        $check->execute([$enrollmentId]);
+        if (!$check->fetchColumn()) {
+            http_response_code(404);
+            echo json_encode(['error' => 'Enrollment not found']);
+            return;
+        }
+    }
+
+    echo json_encode(['success' => true]);
+}
+
+/**
+ * DELETE /probation/{enrollmentId}
+ * ถอดออกจากรายการติดตามโดยตั้งสถานะ CANCELLED (ไม่ hard-delete เพราะมี FK งาน/stakeholder)
+ */
+function deleteProbationEnrollment(PDO $pdo, int $enrollmentId): void
+{
+    $stmt = $pdo->prepare(
+        "UPDATE probation_enrollment
+         SET overall_status = 'CANCELLED'
+         WHERE enrollment_id = ?
+           AND overall_status <> 'CANCELLED'"
+    );
+    $stmt->execute([$enrollmentId]);
+
+    if ($stmt->rowCount() === 0) {
+        $check = $pdo->prepare('SELECT overall_status FROM probation_enrollment WHERE enrollment_id = ?');
+        $check->execute([$enrollmentId]);
+        $status = $check->fetchColumn();
+        if ($status === false) {
+            http_response_code(404);
+            echo json_encode(['error' => 'Enrollment not found']);
+            return;
+        }
+        // already cancelled — treat as success (idempotent)
     }
 
     echo json_encode(['success' => true]);

--- a/database/29-ensure-probation-view-prefixes.sql
+++ b/database/29-ensure-probation-view-prefixes.sql
@@ -1,0 +1,59 @@
+-- ============================================================================
+-- 29-ensure-probation-view-prefixes.sql
+-- บังคับอัปเดต vw_probation_dashboard ให้ JOIN prefixes อีกครั้ง
+-- (กรณี migration 28 ถูก mark ว่า applied แต่ view บน TiDB ยังเป็นรุ่นเก่า)
+--
+-- Apply: docker compose exec backend php scripts/run-migrations.php
+-- Fresh Docker / tidb-init: นิยามเดียวกันอยู่ใน tidb-init.sql แล้ว
+-- ============================================================================
+
+SET NAMES utf8mb4;
+
+DROP VIEW IF EXISTS vw_probation_dashboard;
+CREATE VIEW vw_probation_dashboard AS
+SELECT
+    pe.enrollment_id,
+    p.personnel_id,
+    p.citizen_id,
+    CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name,
+    p.hire_date,
+    pe.start_date AS probation_start,
+    pe.end_date AS probation_end,
+    DATEDIFF(pe.end_date, CURDATE()) AS remaining_days,
+    pe.overall_status,
+    COALESCE(tp.total_tasks, 0) AS total_tasks,
+    COALESCE(tp.completed_tasks, 0) AS completed_tasks,
+    COALESCE(tp.overdue_tasks, 0) AS overdue_tasks,
+    sh.mentor_name,
+    sh.supervisor_name,
+    sh.director_name,
+    o.org_name AS department,
+    pos.position_name
+FROM probation_enrollment pe
+JOIN personnel p ON pe.personnel_id = p.personnel_id
+LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id
+LEFT JOIN organization o ON p.current_org_id = o.org_id
+LEFT JOIN position pos ON p.current_position_id = pos.position_id
+LEFT JOIN (
+    SELECT
+        enrollment_id,
+        COUNT(*) AS total_tasks,
+        SUM(CASE WHEN status = 'COMPLETED' THEN 1 ELSE 0 END) AS completed_tasks,
+        SUM(CASE WHEN status = 'OVERDUE' THEN 1 ELSE 0 END) AS overdue_tasks
+    FROM probation_task_progress
+    GROUP BY enrollment_id
+) tp ON tp.enrollment_id = pe.enrollment_id
+LEFT JOIN (
+    SELECT
+        ps.enrollment_id,
+        MAX(CASE WHEN ps.role_type = 'MENTOR' THEN CONCAT(COALESCE(px2.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p2.first_name, ' ', p2.last_name) END) AS mentor_name,
+        MAX(CASE WHEN ps.role_type = 'SUPERVISOR' THEN CONCAT(COALESCE(px2.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p2.first_name, ' ', p2.last_name) END) AS supervisor_name,
+        MAX(CASE WHEN ps.role_type = 'DIRECTOR' THEN CONCAT(COALESCE(px2.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p2.first_name, ' ', p2.last_name) END) AS director_name
+    FROM probation_stakeholder ps
+    JOIN personnel p2 ON ps.personnel_id = p2.personnel_id
+    LEFT JOIN prefixes px2 ON p2.prefix_id = px2.prefix_id
+    WHERE ps.is_active = 1
+      AND ps.role_type IN ('MENTOR', 'SUPERVISOR', 'DIRECTOR')
+    GROUP BY ps.enrollment_id
+) sh ON sh.enrollment_id = pe.enrollment_id
+WHERE pe.overall_status = 'IN_PROGRESS';

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -83,6 +83,7 @@ services:
       - ./database/25-ensure-multiplier-tables.sql:/docker-entrypoint-initdb.d/25-ensure-multiplier-tables.sql
       - ./database/27-superadmin-permission-overrides.sql:/docker-entrypoint-initdb.d/27-superadmin-permission-overrides.sql
       - ./database/28-prefix-in-probation-view.sql:/docker-entrypoint-initdb.d/28-prefix-in-probation-view.sql
+      - ./database/29-ensure-probation-view-prefixes.sql:/docker-entrypoint-initdb.d/29-ensure-probation-view-prefixes.sql
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "--silent"]
       interval: 10s

--- a/frontend/src/__tests__/composables/useCandidates.test.js
+++ b/frontend/src/__tests__/composables/useCandidates.test.js
@@ -2,8 +2,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 // Mock useApi before importing useCandidates
 const mockGet = vi.fn()
+const mockDel = vi.fn()
 vi.mock('@/composables/useApi.js', () => ({
-  useApi: () => ({ get: mockGet }),
+  useApi: () => ({ get: mockGet, del: mockDel }),
 }))
 
 const { useCandidates } = await import('@/composables/useCandidates.js')
@@ -11,11 +12,13 @@ const { useCandidates } = await import('@/composables/useCandidates.js')
 describe('useCandidates', () => {
   beforeEach(() => {
     mockGet.mockReset()
+    mockDel.mockReset()
   })
 
-  it('returns fetchByLevel function', () => {
-    const { fetchByLevel } = useCandidates()
+  it('returns fetchByLevel and deactivatePersonnel', () => {
+    const { fetchByLevel, deactivatePersonnel } = useCandidates()
     expect(typeof fetchByLevel).toBe('function')
+    expect(typeof deactivatePersonnel).toBe('function')
   })
 
   it('calls API with correct URL and default params', async () => {
@@ -153,7 +156,17 @@ describe('useCandidates', () => {
       remainingDays: 45,
       status: 'NEAR_MET',
       department: 'กองบริหาร',
+      supportiveDays: undefined,
+      equivalenceDays: undefined,
+      diverseStatus: undefined,
     })
+  })
+
+  it('deactivates personnel via DELETE civil-servants', async () => {
+    mockDel.mockResolvedValue({ success: true })
+    const { deactivatePersonnel } = useCandidates()
+    await deactivatePersonnel(42)
+    expect(mockDel).toHaveBeenCalledWith('/civil-servants/42')
   })
 
   it('maps 91 remaining days as NOT_MET and 90 as NEAR_MET', async () => {

--- a/frontend/src/__tests__/composables/useProbation.test.js
+++ b/frontend/src/__tests__/composables/useProbation.test.js
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 const mockGet = vi.fn()
+const mockPut = vi.fn()
+const mockDel = vi.fn()
 vi.mock('@/composables/useApi.js', () => ({
-  useApi: () => ({ get: mockGet }),
+  useApi: () => ({ get: mockGet, put: mockPut, del: mockDel }),
 }))
 
 const { useProbation } = await import('@/composables/useProbation.js')
@@ -10,11 +12,15 @@ const { useProbation } = await import('@/composables/useProbation.js')
 describe('useProbation', () => {
   beforeEach(() => {
     mockGet.mockReset()
+    mockPut.mockReset()
+    mockDel.mockReset()
   })
 
-  it('returns fetchList function', () => {
-    const { fetchList } = useProbation()
+  it('returns fetchList, update, and remove', () => {
+    const { fetchList, update, remove } = useProbation()
     expect(typeof fetchList).toBe('function')
+    expect(typeof update).toBe('function')
+    expect(typeof remove).toBe('function')
   })
 
   it('calls API with correct URL and default params', async () => {
@@ -83,11 +89,30 @@ describe('useProbation', () => {
       department: 'กองคลัง',
       startDate: '1 เม.ย. 2567',
       endDate: '1 ต.ค. 2567',
+      startDateIso: '',
+      endDateIso: '',
       remainingDays: 120,
+      overallStatus: 'IN_PROGRESS',
       status: 'NOT_DUE',
       totalTasks: 5,
       completedTasks: 2,
+      remarks: '',
     })
+  })
+
+  it('updates and removes enrollment via API', async () => {
+    mockPut.mockResolvedValue({ success: true })
+    mockDel.mockResolvedValue({ success: true })
+    const { update, remove } = useProbation()
+
+    await update(10, { start_date: '2024-04-01', end_date: '2024-10-01' })
+    expect(mockPut).toHaveBeenCalledWith('/probation/10', {
+      start_date: '2024-04-01',
+      end_date: '2024-10-01',
+    })
+
+    await remove(10)
+    expect(mockDel).toHaveBeenCalledWith('/probation/10')
   })
 
   it('passes through terminal backend statuses', async () => {

--- a/frontend/src/__tests__/pages/CandidateListsPage.test.js
+++ b/frontend/src/__tests__/pages/CandidateListsPage.test.js
@@ -1,15 +1,34 @@
 import { mount, flushPromises } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
+import { setActivePinia, createPinia } from 'pinia'
+import { useAuthStore } from '@/stores/auth.js'
 
 const mockFetchOverview = vi.fn()
 const mockFetchByLevel = vi.fn()
+const mockDeactivatePersonnel = vi.fn()
+const mockPush = vi.fn()
 
 vi.mock('@/composables/useCandidates.js', () => ({
   useCandidates: () => ({
     fetchOverview: mockFetchOverview,
     fetchByLevel: mockFetchByLevel,
+    deactivatePersonnel: mockDeactivatePersonnel,
   }),
+}))
+
+vi.mock('vue-router', async () => {
+  const actual = await vi.importActual('vue-router')
+  return {
+    ...actual,
+    useRouter: () => ({ push: mockPush }),
+  }
+})
+
+const mockConfirmDelete = vi.fn(async () => true)
+vi.mock('@/composables/useConfirm.js', () => ({
+  confirmDelete: (...args) => mockConfirmDelete(...args),
+  confirmSave: vi.fn(async () => true),
 }))
 
 vi.mock('@/composables/useRemainingDays.js', () => ({
@@ -83,6 +102,14 @@ describe('CandidateListsPage', () => {
   beforeEach(() => {
     mockFetchOverview.mockReset()
     mockFetchByLevel.mockReset()
+    mockDeactivatePersonnel.mockReset()
+    mockPush.mockReset()
+    mockConfirmDelete.mockReset()
+    mockConfirmDelete.mockResolvedValue(true)
+    setActivePinia(createPinia())
+    const auth = useAuthStore()
+    auth.user = { id: 1, role: 'admin', username: 'tester' }
+    auth.token = 'test-token'
   })
 
   it('renders overview stat cards and top-5 table after fetch', async () => {
@@ -225,6 +252,31 @@ describe('CandidateListsPage', () => {
     expect(wrapper.vm.showViewModal).toBe(false)
 
     wrapper.unmount()
+  })
+
+  it('provides view/edit/delete actions for admin and navigates edit to profile', async () => {
+    mockFetchByLevel.mockResolvedValue(byLevelPayload)
+    const wrapper = mount(CandidateListsPage, { props: { section: 'general' } })
+    await flushPromises()
+
+    const keys = wrapper.vm.rowActions(byLevelPayload.data[0]).map((a) => a.key)
+    expect(keys).toEqual(['view', 'edit', 'delete'])
+
+    wrapper.vm.openEdit(byLevelPayload.data[0])
+    expect(mockPush).toHaveBeenCalledWith('/profile/10')
+  })
+
+  it('deactivates personnel after delete confirmation', async () => {
+    mockFetchByLevel.mockResolvedValue(byLevelPayload)
+    mockDeactivatePersonnel.mockResolvedValue({ success: true })
+    const wrapper = mount(CandidateListsPage, { props: { section: 'general' } })
+    await flushPromises()
+    mockFetchByLevel.mockClear()
+
+    await wrapper.vm.confirmDelete(byLevelPayload.data[0])
+    expect(mockConfirmDelete).toHaveBeenCalled()
+    expect(mockDeactivatePersonnel).toHaveBeenCalledWith(10)
+    expect(mockFetchByLevel).toHaveBeenCalled()
   })
 
   it('changes page via PaginationBar and fetches with new offset', async () => {

--- a/frontend/src/__tests__/pages/ProbationEndPage.test.js
+++ b/frontend/src/__tests__/pages/ProbationEndPage.test.js
@@ -1,25 +1,45 @@
 import { mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useAuthStore } from '@/stores/auth.js'
 
 const mockFetchList = vi.fn()
+const mockUpdate = vi.fn()
+const mockRemove = vi.fn()
 
 vi.mock('@/composables/useProbation.js', () => ({
-  useProbation: () => ({ fetchList: mockFetchList }),
+  useProbation: () => ({
+    fetchList: mockFetchList,
+    update: mockUpdate,
+    remove: mockRemove,
+  }),
+}))
+
+const mockConfirmDelete = vi.fn(async () => true)
+const mockConfirmSave = vi.fn(async () => true)
+vi.mock('@/composables/useConfirm.js', () => ({
+  confirmDelete: (...args) => mockConfirmDelete(...args),
+  confirmSave: (...args) => mockConfirmSave(...args),
 }))
 
 const ProbationEndPage = (await import('@/pages/ProbationEndPage.vue')).default
 
 const sampleRow = {
   enrollmentId: 9,
+  personnelId: 3,
   name: 'สมหญิง รักดี',
   position: 'นักวิชาการศึกษา',
   department: 'สำนักงานเขตพื้นที่การศึกษา',
   startDate: '1 ต.ค. 2567',
   endDate: '30 ก.ย. 2569',
+  startDateIso: '2024-10-01',
+  endDateIso: '2026-09-30',
   remainingDays: 120,
+  overallStatus: 'IN_PROGRESS',
   status: 'in_progress',
   totalTasks: 4,
   completedTasks: 1,
+  remarks: '',
 }
 
 function resolvedData(rows = [sampleRow]) {
@@ -30,7 +50,12 @@ function resolvedData(rows = [sampleRow]) {
   })
 }
 
-async function mountPage() {
+async function mountPage({ role = 'admin' } = {}) {
+  setActivePinia(createPinia())
+  const auth = useAuthStore()
+  auth.user = { id: 1, role, username: 'tester' }
+  auth.token = 'test-token'
+
   const wrapper = mount(ProbationEndPage)
   await vi.waitFor(() => {
     expect(mockFetchList).toHaveBeenCalled()
@@ -78,6 +103,49 @@ describe('ProbationEndPage', () => {
     wrapper.vm.showViewModal = false
     await wrapper.vm.$nextTick()
     expect(document.body.textContent).not.toContain('รายละเอียดการทดลองปฏิบัติราชการ')
+  })
+
+  it('shows view/edit/delete for admin and hides delete for operator', async () => {
+    const adminWrapper = await mountPage({ role: 'admin' })
+    const adminKeys = adminWrapper.vm.rowActions(sampleRow).map((a) => a.key)
+    expect(adminKeys).toEqual(['view', 'edit', 'delete'])
+    adminWrapper.unmount()
+
+    vi.clearAllMocks()
+    resolvedData()
+    const opWrapper = await mountPage({ role: 'operator' })
+    const opKeys = opWrapper.vm.rowActions(sampleRow).map((a) => a.key)
+    expect(opKeys).toEqual(['view', 'edit'])
+  })
+
+  it('saves edit after confirmation', async () => {
+    mockUpdate.mockResolvedValue({ success: true })
+    const wrapper = await mountPage()
+
+    wrapper.vm.openEdit(sampleRow)
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.showEditModal).toBe(true)
+    expect(wrapper.vm.formData.start_date).toBe('2024-10-01')
+
+    await wrapper.vm.handleSave()
+    expect(mockConfirmSave).toHaveBeenCalled()
+    expect(mockUpdate).toHaveBeenCalledWith(9, expect.objectContaining({
+      start_date: '2024-10-01',
+      end_date: '2026-09-30',
+      overall_status: 'IN_PROGRESS',
+    }))
+  })
+
+  it('deletes enrollment after confirmation', async () => {
+    mockRemove.mockResolvedValue({ success: true })
+    const wrapper = await mountPage()
+    mockFetchList.mockClear()
+    resolvedData([])
+
+    await wrapper.vm.confirmDelete(sampleRow)
+    expect(mockConfirmDelete).toHaveBeenCalled()
+    expect(mockRemove).toHaveBeenCalledWith(9)
+    expect(mockFetchList).toHaveBeenCalled()
   })
 
   it('search input debounces and resets offset before refetching', async () => {

--- a/frontend/src/composables/useCandidates.js
+++ b/frontend/src/composables/useCandidates.js
@@ -48,5 +48,9 @@ export function useCandidates() {
     }
   }
 
-  return { fetchByLevel, fetchOverview }
+  async function deactivatePersonnel(personnelId) {
+    return api.del(`/civil-servants/${personnelId}`)
+  }
+
+  return { fetchByLevel, fetchOverview, deactivatePersonnel }
 }

--- a/frontend/src/composables/useProbation.js
+++ b/frontend/src/composables/useProbation.js
@@ -19,6 +19,14 @@ export function useProbation() {
     }
   }
 
+  async function update(enrollmentId, payload) {
+    return api.put(`/probation/${enrollmentId}`, payload)
+  }
+
+  async function remove(enrollmentId) {
+    return api.del(`/probation/${enrollmentId}`)
+  }
+
   function mapProbationRow(row) {
     return {
       enrollmentId: row.enrollment_id,
@@ -28,12 +36,16 @@ export function useProbation() {
       department: row.department,
       startDate: row.start_date_thai,
       endDate: row.end_date_thai,
+      startDateIso: row.start_date || '',
+      endDateIso: row.end_date || '',
       remainingDays: row.remaining_days,
+      overallStatus: row.status,
       status: probationStatusFor(row.status, row.remaining_days),
       totalTasks: row.total_tasks,
       completedTasks: row.completed_tasks,
+      remarks: row.remarks || '',
     }
   }
 
-  return { fetchList }
+  return { fetchList, update, remove }
 }

--- a/frontend/src/pages/CandidateListsPage.vue
+++ b/frontend/src/pages/CandidateListsPage.vue
@@ -142,6 +142,7 @@
                 <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">วันครบกำหนด</th>
                 <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">วันคงเหลือ</th>
                 <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">สถานะ</th>
+                <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">จัดการ</th>
               </tr>
             </thead>
             <tbody class="divide-y divide-gray-200">
@@ -161,9 +162,12 @@
                 <td class="px-6 py-3">
                   <StatusBadge :status="row.status" />
                 </td>
+                <td class="px-6 py-3 text-right">
+                  <TableRowActions :actions="rowActions(row)" />
+                </td>
               </tr>
               <tr v-if="overviewData.top5.length === 0">
-                <td colspan="7" class="px-6 py-8 text-center text-gray-400">ไม่พบข้อมูล</td>
+                <td colspan="8" class="px-6 py-8 text-center text-gray-400">ไม่พบข้อมูล</td>
               </tr>
             </tbody>
           </table>
@@ -268,9 +272,7 @@
                   <StatusBadge :status="row.status" />
                 </td>
                 <td class="px-6 py-3 text-right">
-                  <TableRowActions
-                    :actions="[{ key: 'view', label: 'ดูรายละเอียด', onClick: () => openView(row) }]"
-                  />
+                  <TableRowActions :actions="rowActions(row)" />
                 </td>
               </tr>
               <tr v-if="rows.length === 0">
@@ -370,8 +372,12 @@
 
 <script setup>
 import { ref, computed, watch, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
 import { useCandidates } from '@/composables/useCandidates.js'
 import { getCandidateRemainingDaysClass, formatRemainingDays } from '@/composables/useRemainingDays.js'
+import { useAuthStore } from '@/stores/auth.js'
+import { useUiStore } from '@/stores/ui.js'
+import { confirmDelete as confirmDeleteAction } from '@/composables/useConfirm.js'
 import StatCard from '@/components/StatCard.vue'
 import StatusBadge from '@/components/StatusBadge.vue'
 import SkeletonLoader from '@/components/SkeletonLoader.vue'
@@ -387,7 +393,28 @@ const props = defineProps({
   section: { type: String, default: 'overview' },
 })
 
-const { fetchByLevel, fetchOverview } = useCandidates()
+const { fetchByLevel, fetchOverview, deactivatePersonnel } = useCandidates()
+const router = useRouter()
+const auth = useAuthStore()
+const ui = useUiStore()
+
+const isAdmin = computed(() => auth.isAdmin)
+
+function rowActions(row) {
+  const actions = [
+    { key: 'view', label: 'ดูรายละเอียด', onClick: () => openView(row) },
+    { key: 'edit', label: 'แก้ไข', onClick: () => openEdit(row) },
+  ]
+  if (isAdmin.value) {
+    actions.push({
+      key: 'delete',
+      label: 'ลบ',
+      variant: 'danger',
+      onClick: () => confirmDelete(row),
+    })
+  }
+  return actions
+}
 
 // Sub-tab state (reactive, not router per D-04)
 const activeSubTab = ref(null)
@@ -415,6 +442,30 @@ const viewingRow = ref(null)
 function openView(row) {
   viewingRow.value = row
   showViewModal.value = true
+}
+
+function openEdit(row) {
+  if (!row?.personnelId) return
+  router.push(`/profile/${row.personnelId}`)
+}
+
+async function confirmDelete(row) {
+  const ok = await confirmDeleteAction({
+    message: `คุณต้องการปิดใช้งาน ${row.name} จากระบบหรือไม่?`,
+    detail: 'จะไม่แสดงในบัญชีรายชื่อผู้มีคุณสมบัติ (สามารถเปิดใช้งานใหม่ได้ภายหลัง)',
+  })
+  if (!ok) return
+  try {
+    await deactivatePersonnel(row.personnelId)
+    ui.showToast('ปิดใช้งานสำเร็จ', 'success')
+    if (isOverview.value) {
+      fetchOverviewData()
+    } else {
+      fetchData()
+    }
+  } catch (err) {
+    ui.showToast(err.message || 'เกิดข้อผิดพลาด', 'error')
+  }
 }
 
 // Configuration maps

--- a/frontend/src/pages/ProbationEndPage.vue
+++ b/frontend/src/pages/ProbationEndPage.vue
@@ -118,9 +118,7 @@
                 <StatusBadge :status="row.status" />
               </td>
               <td class="px-6 py-3 text-sm text-right">
-                <TableRowActions
-                  :actions="[{ key: 'view', label: 'ดูรายละเอียด', onClick: () => openView(row) }]"
-                />
+                <TableRowActions :actions="rowActions(row)" />
               </td>
             </tr>
             <tr v-if="rows.length === 0 && !loading">
@@ -204,22 +202,114 @@
         </div>
       </div>
     </Teleport>
+
+    <!-- ==================== Edit Modal ==================== -->
+    <Teleport to="body">
+      <div v-if="showEditModal" class="fixed inset-0 z-50 flex items-center justify-center">
+        <div class="absolute inset-0 bg-black/50" @click="closeEditModal"></div>
+        <div class="relative bg-white rounded-lg shadow-xl w-full max-w-lg mx-4 max-h-[90vh] overflow-y-auto">
+          <div class="px-6 py-4 border-b border-gray-200">
+            <h2 class="text-lg font-semibold text-gray-900">แก้ไขการทดลองปฏิบัติราชการ</h2>
+            <p class="text-sm text-gray-500 mt-1">{{ editingRow?.name }}</p>
+          </div>
+          <form @submit.prevent="handleSave" class="px-6 py-4 space-y-4">
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <label class="block text-sm font-medium text-gray-700 mb-1">วันเริ่มทดลอง <span class="text-red-500">*</span></label>
+                <ThaiDatePicker
+                  v-model="formData.start_date"
+                  :class="{ 'ring-2 ring-red-500 rounded-lg': formErrors.start_date }"
+                />
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-gray-700 mb-1">วันครบกำหนด <span class="text-red-500">*</span></label>
+                <ThaiDatePicker
+                  v-model="formData.end_date"
+                  :class="{ 'ring-2 ring-red-500 rounded-lg': formErrors.end_date }"
+                />
+              </div>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700 mb-1">สถานะ</label>
+              <select
+                v-model="formData.overall_status"
+                class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              >
+                <option value="IN_PROGRESS">กำลังดำเนินการ</option>
+                <option value="COMPLETED">ผ่านทดลอง</option>
+                <option value="FAILED">ไม่ผ่านทดลอง</option>
+                <option value="EXTENDED">ขยายเวลา</option>
+              </select>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700 mb-1">หมายเหตุ</label>
+              <textarea
+                v-model="formData.remarks"
+                rows="3"
+                class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                placeholder="ระบุหมายเหตุ (ถ้ามี)"
+              />
+            </div>
+            <div class="pt-2 flex justify-end gap-2 border-t border-gray-200">
+              <button
+                type="button"
+                @click="closeEditModal"
+                class="px-4 py-2 text-sm text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+              >
+                ยกเลิก
+              </button>
+              <button
+                type="submit"
+                :disabled="saving"
+                class="px-4 py-2 text-sm text-white bg-blue-500 rounded-lg hover:bg-blue-600 transition-colors disabled:opacity-50"
+              >
+                {{ saving ? 'กำลังบันทึก...' : 'บันทึก' }}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </Teleport>
   </div>
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useProbation } from '@/composables/useProbation.js'
 import { getRemainingDaysClass, formatRemainingDays } from '@/composables/useRemainingDays.js'
+import { useAuthStore } from '@/stores/auth.js'
+import { useUiStore } from '@/stores/ui.js'
+import { confirmDelete as confirmDeleteAction, confirmSave } from '@/composables/useConfirm.js'
 import StatCard from '@/components/StatCard.vue'
 import StatusBadge from '@/components/StatusBadge.vue'
 import SkeletonLoader from '@/components/SkeletonLoader.vue'
 import EmptyState from '@/components/EmptyState.vue'
 import PaginationBar from '@/components/PaginationBar.vue'
 import TableRowActions from '@/components/TableRowActions.vue'
+import ThaiDatePicker from '@/components/ThaiDatePicker.vue'
 import { Users, UserCheck, Clock, AlertTriangle, AlertCircle, Home, Search } from 'lucide-vue-next'
 
-const { fetchList } = useProbation()
+const { fetchList, update, remove } = useProbation()
+const auth = useAuthStore()
+const ui = useUiStore()
+
+const isAdmin = computed(() => auth.isAdmin)
+
+function rowActions(row) {
+  const actions = [
+    { key: 'view', label: 'ดูรายละเอียด', onClick: () => openView(row) },
+    { key: 'edit', label: 'แก้ไข', onClick: () => openEdit(row) },
+  ]
+  if (isAdmin.value) {
+    actions.push({
+      key: 'delete',
+      label: 'ลบ',
+      variant: 'danger',
+      onClick: () => confirmDelete(row),
+    })
+  }
+  return actions
+}
 
 const loading = ref(false)
 const error = ref(null)
@@ -238,6 +328,78 @@ const viewingRow = ref(null)
 function openView(row) {
   viewingRow.value = row
   showViewModal.value = true
+}
+
+// Edit modal state
+const showEditModal = ref(false)
+const editingRow = ref(null)
+const saving = ref(false)
+const formErrors = ref({})
+const formData = ref({
+  start_date: '',
+  end_date: '',
+  overall_status: 'IN_PROGRESS',
+  remarks: '',
+})
+
+function openEdit(row) {
+  editingRow.value = row
+  formData.value = {
+    start_date: row.startDateIso || '',
+    end_date: row.endDateIso || '',
+    overall_status: row.overallStatus || 'IN_PROGRESS',
+    remarks: row.remarks || '',
+  }
+  formErrors.value = {}
+  showEditModal.value = true
+}
+
+function closeEditModal() {
+  showEditModal.value = false
+  editingRow.value = null
+  formErrors.value = {}
+}
+
+function validateForm() {
+  const errors = {}
+  if (!formData.value.start_date) errors.start_date = true
+  if (!formData.value.end_date) errors.end_date = true
+  formErrors.value = errors
+  return Object.keys(errors).length === 0
+}
+
+async function handleSave() {
+  if (!validateForm() || !editingRow.value) return
+  const ok = await confirmSave({
+    message: 'คุณต้องการบันทึกการแก้ไขรายการทดลองปฏิบัติราชการนี้หรือไม่?',
+  })
+  if (!ok) return
+  saving.value = true
+  try {
+    await update(editingRow.value.enrollmentId, { ...formData.value })
+    ui.showToast('อัปเดตสำเร็จ', 'success')
+    closeEditModal()
+    fetchData()
+  } catch (err) {
+    ui.showToast(err.message || 'เกิดข้อผิดพลาด', 'error')
+  } finally {
+    saving.value = false
+  }
+}
+
+async function confirmDelete(row) {
+  const ok = await confirmDeleteAction({
+    message: `คุณต้องการลบรายการทดลองของ ${row.name} หรือไม่?`,
+    detail: 'รายการจะถูกถอดออกจากรายการติดตาม (ไม่ลบประวัติถาวร)',
+  })
+  if (!ok) return
+  try {
+    await remove(row.enrollmentId)
+    ui.showToast('ลบสำเร็จ', 'success')
+    fetchData()
+  } catch (err) {
+    ui.showToast(err.message || 'เกิดข้อผิดพลาด', 'error')
+  }
 }
 
 async function fetchData() {


### PR DESCRIPTION
## Summary
- Add view / edit / delete row actions on Candidates and Probation pages (delete is admin-only).
- Probation: expand PUT fields, soft-delete via `CANCELLED`, keep Thai name prefixes reliable (migration 29 + list join).
- Candidates: edit opens profile; delete soft-deactivates personnel via `DELETE /civil-servants/{id}`.

## Test plan
- [x] Frontend unit tests for ProbationEndPage, CandidateListsPage, useProbation, useCandidates
- [x] Schema parity: `node scripts/validate-schema-parity.mjs`
- [ ] Smoke on staging/prod after Render deploy: probation edit/delete, candidates view/edit/delete as admin vs operator

Made with [Cursor](https://cursor.com)