### PR TITLE
feat: add personnel master CRUD menu and API

### DIFF
--- a/backend/authz.php
+++ b/backend/authz.php
@@ -48,12 +48,13 @@ function defaultPermissionMatrix(): array
         ],
         'operator' => [
             'read' => ['*'],
+            // personnel master write = admin/superadmin เท่านั้น (ADR-0004)
             'create' => [
-                'multiplier', 'personnel', 'candidates', 'probation',
+                'multiplier', 'candidates', 'probation',
                 'equivalence', 'supportive', 'diverse', 'photos',
             ],
             'update' => [
-                'multiplier', 'personnel', 'candidates', 'probation',
+                'multiplier', 'candidates', 'probation',
                 'equivalence', 'supportive', 'diverse',
             ],
             'delete' => [],

--- a/backend/routes/personnel.php
+++ b/backend/routes/personnel.php
@@ -1,13 +1,19 @@
 <?php
 // ============================================================================
 // routes/personnel.php
-// Personnel typeahead / search for career time-entry modals
+// Personnel typeahead + master CRUD (ข้อมูลบุคลากร)
 //
 // Endpoints:
-//   GET /personnel?search=&limit= — ค้นหาบุคลากรที่ใช้งานอยู่ (typeahead)
+//   GET  /personnel?search=&limit=              — typeahead (ไม่มี offset)
+//   GET  /personnel?offset=&limit=&search=      — รายการมาสเตอร์ + pagination
+//   GET  /personnel/lookups                     — คำนำหน้าสำหรับฟอร์ม
+//   GET  /personnel/{id}                        — รายละเอียดคนหนึ่ง
+//   POST /personnel                             — สร้าง (admin+)
+//   PUT  /personnel/{id}                        — แก้ไข / ปิด·เปิดใช้งาน (admin+)
 // ============================================================================
 
 include_once __DIR__ . '/../helpers.php';
+include_once __DIR__ . '/../audit.php';
 
 /**
  * SQL สำหรับ typeahead บุคลากร — LIMIT เป็นตัวเลขที่ clamp แล้ว (ห้าม bind เป็น ?)
@@ -63,22 +69,438 @@ function searchPersonnelTypeahead(PDO $pdo, string $search, int $limit = 10): ar
 }
 
 /**
+ * SELECT columns สำหรับมาสเตอร์รายการ/รายคน
+ */
+function personnelMasterSelectSql(): string
+{
+    $fullName = sqlPersonnelFullName('p', 'px');
+    return "
+        SELECT p.personnel_id, p.citizen_id, p.employee_id,
+               p.prefix_id, p.first_name, p.last_name,
+               {$fullName} AS full_name,
+               p.is_active,
+               pos.position_name AS current_position,
+               o.org_name AS department,
+               px.prefix_name_th
+        FROM personnel p
+        LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id
+        LEFT JOIN `position` pos ON p.current_position_id = pos.position_id
+        LEFT JOIN organization o ON p.current_org_id = o.org_id
+    ";
+}
+
+/**
+ * รายการมาสเตอร์บุคลากร (pagination)
+ *
+ * @return array{data: list<array<string,mixed>>, pagination: array<string,mixed>}
+ */
+function listPersonnelMaster(
+    PDO $pdo,
+    string $search = '',
+    int $limit = 20,
+    int $offset = 0,
+    bool $includeInactive = false
+): array {
+    $limit = max(1, min(200, $limit));
+    $offset = max(0, $offset);
+    $fullName = sqlPersonnelFullName('p', 'px');
+
+    $where = [];
+    $params = [];
+
+    if (!$includeInactive) {
+        $where[] = 'p.is_active = 1';
+    }
+
+    $q = trim($search);
+    if ($q !== '') {
+        $where[] = '(
+            p.first_name LIKE ?
+            OR p.last_name LIKE ?
+            OR p.citizen_id LIKE ?
+            OR p.employee_id LIKE ?
+            OR ' . $fullName . ' LIKE ?
+        )';
+        $term = "%{$q}%";
+        $params = [$term, $term, $term, $term, $term];
+    }
+
+    $whereSql = $where ? ('WHERE ' . implode(' AND ', $where)) : '';
+
+    $countSql = "
+        SELECT COUNT(*)
+        FROM personnel p
+        LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id
+        {$whereSql}
+    ";
+    $countStmt = $pdo->prepare($countSql);
+    $countStmt->execute($params);
+    $total = (int) $countStmt->fetchColumn();
+
+    $listSql = personnelMasterSelectSql()
+        . " {$whereSql} ORDER BY p.first_name, p.last_name, p.personnel_id"
+        . " LIMIT {$limit} OFFSET {$offset}";
+    $listStmt = $pdo->prepare($listSql);
+    $listStmt->execute($params);
+    $rows = $listStmt->fetchAll(PDO::FETCH_ASSOC);
+
+    return [
+        'data' => $rows,
+        'pagination' => [
+            'total' => $total,
+            'limit' => $limit,
+            'offset' => $offset,
+            'has_more' => ($offset + $limit) < $total,
+        ],
+    ];
+}
+
+/**
+ * @return array<string, mixed>|null
+ */
+function getPersonnelById(PDO $pdo, int $id): ?array
+{
+    if ($id <= 0) {
+        return null;
+    }
+    $stmt = $pdo->prepare(personnelMasterSelectSql() . ' WHERE p.personnel_id = ? LIMIT 1');
+    $stmt->execute([$id]);
+    $row = $stmt->fetch(PDO::FETCH_ASSOC);
+    return $row ?: null;
+}
+
+/**
+ * @return list<array{prefix_id: int|string, prefix_name_th: string, prefix_code: string}>
+ */
+function getPersonnelLookups(PDO $pdo): array
+{
+    $stmt = $pdo->query(
+        'SELECT prefix_id, prefix_code, prefix_name_th
+         FROM prefixes
+         WHERE is_active = 1
+         ORDER BY prefix_name_th, prefix_id'
+    );
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}
+
+function isValidCitizenId(string $citizenId): bool
+{
+    return (bool) preg_match('/^\d{13}$/', $citizenId);
+}
+
+function personnelPrefixExists(PDO $pdo, int $prefixId): bool
+{
+    if ($prefixId <= 0) {
+        return false;
+    }
+    $stmt = $pdo->prepare('SELECT 1 FROM prefixes WHERE prefix_id = ? AND is_active = 1 LIMIT 1');
+    $stmt->execute([$prefixId]);
+    return (bool) $stmt->fetchColumn();
+}
+
+/**
+ * สร้างบุคลากร — คืน personnel_id หรือเขียน error response แล้วคืน null
+ *
+ * @param array<string, mixed>|null $input
+ */
+function createPersonnelRecord(PDO $pdo, array $auth, ?array $input = null): ?int
+{
+    $data = $input ?? json_decode(file_get_contents('php://input'), true);
+    if (!is_array($data)) {
+        http_response_code(400);
+        echo json_encode(['error' => 'รูปแบบข้อมูลไม่ถูกต้อง'], JSON_UNESCAPED_UNICODE);
+        return null;
+    }
+
+    $firstName = trim((string) ($data['first_name'] ?? ''));
+    $lastName = trim((string) ($data['last_name'] ?? ''));
+    $citizenId = trim((string) ($data['citizen_id'] ?? ''));
+    $employeeIdRaw = trim((string) ($data['employee_id'] ?? ''));
+    $employeeId = $employeeIdRaw === '' ? null : $employeeIdRaw;
+    $prefixId = isset($data['prefix_id']) && $data['prefix_id'] !== '' && $data['prefix_id'] !== null
+        ? (int) $data['prefix_id']
+        : null;
+
+    if ($firstName === '' || $lastName === '') {
+        http_response_code(400);
+        echo json_encode(['error' => 'กรุณาระบุชื่อและนามสกุล'], JSON_UNESCAPED_UNICODE);
+        return null;
+    }
+    if (!isValidCitizenId($citizenId)) {
+        http_response_code(400);
+        echo json_encode(['error' => 'เลขบัตรประชาชนต้องเป็นตัวเลข 13 หลัก'], JSON_UNESCAPED_UNICODE);
+        return null;
+    }
+    if ($prefixId !== null && $prefixId <= 0) {
+        $prefixId = null;
+    }
+    if ($prefixId !== null && !personnelPrefixExists($pdo, $prefixId)) {
+        http_response_code(400);
+        echo json_encode(['error' => 'คำนำหน้าไม่ถูกต้อง'], JSON_UNESCAPED_UNICODE);
+        return null;
+    }
+
+    try {
+        $stmt = $pdo->prepare(
+            'INSERT INTO personnel (citizen_id, first_name, last_name, prefix_id, employee_id, is_active)
+             VALUES (?, ?, ?, ?, ?, 1)'
+        );
+        $stmt->execute([$citizenId, $firstName, $lastName, $prefixId, $employeeId]);
+    } catch (PDOException $e) {
+        if ($e->getCode() === '23000') {
+            http_response_code(409);
+            $msg = str_contains($e->getMessage(), 'employee_id')
+                ? 'รหัสพนักงานนี้ถูกใช้งานแล้ว'
+                : 'เลขบัตรประชาชนนี้มีอยู่ในระบบแล้ว';
+            echo json_encode(['error' => $msg], JSON_UNESCAPED_UNICODE);
+            return null;
+        }
+        throw $e;
+    }
+
+    $newId = (int) $pdo->lastInsertId();
+    logAudit(
+        $pdo,
+        (int) ($auth['user_id'] ?? 0),
+        'CREATE',
+        'personnel',
+        $newId,
+        null,
+        [
+            // ไม่ใส่ citizen_id ใน audit (PII) — เก็บเฉพาะรหัส record + ชื่อ
+            'first_name' => $firstName,
+            'last_name' => $lastName,
+            'prefix_id' => $prefixId,
+            'employee_id' => $employeeId,
+        ]
+    );
+
+    return $newId;
+}
+
+/**
+ * แก้ไขบุคลากร — คืน true เมื่อสำเร็จ; เขียน error แล้วคืน false เมื่อล้มเหลว
+ *
+ * @param array<string, mixed>|null $input
+ */
+function updatePersonnelRecord(PDO $pdo, int $id, array $auth, ?array $input = null): bool
+{
+    $data = $input ?? json_decode(file_get_contents('php://input'), true);
+    if (!is_array($data)) {
+        http_response_code(400);
+        echo json_encode(['error' => 'รูปแบบข้อมูลไม่ถูกต้อง'], JSON_UNESCAPED_UNICODE);
+        return false;
+    }
+
+    if (array_key_exists('citizen_id', $data)) {
+        http_response_code(400);
+        echo json_encode(
+            ['error' => 'ไม่สามารถแก้ไขเลขบัตรประชาชนได้ — หากผิดให้ปิดใช้งานแล้วสร้างใหม่'],
+            JSON_UNESCAPED_UNICODE
+        );
+        return false;
+    }
+
+    $before = getPersonnelById($pdo, $id);
+    if ($before === null) {
+        http_response_code(404);
+        echo json_encode(['error' => 'ไม่พบบุคลากร'], JSON_UNESCAPED_UNICODE);
+        return false;
+    }
+
+    $sets = [];
+    $params = [];
+
+    if (array_key_exists('first_name', $data)) {
+        $firstName = trim((string) $data['first_name']);
+        if ($firstName === '') {
+            http_response_code(400);
+            echo json_encode(['error' => 'ชื่อต้องไม่ว่าง'], JSON_UNESCAPED_UNICODE);
+            return false;
+        }
+        $sets[] = 'first_name = ?';
+        $params[] = $firstName;
+    }
+    if (array_key_exists('last_name', $data)) {
+        $lastName = trim((string) $data['last_name']);
+        if ($lastName === '') {
+            http_response_code(400);
+            echo json_encode(['error' => 'นามสกุลต้องไม่ว่าง'], JSON_UNESCAPED_UNICODE);
+            return false;
+        }
+        $sets[] = 'last_name = ?';
+        $params[] = $lastName;
+    }
+    if (array_key_exists('prefix_id', $data)) {
+        $prefixId = $data['prefix_id'];
+        if ($prefixId === '' || $prefixId === null) {
+            $sets[] = 'prefix_id = NULL';
+        } else {
+            $prefixId = (int) $prefixId;
+            if (!personnelPrefixExists($pdo, $prefixId)) {
+                http_response_code(400);
+                echo json_encode(['error' => 'คำนำหน้าไม่ถูกต้อง'], JSON_UNESCAPED_UNICODE);
+                return false;
+            }
+            $sets[] = 'prefix_id = ?';
+            $params[] = $prefixId;
+        }
+    }
+    if (array_key_exists('employee_id', $data)) {
+        $employeeIdRaw = trim((string) ($data['employee_id'] ?? ''));
+        if ($employeeIdRaw === '') {
+            $sets[] = 'employee_id = NULL';
+        } else {
+            $sets[] = 'employee_id = ?';
+            $params[] = $employeeIdRaw;
+        }
+    }
+    if (array_key_exists('is_active', $data)) {
+        $sets[] = 'is_active = ?';
+        $params[] = (int) (bool) $data['is_active'];
+    }
+
+    if ($sets === []) {
+        http_response_code(400);
+        echo json_encode(['error' => 'ไม่มีข้อมูลที่จะอัปเดต'], JSON_UNESCAPED_UNICODE);
+        return false;
+    }
+
+    $params[] = $id;
+    try {
+        $sql = 'UPDATE personnel SET ' . implode(', ', $sets) . ' WHERE personnel_id = ?';
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute($params);
+    } catch (PDOException $e) {
+        if ($e->getCode() === '23000') {
+            http_response_code(409);
+            echo json_encode(['error' => 'รหัสพนักงานนี้ถูกใช้งานแล้ว'], JSON_UNESCAPED_UNICODE);
+            return false;
+        }
+        throw $e;
+    }
+
+    $after = getPersonnelById($pdo, $id);
+    logAudit(
+        $pdo,
+        (int) ($auth['user_id'] ?? 0),
+        'UPDATE',
+        'personnel',
+        $id,
+        [
+            'first_name' => $before['first_name'],
+            'last_name' => $before['last_name'],
+            'prefix_id' => $before['prefix_id'],
+            'employee_id' => $before['employee_id'],
+            'is_active' => $before['is_active'],
+        ],
+        [
+            'first_name' => $after['first_name'] ?? null,
+            'last_name' => $after['last_name'] ?? null,
+            'prefix_id' => $after['prefix_id'] ?? null,
+            'employee_id' => $after['employee_id'] ?? null,
+            'is_active' => $after['is_active'] ?? null,
+        ]
+    );
+
+    return true;
+}
+
+/**
  * @param PDO $pdo
  * @param string $method
  * @param array<int, string> $path
  */
 function handlePersonnel(PDO $pdo, string $method, array $path): void
 {
-    if ($method !== 'GET') {
+    $actionMap = ['GET' => 'read', 'POST' => 'create', 'PUT' => 'update'];
+    if (!isset($actionMap[$method])) {
         respondMethodNotAllowed();
         return;
     }
+    requirePermission($actionMap[$method], 'personnel');
 
-    requirePermission('read', 'personnel');
+    $sub = $path[1] ?? null;
 
-    $search = (string) ($_GET['search'] ?? '');
-    $limit = intval($_GET['limit'] ?? 10);
-    $rows = searchPersonnelTypeahead($pdo, $search, $limit);
+    if ($method === 'GET') {
+        if ($sub === 'lookups') {
+            echo json_encode([
+                'success' => true,
+                'data' => ['prefixes' => getPersonnelLookups($pdo)],
+            ], JSON_UNESCAPED_UNICODE);
+            return;
+        }
 
-    echo json_encode(['success' => true, 'data' => $rows]);
+        if ($sub !== null && $sub !== '') {
+            $id = (int) $sub;
+            $row = getPersonnelById($pdo, $id);
+            if ($row === null) {
+                http_response_code(404);
+                echo json_encode(['error' => 'ไม่พบบุคลากร'], JSON_UNESCAPED_UNICODE);
+                return;
+            }
+            echo json_encode(['success' => true, 'data' => $row], JSON_UNESCAPED_UNICODE);
+            return;
+        }
+
+        // Master list when offset is present; otherwise typeahead (backward compatible)
+        if (array_key_exists('offset', $_GET)) {
+            $includeInactive = isset($_GET['include_inactive']) && (string) $_GET['include_inactive'] !== '0';
+            if ($includeInactive) {
+                $role = getAuthenticatedUser()['role'] ?? '';
+                if ($role !== 'admin' && $role !== 'superadmin') {
+                    // แผน: โชว์คนปิดใช้งานเฉพาะแอดมิน — กัน operator/viewer ดึงรายการปิดใช้งานผ่าน query
+                    $includeInactive = false;
+                }
+            }
+            $result = listPersonnelMaster(
+                $pdo,
+                (string) ($_GET['search'] ?? ''),
+                intval($_GET['limit'] ?? 20),
+                intval($_GET['offset'] ?? 0),
+                $includeInactive
+            );
+            echo json_encode([
+                'success' => true,
+                'data' => $result['data'],
+                'pagination' => $result['pagination'],
+            ], JSON_UNESCAPED_UNICODE);
+            return;
+        }
+
+        $search = (string) ($_GET['search'] ?? '');
+        $limit = intval($_GET['limit'] ?? 10);
+        $rows = searchPersonnelTypeahead($pdo, $search, $limit);
+        echo json_encode(['success' => true, 'data' => $rows], JSON_UNESCAPED_UNICODE);
+        return;
+    }
+
+    if ($method === 'POST') {
+        if ($sub !== null && $sub !== '') {
+            http_response_code(404);
+            echo json_encode(['error' => 'Not found'], JSON_UNESCAPED_UNICODE);
+            return;
+        }
+        $auth = getAuthenticatedUser();
+        $newId = createPersonnelRecord($pdo, $auth ?? []);
+        if ($newId === null) {
+            return;
+        }
+        http_response_code(201);
+        echo json_encode(['success' => true, 'personnel_id' => $newId], JSON_UNESCAPED_UNICODE);
+        return;
+    }
+
+    // PUT
+    if ($sub === null || $sub === '') {
+        http_response_code(400);
+        echo json_encode(['error' => 'กรุณาระบุรหัสบุคลากร'], JSON_UNESCAPED_UNICODE);
+        return;
+    }
+    $auth = getAuthenticatedUser();
+    $ok = updatePersonnelRecord($pdo, (int) $sub, $auth ?? []);
+    if (!$ok) {
+        return;
+    }
+    echo json_encode(['success' => true], JSON_UNESCAPED_UNICODE);
 }

--- a/backend/tests/Integration/PersonnelMasterCrudTest.php
+++ b/backend/tests/Integration/PersonnelMasterCrudTest.php
@@ -1,0 +1,191 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Integration;
+
+use PDO;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+putenv('JWT_SECRET=integration-test-secret');
+
+require_once __DIR__ . '/../../config.php';
+require_once __DIR__ . '/../../routes/personnel.php';
+
+/**
+ * Master CRUD บุคลากร — สร้าง / รายการ / แก้ / ห้ามแก้ citizen_id / ปิดใช้งาน
+ */
+final class PersonnelMasterCrudTest extends TestCase
+{
+    private static ?PDO $pdo = null;
+    /** @var list<int> */
+    private array $personnelIds = [];
+    /** @var list<int> */
+    private array $prefixIds = [];
+    private string $suffix = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$pdo = testPdo();
+    }
+
+    protected function setUp(): void
+    {
+        if (self::$pdo === null) {
+            self::markTestSkipped('ต่อ MySQL ไม่ได้ — รัน: docker compose up -d db แล้วใช้ tests/run.sh');
+        }
+        foreach (['personnel', 'prefixes'] as $table) {
+            if (!self::$pdo->query("SHOW TABLES LIKE '{$table}'")->fetchColumn()) {
+                self::markTestSkipped("ไม่พบตาราง {$table}");
+            }
+        }
+        $this->suffix = bin2hex(random_bytes(3));
+        self::$pdo->prepare(
+            'INSERT INTO prefixes (prefix_code, prefix_name_th) VALUES (?, ?)'
+        )->execute(['M' . $this->suffix, 'นาย']);
+        $this->prefixIds[] = (int) self::$pdo->lastInsertId();
+    }
+
+    protected function tearDown(): void
+    {
+        if (self::$pdo === null) {
+            return;
+        }
+        foreach ($this->personnelIds as $id) {
+            self::$pdo->prepare('DELETE FROM personnel WHERE personnel_id = ?')->execute([$id]);
+        }
+        foreach ($this->prefixIds as $id) {
+            self::$pdo->prepare('DELETE FROM prefixes WHERE prefix_id = ?')->execute([$id]);
+        }
+    }
+
+    #[Test]
+    public function create_list_update_deactivate_and_reject_citizen_id_change(): void
+    {
+        $auth = ['user_id' => 1];
+        $citizenId = '1' . str_pad((string) hexdec(substr($this->suffix, 0, 5)), 12, '0', STR_PAD_LEFT);
+        $citizenId = substr($citizenId, 0, 13);
+
+        ob_start();
+        $newId = createPersonnelRecord(self::$pdo, $auth, [
+            'first_name' => 'สมชาย' . $this->suffix,
+            'last_name' => 'ใจดี',
+            'citizen_id' => $citizenId,
+            'prefix_id' => $this->prefixIds[0],
+            'employee_id' => 'EMP' . $this->suffix,
+        ]);
+        $createOut = ob_get_clean();
+        self::assertNotNull($newId, 'create should succeed: ' . $createOut);
+        $this->personnelIds[] = $newId;
+
+        $listed = listPersonnelMaster(self::$pdo, 'สมชาย' . $this->suffix, 20, 0, false);
+        self::assertGreaterThanOrEqual(1, $listed['pagination']['total']);
+        $found = null;
+        foreach ($listed['data'] as $row) {
+            if ((int) $row['personnel_id'] === $newId) {
+                $found = $row;
+                break;
+            }
+        }
+        self::assertNotNull($found);
+        self::assertSame($citizenId, $found['citizen_id']);
+
+        ob_start();
+        $updated = updatePersonnelRecord(self::$pdo, $newId, $auth, [
+            'first_name' => 'สมหญิง' . $this->suffix,
+            'last_name' => 'รักงาน',
+        ]);
+        $updateOut = ob_get_clean();
+        self::assertTrue($updated, $updateOut);
+        $after = getPersonnelById(self::$pdo, $newId);
+        self::assertSame('สมหญิง' . $this->suffix, $after['first_name']);
+
+        ob_start();
+        $rejected = updatePersonnelRecord(self::$pdo, $newId, $auth, [
+            'citizen_id' => '9999999999999',
+        ]);
+        ob_get_clean();
+        self::assertFalse($rejected);
+        $still = getPersonnelById(self::$pdo, $newId);
+        self::assertSame($citizenId, $still['citizen_id']);
+
+        ob_start();
+        $deactivated = updatePersonnelRecord(self::$pdo, $newId, $auth, ['is_active' => 0]);
+        ob_get_clean();
+        self::assertTrue($deactivated);
+
+        $activeList = listPersonnelMaster(self::$pdo, 'สมหญิง' . $this->suffix, 20, 0, false);
+        foreach ($activeList['data'] as $row) {
+            self::assertNotSame($newId, (int) $row['personnel_id']);
+        }
+
+        $typeahead = searchPersonnelTypeahead(self::$pdo, 'สมหญิง' . $this->suffix, 10);
+        self::assertSame([], $typeahead);
+
+        $withInactive = listPersonnelMaster(self::$pdo, 'สมหญิง' . $this->suffix, 20, 0, true);
+        $inactiveFound = false;
+        foreach ($withInactive['data'] as $row) {
+            if ((int) $row['personnel_id'] === $newId) {
+                $inactiveFound = true;
+                self::assertSame(0, (int) $row['is_active']);
+            }
+        }
+        self::assertTrue($inactiveFound);
+    }
+
+    #[Test]
+    public function duplicate_citizen_id_returns_conflict(): void
+    {
+        $auth = ['user_id' => 1];
+        $citizenId = '2' . str_pad((string) hexdec(substr($this->suffix, 0, 5)), 12, '0', STR_PAD_LEFT);
+        $citizenId = substr($citizenId, 0, 13);
+
+        ob_start();
+        $first = createPersonnelRecord(self::$pdo, $auth, [
+            'first_name' => 'A' . $this->suffix,
+            'last_name' => 'One',
+            'citizen_id' => $citizenId,
+        ]);
+        ob_get_clean();
+        self::assertNotNull($first);
+        $this->personnelIds[] = $first;
+
+        ob_start();
+        $dup = createPersonnelRecord(self::$pdo, $auth, [
+            'first_name' => 'B' . $this->suffix,
+            'last_name' => 'Two',
+            'citizen_id' => $citizenId,
+        ]);
+        $out = ob_get_clean();
+        self::assertNull($dup);
+        self::assertStringContainsString('เลขบัตรประชาชน', $out);
+    }
+
+    #[Test]
+    public function lookups_return_active_prefixes(): void
+    {
+        $lookups = getPersonnelLookups(self::$pdo);
+        self::assertNotEmpty($lookups);
+        $ids = array_map(static fn ($r) => (int) $r['prefix_id'], $lookups);
+        self::assertContains($this->prefixIds[0], $ids);
+    }
+
+    #[Test]
+    public function create_rejects_unknown_prefix_id(): void
+    {
+        $auth = ['user_id' => 1];
+        $citizenId = '3' . str_pad((string) hexdec(substr($this->suffix, 0, 5)), 12, '0', STR_PAD_LEFT);
+        $citizenId = substr($citizenId, 0, 13);
+
+        ob_start();
+        $id = createPersonnelRecord(self::$pdo, $auth, [
+            'first_name' => 'C' . $this->suffix,
+            'last_name' => 'BadPrefix',
+            'citizen_id' => $citizenId,
+            'prefix_id' => 999999991,
+        ]);
+        $out = ob_get_clean();
+        self::assertNull($id);
+        self::assertStringContainsString('คำนำหน้า', $out);
+    }
+}

--- a/backend/tests/Unit/AuditPermissionTest.php
+++ b/backend/tests/Unit/AuditPermissionTest.php
@@ -76,7 +76,7 @@ final class AuditPermissionTest extends TestCase
     {
         return [
             'multiplier (allowed)'   => ['multiplier', true],
-            'personnel (allowed)'    => ['personnel', true],
+            'personnel (denied)'     => ['personnel', false],
             'candidates (allowed)'   => ['candidates', true],
             'probation (allowed)'    => ['probation', true],
             'equivalence (allowed)'  => ['equivalence', true],

--- a/backend/tests/Unit/PersonnelMasterQueryTest.php
+++ b/backend/tests/Unit/PersonnelMasterQueryTest.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../helpers.php';
+require_once __DIR__ . '/../../routes/personnel.php';
+
+/**
+ * Unit: validation + list/typeahead mode helpers (ไม่มี DB)
+ */
+final class PersonnelMasterQueryTest extends TestCase
+{
+    #[Test]
+    public function citizen_id_must_be_exactly_13_digits(): void
+    {
+        self::assertTrue(isValidCitizenId('1234567890123'));
+        self::assertFalse(isValidCitizenId('123456789012'));
+        self::assertFalse(isValidCitizenId('12345678901234'));
+        self::assertFalse(isValidCitizenId('123456789012a'));
+        self::assertFalse(isValidCitizenId(''));
+    }
+
+    #[Test]
+    public function master_select_includes_identity_and_org_columns(): void
+    {
+        $sql = personnelMasterSelectSql();
+        self::assertStringContainsString('p.citizen_id', $sql);
+        self::assertStringContainsString('p.employee_id', $sql);
+        self::assertStringContainsString('p.is_active', $sql);
+        self::assertStringContainsString('position_name', $sql);
+        self::assertStringContainsString('org_name', $sql);
+    }
+}

--- a/backend/tests/run.sh
+++ b/backend/tests/run.sh
@@ -36,27 +36,38 @@ esac
 echo "[run.sh] building test image ${IMAGE} ..."
 docker build -t "${IMAGE}" -f "${DOCKER_SCRIPT_DIR}/Dockerfile.test" "${DOCKER_SCRIPT_DIR}" >/dev/null
 
-# ---- 2) ตรวจ network ของ db (compose สร้าง <project>_smartport-net) --------
-NET="$(docker network ls --format '{{.Name}}' | grep -E 'smartport-net$' | head -1 || true)"
+# ---- 2) ตรวจว่ามี db รันอยู่ แล้วตั้งค่าเชื่อมต่อสำหรับ integration ----------
+NET="$(docker network ls --format '{{.Name}}' | grep -E 'smartport-net$' | head -1 | tr -d '\r' || true)"
+DB_CID="$(docker ps -qf name=smartport-db | head -1 | tr -d '\r' || true)"
 
 NET_ARGS=()
 ENV_ARGS=()
-if [ -n "${NET}" ]; then
+if [ -n "${NET}" ] || [ -n "${DB_CID}" ]; then
   # ดึงค่า DB จาก .env (root + root password = ต่อได้ทุก schema แน่นอน)
   get_env() { grep -E "^$1=" "${ROOT_DIR}/.env" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '\r"' ; }
   DB_NAME="$(get_env MYSQL_DATABASE)"; DB_NAME="${DB_NAME:-civil_service_mgmt}"
   DB_PASS="$(get_env MYSQL_ROOT_PASSWORD)"; DB_PASS="${DB_PASS:-rootpassword}"
 
-  NET_ARGS=(--network "${NET}")
+  if [ -n "${DB_CID}" ] && [ -n "${NET}" ]; then
+    # Docker CLI มองเห็น container + network → ใช้ชื่อ service ตามปกติ
+    NET_ARGS=(--network "${NET}")
+    DB_HOST="db"
+  else
+    # WSL/CLI แยกจาก Docker Desktop: มองเห็น network แต่ไม่เห็น container /
+    # หรือ DNS ชื่อ db พัง — ต่อผ่านพอร์ตที่ publish บน host แทน
+    NET_ARGS=(--add-host=host.docker.internal:host-gateway)
+    DB_HOST="host.docker.internal"
+  fi
+
   ENV_ARGS=(
-    -e MYSQL_HOST=db
+    -e "MYSQL_HOST=${DB_HOST}"
     -e "MYSQL_DATABASE=${DB_NAME}"
     -e MYSQL_USER=root
     -e "MYSQL_PASSWORD=${DB_PASS}"
   )
-  echo "[run.sh] db network: ${NET} — integration suite จะรัน (db=${DB_NAME})"
+  echo "[run.sh] integration จะรัน (db=${DB_NAME} host=${DB_HOST})"
 else
-  echo "[run.sh] ไม่พบ db network — integration จะถูก skip (unit suite อย่างเดียว)"
+  echo "[run.sh] ไม่พบ db network/container — integration จะถูก skip (unit suite อย่างเดียว)"
   echo "[run.sh] (ถ้าต้องการ integration: docker compose up -d --build db backend)"
 fi
 

--- a/frontend/src/__tests__/components/AppSidebar.test.js
+++ b/frontend/src/__tests__/components/AppSidebar.test.js
@@ -86,6 +86,7 @@ describe('AppSidebar', () => {
     userVal = { name: 'op', role: 'operator' }
     const wrapper = mountSidebar()
     const text = wrapper.text()
+    expect(text).toContain('ข้อมูลบุคลากร')
     expect(text).toContain('พ้นทดลองปฏิบัติราชการ')
     expect(text).toContain('Candidate Lists')
     expect(text).toContain('การนับเวลาเพิ่มเติม')

--- a/frontend/src/__tests__/composables/usePersonnelMaster.test.js
+++ b/frontend/src/__tests__/composables/usePersonnelMaster.test.js
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockGet = vi.fn()
+const mockPost = vi.fn()
+const mockPut = vi.fn()
+
+vi.mock('@/composables/useApi.js', () => ({
+  useApi: () => ({
+    get: mockGet,
+    post: mockPost,
+    put: mockPut,
+  }),
+}))
+
+const { usePersonnelMaster } = await import('@/composables/usePersonnelMaster.js')
+
+describe('usePersonnelMaster', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('fetchList sends offset so API uses master list mode', async () => {
+    mockGet.mockResolvedValue({
+      success: true,
+      data: [{
+        personnel_id: 1,
+        citizen_id: '1234567890123',
+        first_name: 'สมชาย',
+        last_name: 'ใจดี',
+        full_name: 'นายสมชาย ใจดี',
+        is_active: 1,
+      }],
+      pagination: { total: 1, limit: 20, offset: 0, has_more: false },
+    })
+
+    const { fetchList } = usePersonnelMaster()
+    const result = await fetchList({ search: 'สมชาย', offset: 0, includeInactive: true })
+
+    expect(mockGet).toHaveBeenCalledWith(expect.stringMatching(/^\/personnel\?/))
+    const url = mockGet.mock.calls[0][0]
+    expect(url).toContain('offset=0')
+    expect(url).toContain('include_inactive=1')
+    expect(url).toContain('search=')
+    expect(result.data[0].personnelId).toBe(1)
+    expect(result.data[0].fullName).toBe('นายสมชาย ใจดี')
+    expect(result.data[0].isActive).toBe(true)
+  })
+
+  it('create posts identity fields', async () => {
+    mockPost.mockResolvedValue({ success: true, personnel_id: 9 })
+    const { create } = usePersonnelMaster()
+    await create({
+      firstName: 'สมชาย',
+      lastName: 'ใจดี',
+      citizenId: '1234567890123',
+      employeeId: 'E1',
+      prefixId: 2,
+    })
+    expect(mockPost).toHaveBeenCalledWith('/personnel', {
+      first_name: 'สมชาย',
+      last_name: 'ใจดี',
+      citizen_id: '1234567890123',
+      employee_id: 'E1',
+      prefix_id: 2,
+    })
+  })
+
+  it('update never sends citizen_id', async () => {
+    mockPut.mockResolvedValue({ success: true })
+    const { update } = usePersonnelMaster()
+    await update(5, { firstName: 'สมหญิง', isActive: false })
+    expect(mockPut).toHaveBeenCalledWith('/personnel/5', {
+      first_name: 'สมหญิง',
+      is_active: 0,
+    })
+  })
+})

--- a/frontend/src/__tests__/pages/PersonnelPage.test.js
+++ b/frontend/src/__tests__/pages/PersonnelPage.test.js
@@ -1,0 +1,103 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useAuthStore } from '@/stores/auth.js'
+
+const mockFetchList = vi.fn()
+const mockFetchLookups = vi.fn()
+const mockCreate = vi.fn()
+const mockUpdate = vi.fn()
+
+vi.mock('@/composables/usePersonnelMaster.js', () => ({
+  usePersonnelMaster: () => ({
+    fetchList: mockFetchList,
+    fetchLookups: mockFetchLookups,
+    create: mockCreate,
+    update: mockUpdate,
+  }),
+}))
+
+vi.mock('vue-router', () => ({
+  RouterLink: { template: '<a :href="to"><slot /></a>', props: ['to'] },
+}))
+
+const PersonnelPage = (await import('@/pages/PersonnelPage.vue')).default
+
+const sampleRow = {
+  personnelId: 7,
+  citizenId: '1234567890123',
+  employeeId: 'E001',
+  prefixId: 1,
+  firstName: 'สมชาย',
+  lastName: 'ใจดี',
+  fullName: 'นายสมชาย ใจดี',
+  isActive: true,
+  currentPosition: 'นักทรัพยากรบุคคล',
+  department: 'ก.พ.',
+}
+
+function resolvedData(rows = [sampleRow]) {
+  mockFetchList.mockResolvedValue({
+    data: rows,
+    pagination: { total: rows.length, limit: 20, offset: 0, has_more: false },
+  })
+  mockFetchLookups.mockResolvedValue([
+    { prefix_id: 1, prefix_code: '001', prefix_name_th: 'นาย' },
+  ])
+}
+
+async function mountPage(role = 'admin') {
+  setActivePinia(createPinia())
+  const auth = useAuthStore()
+  auth.user = { id: 1, role }
+  const wrapper = mount(PersonnelPage)
+  await vi.waitFor(() => expect(mockFetchList).toHaveBeenCalled())
+  await wrapper.vm.$nextTick()
+  return wrapper
+}
+
+describe('PersonnelPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resolvedData()
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('loads data on mount and renders rows', async () => {
+    const wrapper = await mountPage()
+    expect(wrapper.text()).toContain('นายสมชาย ใจดี')
+    expect(wrapper.text()).toContain('1234567890123')
+    expect(mockFetchList).toHaveBeenCalledWith(
+      expect.objectContaining({ offset: 0, includeInactive: false }),
+    )
+  })
+
+  it('shows add button for admin and opens create modal', async () => {
+    const wrapper = await mountPage('admin')
+    expect(wrapper.text()).toContain('เพิ่มบุคลากร')
+    wrapper.vm.openCreate()
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.showFormModal).toBe(true)
+  })
+
+  it('hides add button for non-admin', async () => {
+    const wrapper = await mountPage('operator')
+    expect(wrapper.vm.isAdmin).toBe(false)
+    expect(wrapper.text()).not.toContain('เพิ่มบุคลากร')
+  })
+
+  it('shows error state when loading fails', async () => {
+    mockFetchList.mockRejectedValue(new Error('โหลดข้อมูลไม่สำเร็จ'))
+    const wrapper = await mountPage()
+    await vi.waitFor(() => expect(wrapper.text()).toContain('โหลดข้อมูลไม่สำเร็จ'))
+  })
+
+  it('shows empty state when no rows', async () => {
+    resolvedData([])
+    const wrapper = await mountPage()
+    await vi.waitFor(() => expect(wrapper.text()).toContain('ไม่พบบุคลากร'))
+  })
+})

--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -112,6 +112,7 @@ import { roleLabel } from '@/utils/roleLabels.js'
 import {
   X, BookOpen, LayoutDashboard, UserCheck, Users, Clock, Award, UserMinus,
   Briefcase, FileText, Trophy, ChevronRight, UserCog, FileUp, FileSearch, Shield, ScanText,
+  Contact,
 } from 'lucide-vue-next'
 
 defineProps({ open: Boolean })
@@ -133,6 +134,7 @@ const menuSections = computed(() => [
     id: 'main',
     label: 'MAIN',
     items: [
+      { id: 'personnel', label: 'ข้อมูลบุคลากร', icon: Contact, to: '/personnel' },
       { id: 'probation-end', label: 'พ้นทดลองปฏิบัติราชการ', icon: UserCheck, to: '/probation-end' },
       {
         id: 'candidates', label: 'Candidate Lists', icon: Users,

--- a/frontend/src/composables/usePersonnelMaster.js
+++ b/frontend/src/composables/usePersonnelMaster.js
@@ -1,0 +1,71 @@
+import { useApi } from '@/composables/useApi.js'
+
+/**
+ * Master CRUD สำหรับหน้าข้อมูลบุคลากร (แยกจาก usePersonnelSearch typeahead)
+ */
+export function usePersonnelMaster() {
+  const api = useApi()
+
+  async function fetchList({
+    search = '',
+    limit = 20,
+    offset = 0,
+    includeInactive = false,
+  } = {}) {
+    const params = new URLSearchParams()
+    if (search) params.set('search', search)
+    params.set('limit', String(limit))
+    params.set('offset', String(offset))
+    if (includeInactive) params.set('include_inactive', '1')
+
+    const result = await api.get(`/personnel?${params}`)
+    return {
+      success: result.success,
+      data: (result.data || []).map(mapRow),
+      pagination: result.pagination,
+    }
+  }
+
+  async function fetchLookups() {
+    const result = await api.get('/personnel/lookups')
+    return result.data?.prefixes || []
+  }
+
+  async function create(data) {
+    return api.post('/personnel', {
+      first_name: data.firstName,
+      last_name: data.lastName,
+      citizen_id: data.citizenId,
+      employee_id: data.employeeId || null,
+      prefix_id: data.prefixId || null,
+    })
+  }
+
+  async function update(id, data) {
+    const payload = {}
+    if (data.firstName !== undefined) payload.first_name = data.firstName
+    if (data.lastName !== undefined) payload.last_name = data.lastName
+    if (data.employeeId !== undefined) payload.employee_id = data.employeeId || null
+    if (data.prefixId !== undefined) payload.prefix_id = data.prefixId || null
+    if (data.isActive !== undefined) payload.is_active = data.isActive ? 1 : 0
+    return api.put(`/personnel/${id}`, payload)
+  }
+
+  function mapRow(row) {
+    return {
+      personnelId: row.personnel_id,
+      citizenId: row.citizen_id,
+      employeeId: row.employee_id,
+      prefixId: row.prefix_id,
+      firstName: row.first_name,
+      lastName: row.last_name,
+      fullName: row.full_name,
+      isActive: Boolean(Number(row.is_active)),
+      currentPosition: row.current_position,
+      department: row.department,
+      prefixNameTh: row.prefix_name_th,
+    }
+  }
+
+  return { fetchList, fetchLookups, create, update }
+}

--- a/frontend/src/pages/PersonnelPage.vue
+++ b/frontend/src/pages/PersonnelPage.vue
@@ -1,0 +1,437 @@
+<template>
+  <div class="p-6 space-y-6">
+    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+      <div>
+        <h1 class="text-2xl font-bold text-gray-900">ข้อมูลบุคลากร</h1>
+        <p class="text-sm text-gray-500 mt-1">ค้นหา ดู และจัดการข้อมูลบุคลากรในระบบ (มาสเตอร์)</p>
+      </div>
+      <button
+        v-if="isAdmin"
+        type="button"
+        @click="openCreate"
+        class="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition-colors cursor-pointer self-start"
+      >
+        <Plus class="w-4 h-4" />
+        เพิ่มบุคลากร
+      </button>
+    </div>
+
+    <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-4">
+      <div class="flex flex-col sm:flex-row gap-3 sm:items-center">
+        <div class="max-w-md flex-1">
+          <ListSearchInput
+            v-model="searchQuery"
+            placeholder="ค้นหาชื่อ เลขบัตร หรือรหัสพนักงาน..."
+            ime-guard
+            @search="onSearchInput"
+          />
+        </div>
+        <label v-if="isAdmin" class="flex items-center gap-2 text-sm text-gray-600 cursor-pointer select-none">
+          <input
+            v-model="includeInactive"
+            type="checkbox"
+            class="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+            @change="onIncludeInactiveChange"
+          />
+          แสดงที่ปิดใช้งาน
+        </label>
+      </div>
+    </div>
+
+    <div class="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
+      <div v-if="loading" class="py-12 text-center text-sm text-gray-500">กำลังโหลดข้อมูล...</div>
+
+      <div v-else-if="error" class="py-12 text-center">
+        <p class="text-sm text-red-600 mb-3">{{ error }}</p>
+        <button
+          type="button"
+          @click="fetchData"
+          class="px-4 py-2 bg-blue-500 text-white rounded-lg text-sm hover:bg-blue-600 transition-colors cursor-pointer"
+        >
+          ลองใหม่
+        </button>
+      </div>
+
+      <EmptyState
+        v-else-if="rows.length === 0"
+        :icon="Users"
+        title="ไม่พบบุคลากร"
+        :description="searchQuery ? 'ไม่พบบุคลากรที่ตรงกับคำค้นหา' : 'ยังไม่มีบุคลากรในระบบ'"
+      />
+
+      <div v-else class="overflow-x-auto">
+        <table class="min-w-full divide-y divide-gray-200">
+          <thead class="bg-gray-50">
+            <tr>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ชื่อ-สกุล</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">เลขบัตร</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">รหัสพนักงาน</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ตำแหน่ง</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">หน่วยงาน</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">สถานะ</th>
+              <th v-if="isAdmin" class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">จัดการ</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-200">
+            <tr v-for="row in rows" :key="row.personnelId" class="hover:bg-gray-50 transition-colors">
+              <td class="px-6 py-4 whitespace-nowrap">
+                <RouterLink
+                  :to="`/profile/${row.personnelId}`"
+                  class="text-sm font-medium text-blue-600 hover:text-blue-800"
+                >
+                  {{ row.fullName }}
+                </RouterLink>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700">{{ row.citizenId || '-' }}</td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700">{{ row.employeeId || '-' }}</td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700">{{ row.currentPosition || '-' }}</td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700">{{ row.department || '-' }}</td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <span
+                  class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full"
+                  :class="row.isActive ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'"
+                >
+                  {{ row.isActive ? 'ใช้งาน' : 'ปิดใช้งาน' }}
+                </span>
+              </td>
+              <td v-if="isAdmin" class="px-6 py-4 whitespace-nowrap text-right">
+                <TableRowActions :actions="rowActions(row)" />
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div v-if="!loading && !error && pagination.total > 0" class="px-6 pb-4">
+        <PaginationBar
+          :total="pagination.total"
+          :limit="pagination.limit"
+          :offset="pagination.offset"
+          @update:offset="onPageChange"
+        />
+      </div>
+    </div>
+
+    <!-- Create / Edit Modal -->
+    <div v-if="showFormModal" class="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div class="absolute inset-0 bg-black/40" @click="closeFormModal"></div>
+      <div class="relative bg-white rounded-2xl shadow-xl w-full max-w-md p-6 space-y-4">
+        <h2 class="text-lg font-semibold text-gray-900">
+          {{ editingRow ? 'แก้ไขบุคลากร' : 'เพิ่มบุคลากรใหม่' }}
+        </h2>
+
+        <div class="space-y-3">
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1">คำนำหน้า</label>
+            <select
+              v-model="formData.prefixId"
+              class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option :value="null">— ไม่ระบุ —</option>
+              <option v-for="p in prefixes" :key="p.prefix_id" :value="Number(p.prefix_id)">
+                {{ p.prefix_name_th }}
+              </option>
+            </select>
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1">ชื่อ <span class="text-red-500">*</span></label>
+            <input
+              v-model="formData.firstName"
+              type="text"
+              class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1">นามสกุล <span class="text-red-500">*</span></label>
+            <input
+              v-model="formData.lastName"
+              type="text"
+              class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1">
+              เลขบัตรประชาชน <span v-if="!editingRow" class="text-red-500">*</span>
+            </label>
+            <input
+              v-model="formData.citizenId"
+              type="text"
+              maxlength="13"
+              inputmode="numeric"
+              :disabled="!!editingRow"
+              class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-gray-100 disabled:text-gray-500"
+              placeholder="13 หลัก"
+            />
+            <p v-if="editingRow" class="text-xs text-gray-400 mt-1">เลขบัตรแก้ไขไม่ได้ — หากผิดให้ปิดใช้งานแล้วสร้างใหม่</p>
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1">รหัสพนักงาน</label>
+            <input
+              v-model="formData.employeeId"
+              type="text"
+              class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="(ไม่บังคับ)"
+            />
+          </div>
+        </div>
+
+        <div class="flex justify-end gap-2 pt-2">
+          <button
+            type="button"
+            @click="closeFormModal"
+            class="px-4 py-2 text-sm text-gray-600 hover:bg-gray-100 rounded-lg transition-colors cursor-pointer"
+          >
+            ยกเลิก
+          </button>
+          <button
+            type="button"
+            @click="submitForm"
+            :disabled="saving"
+            class="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors cursor-pointer"
+          >
+            {{ saving ? 'กำลังบันทึก...' : (editingRow ? 'บันทึก' : 'สร้างบุคลากร') }}
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Toggle active confirm -->
+    <div v-if="showToggleConfirm" class="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div class="absolute inset-0 bg-black/40" @click="showToggleConfirm = false"></div>
+      <div class="relative bg-white rounded-2xl shadow-xl w-full max-w-sm p-6 space-y-4">
+        <h2 class="text-lg font-semibold text-gray-900">
+          {{ togglingRow?.isActive ? 'ยืนยันการปิดใช้งาน' : 'ยืนยันการเปิดใช้งาน' }}
+        </h2>
+        <p class="text-sm text-gray-600">
+          คุณต้องการ{{ togglingRow?.isActive ? 'ปิดใช้งาน' : 'เปิดใช้งาน' }}
+          <span class="font-medium text-gray-900">{{ togglingRow?.fullName }}</span> หรือไม่?
+          <template v-if="togglingRow?.isActive">
+            คนนี้จะไม่โผล่ในค้นหา/typeahead ตามปกติ แต่ประวัติรายการเวลายังอ้างอิงได้
+          </template>
+        </p>
+        <div class="flex justify-end gap-2 pt-2">
+          <button
+            type="button"
+            @click="showToggleConfirm = false"
+            class="px-4 py-2 text-sm text-gray-600 hover:bg-gray-100 rounded-lg transition-colors cursor-pointer"
+          >
+            ยกเลิก
+          </button>
+          <button
+            type="button"
+            @click="submitToggleActive"
+            :disabled="saving"
+            class="px-4 py-2 text-white text-sm font-medium rounded-lg disabled:opacity-50 transition-colors cursor-pointer"
+            :class="togglingRow?.isActive ? 'bg-red-600 hover:bg-red-700' : 'bg-green-600 hover:bg-green-700'"
+          >
+            {{ saving ? 'กำลังดำเนินการ...' : (togglingRow?.isActive ? 'ปิดใช้งาน' : 'เปิดใช้งาน') }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { RouterLink } from 'vue-router'
+import { usePersonnelMaster } from '@/composables/usePersonnelMaster.js'
+import { useDebouncedCallback } from '@/composables/useDebouncedCallback.js'
+import { useRequestSeq } from '@/composables/useRequestSeq.js'
+import { useAuthStore } from '@/stores/auth.js'
+import { useUiStore } from '@/stores/ui.js'
+import ListSearchInput from '@/components/ListSearchInput.vue'
+import PaginationBar from '@/components/PaginationBar.vue'
+import EmptyState from '@/components/EmptyState.vue'
+import TableRowActions from '@/components/TableRowActions.vue'
+import { Plus, Ban, CheckCircle, Users } from 'lucide-vue-next'
+
+const { fetchList, fetchLookups, create, update } = usePersonnelMaster()
+const auth = useAuthStore()
+const ui = useUiStore()
+const { next: nextRequest } = useRequestSeq()
+
+const isAdmin = computed(() => auth.isAdmin)
+
+const loading = ref(false)
+const error = ref(null)
+const rows = ref([])
+const pagination = ref({ total: 0, limit: 20, offset: 0, has_more: false })
+const searchQuery = ref('')
+const includeInactive = ref(false)
+const prefixes = ref([])
+
+const { run: scheduleSearch } = useDebouncedCallback(() => {
+  pagination.value.offset = 0
+  fetchData()
+}, 300)
+
+const showFormModal = ref(false)
+const editingRow = ref(null)
+const saving = ref(false)
+
+const defaultFormData = () => ({
+  prefixId: null,
+  firstName: '',
+  lastName: '',
+  citizenId: '',
+  employeeId: '',
+})
+const formData = ref(defaultFormData())
+
+const showToggleConfirm = ref(false)
+const togglingRow = ref(null)
+
+function rowActions(row) {
+  return [
+    { key: 'edit', label: 'แก้ไข', onClick: () => openEdit(row) },
+    {
+      key: 'toggle',
+      label: row.isActive ? 'ปิดใช้งาน' : 'เปิดใช้งาน',
+      icon: row.isActive ? Ban : CheckCircle,
+      variant: row.isActive ? 'danger' : 'success',
+      onClick: () => openToggleActive(row),
+    },
+  ]
+}
+
+async function fetchData() {
+  const req = nextRequest()
+  loading.value = true
+  error.value = null
+  try {
+    const result = await fetchList({
+      search: searchQuery.value,
+      limit: pagination.value.limit,
+      offset: pagination.value.offset,
+      includeInactive: includeInactive.value,
+    })
+    if (!req.isCurrent()) return
+    rows.value = result.data
+    pagination.value = result.pagination
+  } catch (err) {
+    if (!req.isCurrent()) return
+    error.value = err.message || 'ไม่สามารถโหลดข้อมูลได้ กรุณาลองใหม่อีกครั้ง'
+  } finally {
+    if (req.isCurrent()) loading.value = false
+  }
+}
+
+function onPageChange(offset) {
+  pagination.value.offset = offset
+  fetchData()
+}
+
+function onSearchInput() {
+  scheduleSearch()
+}
+
+function onIncludeInactiveChange() {
+  pagination.value.offset = 0
+  fetchData()
+}
+
+function openCreate() {
+  editingRow.value = null
+  formData.value = defaultFormData()
+  showFormModal.value = true
+}
+
+function openEdit(row) {
+  editingRow.value = row
+  formData.value = {
+    prefixId: row.prefixId != null ? Number(row.prefixId) : null,
+    firstName: row.firstName || '',
+    lastName: row.lastName || '',
+    citizenId: row.citizenId || '',
+    employeeId: row.employeeId || '',
+  }
+  showFormModal.value = true
+}
+
+function closeFormModal() {
+  showFormModal.value = false
+  editingRow.value = null
+}
+
+function validateForm() {
+  if (!formData.value.firstName.trim() || !formData.value.lastName.trim()) {
+    ui.showToast('กรุณาระบุชื่อและนามสกุล', 'error')
+    return false
+  }
+  if (!editingRow.value) {
+    const cid = formData.value.citizenId.trim()
+    if (!/^\d{13}$/.test(cid)) {
+      ui.showToast('เลขบัตรประชาชนต้องเป็นตัวเลข 13 หลัก', 'error')
+      return false
+    }
+  }
+  return true
+}
+
+async function submitForm() {
+  if (!validateForm()) return
+  saving.value = true
+  try {
+    if (editingRow.value) {
+      await update(editingRow.value.personnelId, {
+        firstName: formData.value.firstName.trim(),
+        lastName: formData.value.lastName.trim(),
+        employeeId: formData.value.employeeId.trim(),
+        prefixId: formData.value.prefixId,
+      })
+      ui.showToast('บันทึกข้อมูลบุคลากรสำเร็จ', 'success')
+    } else {
+      await create({
+        firstName: formData.value.firstName.trim(),
+        lastName: formData.value.lastName.trim(),
+        citizenId: formData.value.citizenId.trim(),
+        employeeId: formData.value.employeeId.trim(),
+        prefixId: formData.value.prefixId,
+      })
+      ui.showToast('สร้างบุคลากรสำเร็จ', 'success')
+    }
+    closeFormModal()
+    fetchData()
+  } catch (e) {
+    ui.showToast(e.message || 'เกิดข้อผิดพลาด กรุณาลองใหม่', 'error')
+  } finally {
+    saving.value = false
+  }
+}
+
+function openToggleActive(row) {
+  togglingRow.value = row
+  showToggleConfirm.value = true
+}
+
+async function submitToggleActive() {
+  saving.value = true
+  try {
+    const activating = !togglingRow.value.isActive
+    await update(togglingRow.value.personnelId, { isActive: activating })
+    ui.showToast(activating ? 'เปิดใช้งานสำเร็จ' : 'ปิดใช้งานสำเร็จ', 'success')
+    showToggleConfirm.value = false
+    togglingRow.value = null
+    fetchData()
+  } catch (e) {
+    ui.showToast(e.message || 'เกิดข้อผิดพลาด กรุณาลองใหม่', 'error')
+  } finally {
+    saving.value = false
+  }
+}
+
+onMounted(async () => {
+  try {
+    prefixes.value = await fetchLookups()
+  } catch {
+    prefixes.value = []
+    ui.showToast('โหลดรายการคำนำหน้าไม่สำเร็จ', 'error')
+  }
+  fetchData()
+})
+</script>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -42,6 +42,11 @@ const routes = [
         component: () => import('@/pages/ProbationEndPage.vue'),
       },
       {
+        path: 'personnel',
+        name: 'personnel',
+        component: () => import('@/pages/PersonnelPage.vue'),
+      },
+      {
         path: 'profile',
         name: 'my-profile',
         component: () => import('@/pages/ProfilePage.vue'),


### PR DESCRIPTION
## Summary
- Add เมนู/หน้าข้อมูลบุคลากร (`/personnel`) for identity CRUD: search, create, edit, soft-deactivate
- Extend `GET/POST/PUT /personnel` while keeping typeahead when `offset` is absent
- Restrict personnel write to admin/superadmin; harden prefix validation and inactive-list visibility

## Test plan
- [x] Vitest: PersonnelPage, usePersonnelMaster, AppSidebar, typeahead (pre-push full suite 69 files passed)
- [x] PHPUnit: PersonnelMaster CRUD integration + authz + typeahead filters
- [ ] Manual: login as admin → create person → edit → deactivate → confirm typeahead hides them
- [ ] Manual: login as operator → can view list, no create/edit buttons

EOF