### PR TITLE
test: lock operator career shortcuts on ProfilePage

### DIFF
--- a/frontend/src/__tests__/pages/ProfilePage.test.js
+++ b/frontend/src/__tests__/pages/ProfilePage.test.js
@@ -113,6 +113,18 @@ describe('ProfilePage', () => {
     expect(wrapper.text()).not.toContain('ทางลัดเพิ่มรายการนับเวลา')
   })
 
+  it('shows career time shortcuts for operator when personnel is active', async () => {
+    routeParams.value = { id: '5' }
+    const wrapper = await mountPage('operator')
+    await vi.waitFor(() => expect(mockFetchById).toHaveBeenCalledWith('5'))
+    await wrapper.vm.$nextTick()
+    expect(wrapper.text()).toContain('ทางลัดเพิ่มรายการนับเวลา')
+    expect(wrapper.text()).toContain('การนับเกื้อกูล')
+    expect(wrapper.text()).toContain('การนับทวีคูณ')
+    expect(wrapper.text()).toContain('การนับแตกต่าง')
+    expect(wrapper.text()).toContain('การเทียบตำแหน่ง')
+  })
+
   it('navigates to time page with create query when shortcut clicked', async () => {
     routeParams.value = { id: '5' }
     const wrapper = await mountPage('admin')


### PR DESCRIPTION
## Summary
- Add a ProfilePage test that operator sees all four career time shortcuts when the person is active
- Admin and viewer visibility were already covered; this locks the remaining role

## Test plan
- [x] `npx vitest run src/__tests__/pages/ProfilePage.test.js` (8 passed)
- [x] Pre-push full frontend vitest: 73 files / 551 tests