### PR TITLE
feat: career profile shortcuts to open time-entry modals

### DIFF
--- a/backend/api.php
+++ b/backend/api.php
@@ -166,7 +166,7 @@ switch ($path[0]) {
             $stmt = $pdo->prepare(
                 "SELECT p.personnel_id AS servant_id, p.employee_id, p.first_name, p.last_name,
                         p.birth_date, p.appointment_date, p.retirement_date,
-                        p.servant_status,
+                        p.servant_status, p.is_active,
                         CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name,
                         csp.file_path AS photo_path
                  FROM personnel p

--- a/frontend/src/__tests__/pages/DiversePage.test.js
+++ b/frontend/src/__tests__/pages/DiversePage.test.js
@@ -7,6 +7,8 @@ const mockFetchList = vi.fn()
 const mockCreate = vi.fn()
 const mockUpdate = vi.fn()
 const mockRemove = vi.fn()
+const mockReplace = vi.fn()
+const routeQuery = { value: {} }
 
 vi.mock('@/composables/useDiverse.js', () => ({
   useDiverse: () => ({
@@ -32,6 +34,11 @@ vi.mock('@/composables/useConfirm.js', () => ({
 const mockSearchPersonnel = vi.fn(async () => [])
 vi.mock('@/composables/usePersonnelSearch.js', () => ({
   usePersonnelSearch: () => ({ searchPersonnel: (...args) => mockSearchPersonnel(...args) }),
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ get query() { return routeQuery.value } }),
+  useRouter: () => ({ replace: mockReplace }),
 }))
 
 const DiversePage = (await import('@/pages/DiversePage.vue')).default
@@ -99,6 +106,7 @@ function fillValidForm(wrapper) {
 describe('DiversePage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    routeQuery.value = {}
     mockFetchList.mockResolvedValue({
       success: true,
       data: [sampleRow],
@@ -350,5 +358,19 @@ describe('DiversePage', () => {
     const wrapper = await mountPage('admin')
     expect(wrapper.vm.isAdmin).toBe(true)
     expect(wrapper.findAll('button[title="ลบ"]').length).toBeGreaterThan(0)
+  })
+
+  it('opens create modal prefilled from profile create query', async () => {
+    routeQuery.value = {
+      create: '1',
+      personnel_id: '12',
+      full_name: 'นายสมชาย ไทยแท้',
+    }
+    const wrapper = await mountPage()
+    expect(wrapper.vm.showModal).toBe(true)
+    expect(wrapper.vm.formData.personnel_id).toBe(12)
+    expect(wrapper.vm.personnelSearch).toBe('นายสมชาย ไทยแท้')
+    expect(wrapper.vm.selectedPersonnelName).toBe('นายสมชาย ไทยแท้')
+    expect(mockReplace).toHaveBeenCalledWith({ query: {} })
   })
 })

--- a/frontend/src/__tests__/pages/EquivalencePage.test.js
+++ b/frontend/src/__tests__/pages/EquivalencePage.test.js
@@ -8,6 +8,8 @@ const mockCreate = vi.fn()
 const mockUpdate = vi.fn()
 const mockApprove = vi.fn()
 const mockReject = vi.fn()
+const mockReplace = vi.fn()
+const routeQuery = { value: {} }
 
 vi.mock('@/composables/useEquivalence.js', () => ({
   useEquivalence: () => ({
@@ -33,6 +35,11 @@ vi.mock('@/composables/useConfirm.js', () => ({
 
 vi.mock('@/composables/usePersonnelSearch.js', () => ({
   usePersonnelSearch: () => ({ searchPersonnel: vi.fn(async () => []) }),
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ get query() { return routeQuery.value } }),
+  useRouter: () => ({ replace: mockReplace }),
 }))
 
 const EquivalencePage = (await import('@/pages/EquivalencePage.vue')).default
@@ -81,6 +88,7 @@ function fillValidForm(wrapper) {
 describe('EquivalencePage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    routeQuery.value = {}
     mockFetchList.mockResolvedValue({
       success: true,
       data: [sampleRow],
@@ -241,5 +249,18 @@ describe('EquivalencePage', () => {
     expect(wrapper.vm.formData.personnel_id).toBe(9)
     expect(wrapper.vm.personnelSearch).toBe('สมหญิง รักงาน')
     expect(wrapper.vm.showPersonnelDropdown).toBe(false)
+  })
+
+  it('opens create modal prefilled from profile create query', async () => {
+    routeQuery.value = {
+      create: '1',
+      personnel_id: '12',
+      full_name: 'นายสมชาย ไทยแท้',
+    }
+    const wrapper = await mountPage()
+    expect(wrapper.vm.showModal).toBe(true)
+    expect(wrapper.vm.formData.personnel_id).toBe(12)
+    expect(wrapper.vm.personnelSearch).toBe('นายสมชาย ไทยแท้')
+    expect(mockReplace).toHaveBeenCalledWith({ query: {} })
   })
 })

--- a/frontend/src/__tests__/pages/MultiplierPage.test.js
+++ b/frontend/src/__tests__/pages/MultiplierPage.test.js
@@ -9,6 +9,8 @@ const mockCreate = vi.fn()
 const mockUpdate = vi.fn()
 const mockRemove = vi.fn()
 const mockSearchPersonnel = vi.fn(async () => [])
+const mockReplace = vi.fn()
+const routeQuery = { value: {} }
 
 vi.mock('@/composables/useMultiplier.js', () => ({
   useMultiplier: () => ({
@@ -34,6 +36,11 @@ vi.mock('@/composables/useConfirm.js', () => ({
 
 vi.mock('@/composables/usePersonnelSearch.js', () => ({
   usePersonnelSearch: () => ({ searchPersonnel: mockSearchPersonnel }),
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ get query() { return routeQuery.value } }),
+  useRouter: () => ({ replace: mockReplace }),
 }))
 
 const MultiplierPage = (await import('@/pages/MultiplierPage.vue')).default
@@ -117,6 +124,7 @@ function fillValidForm(wrapper) {
 describe('MultiplierPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    routeQuery.value = {}
     resolvedData()
   })
 
@@ -298,5 +306,18 @@ describe('MultiplierPage', () => {
     expect(wrapper.vm.personnelResults).toEqual([])
     expect(wrapper.vm.showPersonnelDropdown).toBe(false)
     vi.useRealTimers()
+  })
+
+  it('opens create modal prefilled from profile create query', async () => {
+    routeQuery.value = {
+      create: '1',
+      personnel_id: '12',
+      full_name: 'นายสมชาย ไทยแท้',
+    }
+    const wrapper = await mountPage()
+    expect(wrapper.vm.showModal).toBe(true)
+    expect(wrapper.vm.formData.personnel_id).toBe(12)
+    expect(wrapper.vm.personnelSearch).toBe('นายสมชาย ไทยแท้')
+    expect(mockReplace).toHaveBeenCalledWith({ query: {} })
   })
 })

--- a/frontend/src/__tests__/pages/ProfilePage.test.js
+++ b/frontend/src/__tests__/pages/ProfilePage.test.js
@@ -1,8 +1,11 @@
 import { mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useAuthStore } from '@/stores/auth.js'
 
 const mockFetchMe = vi.fn()
 const mockFetchById = vi.fn()
+const mockPush = vi.fn()
 const routeParams = { value: {} }
 
 vi.mock('@/composables/useProfile.js', () => ({
@@ -11,15 +14,34 @@ vi.mock('@/composables/useProfile.js', () => ({
 
 vi.mock('vue-router', () => ({
   useRoute: () => ({ get params() { return routeParams.value } }),
+  useRouter: () => ({ push: mockPush }),
 }))
 
 const ProfilePage = (await import('@/pages/ProfilePage.vue')).default
 
-async function mountPage() {
+async function mountPage(role = 'admin') {
+  setActivePinia(createPinia())
+  const auth = useAuthStore()
+  auth.user = { id: 1, role }
   const wrapper = mount(ProfilePage)
   await wrapper.vm.$nextTick()
   await wrapper.vm.$nextTick()
   return wrapper
+}
+
+function activeServant(overrides = {}) {
+  return {
+    servantId: 5,
+    employeeId: 'EMP005',
+    fullName: 'นายสมชาย ไทยแท้',
+    birthDate: '1980-01-01',
+    appointmentDate: '2000-01-01',
+    retirementDate: '2040-09-30',
+    servantStatus: 'active',
+    photoPath: null,
+    isActive: true,
+    ...overrides,
+  }
 }
 
 describe('ProfilePage', () => {
@@ -33,13 +55,7 @@ describe('ProfilePage', () => {
         lastLoginAt: '2024-01-01 10:00:00', createdAt: '2023-01-01',
       },
     })
-    mockFetchById.mockResolvedValue({
-      data: {
-        servantId: 5, employeeId: 'EMP005', fullName: 'นายสมชาย ไทยแท้',
-        birthDate: '1980-01-01', appointmentDate: '2000-01-01',
-        retirementDate: '2040-09-30', servantStatus: 'active', photoPath: null,
-      },
-    })
+    mockFetchById.mockResolvedValue({ data: activeServant() })
   })
 
   afterEach(() => {
@@ -67,5 +83,49 @@ describe('ProfilePage', () => {
     mockFetchMe.mockRejectedValue(new Error('โหลดข้อมูลไม่สำเร็จ'))
     const wrapper = await mountPage()
     await vi.waitFor(() => expect(wrapper.text()).toContain('โหลดข้อมูลไม่สำเร็จ'))
+  })
+
+  it('shows career time shortcuts for admin when personnel is active', async () => {
+    routeParams.value = { id: '5' }
+    const wrapper = await mountPage('admin')
+    await vi.waitFor(() => expect(mockFetchById).toHaveBeenCalledWith('5'))
+    await wrapper.vm.$nextTick()
+    expect(wrapper.text()).toContain('การนับเกื้อกูล')
+    expect(wrapper.text()).toContain('การนับทวีคูณ')
+    expect(wrapper.text()).toContain('การนับแตกต่าง')
+    expect(wrapper.text()).toContain('การเทียบตำแหน่ง')
+  })
+
+  it('hides career time shortcuts when personnel is inactive', async () => {
+    routeParams.value = { id: '5' }
+    mockFetchById.mockResolvedValue({ data: activeServant({ isActive: false }) })
+    const wrapper = await mountPage('admin')
+    await vi.waitFor(() => expect(mockFetchById).toHaveBeenCalledWith('5'))
+    await wrapper.vm.$nextTick()
+    expect(wrapper.text()).not.toContain('ทางลัดเพิ่มรายการนับเวลา')
+  })
+
+  it('hides career time shortcuts for viewer', async () => {
+    routeParams.value = { id: '5' }
+    const wrapper = await mountPage('viewer')
+    await vi.waitFor(() => expect(mockFetchById).toHaveBeenCalledWith('5'))
+    await wrapper.vm.$nextTick()
+    expect(wrapper.text()).not.toContain('ทางลัดเพิ่มรายการนับเวลา')
+  })
+
+  it('navigates to time page with create query when shortcut clicked', async () => {
+    routeParams.value = { id: '5' }
+    const wrapper = await mountPage('admin')
+    await vi.waitFor(() => expect(mockFetchById).toHaveBeenCalledWith('5'))
+    await wrapper.vm.$nextTick()
+
+    const button = wrapper.findAll('button').find((b) => b.text().includes('การนับเกื้อกูล'))
+    expect(button).toBeTruthy()
+    await button.trigger('click')
+
+    expect(mockPush).toHaveBeenCalledWith({
+      path: '/time-counting',
+      query: { create: '1', personnel_id: '5', full_name: 'นายสมชาย ไทยแท้' },
+    })
   })
 })

--- a/frontend/src/__tests__/pages/SupportivePage.test.js
+++ b/frontend/src/__tests__/pages/SupportivePage.test.js
@@ -7,6 +7,8 @@ const mockFetchList = vi.fn()
 const mockCreate = vi.fn()
 const mockUpdate = vi.fn()
 const mockRemove = vi.fn()
+const mockReplace = vi.fn()
+const routeQuery = { value: {} }
 
 vi.mock('@/composables/useSupportive.js', () => ({
   useSupportive: () => ({
@@ -32,6 +34,11 @@ vi.mock('@/composables/useConfirm.js', () => ({
 const mockSearchPersonnel = vi.fn(async () => [])
 vi.mock('@/composables/usePersonnelSearch.js', () => ({
   usePersonnelSearch: () => ({ searchPersonnel: (...args) => mockSearchPersonnel(...args) }),
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ get query() { return routeQuery.value } }),
+  useRouter: () => ({ replace: mockReplace }),
 }))
 
 const SupportivePage = (await import('@/pages/SupportivePage.vue')).default
@@ -77,6 +84,7 @@ function fillValidForm(wrapper) {
 describe('SupportivePage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    routeQuery.value = {}
     mockFetchList.mockResolvedValue({
       success: true,
       data: [sampleRow],
@@ -258,5 +266,25 @@ describe('SupportivePage', () => {
     const wrapper = await mountPage('admin')
     expect(wrapper.vm.isAdmin).toBe(true)
     expect(wrapper.findAll('button[title="ลบ"]').length).toBeGreaterThan(0)
+  })
+
+  it('opens create modal prefilled from profile create query', async () => {
+    routeQuery.value = {
+      create: '1',
+      personnel_id: '12',
+      full_name: 'นายสมชาย ไทยแท้',
+    }
+    const wrapper = await mountPage()
+    expect(wrapper.vm.showModal).toBe(true)
+    expect(wrapper.vm.formData.personnel_id).toBe(12)
+    expect(wrapper.vm.personnelSearch).toBe('นายสมชาย ไทยแท้')
+    expect(mockReplace).toHaveBeenCalledWith({ query: {} })
+  })
+
+  it('does not open create modal without create=1 query', async () => {
+    routeQuery.value = { personnel_id: '12', full_name: 'นายสมชาย ไทยแท้' }
+    const wrapper = await mountPage()
+    expect(wrapper.vm.showModal).toBe(false)
+    expect(mockReplace).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/__tests__/utils/personnelCreateQuery.test.js
+++ b/frontend/src/__tests__/utils/personnelCreateQuery.test.js
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { parsePersonnelCreateQuery } from '@/utils/personnelCreateQuery.js'
+
+describe('parsePersonnelCreateQuery', () => {
+  it('returns personnel prefill when create=1 and valid id', () => {
+    expect(parsePersonnelCreateQuery({
+      create: '1',
+      personnel_id: '12',
+      full_name: 'นายสมชาย ไทยแท้',
+    })).toEqual({
+      personnelId: 12,
+      fullName: 'นายสมชาย ไทยแท้',
+    })
+  })
+
+  it('returns null without create=1', () => {
+    expect(parsePersonnelCreateQuery({
+      personnel_id: '12',
+      full_name: 'นายสมชาย ไทยแท้',
+    })).toBeNull()
+  })
+
+  it('returns null for invalid personnel_id', () => {
+    expect(parsePersonnelCreateQuery({ create: '1', personnel_id: '0' })).toBeNull()
+    expect(parsePersonnelCreateQuery({ create: '1', personnel_id: 'abc' })).toBeNull()
+  })
+})

--- a/frontend/src/composables/useProfile.js
+++ b/frontend/src/composables/useProfile.js
@@ -38,6 +38,7 @@ export function useProfile() {
       appointmentDate: row.appointment_date,
       retirementDate: row.retirement_date,
       servantStatus: row.servant_status,
+      isActive: Boolean(Number(row.is_active)),
       // backend คืน path สัมพัทธ์ (uploads/xxx.jpg) — ต้องประกอบผ่าน API base ก่อนใช้กับ <img>
       photoPath: apiAssetUrl(row.photo_path),
     }

--- a/frontend/src/pages/DiversePage.vue
+++ b/frontend/src/pages/DiversePage.vue
@@ -318,6 +318,7 @@
 
 <script setup>
 import { ref, computed, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import { useDiverse } from '@/composables/useDiverse.js'
 import { useDebouncedCallback } from '@/composables/useDebouncedCallback.js'
 import { useRequestSeq } from '@/composables/useRequestSeq.js'
@@ -327,6 +328,7 @@ import { useAuthStore } from '@/stores/auth.js'
 import { useUiStore } from '@/stores/ui.js'
 import { confirmDelete as confirmDeleteAction, confirmSave } from '@/composables/useConfirm.js'
 import { buildStandardRowActions } from '@/utils/tableRowActions.js'
+import { applyPersonnelCreateQuery } from '@/utils/applyPersonnelCreateQuery.js'
 import PageBreadcrumb from '@/components/PageBreadcrumb.vue'
 import ListSearchInput from '@/components/ListSearchInput.vue'
 import StatCard from '@/components/StatCard.vue'
@@ -346,6 +348,8 @@ const api = useApi()
 const { searchPersonnel } = usePersonnelSearch()
 const auth = useAuthStore()
 const ui = useUiStore()
+const route = useRoute()
+const router = useRouter()
 const { next: nextRequest } = useRequestSeq()
 const { next: nextPersonnelRequest } = useRequestSeq()
 
@@ -609,5 +613,13 @@ async function confirmDelete(row) {
 
 onMounted(() => {
   fetchData()
+  applyPersonnelCreateQuery({
+    route,
+    router,
+    openCreate: openCreateModal,
+    formData,
+    personnelSearch,
+    selectedPersonnelName,
+  })
 })
 </script>

--- a/frontend/src/pages/EquivalencePage.vue
+++ b/frontend/src/pages/EquivalencePage.vue
@@ -396,6 +396,7 @@
 
 <script setup>
 import { ref, computed, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import { useEquivalence } from '@/composables/useEquivalence.js'
 import { useDebouncedCallback } from '@/composables/useDebouncedCallback.js'
 import { useRequestSeq } from '@/composables/useRequestSeq.js'
@@ -404,6 +405,7 @@ import { usePersonnelSearch } from '@/composables/usePersonnelSearch.js'
 import { useUiStore } from '@/stores/ui.js'
 import { useAuthStore } from '@/stores/auth.js'
 import { confirmAction, confirmSave } from '@/composables/useConfirm.js'
+import { applyPersonnelCreateQuery } from '@/utils/applyPersonnelCreateQuery.js'
 import PageBreadcrumb from '@/components/PageBreadcrumb.vue'
 import ListSearchInput from '@/components/ListSearchInput.vue'
 import StatCard from '@/components/StatCard.vue'
@@ -423,6 +425,8 @@ const api = useApi()
 const { searchPersonnel } = usePersonnelSearch()
 const ui = useUiStore()
 const auth = useAuthStore()
+const route = useRoute()
+const router = useRouter()
 const { next: nextRequest } = useRequestSeq()
 const { next: nextPersonnelRequest } = useRequestSeq()
 
@@ -727,5 +731,12 @@ function openView(record) {
 
 onMounted(() => {
   fetchData()
+  applyPersonnelCreateQuery({
+    route,
+    router,
+    openCreate,
+    formData,
+    personnelSearch,
+  })
 })
 </script>

--- a/frontend/src/pages/MultiplierPage.vue
+++ b/frontend/src/pages/MultiplierPage.vue
@@ -356,6 +356,7 @@
 
 <script setup>
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import { useApi } from '@/composables/useApi.js'
 import { usePersonnelSearch } from '@/composables/usePersonnelSearch.js'
 import { useDebouncedCallback } from '@/composables/useDebouncedCallback.js'
@@ -363,6 +364,7 @@ import { useRequestSeq } from '@/composables/useRequestSeq.js'
 import { useMultiplier } from '@/composables/useMultiplier.js'
 import { useAuthStore } from '@/stores/auth.js'
 import { confirmDelete as confirmDeleteAction, confirmSave } from '@/composables/useConfirm.js'
+import { applyPersonnelCreateQuery } from '@/utils/applyPersonnelCreateQuery.js'
 import StatCard from '@/components/StatCard.vue'
 import SkeletonLoader from '@/components/SkeletonLoader.vue'
 import EmptyState from '@/components/EmptyState.vue'
@@ -385,6 +387,8 @@ const api = useApi()
 const { searchPersonnel } = usePersonnelSearch()
 const { fetchList, fetchAreas, create, update, remove } = useMultiplier()
 const auth = useAuthStore()
+const route = useRoute()
+const router = useRouter()
 const isAdmin = computed(() => auth.isAdmin)
 const { next: nextRequest } = useRequestSeq()
 const { next: nextPersonnelRequest } = useRequestSeq()
@@ -657,6 +661,13 @@ function onGlobalKeydown(e) {
 onMounted(() => {
   fetchData()
   window.addEventListener('keydown', onGlobalKeydown)
+  applyPersonnelCreateQuery({
+    route,
+    router,
+    openCreate: openCreateModal,
+    formData,
+    personnelSearch,
+  })
 })
 
 onBeforeUnmount(() => {

--- a/frontend/src/pages/ProfilePage.vue
+++ b/frontend/src/pages/ProfilePage.vue
@@ -54,42 +54,60 @@
       </dl>
     </div>
 
-    <!-- Servant detail -->
-    <div v-else-if="isDetail && servant" class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 max-w-2xl">
-      <div class="flex items-center gap-4 mb-6">
-        <img
-          v-if="servant.photoPath"
-          :src="servant.photoPath"
-          alt="รูปข้าราชการ"
-          class="w-20 h-20 rounded-lg object-cover border border-gray-200"
-        />
-        <div v-else class="w-20 h-20 rounded-lg bg-gray-100 flex items-center justify-center">
-          <User class="w-10 h-10 text-gray-400" />
+    <!-- Servant detail + career shortcuts -->
+    <template v-else-if="isDetail && servant">
+      <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 max-w-2xl">
+        <div class="flex items-center gap-4 mb-6">
+          <img
+            v-if="servant.photoPath"
+            :src="servant.photoPath"
+            alt="รูปข้าราชการ"
+            class="w-20 h-20 rounded-lg object-cover border border-gray-200"
+          />
+          <div v-else class="w-20 h-20 rounded-lg bg-gray-100 flex items-center justify-center">
+            <User class="w-10 h-10 text-gray-400" />
+          </div>
+          <div>
+            <p class="text-lg font-semibold text-gray-900">{{ servant.fullName }}</p>
+            <p class="text-sm text-gray-500">รหัสพนักงาน: {{ servant.employeeId }}</p>
+          </div>
         </div>
-        <div>
-          <p class="text-lg font-semibold text-gray-900">{{ servant.fullName }}</p>
-          <p class="text-sm text-gray-500">รหัสพนักงาน: {{ servant.employeeId }}</p>
+        <dl class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div>
+            <dt class="text-xs text-gray-500">วันเกิด</dt>
+            <dd class="text-sm text-gray-900">{{ servant.birthDate || '-' }}</dd>
+          </div>
+          <div>
+            <dt class="text-xs text-gray-500">วันบรรจุ</dt>
+            <dd class="text-sm text-gray-900">{{ servant.appointmentDate || '-' }}</dd>
+          </div>
+          <div>
+            <dt class="text-xs text-gray-500">วันเกษียณ</dt>
+            <dd class="text-sm text-gray-900">{{ servant.retirementDate || '-' }}</dd>
+          </div>
+          <div>
+            <dt class="text-xs text-gray-500">สถานะ</dt>
+            <dd class="text-sm text-gray-900">{{ servant.servantStatus || '-' }}</dd>
+          </div>
+        </dl>
+      </div>
+
+      <div v-if="careerShortcuts.length" class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 max-w-2xl">
+        <h2 class="text-sm font-semibold text-gray-900">ทางลัดเพิ่มรายการนับเวลา</h2>
+        <p class="text-xs text-gray-500 mt-1 mb-4">เปิดหน้าโมดูลแล้วเริ่มฟอร์มพร้อมบุคลากรคนนี้</p>
+        <div class="flex flex-col sm:flex-row sm:flex-wrap gap-2">
+          <button
+            v-for="item in careerShortcuts"
+            :key="item.path"
+            type="button"
+            class="px-4 py-2 bg-blue-500 text-white rounded-lg text-sm hover:bg-blue-600 transition-colors text-left"
+            @click="goCreateTimeEntry(item.path)"
+          >
+            {{ item.label }}
+          </button>
         </div>
       </div>
-      <dl class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-        <div>
-          <dt class="text-xs text-gray-500">วันเกิด</dt>
-          <dd class="text-sm text-gray-900">{{ servant.birthDate || '-' }}</dd>
-        </div>
-        <div>
-          <dt class="text-xs text-gray-500">วันบรรจุ</dt>
-          <dd class="text-sm text-gray-900">{{ servant.appointmentDate || '-' }}</dd>
-        </div>
-        <div>
-          <dt class="text-xs text-gray-500">วันเกษียณ</dt>
-          <dd class="text-sm text-gray-900">{{ servant.retirementDate || '-' }}</dd>
-        </div>
-        <div>
-          <dt class="text-xs text-gray-500">สถานะ</dt>
-          <dd class="text-sm text-gray-900">{{ servant.servantStatus || '-' }}</dd>
-        </div>
-      </dl>
-    </div>
+    </template>
 
     <EmptyState
       v-else
@@ -102,15 +120,27 @@
 
 <script setup>
 import { ref, computed, watch, onMounted } from 'vue'
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { useProfile } from '@/composables/useProfile.js'
 import { useRequestSeq } from '@/composables/useRequestSeq.js'
+import { useAuthStore } from '@/stores/auth.js'
 import SkeletonLoader from '@/components/SkeletonLoader.vue'
 import EmptyState from '@/components/EmptyState.vue'
 import { roleLabel } from '@/utils/roleLabels.js'
 import { User, AlertCircle } from 'lucide-vue-next'
 
+const TIME_SHORTCUTS = [
+  { resource: 'supportive', label: 'การนับเกื้อกูล', path: '/time-counting' },
+  { resource: 'multiplier', label: 'การนับทวีคูณ', path: '/time-multiplier' },
+  { resource: 'diverse', label: 'การนับแตกต่าง', path: '/time-difference' },
+  { resource: 'equivalence', label: 'การเทียบตำแหน่ง', path: '/position-compare' },
+]
+
+const OPERATOR_CREATE = new Set(['supportive', 'multiplier', 'diverse', 'equivalence'])
+
 const route = useRoute()
+const router = useRouter()
+const auth = useAuthStore()
 const { fetchMe, fetchById } = useProfile()
 const { next: nextRequest } = useRequestSeq()
 
@@ -120,6 +150,30 @@ const account = ref(null)
 const servant = ref(null)
 
 const isDetail = computed(() => !!route.params.id)
+
+function canCreateResource(resource) {
+  const role = auth.user?.role
+  if (role === 'admin' || role === 'superadmin') return true
+  if (role === 'operator') return OPERATOR_CREATE.has(resource)
+  return false
+}
+
+const careerShortcuts = computed(() => {
+  if (!servant.value?.isActive) return []
+  return TIME_SHORTCUTS.filter((item) => canCreateResource(item.resource))
+})
+
+function goCreateTimeEntry(path) {
+  if (!servant.value) return
+  router.push({
+    path,
+    query: {
+      create: '1',
+      personnel_id: String(servant.value.servantId),
+      full_name: servant.value.fullName || '',
+    },
+  })
+}
 
 async function fetchData() {
   const req = nextRequest()

--- a/frontend/src/pages/SupportivePage.vue
+++ b/frontend/src/pages/SupportivePage.vue
@@ -258,6 +258,7 @@
 
 <script setup>
 import { ref, computed, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import { useSupportive } from '@/composables/useSupportive.js'
 import { useDebouncedCallback } from '@/composables/useDebouncedCallback.js'
 import { useRequestSeq } from '@/composables/useRequestSeq.js'
@@ -267,6 +268,7 @@ import { useAuthStore } from '@/stores/auth.js'
 import { useUiStore } from '@/stores/ui.js'
 import { confirmDelete as confirmDeleteAction, confirmSave } from '@/composables/useConfirm.js'
 import { buildStandardRowActions } from '@/utils/tableRowActions.js'
+import { applyPersonnelCreateQuery } from '@/utils/applyPersonnelCreateQuery.js'
 import PageBreadcrumb from '@/components/PageBreadcrumb.vue'
 import ListSearchInput from '@/components/ListSearchInput.vue'
 import StatCard from '@/components/StatCard.vue'
@@ -283,6 +285,8 @@ const api = useApi()
 const { searchPersonnel } = usePersonnelSearch()
 const auth = useAuthStore()
 const ui = useUiStore()
+const route = useRoute()
+const router = useRouter()
 const { next: nextRequest } = useRequestSeq()
 const { next: nextPersonnelRequest } = useRequestSeq()
 
@@ -518,5 +522,12 @@ function selectPersonnel(person) {
 
 onMounted(() => {
   fetchData()
+  applyPersonnelCreateQuery({
+    route,
+    router,
+    openCreate,
+    formData,
+    personnelSearch,
+  })
 })
 </script>

--- a/frontend/src/utils/applyPersonnelCreateQuery.js
+++ b/frontend/src/utils/applyPersonnelCreateQuery.js
@@ -1,0 +1,23 @@
+import { parsePersonnelCreateQuery } from '@/utils/personnelCreateQuery.js'
+
+/**
+ * Profile shortcut → open create modal with personnel prefilled, then clear query.
+ * @returns {boolean} true if a create query was consumed
+ */
+export function applyPersonnelCreateQuery({
+  route,
+  router,
+  openCreate,
+  formData,
+  personnelSearch,
+  selectedPersonnelName = null,
+}) {
+  const prefill = parsePersonnelCreateQuery(route.query)
+  if (!prefill) return false
+  openCreate()
+  formData.value.personnel_id = prefill.personnelId
+  personnelSearch.value = prefill.fullName
+  if (selectedPersonnelName) selectedPersonnelName.value = prefill.fullName
+  router.replace({ query: {} })
+  return true
+}

--- a/frontend/src/utils/personnelCreateQuery.js
+++ b/frontend/src/utils/personnelCreateQuery.js
@@ -1,0 +1,14 @@
+/**
+ * Parse profile → time-page shortcut query:
+ * ?create=1&personnel_id=123&full_name=...
+ * @returns {{ personnelId: number, fullName: string } | null}
+ */
+export function parsePersonnelCreateQuery(query = {}) {
+  if (String(query?.create ?? '') !== '1') return null
+  const personnelId = Number(query.personnel_id)
+  if (!Number.isFinite(personnelId) || personnelId <= 0) return null
+  return {
+    personnelId,
+    fullName: typeof query.full_name === 'string' ? query.full_name : '',
+  }
+}


### PR DESCRIPTION
## Summary
- Add role-gated career shortcuts on `/profile/:id` that open the four time-entry modules with create modal prefilled (`create=1`, `personnel_id`, `full_name`)
- Expose `is_active` from `GET /profile/:id` and hide shortcuts for inactive personnel / viewers
- Share parse/apply helpers so Supportive, Multiplier, Diverse, and Equivalence pages consume the query then clear it

## Test plan
- [x] Vitest: ProfilePage shortcuts + inactive/viewer gates
- [x] Vitest: create-query prefill on all four time pages
- [x] Full frontend suite (527) + pre-push hook on push
- [ ] Manual: open active personnel profile as admin → each shortcut opens modal with person selected
- [ ] Manual: inactive personnel / viewer → no shortcut section