### PR TITLE
test: guard multiplier synthetic classification

### DIFF
--- a/scripts/ci-local.ps1
+++ b/scripts/ci-local.ps1
@@ -4,11 +4,12 @@
   Local CI gate — mirrors .github/workflows/ci.yml without GitHub Actions minutes.
 
 .DESCRIPTION
-  Jobs (same as ci.yml):
-    1) Frontend: npm ci (optional) + npm test + npm run build
-    2) E2E:      Playwright Chromium checks all 21 menus (Docker db + backend)
-    3) Backend:  bash backend/tests/run.sh  (Docker PHPUnit; needs Git Bash)
-    4) Docker:   build frontend + backend images (no push)
+  Local gates:
+    0) Fast gates: schema parity + multiplier validator regression
+    1) Frontend:  npm ci (optional) + npm test + npm run build
+    2) E2E:       Playwright Chromium checks all sidebar menus (Docker db + backend)
+    3) Backend:   bash backend/tests/run.sh  (Docker PHPUnit; needs Git Bash)
+    4) Docker:    build frontend + backend images (no push)
 
   Prerequisites:
     - Node 24+, npm
@@ -56,10 +57,11 @@ if ($Help) {
 Usage: .\scripts\ci-local.ps1 [-SkipInstall] [-SkipFrontend] [-SkipE2E] [-SkipBackend] [-SkipDocker] [-Help]
 
 Mirrors .github/workflows/ci.yml locally (no GitHub Actions minutes):
-  1) Frontend  npm ci + vitest (forks/2) + build
-  2) E2E       Docker db/backend + Playwright Chromium (21 menus)
-  3) Backend   bash backend/tests/run.sh
-  4) Docker    build frontend + backend images
+  0) Fast gates schema parity + multiplier validator regression
+  1) Frontend   npm ci + vitest (forks/2) + build
+  2) E2E        Docker db/backend + Playwright Chromium (all sidebar menus)
+  3) Backend    bash backend/tests/run.sh
+  4) Docker     build frontend + backend images
 
 E2E prerequisites: Docker Desktop, frontend dependencies, Playwright Chromium,
 and a local .env file. The Compose services remain running after the gate.
@@ -103,6 +105,15 @@ if ($LASTEXITCODE -eq 0) {
   $failed += 'schema-parity'
 }
 
+Write-Step 'Multiplier Validator Regression'
+& node --test (Join-Path $Root 'scripts\tests\validate-multiplier-phase0.test.mjs')
+if ($LASTEXITCODE -eq 0) {
+  Write-Ok 'multiplier validator regression'
+} else {
+  Write-Fail 'multiplier validator regression'
+  $failed += 'multiplier-validator-regression'
+}
+
 # ---- 1) Frontend Build & Test ----------------------------------------------
 if (-not $SkipFrontend) {
   Write-Step 'Frontend Build & Test'
@@ -136,7 +147,7 @@ if (-not $SkipFrontend) {
   Write-Host 'skip frontend (-SkipFrontend)'
 }
 
-# ---- 2) Playwright E2E: all 21 menus --------------------------------------
+# ---- 2) Playwright E2E: all sidebar menus ---------------------------------
 if (-not $SkipE2E) {
   Write-Step 'E2E All Menus (Docker + Playwright Chromium)'
   if (-not (Test-Path -LiteralPath (Join-Path $Root '.env'))) {
@@ -169,7 +180,7 @@ if (-not $SkipE2E) {
       } finally {
         Pop-Location
       }
-      Write-Ok 'all 21 menu destinations rendered'
+      Write-Ok 'all sidebar menu destinations rendered'
     } catch {
       Write-Fail $_.Exception.Message
       $failed += 'e2e'

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -2,11 +2,12 @@
 # ============================================================================
 # ci-local.sh — Local CI gate (mirrors .github/workflows/ci.yml, no Actions minutes)
 #
-# Jobs:
-#   1) Frontend: npm ci (optional) + vitest + build
-#   2) E2E:      Playwright Chromium checks all 21 menus (Docker db + backend)
-#   3) Backend:  bash backend/tests/run.sh
-#   4) Docker:   build frontend + backend images (no push)
+# Local gates:
+#   0) Fast gates: schema parity + multiplier validator regression
+#   1) Frontend:  npm ci (optional) + vitest + build
+#   2) E2E:       Playwright Chromium checks all sidebar menus (Docker db + backend)
+#   3) Backend:   bash backend/tests/run.sh
+#   4) Docker:    build frontend + backend images (no push)
 #
 # Usage:
 #   bash scripts/ci-local.sh
@@ -63,6 +64,13 @@ else
   fail 'schema parity'
 fi
 
+step 'Multiplier Validator Regression'
+if node --test "${ROOT}/scripts/tests/validate-multiplier-phase0.test.mjs"; then
+  ok 'multiplier validator regression'
+else
+  fail 'multiplier validator regression'
+fi
+
 # ---- 1) Frontend -----------------------------------------------------------
 if [[ "${SKIP_FRONTEND}" -eq 0 ]]; then
   step 'Frontend Build & Test'
@@ -87,7 +95,7 @@ else
   echo 'skip frontend (--skip-frontend)'
 fi
 
-# ---- 2) Playwright E2E: all 21 menus --------------------------------------
+# ---- 2) Playwright E2E: all sidebar menus ---------------------------------
 if [[ "${SKIP_E2E}" -eq 0 ]]; then
   step 'E2E All Menus (Docker + Playwright Chromium)'
   if [[ ! -f "${ROOT}/.env" ]]; then
@@ -115,7 +123,7 @@ if [[ "${SKIP_E2E}" -eq 0 ]]; then
     cd frontend
     npm run test:e2e:menus
   ); then
-    ok 'all 21 menu destinations rendered'
+    ok 'all sidebar menu destinations rendered'
   else
     fail 'e2e'
   fi

--- a/scripts/tests/validate-multiplier-phase0.test.mjs
+++ b/scripts/tests/validate-multiplier-phase0.test.mjs
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const VALIDATOR = resolve(ROOT, 'scripts', 'validate-multiplier-phase0.mjs');
+
+test('TEST_SEED fixtures remain synthetic-only and blocked from production readiness', () => {
+  const result = spawnSync(process.execPath, [VALIDATOR], {
+    cwd: ROOT,
+    encoding: 'utf8',
+  });
+  const output = `${result.stdout ?? ''}\n${result.stderr ?? ''}`;
+
+  assert.equal(result.error, undefined, result.error?.message);
+  assert.equal(result.status, 0, output);
+  assert.match(output, /TECHNICAL CHECKS PASSED — SYNTHETIC_ONLY/);
+  assert.match(output, /ยังห้ามสร้าง migration seed/);
+  assert.match(output, /ยังไม่พร้อม director review/);
+  assert.doesNotMatch(output, /ALL CHECKS PASSED/);
+  assert.doesNotMatch(output, /All rows verified by HR/i);
+  assert.doesNotMatch(output, /\breal\s*:\s*\d+/i);
+});


### PR DESCRIPTION
## Summary
- execute the real Phase 0 validator from a Node CLI regression test
- require TEST_SEED fixtures to remain SYNTHETIC_ONLY and blocked from production/director readiness
- wire the regression into PowerShell and Bash local CI fast gates

## Verification
- node --test scripts/tests/validate-multiplier-phase0.test.mjs
- .\\scripts\\ci-local.ps1 -SkipInstall -SkipFrontend -SkipE2E -SkipBackend -SkipDocker
- bash scripts/ci-local.sh --skip-install --skip-frontend --skip-e2e --skip-backend --skip-docker
- full local CI evidence recorded on Issue #105

GitHub Actions auto-trigger is disabled; verification used local CI to conserve quota.

Closes #105