### PR TITLE
fix(security): omit citizen_id from personnel typeahead response

### DIFF
--- a/backend/routes/personnel.php
+++ b/backend/routes/personnel.php
@@ -27,7 +27,7 @@ function personnelTypeaheadSql(int $limit = 10): string
     $fullName = sqlPersonnelFullName('p', 'px');
 
     return "
-        SELECT p.personnel_id, p.citizen_id,
+        SELECT p.personnel_id,
                {$fullName} AS full_name,
                p.first_name, p.last_name,
                pos.position_name AS current_position,

--- a/backend/tests/Integration/PersonnelTypeaheadSearchTest.php
+++ b/backend/tests/Integration/PersonnelTypeaheadSearchTest.php
@@ -80,6 +80,7 @@ final class PersonnelTypeaheadSearchTest extends TestCase
         self::assertNotEmpty($rows);
         self::assertSame($this->personnelId, (int) $rows[0]['personnel_id']);
         self::assertSame('นาย' . $this->firstName . ' ' . $this->lastName, $rows[0]['full_name']);
+        self::assertArrayNotHasKey('citizen_id', $rows[0]);
     }
 
     #[Test]

--- a/backend/tests/Unit/PersonnelTypeaheadQueryTest.php
+++ b/backend/tests/Unit/PersonnelTypeaheadQueryTest.php
@@ -41,6 +41,10 @@ final class PersonnelTypeaheadQueryTest extends TestCase
         self::assertStringContainsString('p.citizen_id LIKE ?', $sql);
         self::assertStringContainsString('p.employee_id LIKE ?', $sql);
         self::assertStringContainsString('prefix_name_th', $sql);
+        // PII: search by citizen_id ok, but do not return it in typeahead JSON
+        $selectClause = strstr($sql, 'FROM', true);
+        self::assertNotFalse($selectClause);
+        self::assertStringNotContainsString('citizen_id', $selectClause);
         // full_name expression used in WHERE (not only SELECT)
         self::assertGreaterThanOrEqual(
             2,


### PR DESCRIPTION
## Summary
- Remove `citizen_id` from typeahead SELECT JSON (PII) — UI never displayed it
- Keep `citizen_id LIKE` in WHERE so search by Thai ID still works
- Master list/detail unchanged

## Test plan
- [x] `bash backend/tests/run.sh --filter PersonnelTypeahead` (unit OK)
- [x] Pre-push frontend vitest: 538 passed
- [ ] Optional: integration with DB up — search by citizen_id returns row without key