### PR TITLE
feat: link empty typeahead to personnel create for admins

### DIFF
--- a/frontend/src/__tests__/pages/DiversePage.test.js
+++ b/frontend/src/__tests__/pages/DiversePage.test.js
@@ -39,6 +39,11 @@ vi.mock('@/composables/usePersonnelSearch.js', () => ({
 vi.mock('vue-router', () => ({
   useRoute: () => ({ get query() { return routeQuery.value } }),
   useRouter: () => ({ replace: mockReplace }),
+  RouterLink: {
+    name: 'RouterLink',
+    props: ['to'],
+    template: '<a class="router-link"><slot /></a>',
+  },
 }))
 
 const DiversePage = (await import('@/pages/DiversePage.vue')).default

--- a/frontend/src/__tests__/pages/EquivalencePage.test.js
+++ b/frontend/src/__tests__/pages/EquivalencePage.test.js
@@ -40,6 +40,11 @@ vi.mock('@/composables/usePersonnelSearch.js', () => ({
 vi.mock('vue-router', () => ({
   useRoute: () => ({ get query() { return routeQuery.value } }),
   useRouter: () => ({ replace: mockReplace }),
+  RouterLink: {
+    name: 'RouterLink',
+    props: ['to'],
+    template: '<a class="router-link"><slot /></a>',
+  },
 }))
 
 const EquivalencePage = (await import('@/pages/EquivalencePage.vue')).default

--- a/frontend/src/__tests__/pages/MultiplierPage.test.js
+++ b/frontend/src/__tests__/pages/MultiplierPage.test.js
@@ -41,6 +41,11 @@ vi.mock('@/composables/usePersonnelSearch.js', () => ({
 vi.mock('vue-router', () => ({
   useRoute: () => ({ get query() { return routeQuery.value } }),
   useRouter: () => ({ replace: mockReplace }),
+  RouterLink: {
+    name: 'RouterLink',
+    props: ['to'],
+    template: '<a class="router-link"><slot /></a>',
+  },
 }))
 
 const MultiplierPage = (await import('@/pages/MultiplierPage.vue')).default

--- a/frontend/src/__tests__/pages/PersonnelPage.test.js
+++ b/frontend/src/__tests__/pages/PersonnelPage.test.js
@@ -19,7 +19,12 @@ vi.mock('@/composables/usePersonnelMaster.js', () => ({
 
 vi.mock('vue-router', () => ({
   RouterLink: { template: '<a :href="to"><slot /></a>', props: ['to'] },
+  useRoute: () => ({ get query() { return routeQuery.value } }),
+  useRouter: () => ({ replace: mockReplace }),
 }))
+
+const mockReplace = vi.fn()
+const routeQuery = { value: {} }
 
 const PersonnelPage = (await import('@/pages/PersonnelPage.vue')).default
 
@@ -59,6 +64,7 @@ async function mountPage(role = 'admin') {
 describe('PersonnelPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    routeQuery.value = {}
     resolvedData()
   })
 
@@ -81,6 +87,20 @@ describe('PersonnelPage', () => {
     wrapper.vm.openCreate()
     await wrapper.vm.$nextTick()
     expect(wrapper.vm.showFormModal).toBe(true)
+  })
+
+  it('opens create modal from ?create=1 for admin and clears query', async () => {
+    routeQuery.value = { create: '1' }
+    const wrapper = await mountPage('admin')
+    expect(wrapper.vm.showFormModal).toBe(true)
+    expect(mockReplace).toHaveBeenCalledWith({ query: {} })
+  })
+
+  it('does not open create modal from ?create=1 for operator', async () => {
+    routeQuery.value = { create: '1' }
+    const wrapper = await mountPage('operator')
+    expect(wrapper.vm.showFormModal).toBe(false)
+    expect(mockReplace).not.toHaveBeenCalled()
   })
 
   it('hides add button for non-admin', async () => {

--- a/frontend/src/__tests__/pages/SupportivePage.test.js
+++ b/frontend/src/__tests__/pages/SupportivePage.test.js
@@ -39,6 +39,11 @@ vi.mock('@/composables/usePersonnelSearch.js', () => ({
 vi.mock('vue-router', () => ({
   useRoute: () => ({ get query() { return routeQuery.value } }),
   useRouter: () => ({ replace: mockReplace }),
+  RouterLink: {
+    name: 'RouterLink',
+    props: ['to'],
+    template: '<a class="router-link" :href="typeof to === \'string\' ? to : (to?.path || \'#\')"><slot /></a>',
+  },
 }))
 
 const SupportivePage = (await import('@/pages/SupportivePage.vue')).default
@@ -266,6 +271,32 @@ describe('SupportivePage', () => {
     const wrapper = await mountPage('admin')
     expect(wrapper.vm.isAdmin).toBe(true)
     expect(wrapper.findAll('button[title="ลบ"]').length).toBeGreaterThan(0)
+  })
+
+  it('shows admin create link when typeahead finds no personnel', async () => {
+    const wrapper = await mountPage('admin')
+    wrapper.vm.showModal = true
+    wrapper.vm.personnelSearch = 'ไม่มีคนนี้'
+    wrapper.vm.personnelResults = []
+    wrapper.vm.showPersonnelDropdown = true
+    wrapper.vm.personnelSearchFailed = false
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.text()).toContain('ไม่พบบุคลากรที่ตรงกับคำค้น')
+    expect(wrapper.text()).toContain('ไปสร้างที่ข้อมูลบุคลากร')
+  })
+
+  it('hides admin create link for operator on empty typeahead', async () => {
+    const wrapper = await mountPage('operator')
+    wrapper.vm.showModal = true
+    wrapper.vm.personnelSearch = 'ไม่มีคนนี้'
+    wrapper.vm.personnelResults = []
+    wrapper.vm.showPersonnelDropdown = true
+    wrapper.vm.personnelSearchFailed = false
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.text()).toContain('ไม่พบบุคลากรที่ตรงกับคำค้น')
+    expect(wrapper.text()).not.toContain('ไปสร้างที่ข้อมูลบุคลากร')
   })
 
   it('opens create modal prefilled from profile create query', async () => {

--- a/frontend/src/__tests__/utils/personnelTypeaheadEmpty.test.js
+++ b/frontend/src/__tests__/utils/personnelTypeaheadEmpty.test.js
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import {
+  showPersonnelTypeaheadEmpty,
+  personnelCreateLinkVisible,
+  PERSONNEL_MASTER_CREATE_TO,
+  PERSONNEL_MASTER_CREATE_LINK_LABEL,
+  shouldOpenPersonnelMasterCreate,
+} from '@/utils/personnelTypeaheadEmpty.js'
+
+describe('showPersonnelTypeaheadEmpty', () => {
+  it('is true when dropdown open, query long enough, and no results', () => {
+    expect(showPersonnelTypeaheadEmpty({
+      showDropdown: true,
+      query: 'สมชาย',
+      resultsLength: 0,
+    })).toBe(true)
+  })
+
+  it('is false when results exist, dropdown closed, or query too short', () => {
+    expect(showPersonnelTypeaheadEmpty({
+      showDropdown: true,
+      query: 'สมชาย',
+      resultsLength: 1,
+    })).toBe(false)
+    expect(showPersonnelTypeaheadEmpty({
+      showDropdown: false,
+      query: 'สมชาย',
+      resultsLength: 0,
+    })).toBe(false)
+    expect(showPersonnelTypeaheadEmpty({
+      showDropdown: true,
+      query: 'ส',
+      resultsLength: 0,
+    })).toBe(false)
+  })
+})
+
+describe('personnelCreateLinkVisible', () => {
+  it('is true only for admin when search did not fail', () => {
+    expect(personnelCreateLinkVisible({ isAdmin: true, searchFailed: false })).toBe(true)
+    expect(personnelCreateLinkVisible({ isAdmin: true, searchFailed: true })).toBe(false)
+    expect(personnelCreateLinkVisible({ isAdmin: false, searchFailed: false })).toBe(false)
+  })
+})
+
+describe('PERSONNEL_MASTER_CREATE_TO', () => {
+  it('points at /personnel?create=1', () => {
+    expect(PERSONNEL_MASTER_CREATE_TO).toEqual({
+      path: '/personnel',
+      query: { create: '1' },
+    })
+  })
+
+  it('exposes Thai link label', () => {
+    expect(PERSONNEL_MASTER_CREATE_LINK_LABEL).toBe('ไปสร้างที่ข้อมูลบุคลากร')
+  })
+})
+
+describe('shouldOpenPersonnelMasterCreate', () => {
+  it('is true for create=1', () => {
+    expect(shouldOpenPersonnelMasterCreate({ create: '1' })).toBe(true)
+  })
+
+  it('is false without create=1', () => {
+    expect(shouldOpenPersonnelMasterCreate({})).toBe(false)
+    expect(shouldOpenPersonnelMasterCreate({ create: '0' })).toBe(false)
+  })
+})

--- a/frontend/src/pages/DiversePage.vue
+++ b/frontend/src/pages/DiversePage.vue
@@ -167,13 +167,22 @@
                   <span class="text-gray-400 text-xs">{{ person.current_position || '' }}</span>
                 </button>
               </div>
-              <p
+              <div
                 v-else-if="showPersonnelDropdown && personnelSearch.trim().length >= 2"
                 class="text-xs mt-1"
                 :class="personnelSearchFailed ? 'text-red-500' : 'text-gray-500'"
               >
-                {{ personnelSearchFailed ? 'ค้นหาไม่สำเร็จ กรุณาลองใหม่' : 'ไม่พบบุคลากรที่ตรงกับคำค้น' }}
-              </p>
+                <p>
+                  {{ personnelSearchFailed ? 'ค้นหาไม่สำเร็จ กรุณาลองใหม่' : 'ไม่พบบุคลากรที่ตรงกับคำค้น' }}
+                </p>
+                <RouterLink
+                  v-if="personnelCreateLinkVisible({ isAdmin, searchFailed: personnelSearchFailed })"
+                  :to="PERSONNEL_MASTER_CREATE_TO"
+                  class="inline-block mt-1 text-blue-600 hover:text-blue-800 underline"
+                >
+                  {{ PERSONNEL_MASTER_CREATE_LINK_LABEL }}
+                </RouterLink>
+              </div>
             </div>
             <p v-if="validationErrors.personnel_id" class="text-red-500 text-xs mt-1">{{ validationErrors.personnel_id }}</p>
             <p v-if="formData.personnel_id && selectedPersonnelName" class="text-green-600 text-xs mt-1">เลือกแล้ว: {{ selectedPersonnelName }}</p>
@@ -318,7 +327,7 @@
 
 <script setup>
 import { ref, computed, onMounted } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
+import { RouterLink, useRoute, useRouter } from 'vue-router'
 import { useDiverse } from '@/composables/useDiverse.js'
 import { useDebouncedCallback } from '@/composables/useDebouncedCallback.js'
 import { useRequestSeq } from '@/composables/useRequestSeq.js'
@@ -329,6 +338,11 @@ import { useUiStore } from '@/stores/ui.js'
 import { confirmDelete as confirmDeleteAction, confirmSave } from '@/composables/useConfirm.js'
 import { buildStandardRowActions } from '@/utils/tableRowActions.js'
 import { applyPersonnelCreateQuery } from '@/utils/applyPersonnelCreateQuery.js'
+import {
+  PERSONNEL_MASTER_CREATE_LINK_LABEL,
+  PERSONNEL_MASTER_CREATE_TO,
+  personnelCreateLinkVisible,
+} from '@/utils/personnelTypeaheadEmpty.js'
 import PageBreadcrumb from '@/components/PageBreadcrumb.vue'
 import ListSearchInput from '@/components/ListSearchInput.vue'
 import StatCard from '@/components/StatCard.vue'

--- a/frontend/src/pages/EquivalencePage.vue
+++ b/frontend/src/pages/EquivalencePage.vue
@@ -182,13 +182,22 @@
                     {{ person.full_name }}
                   </button>
                 </div>
-                <p
+                <div
                   v-else-if="showPersonnelDropdown && personnelSearch.trim().length >= 2"
                   class="text-xs mt-1"
                   :class="personnelSearchFailed ? 'text-red-500' : 'text-gray-500'"
                 >
-                  {{ personnelSearchFailed ? 'ค้นหาไม่สำเร็จ กรุณาลองใหม่' : 'ไม่พบบุคลากรที่ตรงกับคำค้น' }}
-                </p>
+                  <p>
+                    {{ personnelSearchFailed ? 'ค้นหาไม่สำเร็จ กรุณาลองใหม่' : 'ไม่พบบุคลากรที่ตรงกับคำค้น' }}
+                  </p>
+                  <RouterLink
+                    v-if="personnelCreateLinkVisible({ isAdmin, searchFailed: personnelSearchFailed })"
+                    :to="PERSONNEL_MASTER_CREATE_TO"
+                    class="inline-block mt-1 text-blue-600 hover:text-blue-800 underline"
+                  >
+                    {{ PERSONNEL_MASTER_CREATE_LINK_LABEL }}
+                  </RouterLink>
+                </div>
               </div>
               <p v-if="formErrors.personnel_id" class="text-xs text-red-500 mt-1">{{ formErrors.personnel_id }}</p>
             </div>
@@ -396,7 +405,7 @@
 
 <script setup>
 import { ref, computed, onMounted } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
+import { RouterLink, useRoute, useRouter } from 'vue-router'
 import { useEquivalence } from '@/composables/useEquivalence.js'
 import { useDebouncedCallback } from '@/composables/useDebouncedCallback.js'
 import { useRequestSeq } from '@/composables/useRequestSeq.js'
@@ -406,6 +415,11 @@ import { useUiStore } from '@/stores/ui.js'
 import { useAuthStore } from '@/stores/auth.js'
 import { confirmAction, confirmSave } from '@/composables/useConfirm.js'
 import { applyPersonnelCreateQuery } from '@/utils/applyPersonnelCreateQuery.js'
+import {
+  PERSONNEL_MASTER_CREATE_LINK_LABEL,
+  PERSONNEL_MASTER_CREATE_TO,
+  personnelCreateLinkVisible,
+} from '@/utils/personnelTypeaheadEmpty.js'
 import PageBreadcrumb from '@/components/PageBreadcrumb.vue'
 import ListSearchInput from '@/components/ListSearchInput.vue'
 import StatCard from '@/components/StatCard.vue'
@@ -425,6 +439,7 @@ const api = useApi()
 const { searchPersonnel } = usePersonnelSearch()
 const ui = useUiStore()
 const auth = useAuthStore()
+const isAdmin = computed(() => auth.isAdmin)
 const route = useRoute()
 const router = useRouter()
 const { next: nextRequest } = useRequestSeq()

--- a/frontend/src/pages/MultiplierPage.vue
+++ b/frontend/src/pages/MultiplierPage.vue
@@ -265,13 +265,22 @@
                   <span class="text-gray-400 text-xs ml-2">{{ person.current_position || '' }}</span>
                 </button>
               </div>
-              <p
+              <div
                 v-else-if="showPersonnelDropdown && personnelSearch.trim().length >= 2"
                 class="text-xs mt-1"
                 :class="personnelSearchFailed ? 'text-red-500' : 'text-gray-500'"
               >
-                {{ personnelSearchFailed ? 'ค้นหาไม่สำเร็จ กรุณาลองใหม่' : 'ไม่พบบุคลากรที่ตรงกับคำค้น' }}
-              </p>
+                <p>
+                  {{ personnelSearchFailed ? 'ค้นหาไม่สำเร็จ กรุณาลองใหม่' : 'ไม่พบบุคลากรที่ตรงกับคำค้น' }}
+                </p>
+                <RouterLink
+                  v-if="personnelCreateLinkVisible({ isAdmin, searchFailed: personnelSearchFailed })"
+                  :to="PERSONNEL_MASTER_CREATE_TO"
+                  class="inline-block mt-1 text-blue-600 hover:text-blue-800 underline"
+                >
+                  {{ PERSONNEL_MASTER_CREATE_LINK_LABEL }}
+                </RouterLink>
+              </div>
             </div>
             <p v-if="formErrors.personnel_id" class="text-xs text-red-500 mt-1">กรุณาเลือกบุคลากร</p>
             <p v-else-if="formData.personnel_id && personnelSearch" class="text-xs text-green-600 mt-1">เลือกแล้ว: {{ personnelSearch }}</p>
@@ -356,7 +365,7 @@
 
 <script setup>
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
+import { RouterLink, useRoute, useRouter } from 'vue-router'
 import { useApi } from '@/composables/useApi.js'
 import { usePersonnelSearch } from '@/composables/usePersonnelSearch.js'
 import { useDebouncedCallback } from '@/composables/useDebouncedCallback.js'
@@ -365,6 +374,11 @@ import { useMultiplier } from '@/composables/useMultiplier.js'
 import { useAuthStore } from '@/stores/auth.js'
 import { confirmDelete as confirmDeleteAction, confirmSave } from '@/composables/useConfirm.js'
 import { applyPersonnelCreateQuery } from '@/utils/applyPersonnelCreateQuery.js'
+import {
+  PERSONNEL_MASTER_CREATE_LINK_LABEL,
+  PERSONNEL_MASTER_CREATE_TO,
+  personnelCreateLinkVisible,
+} from '@/utils/personnelTypeaheadEmpty.js'
 import StatCard from '@/components/StatCard.vue'
 import SkeletonLoader from '@/components/SkeletonLoader.vue'
 import EmptyState from '@/components/EmptyState.vue'

--- a/frontend/src/pages/PersonnelPage.vue
+++ b/frontend/src/pages/PersonnelPage.vue
@@ -238,12 +238,13 @@
 
 <script setup>
 import { ref, computed, onMounted } from 'vue'
-import { RouterLink } from 'vue-router'
+import { RouterLink, useRoute, useRouter } from 'vue-router'
 import { usePersonnelMaster } from '@/composables/usePersonnelMaster.js'
 import { useDebouncedCallback } from '@/composables/useDebouncedCallback.js'
 import { useRequestSeq } from '@/composables/useRequestSeq.js'
 import { useAuthStore } from '@/stores/auth.js'
 import { useUiStore } from '@/stores/ui.js'
+import { shouldOpenPersonnelMasterCreate } from '@/utils/personnelTypeaheadEmpty.js'
 import ListSearchInput from '@/components/ListSearchInput.vue'
 import PaginationBar from '@/components/PaginationBar.vue'
 import EmptyState from '@/components/EmptyState.vue'
@@ -253,6 +254,8 @@ import { Plus, Ban, CheckCircle, Users } from 'lucide-vue-next'
 const { fetchList, fetchLookups, create, update } = usePersonnelMaster()
 const auth = useAuthStore()
 const ui = useUiStore()
+const route = useRoute()
+const router = useRouter()
 const { next: nextRequest } = useRequestSeq()
 
 const isAdmin = computed(() => auth.isAdmin)
@@ -433,5 +436,9 @@ onMounted(async () => {
     ui.showToast('โหลดรายการคำนำหน้าไม่สำเร็จ', 'error')
   }
   fetchData()
+  if (isAdmin.value && shouldOpenPersonnelMasterCreate(route.query)) {
+    openCreate()
+    router.replace({ query: {} })
+  }
 })
 </script>

--- a/frontend/src/pages/SupportivePage.vue
+++ b/frontend/src/pages/SupportivePage.vue
@@ -165,13 +165,22 @@
                   {{ person.full_name }}
                 </button>
               </div>
-              <p
+              <div
                 v-else-if="showPersonnelDropdown && personnelSearch.trim().length >= 2"
                 class="text-xs mt-1"
                 :class="personnelSearchFailed ? 'text-red-500' : 'text-gray-500'"
               >
-                {{ personnelSearchFailed ? 'ค้นหาไม่สำเร็จ กรุณาลองใหม่' : 'ไม่พบบุคลากรที่ตรงกับคำค้น' }}
-              </p>
+                <p>
+                  {{ personnelSearchFailed ? 'ค้นหาไม่สำเร็จ กรุณาลองใหม่' : 'ไม่พบบุคลากรที่ตรงกับคำค้น' }}
+                </p>
+                <RouterLink
+                  v-if="personnelCreateLinkVisible({ isAdmin, searchFailed: personnelSearchFailed })"
+                  :to="PERSONNEL_MASTER_CREATE_TO"
+                  class="inline-block mt-1 text-blue-600 hover:text-blue-800 underline"
+                >
+                  {{ PERSONNEL_MASTER_CREATE_LINK_LABEL }}
+                </RouterLink>
+              </div>
               <p v-if="formErrors.personnel_id" class="text-xs text-red-500 mt-1">กรุณาเลือกบุคลากร</p>
             </div>
           </div>
@@ -258,7 +267,7 @@
 
 <script setup>
 import { ref, computed, onMounted } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
+import { RouterLink, useRoute, useRouter } from 'vue-router'
 import { useSupportive } from '@/composables/useSupportive.js'
 import { useDebouncedCallback } from '@/composables/useDebouncedCallback.js'
 import { useRequestSeq } from '@/composables/useRequestSeq.js'
@@ -269,6 +278,11 @@ import { useUiStore } from '@/stores/ui.js'
 import { confirmDelete as confirmDeleteAction, confirmSave } from '@/composables/useConfirm.js'
 import { buildStandardRowActions } from '@/utils/tableRowActions.js'
 import { applyPersonnelCreateQuery } from '@/utils/applyPersonnelCreateQuery.js'
+import {
+  PERSONNEL_MASTER_CREATE_LINK_LABEL,
+  PERSONNEL_MASTER_CREATE_TO,
+  personnelCreateLinkVisible,
+} from '@/utils/personnelTypeaheadEmpty.js'
 import PageBreadcrumb from '@/components/PageBreadcrumb.vue'
 import ListSearchInput from '@/components/ListSearchInput.vue'
 import StatCard from '@/components/StatCard.vue'

--- a/frontend/src/utils/personnelTypeaheadEmpty.js
+++ b/frontend/src/utils/personnelTypeaheadEmpty.js
@@ -1,0 +1,38 @@
+/**
+ * Typeahead empty-state helpers for time-entry modals (ADR-0004 §7).
+ * Admin gets a link to create on ข้อมูลบุคลากร — never inline create.
+ */
+
+export const PERSONNEL_MASTER_CREATE_TO = {
+  path: '/personnel',
+  query: { create: '1' },
+}
+
+export const PERSONNEL_MASTER_CREATE_LINK_LABEL = 'ไปสร้างที่ข้อมูลบุคลากร'
+
+/**
+ * Same gate as the existing empty message under typeahead inputs.
+ */
+export function showPersonnelTypeaheadEmpty({
+  showDropdown = false,
+  query = '',
+  resultsLength = 0,
+} = {}) {
+  return Boolean(showDropdown)
+    && String(query).trim().length >= 2
+    && Number(resultsLength) === 0
+}
+
+/**
+ * Link only when admin/superadmin and search succeeded with zero hits.
+ */
+export function personnelCreateLinkVisible({ isAdmin = false, searchFailed = false } = {}) {
+  return Boolean(isAdmin) && !searchFailed
+}
+
+/**
+ * Personnel master page: open create modal from ?create=1
+ */
+export function shouldOpenPersonnelMasterCreate(query = {}) {
+  return String(query?.create ?? '') === '1'
+}


### PR DESCRIPTION
## Summary
- ADR-0004 §7: when time-entry typeahead finds no personnel, admins see a link to create on ข้อมูลบุคลากร (`/personnel?create=1`) — no inline create
- Shared helper + wire Supportive/Multiplier/Diverse/Equivalence; PersonnelPage opens create modal from `?create=1`

## Test plan
- [x] `npx vitest run` helper + Personnel + Supportive (+ related page mocks) earlier
- [x] Pre-push full frontend suite: 538 passed
- [ ] Manual: admin empty typeahead → link → create modal; operator sees message only