### PR TITLE
fix(test): run menu e2e against current backend

### DIFF
--- a/frontend/e2e/features/all-menu-content.spec.js
+++ b/frontend/e2e/features/all-menu-content.spec.js
@@ -3,6 +3,7 @@ import { loginAsAdmin } from '../helpers/auth.js'
 
 const expectedMenuPaths = [
   '/dashboard',
+  '/personnel',
   '/probation-end',
   '/candidates/overview',
   '/candidates/general',
@@ -43,7 +44,7 @@ test('all sidebar menu destinations keep the content area rendered', async ({ pa
     }))
   ))
 
-  expect(destinations).toHaveLength(21)
+  expect(destinations).toHaveLength(expectedMenuPaths.length)
   expect(destinations.map(({ href }) => href).sort()).toEqual([...expectedMenuPaths].sort())
 
   for (const { href, label } of destinations) {

--- a/scripts/ci-local.ps1
+++ b/scripts/ci-local.ps1
@@ -155,7 +155,7 @@ if (-not $SkipE2E) {
     $failed += 'e2e'
   } else {
     try {
-      docker compose --project-directory $Root up -d db backend
+      docker compose --project-directory $Root up -d --build db backend
       if ($LASTEXITCODE -ne 0) { throw "docker compose up exited $LASTEXITCODE" }
 
       $backendReady = $false

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -103,7 +103,7 @@ if [[ "${SKIP_E2E}" -eq 0 ]]; then
   elif (
     set -e
     cd "${ROOT}"
-    docker compose up -d db backend
+    docker compose up -d --build db backend
     backend_ready=0
     for _ in $(seq 1 60); do
       if docker compose exec -T db sh -c \


### PR DESCRIPTION
## Summary
- include /personnel in the all-sidebar-menu Playwright contract
- derive the expected destination count from expectedMenuPaths
- rebuild the Compose backend before local E2E so the browser never tests a stale image

## Root cause
The existing local backend image was created on 2026-08-01 and did not contain the current personnel route. After /personnel was added to E2E coverage, that stale image returned the legacy typeahead response without pagination.

## Verification
- PowerShell E2E-only local CI: PASS, 22 destinations
- Bash E2E-only local CI: PASS, 22 destinations
- full .\\scripts\\ci-local.ps1 -SkipInstall: PASS
  - frontend 73 files / 551 tests
  - backend 330 tests / 865 assertions, 1 skipped
  - schema parity, production build, E2E, and Docker builds passed
- post-rebase PowerShell fast+E2E: PASS
- post-rebase Bash fast gate: PASS

GitHub Actions auto-trigger is disabled; verification used local CI to conserve quota.

Closes #106