### PR TITLE
test: lock personnel operator 403 and include_inactive gate

### DIFF
--- a/backend/routes/personnel.php
+++ b/backend/routes/personnel.php
@@ -188,6 +188,17 @@ function isValidCitizenId(string $citizenId): bool
     return (bool) preg_match('/^\d{13}$/', $citizenId);
 }
 
+/**
+ * Master list ?include_inactive=1 — admin/superadmin only (soft-deny, not 403).
+ */
+function resolvePersonnelIncludeInactive(bool $requested, string $role): bool
+{
+    if (!$requested) {
+        return false;
+    }
+    return $role === 'admin' || $role === 'superadmin';
+}
+
 function personnelPrefixExists(PDO $pdo, int $prefixId): bool
 {
     if ($prefixId <= 0) {
@@ -445,14 +456,11 @@ function handlePersonnel(PDO $pdo, string $method, array $path): void
 
         // Master list when offset is present; otherwise typeahead (backward compatible)
         if (array_key_exists('offset', $_GET)) {
-            $includeInactive = isset($_GET['include_inactive']) && (string) $_GET['include_inactive'] !== '0';
-            if ($includeInactive) {
-                $role = getAuthenticatedUser()['role'] ?? '';
-                if ($role !== 'admin' && $role !== 'superadmin') {
-                    // แผน: โชว์คนปิดใช้งานเฉพาะแอดมิน — กัน operator/viewer ดึงรายการปิดใช้งานผ่าน query
-                    $includeInactive = false;
-                }
-            }
+            $requestedInactive = isset($_GET['include_inactive']) && (string) $_GET['include_inactive'] !== '0';
+            $includeInactive = resolvePersonnelIncludeInactive(
+                $requestedInactive,
+                (string) (getAuthenticatedUser()['role'] ?? '')
+            );
             $result = listPersonnelMaster(
                 $pdo,
                 (string) ($_GET['search'] ?? ''),

--- a/backend/tests/Unit/PermissionOverrideTest.php
+++ b/backend/tests/Unit/PermissionOverrideTest.php
@@ -22,6 +22,8 @@ final class PermissionOverrideTest extends TestCase
         self::assertTrue(checkPermissionDefault('operator', 'create', 'multiplier'));
         self::assertFalse(checkPermissionDefault('operator', 'delete', 'multiplier'));
         self::assertFalse(checkPermissionDefault('operator', 'update', 'equivalence_approval'));
+        self::assertFalse(checkPermissionDefault('operator', 'create', 'personnel'));
+        self::assertFalse(checkPermissionDefault('operator', 'update', 'personnel'));
     }
 
     #[Test]

--- a/backend/tests/Unit/PersonnelAuthzHttpTest.php
+++ b/backend/tests/Unit/PersonnelAuthzHttpTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PDO;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../authz.php';
+require_once __DIR__ . '/../../helpers.php';
+require_once __DIR__ . '/../../routes/personnel.php';
+
+/**
+ * HTTP contract: operator/viewer cannot write personnel (403);
+ * include_inactive is admin-only (soft-deny, not 403).
+ */
+final class PersonnelAuthzHttpTest extends TestCase
+{
+    #[Test]
+    public function operator_create_personnel_is_403(): void
+    {
+        $denied = $this->evaluate('create', 'personnel', 'operator');
+        self::assertSame(403, $denied['status'] ?? null);
+        self::assertSame('Forbidden', $denied['body']['error'] ?? null);
+        self::assertSame('create:personnel', $denied['body']['required_permission'] ?? null);
+    }
+
+    #[Test]
+    public function operator_update_personnel_is_403(): void
+    {
+        $denied = $this->evaluate('update', 'personnel', 'operator');
+        self::assertSame(403, $denied['status'] ?? null);
+        self::assertSame('update:personnel', $denied['body']['required_permission'] ?? null);
+    }
+
+    #[Test]
+    public function viewer_create_personnel_is_403(): void
+    {
+        $denied = $this->evaluate('create', 'personnel', 'viewer');
+        self::assertSame(403, $denied['status'] ?? null);
+        self::assertSame('create:personnel', $denied['body']['required_permission'] ?? null);
+    }
+
+    #[Test]
+    public function operator_read_personnel_is_allowed(): void
+    {
+        self::assertNull($this->evaluate('read', 'personnel', 'operator'));
+    }
+
+    #[Test]
+    public function admin_create_personnel_is_allowed(): void
+    {
+        self::assertNull($this->evaluate('create', 'personnel', 'admin'));
+    }
+
+    #[Test]
+    public function include_inactive_false_for_every_role_when_not_requested(): void
+    {
+        foreach (['admin', 'superadmin', 'operator', 'viewer', ''] as $role) {
+            self::assertFalse(resolvePersonnelIncludeInactive(false, $role));
+        }
+    }
+
+    #[Test]
+    public function include_inactive_true_only_for_admin_and_superadmin(): void
+    {
+        self::assertTrue(resolvePersonnelIncludeInactive(true, 'admin'));
+        self::assertTrue(resolvePersonnelIncludeInactive(true, 'superadmin'));
+        self::assertFalse(resolvePersonnelIncludeInactive(true, 'operator'));
+        self::assertFalse(resolvePersonnelIncludeInactive(true, 'viewer'));
+        self::assertFalse(resolvePersonnelIncludeInactive(true, ''));
+    }
+
+    /**
+     * @return array{status:int, body:array<string,mixed>}|null
+     */
+    private function evaluate(string $action, string $resource, string $role): ?array
+    {
+        $pdo = $this->sqliteOverrides();
+        if ($pdo === null) {
+            self::markTestSkipped('pdo_sqlite not available');
+        }
+
+        clearPermissionOverrideCache();
+        return evaluatePermissionAccess($action, $resource, [
+            'user_id' => 2,
+            'role' => $role,
+        ], $pdo);
+    }
+
+    private function sqliteOverrides(): ?PDO
+    {
+        if (!in_array('sqlite', PDO::getAvailableDrivers(), true)) {
+            return null;
+        }
+
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec(
+            'CREATE TABLE role_permission_overrides (
+                role TEXT NOT NULL,
+                action TEXT NOT NULL,
+                resource TEXT NOT NULL,
+                allowed INTEGER NOT NULL
+            )'
+        );
+        return $pdo;
+    }
+}


### PR DESCRIPTION
## Summary
- Add HTTP-contract unit tests: operator/viewer get 403 on personnel create/update; operator can read; admin can create
- Extract `resolvePersonnelIncludeInactive` so the admin-only inactive list gate is testable (soft-deny, not 403)

## Test plan
- [x] `bash backend/tests/run.sh --filter PersonnelAuthzHttpTest` (7 OK)
- [x] `PermissionOverrideTest` + `PersonnelMaster` filters
- [x] Pre-push frontend vitest: 538 passed

Made with [Cursor](https://cursor.com)