### PR TITLE
test: harden synthetic multiplier UAT

### DIFF
--- a/docs/multiplier_phase0_synthetic_uat_2026-08-14.md
+++ b/docs/multiplier_phase0_synthetic_uat_2026-08-14.md
@@ -1,0 +1,85 @@
+# Multiplier Phase 0 — Synthetic UAT Report
+
+**Run date:** 2026-08-14 (+07)
+
+**Issue:** #23
+
+**Status:** `SIMULATION_ONLY` — ไม่ใช่ HR sign-off และยังไม่ใช่ director-ready
+
+## Scope and fixture
+
+This run uses the repository's `TEST_SEED` fixtures:
+
+- `docs/multiplier_phase0_master_data_template.csv` — 14 master rows
+- `docs/multiplier_phase0_uat_cases_template.csv` — 10 synthetic UAT cases
+- multiplier ratio: 200%
+
+The run used a fresh isolated MySQL volume and an isolated API at
+`http://127.0.0.1:8001`. UAT records were created and deleted in that database;
+`multiplier_experience` had 0 rows after cleanup.
+
+## Gate results
+
+| Gate | Result |
+|---|---|
+| Offline Phase 0 validator | **12/12 technical PASS (`SYNTHETIC_ONLY`)** |
+| Live API UAT (`TC-001`–`TC-010`) | **10/10 PASS, 0 FAIL** |
+| Areas loaded by API | **14** |
+| Active personnel pool | **7** |
+| Whole-province Satun rows | **0** |
+| Blank legal-reference fields (format check only) | **0** |
+| Blank source-reference fields (format check only) | **0** |
+| HR-approved legal/source references | **0/14** |
+| Duplicate exact periods | **0** |
+| Ambiguous active overlaps | **0** |
+| Master rows containing `TEST_SEED` references | **14/14** |
+
+The blank-reference checks and `Verification fields populated (format only)`
+only test whether those CSV fields are non-empty. They are not evidence of valid
+references or HR approval in this run: all 14 master rows contain `TEST_SEED`
+placeholder text rather than reviewed legal/source references or HR signatures.
+The validator therefore classifies this package as `SYNTHETIC_ONLY` and blocks
+the migration-seed/director-ready verdict.
+
+## Live API case results
+
+Each comparison cell is `expected / actual`. The 360-day breakdown is
+`years-months-days`.
+
+| Case | Eligible days | Effective days | Bonus days | 360-day breakdown | Result |
+|---|---:|---:|---:|---:|---|
+| TC-001 | 16 / 16 | 32 / 32 | 16 / 16 | 0-1-2 / 0-1-2 | PASS |
+| TC-002 | 61 / 61 | 122 / 122 | 61 / 61 | 0-4-2 / 0-4-2 | PASS |
+| TC-003 | 29 / 29 | 58 / 58 | 29 / 29 | 0-1-28 / 0-1-28 | PASS |
+| TC-004 | 31 / 31 | 62 / 62 | 31 / 31 | 0-2-2 / 0-2-2 | PASS |
+| TC-005 | 10 / 10 | 20 / 20 | 10 / 10 | 0-0-20 / 0-0-20 | PASS |
+| TC-006 | 6 / 6 | 12 / 12 | 6 / 6 | 0-0-12 / 0-0-12 | PASS |
+| TC-007 | 16 / 16 | 32 / 32 | 16 / 16 | 0-1-2 / 0-1-2 | PASS |
+| TC-008 | 31 / 31 | 62 / 62 | 31 / 31 | 0-2-2 / 0-2-2 | PASS |
+| TC-009 | 30 / 30 | 60 / 60 | 30 / 30 | 0-2-0 / 0-2-0 | PASS |
+| TC-010 | 15 / 15 | 30 / 30 | 15 / 15 | 0-1-0 / 0-1-0 | PASS |
+
+## Test harness note
+
+The current `/personnel` typeahead contract requires at least two search
+characters, while the UAT script previously sent one Thai character (`า`). The
+script now requests the active personnel master list with `offset=0`, so the
+same harness works with both repository fixtures and real HR data without
+depending on fixture-specific names or employee IDs.
+
+After the review fix, the live suite was rerun against a fresh backend image
+built from the current branch. The master-list request returned seven active
+personnel, all ten cases passed, and cleanup left no rows in
+`multiplier_experience`.
+
+## Verdict
+
+**Synthetic technical gate: PASS.** The calculation engine, API create/delete
+flow, boundary cases, bonus-day values, and 360-day breakdown matched the
+synthetic expected values.
+
+**HR/director readiness: NO.** Before production or director review, HR must
+replace `TEST_SEED` with real master data and Excel cases, provide legal/source
+references, confirm Satun and emergency-decree coverage, and sign the validation
+pack. Then rerun the same offline validator, live API UAT, and data-quality
+queries against the HR-approved package.

--- a/docs/multiplier_phase0_validation_pack.md
+++ b/docs/multiplier_phase0_validation_pack.md
@@ -103,7 +103,7 @@ Mismatch log: **ไม่มี** (0 FAIL)
 | No ambiguous active overlap | ไม่มีช่วงซ้อนคลุมเครือ | PASS | PASS (0) | |
 | District precedence reviewed | สงขลา/สตูลเป็น district-level | PASS | PASS (8 district rows) | |
 | Emergency decree coverage reviewed | มี E-001..E-003 | PASS (TEST_SEED) | PASS (3 rows) | รอ HR confirm วันที่ |
-| UAT cases complete | ≥ 10 cases + clamp | PASS | Live 10/10 PASS | synthetic เท่านั้น |
+| UAT case structure complete | ≥ 10 cases + clamp | PASS | Live 10/10 PASS | synthetic เท่านั้น |
 
 Local DB snapshot: 14 areas (ยะลา 2, ปัตตานี 2, นราธิวาส 2, สงขลา 4, สตูล 4)
 

--- a/frontend/docs/multiplier_verification_report.md
+++ b/frontend/docs/multiplier_verification_report.md
@@ -130,7 +130,9 @@ node scripts/uat-multiplier-live-api.mjs
 
 All PASS against `docs/multiplier_phase0_master_data_template.csv` + `docs/multiplier_phase0_uat_cases_template.csv`.
 
-Note: check “All rows verified by HR” passes because `verified_by=TEST_SEED` is non-TODO text — **not** a real HR signature.
+Note: `Verification fields populated (format only)` checks only that the field is
+non-empty. The validator classifies `verified_by=TEST_SEED` as `SYNTHETIC_ONLY`
+and does **not** treat it as a real HR signature.
 
 ### Live API UAT (TC-001..TC-010)
 

--- a/scripts/uat-multiplier-live-api.mjs
+++ b/scripts/uat-multiplier-live-api.mjs
@@ -150,8 +150,9 @@ async function main() {
     process.exit(2)
   }
 
-  // /personnel requires a non-empty search; use common Thai vowel to collect a pool
-  const peopleRes = await api('GET', `/personnel?search=${encodeURIComponent('า')}&limit=20`, {
+  // Use the paginated master list so the UAT works with both TEST_SEED and real HR data.
+  // Supplying offset selects this mode without relying on fixture-specific search text.
+  const peopleRes = await api('GET', '/personnel?offset=0&limit=20', {
     token,
   })
   if (peopleRes.status !== 200) {

--- a/scripts/validate-multiplier-phase0.mjs
+++ b/scripts/validate-multiplier-phase0.mjs
@@ -33,6 +33,7 @@ function parseCsv(path) {
 }
 
 const isTodo = (v) => v === '' || /^TODO/i.test(v);
+const isTestSeed = (v) => /TEST_SEED/i.test(v);
 const isDate = (v) => /^\d{4}-\d{2}-\d{2}$/.test(v);
 const toUtc = (v) => Date.parse(`${v}T00:00:00Z`);
 const inclusiveDays = (a, b) => Math.round((toUtc(b) - toUtc(a)) / 86400000) + 1;
@@ -138,24 +139,24 @@ check(
     : decreeRows.filter((r) => !isDate(r.effective_start_date)).map((r) => `${r.row_id}: effective_start_date ยังเป็น TODO`)
 );
 
-// --- Check 9: UAT cases >= 10 with real data ---
-const realCases = uat.filter((r) => !isTodo(r.province) && isDate(r.service_start_date) && isDate(r.service_end_date));
+// --- Check 9: UAT cases >= 10 with structurally valid data ---
+const validCases = uat.filter((r) => !isTodo(r.province) && isDate(r.service_start_date) && isDate(r.service_end_date));
 check(
-  `UAT cases complete (>= ${MIN_UAT_CASES} real cases)`,
-  realCases.length >= MIN_UAT_CASES ? [] : [`มี real case ${realCases.length}/${MIN_UAT_CASES}`]
+  `UAT case structure complete (>= ${MIN_UAT_CASES} cases)`,
+  validCases.length >= MIN_UAT_CASES ? [] : [`มี valid case ${validCases.length}/${MIN_UAT_CASES}`]
 );
 
 // --- Check 10: boundary cases present (clamp start + clamp end) ---
-const clampStart = realCases.some((r) => toUtc(r.service_start_date) < toUtc(r.expected_eligible_start_date));
-const clampEnd = realCases.some((r) => toUtc(r.service_end_date) > toUtc(r.expected_eligible_end_date));
+const clampStart = validCases.some((r) => toUtc(r.service_start_date) < toUtc(r.expected_eligible_start_date));
+const clampEnd = validCases.some((r) => toUtc(r.service_end_date) > toUtc(r.expected_eligible_end_date));
 check('Boundary UAT cases present', [
   ...(clampStart ? [] : ['ไม่มี case ที่เริ่มงานก่อนวันเริ่มประกาศ (clamp start)']),
   ...(clampEnd ? [] : ['ไม่มี case ที่สิ้นสุดงานหลังวันสิ้นสุดประกาศ (clamp end)']),
 ]);
 
-// --- Check 11: recompute expected values for every real UAT case ---
+// --- Check 11: recompute expected values for every structurally valid UAT case ---
 const calcErrs = [];
-for (const r of realCases) {
+for (const r of validCases) {
   const caseErr = (msg) => calcErrs.push(`${r.case_id}: ${msg}`);
   const serviceDays = inclusiveDays(r.service_start_date, r.service_end_date);
   if (serviceDays !== Number(r.expected_service_days))
@@ -192,9 +193,9 @@ for (const r of realCases) {
 }
 check('UAT expected values match calculation rules', calcErrs);
 
-// --- Check 12: HR verification fields filled ---
+// --- Check 12: verification fields filled (format check, not HR approval) ---
 check(
-  'All rows verified by HR',
+  'Verification fields populated (format only)',
   [
     ...master.filter((r) => isTodo(r.verified_by)).map((r) => `${r.row_id}: verified_by ยังเป็น TODO`),
     ...uat.filter((r) => isTodo(r.verified_by)).map((r) => `${r.case_id}: verified_by ยังเป็น TODO`),
@@ -202,8 +203,12 @@ check(
 );
 
 // --- Report ---
+const syntheticMasterRows = master.filter((r) => Object.values(r).some(isTestSeed));
+const syntheticUatRows = uat.filter((r) => Object.values(r).some(isTestSeed));
+const hasSyntheticData = syntheticMasterRows.length > 0 || syntheticUatRows.length > 0;
+
 console.log('Phase 0 Multiplier Master Data — Validation Report');
-console.log(`master rows: ${master.length}, uat rows: ${uat.length} (real: ${realCases.length})`);
+console.log(`master rows: ${master.length} (synthetic: ${syntheticMasterRows.length}), uat rows: ${uat.length} (valid: ${validCases.length}, synthetic: ${syntheticUatRows.length})`);
 console.log('');
 let failed = 0;
 for (const r of results) {
@@ -216,5 +221,11 @@ for (const r of results) {
   }
 }
 console.log('');
-console.log(failed === 0 ? 'ALL CHECKS PASSED — พร้อมสร้าง database/13-multiplier-time-counting.sql' : `${failed}/${results.length} checks ไม่ผ่าน — ยังห้ามสร้าง migration seed`);
+if (failed > 0) {
+  console.log(`${failed}/${results.length} checks ไม่ผ่าน — ยังห้ามสร้าง migration seed`);
+} else if (hasSyntheticData) {
+  console.log('TECHNICAL CHECKS PASSED — SYNTHETIC_ONLY; ยังห้ามสร้าง migration seed และยังไม่พร้อม director review');
+} else {
+  console.log('ALL CHECKS PASSED — พร้อมสร้าง database/13-multiplier-time-counting.sql');
+}
 process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary
- make the multiplier live-API UAT select active personnel through the data-independent master-list contract
- classify TEST_SEED packages as SYNTHETIC_ONLY instead of implying HR verification or production readiness
- document expected-versus-actual eligible, effective, bonus, and 360-day results for all ten synthetic cases

## Issue
Relates to #23.

Issue #23 remains open because HR-approved Excel/manual cases, legal/source references, and sign-off are still required before director review.

## Verification
- Frontend Vitest: 73 files, 551 tests passed (local threads/4 override used to avoid the serial jsdom timeout)
- Frontend production build: passed
- Backend PHPUnit Unit: 236 tests, 405 assertions, 1 skipped
- Multiplier offline validator: 12/12 technical checks passed; correctly reports SYNTHETIC_ONLY
- Isolated live API UAT: 10/10 passed; cleanup left 0 multiplier_experience rows
- Schema parity: 25 migrations, 41 tables, 4 views; no drift
- git diff --check and Node syntax checks: passed

## Readiness
Synthetic technical gate only. Not HR sign-off and not director-ready.