### PR TITLE
fix(security): redact citizen_id from legacy /civil-servants

### DIFF
--- a/backend/api.php
+++ b/backend/api.php
@@ -319,62 +319,14 @@ switch ($path[0]) {
 
         if ($method == 'GET') {
             requirePermission('read', 'personnel');
+            include_once __DIR__ . '/routes/personnel.php';
+            // Fail-closed: ไม่มี role = viewer (redact citizen_id เสมอ)
+            $role = (string) (getAuthenticatedUser()['role'] ?? 'viewer');
             $search = $_GET['search'] ?? '';
             $limit = intval($_GET['limit'] ?? 20);
             $offset = intval($_GET['offset'] ?? 0);
 
-            // Build search query
-            $searchQuery = '';
-            $params = [];
-
-            if (!empty($search)) {
-                $searchQuery = " WHERE (p.first_name LIKE ? OR p.last_name LIKE ? OR p.employee_id LIKE ?)";
-                $searchTerm = "%{$search}%";
-                $params = [$searchTerm, $searchTerm, $searchTerm];
-            } else {
-                $searchQuery = " WHERE 1=1";
-            }
-
-            $sql = "
-                SELECT
-                    p.personnel_id AS servant_id,
-                    p.employee_id,
-                    p.citizen_id,
-                    CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) as full_name,
-                    p.first_name,
-                    p.last_name,
-                    p.birth_date,
-                    p.appointment_date,
-                    p.retirement_date,
-                    p.servant_status
-                FROM personnel p
-                LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id
-                {$searchQuery}
-                AND p.is_active = 1
-                ORDER BY p.first_name, p.last_name
-                LIMIT ? OFFSET ?
-            ";
-
-            $stmt = $pdo->prepare($sql);
-            $stmt->execute(array_merge($params, [$limit, $offset]));
-            $servants = $stmt->fetchAll(PDO::FETCH_ASSOC);
-
-            // Get total count for pagination (must match is_active filter on the list query)
-            $countSql = "SELECT COUNT(*) as total FROM personnel p {$searchQuery} AND p.is_active = 1";
-            $countStmt = $pdo->prepare($countSql);
-            $countStmt->execute($params);
-            $total = $countStmt->fetch(PDO::FETCH_ASSOC)['total'];
-
-            echo json_encode([
-                'success' => true,
-                'data' => $servants,
-                'pagination' => [
-                    'total' => $total,
-                    'limit' => $limit,
-                    'offset' => $offset,
-                    'has_more' => ($offset + $limit) < $total
-                ]
-            ]);
+            echo json_encode(legacyCivilServantsList($pdo, $role, $search, $limit, $offset));
         } elseif ($method === 'DELETE' && $servantId > 0) {
             // Soft-delete: ปิดใช้งานบุคลากร (ออกจากรายชื่อ candidates ที่กรอง is_active=1)
             requirePermission('delete', 'personnel');

--- a/backend/routes/personnel.php
+++ b/backend/routes/personnel.php
@@ -214,6 +214,79 @@ function redactPersonnelCitizenIdForRole(array $row, string $role): array
     return $row;
 }
 
+/**
+ * Legacy /civil-servants list (เรียกจาก api.php) — contract เดิม + pagination
+ * แต่ค้นหาด้วย citizen_id ได้โดย "ไม่ให้ค่าคืน" แก่ role ที่ไม่ใช่ admin/superadmin
+ * (CONTEXT.md: operator/viewer ค้นหาด้วยเลขบัตรได้ แต่ต้องไม่เห็นค่าใน response)
+ *
+ * LIMIT/OFFSET เป็นตัวเลข clamp แล้วใน string — ห้าม bind เป็น ?
+ * เพราะ PDO ATTR_EMULATE_PREPARES=false ทำให้ LIMIT ? พังบน MySQL/TiDB
+ *
+ * @return array{success:bool, data:list<array<string, mixed>>, pagination:array<string, mixed>}
+ */
+function legacyCivilServantsList(PDO $pdo, string $role, string $search, int $limit, int $offset): array
+{
+    $limit = max(1, min(200, $limit));
+    $offset = max(0, $offset);
+
+    $params = [];
+    $searchTermSql = trim($search);
+    if ($searchTermSql !== '') {
+        $searchQuery = ' WHERE (p.first_name LIKE ? OR p.last_name LIKE ? OR p.employee_id LIKE ? OR p.citizen_id LIKE ?)';
+        $searchTerm = "%{$searchTermSql}%";
+        $params = [$searchTerm, $searchTerm, $searchTerm, $searchTerm];
+    } else {
+        $searchQuery = ' WHERE 1=1';
+    }
+
+    $sql = "
+        SELECT
+            p.personnel_id AS servant_id,
+            p.employee_id,
+            p.citizen_id,
+            CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) as full_name,
+            p.first_name,
+            p.last_name,
+            p.birth_date,
+            p.appointment_date,
+            p.retirement_date,
+            p.servant_status
+        FROM personnel p
+        LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id
+        {$searchQuery}
+        AND p.is_active = 1
+        ORDER BY p.first_name, p.last_name
+        LIMIT {$limit} OFFSET {$offset}
+    ";
+
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute($params);
+    $servants = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    // PII gate: role ที่ไม่ใช่ admin/superadmin ต้องไม่ได้รับ citizen_id
+    $servants = array_map(
+        static fn (array $row): array => redactPersonnelCitizenIdForRole($row, $role),
+        $servants
+    );
+
+    // นับ total ให้ตรงกับ filter ของ list query (is_active = 1)
+    $countSql = "SELECT COUNT(*) as total FROM personnel p {$searchQuery} AND p.is_active = 1";
+    $countStmt = $pdo->prepare($countSql);
+    $countStmt->execute($params);
+    $total = (int) $countStmt->fetch(PDO::FETCH_ASSOC)['total'];
+
+    return [
+        'success' => true,
+        'data' => $servants,
+        'pagination' => [
+            'total' => $total,
+            'limit' => $limit,
+            'offset' => $offset,
+            'has_more' => ($offset + $limit) < $total,
+        ],
+    ];
+}
+
 function personnelPrefixExists(PDO $pdo, int $prefixId): bool
 {
     if ($prefixId <= 0) {

--- a/backend/tests/Integration/LegacyCivilServantsListTest.php
+++ b/backend/tests/Integration/LegacyCivilServantsListTest.php
@@ -1,0 +1,144 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Integration;
+
+use PDO;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../routes/personnel.php';
+
+/**
+ * HTTP-contract ของ legacy GET /civil-servants (Issue #110):
+ * operator/viewer ต้องไม่เคยได้รับ citizen_id — admin/superadmin ยังเห็นเหมือนเดิม
+ * และค้นหาด้วยเลขบัตรประชาชนได้โดยไม่ echo ค่ากลับ
+ */
+final class LegacyCivilServantsListTest extends TestCase
+{
+    private static ?PDO $pdo = null;
+    private string $suffix = '';
+    private int $personnelId = 0;
+    private int $prefixId = 0;
+    private string $citizenId = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$pdo = testPdo();
+    }
+
+    protected function setUp(): void
+    {
+        if (self::$pdo === null) {
+            self::markTestSkipped('ต่อ MySQL ไม่ได้ — รัน: docker compose up -d db แล้วใช้ tests/run.sh');
+        }
+        foreach (['personnel', 'prefixes'] as $table) {
+            if (!self::$pdo->query("SHOW TABLES LIKE '{$table}'")->fetchColumn()) {
+                self::markTestSkipped("ไม่พบตาราง {$table}");
+            }
+        }
+
+        $this->suffix = bin2hex(random_bytes(3));
+        $this->citizenId = '9' . $this->suffix . str_repeat('0', max(0, 12 - strlen($this->suffix) - 1));
+
+        self::$pdo->prepare(
+            'INSERT INTO prefixes (prefix_code, prefix_name_th) VALUES (?, ?)'
+        )->execute(['L' . $this->suffix, 'นาย']);
+        $this->prefixId = (int) self::$pdo->lastInsertId();
+
+        self::$pdo->prepare(
+            'INSERT INTO personnel (citizen_id, first_name, last_name, prefix_id, employee_id, is_active)
+             VALUES (?, ?, ?, ?, ?, 1)'
+        )->execute([
+            $this->citizenId,
+            'ทดสอบ' . $this->suffix,
+            'นามสกุล' . $this->suffix,
+            $this->prefixId,
+            'E' . $this->suffix,
+        ]);
+        $this->personnelId = (int) self::$pdo->lastInsertId();
+    }
+
+    protected function tearDown(): void
+    {
+        if (self::$pdo === null) {
+            return;
+        }
+        if ($this->personnelId > 0) {
+            self::$pdo->prepare('DELETE FROM personnel WHERE personnel_id = ?')->execute([$this->personnelId]);
+        }
+        if ($this->prefixId > 0) {
+            self::$pdo->prepare('DELETE FROM prefixes WHERE prefix_id = ?')->execute([$this->prefixId]);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>|null row ของ seed ตาม personnel_id
+     */
+    private function seededRow(array $payload): ?array
+    {
+        foreach ($payload['data'] as $row) {
+            if ((int) ($row['servant_id'] ?? 0) === $this->personnelId) {
+                return $row;
+            }
+        }
+        return null;
+    }
+
+    #[Test]
+    public function citizen_id_present_only_for_admin_and_superadmin(): void
+    {
+        foreach (['admin', 'superadmin'] as $role) {
+            $payload = legacyCivilServantsList(self::$pdo, $role, '', 200, 0);
+            $row = $this->seededRow($payload);
+            self::assertNotNull($row, "role {$role} ต้องเห็น seeded row");
+            self::assertArrayHasKey('citizen_id', $row, "role {$role} ต้องได้ citizen_id");
+            self::assertSame($this->citizenId, $row['citizen_id']);
+        }
+
+        foreach (['operator', 'viewer'] as $role) {
+            $payload = legacyCivilServantsList(self::$pdo, $role, '', 200, 0);
+            $row = $this->seededRow($payload);
+            self::assertNotNull($row, "role {$role} ต้องเห็น seeded row");
+            self::assertArrayNotHasKey('citizen_id', $row, "role {$role} ต้องไม่ได้รับ citizen_id");
+        }
+    }
+
+    #[Test]
+    public function unknown_role_is_redacted_fail_closed(): void
+    {
+        $payload = legacyCivilServantsList(self::$pdo, '', '', 200, 0);
+        $row = $this->seededRow($payload);
+        self::assertNotNull($row);
+        self::assertArrayNotHasKey('citizen_id', $row);
+    }
+
+    #[Test]
+    public function search_by_citizen_id_finds_row_without_echoing_pii(): void
+    {
+        foreach (['admin', 'superadmin', 'operator', 'viewer'] as $role) {
+            $payload = legacyCivilServantsList(self::$pdo, $role, $this->citizenId, 50, 0);
+            $row = $this->seededRow($payload);
+            self::assertNotNull($row, "role {$role} ต้องค้นหาด้วย citizen_id เจอ");
+
+            if ($role === 'admin' || $role === 'superadmin') {
+                self::assertSame($this->citizenId, $row['citizen_id'] ?? null);
+            } else {
+                self::assertArrayNotHasKey('citizen_id', $row, "role {$role} ต้องไม่ echo citizen_id");
+            }
+        }
+    }
+
+    #[Test]
+    public function pagination_contract_is_preserved(): void
+    {
+        $payload = legacyCivilServantsList(self::$pdo, 'viewer', '', 10, 0);
+        self::assertTrue($payload['success'] ?? false);
+        self::assertArrayHasKey('total', $payload['pagination']);
+        self::assertArrayHasKey('limit', $payload['pagination']);
+        self::assertArrayHasKey('offset', $payload['pagination']);
+        self::assertArrayHasKey('has_more', $payload['pagination']);
+        self::assertSame(10, $payload['pagination']['limit']);
+        self::assertSame(0, $payload['pagination']['offset']);
+    }
+}

--- a/docs/superpowers/plans/2026-08-15-issue-110-citizen-id-redaction-prp-plan.md
+++ b/docs/superpowers/plans/2026-08-15-issue-110-citizen-id-redaction-prp-plan.md
@@ -1,0 +1,65 @@
+# PRP Plan — Issue #110: Prevent citizen_id disclosure from legacy /civil-servants
+
+> Branch: `issue-110-citizen-id-redaction` · Parent audit: #109 · Severity: High (authenticated PII disclosure)
+
+## Context
+
+`GET /civil-servants` (backend/api.php, `case 'civil-servants'`) authorizes `read:personnel`
+(granted to operator + viewer) but SELECTs and returns `p.citizen_id` verbatim.
+CONTEXT.md contract: operator/viewer may **search** by citizen ID but must never **receive**
+it in list/detail/typeahead JSON. Canonical redaction already exists:
+`redactPersonnelCitizenIdForRole()` + `personnelRoleSeesCitizenId()` in `backend/routes/personnel.php`.
+
+## Audit of other leak surfaces (issue plan step 4)
+
+- Grep across backend for `citizen_id` in response-building code:
+  - `api.php:342` — the only legacy SELECT returning citizen_id. **Fix target.**
+  - `routes/personnel.php` — typeahead uses citizen_id in WHERE only (no echo); master list/detail already redacted.
+  - `QualificationEngine.php`, `ImportService.php`, `sync/*` — internal computation/ingest, not JSON responses.
+- Legacy route has **no single-record GET variant** (`$path[1]` is ignored for GET) — list only.
+
+## Changes
+
+### 1. `backend/routes/personnel.php` — new extracted handler
+
+```php
+function legacyCivilServantsList(PDO $pdo, string $role, string $search, int $limit, int $offset): array
+```
+
+- Moves the legacy list query out of api.php (testable, matches repo handler pattern).
+- Adds `OR p.citizen_id LIKE ?` to the search WHERE (search-by-citizen-ID stays allowed;
+  parity with canonical typeahead) — filter only, never echoed.
+- Applies `redactPersonnelCitizenIdForRole($row, $role)` to every row before returning.
+- Returns the same payload shape: `{success, data, pagination}`.
+
+### 2. `backend/api.php` — `case 'civil-servants'` GET
+
+- `requirePermission('read', 'personnel')` unchanged.
+- `include_once __DIR__ . '/routes/personnel.php'` (functions; include_once-safe vs case 'personnel').
+- `$role = (string) (getAuthenticatedUser()['role'] ?? 'viewer')` — fail-closed default.
+- Delegates to `legacyCivilServantsList()` and echoes JSON.
+- DELETE branch untouched.
+
+## Tests
+
+### Integration — new `backend/tests/Integration/LegacyCivilServantsListTest.php`
+
+Seed one active personnel row with known citizen_id; per role (admin, superadmin, operator, viewer):
+
+1. List returns rows; `citizen_id` key present for admin/superadmin, **absent** for operator/viewer.
+2. Search by that citizen ID finds the row for all roles, still without the key for operator/viewer.
+3. Pagination keys unchanged.
+
+Skips via `testPdo()` when MySQL unavailable (repo convention).
+
+### Regression
+
+- Existing `PersonnelAuthzHttpTest` (helper contract) must stay green.
+- Local CI gate: `scripts/ci-local.ps1` (frontend vitest+build, backend PHPUnit, skip docker builds if db-only).
+
+## Acceptance criteria (from issue)
+
+- [ ] Operator/viewer responses never contain `citizen_id` key or value
+- [ ] Admin/superadmin visibility explicitly tested and unchanged
+- [ ] Search by citizen ID allowed without echoing PII
+- [ ] Backend tests + local CI pass


### PR DESCRIPTION
## Summary

Closes #110 (parent audit: #109)

- Legacy `GET /civil-servants` selected `p.citizen_id` and returned it to any role holding `read:personnel` (operator + viewer) — authenticated PII disclosure violating the CONTEXT.md contract.
- Extracted the legacy query into `legacyCivilServantsList()` (`backend/routes/personnel.php`) and applied the canonical `redactPersonnelCitizenIdForRole()` helper; role defaults to `viewer` (fail-closed redaction).
- Citizen-ID search remains allowed (WHERE filter only) but never echoes the value to non-admin roles; `LIMIT`/`OFFSET` clamped as literals per repo convention (`ATTR_EMULATE_PREPARES=false`).
- Bypass audit: `api.php:342` was the only legacy response selecting `citizen_id`; `/personnel` master/typeahead already redact or use it in WHERE only. No single-record GET variant exists on the legacy route.

## API / schema notes

- Response shape unchanged; the `citizen_id` key is simply omitted from list rows for operator/viewer.
- No schema changes.

## Verification

- New `LegacyCivilServantsListTest` (integration, 4 tests / 27 assertions): per-role visibility for admin/superadmin/operator/viewer, unknown-role fail-closed, search-by-citizen-ID without echo, pagination contract.
- Backend full suite via `backend/tests/run.sh`: 334 tests OK (1 expected skip).
- Frontend vitest: 551/551 passed.
- Local CI gate `scripts/ci-local.ps1 -SkipInstall`: all jobs passed.

## Test plan

- [x] Backend PHPUnit (unit + integration) green
- [x] Frontend vitest green
- [x] ci-local.ps1 full gate green