### PR TITLE
fix(security): harden XLSX import — no formula evaluation + phpspreadsheet 2.4.7

### DIFF
--- a/backend/ImportService.php
+++ b/backend/ImportService.php
@@ -80,6 +80,8 @@ class ImportService
         $reader = IOFactory::createReader('Xlsx');
         $reader->setReadDataOnly(true);     // ปิด formula/style/external-ref (ลด attack surface)
         $reader->setReadEmptyCells(false);
+        // โหลดเฉพาะชีตที่ใช้จริง — ไม่ parse ชีตอื่นที่แนบมาใน workbook (attack surface + memory)
+        $reader->setLoadSheetsOnly(array_keys(self::SHEETS));
         $book = $reader->load($xlsxPath);
         $result = [];
 
@@ -93,7 +95,10 @@ class ImportService
             if ($ws->getHighestDataRow() - 1 > self::MAX_ROWS_PER_SHEET) {
                 throw new RuntimeException("ชีต {$name} มีข้อมูลเกิน " . self::MAX_ROWS_PER_SHEET . ' แถว');
             }
-            $rows = $ws->toArray(null, true, false, false); // raw values, 0-indexed
+            // toArray($null, FALSE, false, false) — arg ที่ 2 คือ calculateFormulas:
+            // ต้องเป็น false เสมอ ห้าม evaluate สูตรของไฟล์ที่อัปโหลดเด็ดขาด
+            // (โค้ดเดิมส่ง true → สูตรอย่าง =WEBSERVICE() ถูกคำนวณ = SSRF, class ของ CVE-2026-59931)
+            $rows = $ws->toArray(null, false, false, false); // raw values, 0-indexed
             array_shift($rows); // ตัด header
 
             $parsed = [];
@@ -120,6 +125,19 @@ class ImportService
     private function validate(array $sheets): array
     {
         $errors = [];
+
+        // Fail-closed: reject ทุกไฟล์ที่มีสูตรหลงเหลือ (ค่าเริ่มด้วย '=') — toArray ไม่ evaluate สูตร
+        // ดังนั้นสูตรจะมาเป็น raw string; ถ้าผ่านเข้า persist ได้จะเก็บ "=..." เป็นข้อมูลเสีย
+        // (กัน class ของ CVE-2026-59931 เช่น =WEBSERVICE() ด้วย)
+        foreach ($sheets as $name => $rows) {
+            foreach ($rows as $i => $row) {
+                foreach ($row as $col => $val) {
+                    if (is_string($val) && str_starts_with($val, '=')) {
+                        $errors[] = "{$name} แถว " . ($i + 2) . " ({$col}): พบสูตร (formula) — กรุณาวางข้อมูลเป็นค่าคงที่ (paste as values) ก่อนนำเข้า";
+                    }
+                }
+            }
+        }
 
         // Personnel เป็นแกน — citizen_id เป็น key ของตารางลูก
         $citizenIds = [];

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -269,16 +269,16 @@
         },
         {
             "name": "phpoffice/phpspreadsheet",
-            "version": "2.4.6",
+            "version": "2.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPOffice/PhpSpreadsheet.git",
-                "reference": "0bbef382b7d9c1dbda10c8113d564ff9159a7e79"
+                "reference": "03e65f7c3399756d77f656118f75a61e0fca23c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/0bbef382b7d9c1dbda10c8113d564ff9159a7e79",
-                "reference": "0bbef382b7d9c1dbda10c8113d564ff9159a7e79",
+                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/03e65f7c3399756d77f656118f75a61e0fca23c6",
+                "reference": "03e65f7c3399756d77f656118f75a61e0fca23c6",
                 "shasum": ""
             },
             "require": {
@@ -369,9 +369,9 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPOffice/PhpSpreadsheet/issues",
-                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/2.4.6"
+                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/2.4.7"
             },
-            "time": "2026-06-07T02:31:12+00:00"
+            "time": "2026-07-12T19:37:16+00:00"
         },
         {
             "name": "psr/simple-cache",
@@ -488,20 +488,19 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.7.0",
+            "version": "v5.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
-                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
                 "shasum": ""
             },
             "require": {
-                "ext-ctype": "*",
                 "ext-json": "*",
                 "ext-tokenizer": "*",
                 "php": ">=7.4"
@@ -540,9 +539,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
             },
-            "time": "2025-12-06T11:56:16+00:00"
+            "time": "2026-07-04T14:30:18+00:00"
         },
         {
             "name": "phar-io/manifest",

--- a/backend/tests/Integration/ImportFormulaHardeningTest.php
+++ b/backend/tests/Integration/ImportFormulaHardeningTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration;
+
+use ImportService;
+use PDO;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Throwable;
+
+/**
+ * Issue #111 — regression สำหรับ hardening ของ XLSX import:
+ * 1) ไฟล์ที่มีเซลล์สูตรต้องถูก "ปฏิเสธทั้งไฟล์" (fail-closed) — สูตรไม่ถูก evaluate เด็ดขาด
+ *    (โค้ดเดิมส่ง calculateFormulas=true → สูตรกลุ่ม CVE-2026-59931 เช่น =WEBSERVICE()
+ *    จะทำให้เกิด SSRF/outbound request ระหว่าง import)
+ * 2) ไฟล์ binary แปลกปลอม (OLE/XLS) ที่เปลี่ยนนามสกุลเป็น .xlsx ต้อง fail closed
+ *
+ * ใช้ citizen_id ช่วง 11001002990% เหมือน ImportServiceTest → cleanup ทั้ง setUp/tearDown
+ */
+final class ImportFormulaHardeningTest extends TestCase
+{
+    /** checksum ผ่าน (ช่วง test data เดียวกับ ImportServiceTest) */
+    private const CITIZEN_ID = '1100100299021';
+    private const ORG_NAME = 'องค์กรทดสอบ-formula-111';
+    private const POSITION_NAME = 'ตำแหน่งทดสอบ-formula-111';
+
+    private static ?PDO $pdo = null;
+    /** @var list<string> */
+    private array $tmpFiles = [];
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$pdo = testPdo();
+    }
+
+    protected function setUp(): void
+    {
+        if (self::$pdo === null) {
+            self::markTestSkipped('ต่อ MySQL ไม่ได้ — รัน: docker compose up -d db แล้วใช้ tests/run.sh');
+        }
+        if (!self::$pdo->query("SHOW TABLES LIKE 'personnel'")->fetchColumn()) {
+            self::markTestSkipped('ไม่พบตาราง personnel');
+        }
+        $this->cleanup();
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tmpFiles as $f) {
+            if (is_file($f)) {
+                @unlink($f);
+            }
+        }
+        if (self::$pdo !== null) {
+            $this->cleanup();
+        }
+    }
+
+    #[Test]
+    public function workbook_with_formula_cells_is_rejected_fail_closed(): void
+    {
+        // จำลองไฟล์จาก Excel จริงแบบควบคุม XML ได้เอง: เซลล์สูตรมี <f> + cached <v>
+        // (writer ของ library ไม่เขียน <v> เมื่อปิด preCalculate จึงต้องประกอบ ZIP เอง)
+        // ต้องถูกปฏิเสธทั้งไฟล์ก่อนแตะ DB — สูตรไม่ถูก evaluate จึงไม่มีทางเกิด outbound request
+        $path = $this->buildMaliciousWorkbook([
+            'B2' => ['=1+1', 'SENTINEL'],
+            'C2' => ['=WEBSERVICE("http://169.254.169.254/latest/")', 'CACHED-OK'],
+        ]);
+
+        $result = (new ImportService(self::$pdo))->importFromFile($path);
+
+        self::assertFalse($result['success'], 'ไฟล์มีสูตรต้องถูกปฏิเสธ');
+        self::assertStringContainsString('สูตร', implode(' ', $result['errors']));
+
+        // nothing persisted — parse ล้มก่อน persist
+        $stmt = self::$pdo->prepare('SELECT COUNT(*) FROM personnel WHERE citizen_id = ?');
+        $stmt->execute([self::CITIZEN_ID]);
+        self::assertSame(0, (int) $stmt->fetchColumn(), 'ต้องไม่มีแถวถูก insert จากไฟล์ที่มีสูตร');
+    }
+
+    /**
+     * ประกอบ .xlsx ขั้นต่ำ (OOXML) ด้วย ZipArchive — ชีต Personnel 1 แถวข้อมูล
+     * บางเซลล์เป็น formula + cached value ตามที่กำหนด
+     *
+     * @param array<string, array{0:string, 1:string}> $formulaCells coord => [สูตร, cached value]
+     */
+    private function buildMaliciousWorkbook(array $formulaCells): string
+    {
+        $headers = ['citizen_id', 'first_name', 'last_name', 'hire_date', 'current_level_code', 'current_level_start_date', 'education_level', 'org_name', 'position_name'];
+        $values = [self::CITIZEN_ID, 'ชื่อจริง', 'นามสกุลจริง', '2015-01-01', 'K3', '2020-01-01', 'BACHELOR', self::ORG_NAME, self::POSITION_NAME];
+
+        $colLetter = static fn (int $i): string => chr(ord('A') + $i);
+
+        $row1 = '';
+        foreach ($headers as $i => $h) {
+            $row1 .= '<c r="' . $colLetter($i) . '1" t="inlineStr"><is><t>' . htmlspecialchars($h, ENT_XML1) . '</t></is></c>';
+        }
+        $row2 = '';
+        foreach ($values as $i => $v) {
+            $coord = $colLetter($i) . '2';
+            if (isset($formulaCells[$coord])) {
+                [$formula, $cached] = $formulaCells[$coord];
+                $row2 .= '<c r="' . $coord . '" t="str"><f>' . htmlspecialchars($formula, ENT_XML1) . '</f><v>' . htmlspecialchars($cached, ENT_XML1) . '</v></c>';
+            } else {
+                $row2 .= '<c r="' . $coord . '" t="inlineStr"><is><t>' . htmlspecialchars($v, ENT_XML1) . '</t></is></c>';
+            }
+        }
+
+        $sheetXml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+            . '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
+            . '<dimension ref="A1:I2"/><sheetData>'
+            . '<row r="1">' . $row1 . '</row>'
+            . '<row r="2">' . $row2 . '</row>'
+            . '</sheetData></worksheet>';
+
+        $workbookXml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+            . '<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">'
+            . '<sheets><sheet name="Personnel" sheetId="1" r:id="rId1"/></sheets></workbook>';
+
+        $workbookRels = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+            . '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+            . '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/></Relationships>';
+
+        $rootRels = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+            . '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+            . '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/></Relationships>';
+
+        $contentTypes = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+            . '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">'
+            . '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>'
+            . '<Default Extension="xml" ContentType="application/xml"/>'
+            . '<Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>'
+            . '<Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/></Types>';
+
+        $base = tempnam(sys_get_temp_dir(), 'imp111_');
+        $this->tmpFiles[] = $base; // tempnam สร้างไฟล์เปล่าไว้ — ลบตอน tearDown ด้วย
+        $path = $base . '.xlsx';
+        $zip = new \ZipArchive();
+        self::assertTrue($zip->open($path, \ZipArchive::CREATE) === true, 'สร้าง zip fixture ไม่ได้');
+        $zip->addFromString('[Content_Types].xml', $contentTypes);
+        $zip->addFromString('_rels/.rels', $rootRels);
+        $zip->addFromString('xl/workbook.xml', $workbookXml);
+        $zip->addFromString('xl/_rels/workbook.xml.rels', $workbookRels);
+        $zip->addFromString('xl/worksheets/sheet1.xml', $sheetXml);
+        $zip->close();
+        $this->tmpFiles[] = $path;
+
+        return $path;
+    }
+
+    #[Test]
+    public function ole_binary_renamed_to_xlsx_fails_closed(): void
+    {
+        // OLE/XLS magic (D0 CF 11 E0) — ไม่ใช่ ZIP → Xlsx reader ต้อง throw แล้วถูกห่อเป็น error
+        $base = tempnam(sys_get_temp_dir(), 'imp111c_');
+        $this->tmpFiles[] = $base;
+        $path = $base . '.xlsx';
+        file_put_contents($path, "\xD0\xCF\x11\xE0\xA1\xB1\x1A\xE1" . str_repeat("\x00", 512));
+        $this->tmpFiles[] = $path;
+
+        $result = (new ImportService(self::$pdo))->importFromFile($path);
+
+        self::assertFalse($result['success']);
+        self::assertNotEmpty($result['errors']);
+        self::assertStringContainsString('อ่านไฟล์ Excel ไม่ได้', implode(' ', $result['errors']));
+    }
+
+    private function cleanup(): void
+    {
+        $ids = 'SELECT personnel_id FROM personnel WHERE citizen_id = ' . self::$pdo->quote(self::CITIZEN_ID);
+        try {
+            self::$pdo->exec("DELETE FROM diverse_experience WHERE personnel_id IN ({$ids})");
+            self::$pdo->exec("DELETE FROM position_equivalence WHERE personnel_id IN ({$ids})");
+            self::$pdo->exec("DELETE FROM personnel_position_history WHERE personnel_id IN ({$ids})");
+            self::$pdo->exec('DELETE FROM personnel WHERE citizen_id = ' . self::$pdo->quote(self::CITIZEN_ID));
+            self::$pdo->exec('DELETE FROM organization WHERE org_name = ' . self::$pdo->quote(self::ORG_NAME));
+            self::$pdo->exec('DELETE FROM `position` WHERE position_name = ' . self::$pdo->quote(self::POSITION_NAME));
+        } catch (Throwable $e) {
+            // ตารางอาจยังไม่มีในบาง schema — ปล่อยให้ test จริงจับ
+        }
+    }
+}

--- a/docs/superpowers/plans/2026-08-15-issue-111-xlsx-import-hardening-prp-plan.md
+++ b/docs/superpowers/plans/2026-08-15-issue-111-xlsx-import-hardening-prp-plan.md
@@ -1,0 +1,56 @@
+# PRP Plan — Issue #111: XLSX import hardening (PhpSpreadsheet upgrade + formula evaluation)
+
+**Date:** 2026-08-15 · **Issue:** #111 · **Branch:** `issue-111-xlsx-import-hardening`
+
+## Problem
+
+1. `ImportService::parseWorkbook()` เรียก `$ws->toArray(null, true, false, false)` โดย arg ที่ 2
+   (`calculateFormulas`) เป็น `true` → สูตรในไฟล์ที่ user อัปโหลดถูก **evaluate** จริง
+   สูตรกลุ่ม CVE-2026-59931 เช่น `=WEBSERVICE("http://169.254.169.254/...")` ทำให้เกิด
+   SSRF/outbound request จากเซิร์ฟเวอร์ (cloud metadata leak)
+2. phpspreadsheet ติดตั้งอยู่ที่ 2.4.6 ซึ่งยังมี advisory:
+   - CVE-2026-59931 (WEBSERVICE SSRF redirect bypass)
+   - CVE-2026-59932 (Gnumeric gzip memory exhaustion)
+   - CVE-2026-59933 (OLE sector-chain loop)
+   ทั้งหมดแก้ใน 2.4.7 (2.x line)
+3. ไฟล์ binary แปลกปลอม (OLE/XLS) เปลี่ยนนามสกุลเป็น `.xlsx` ต้อง fail closed
+   ด้วยข้อความที่เข้าใจง่าย (ไม่ 500)
+
+## Plan
+
+### 1. Upgrade dependency
+- `composer update phpoffice/phpspreadsheet` → 2.4.7 (+ nikic/php-parser v5.8.0)
+- ตรวจ `composer audit` = clean
+
+### 2. ปิด formula evaluation ที่ต้นทาง (`backend/ImportService.php`)
+- `toArray(null, FALSE, false, false)` — calculateFormulas เป็น false เสมอ
+  → import ใช้ cached value เท่านั้น; สูตรมาเป็น raw string `"=..."` ไม่ถูกคำนวณ
+- `setReadDataOnly(true)` — ไม่โหลด formula/style/external ref (ลด attack surface)
+- `setLoadSheetsOnly(['Personnel','Diverse','Equivalence','History'])` —
+  ไม่ parse ชีตอื่นที่แนบมาใน workbook
+
+### 3. Fail-closed validation สำหรับสูตร (`validate()`)
+- สแกนทุกชีต: ค่า string ที่ขึ้นต้นด้วย `=` → error
+  `"{Sheet} แถว N (field): พบสูตร (formula) — กรุณาวางข้อมูลเป็นค่าคงที่ (paste as values) ก่อนนำเข้า"`
+- ตรวจที่ `validate()` (ไม่ใช่ throw ใน parse) เพื่อให้ข้อความ error ถึง user ตรง ๆ
+  ไม่ถูกบังโดย generic catch ของ `importFromFile()`
+
+### 4. Regression tests (`backend/tests/Integration/ImportFormulaHardeningTest.php`)
+- สร้าง malicious OOXML ด้วย ZipArchive (fixture ไม่ต้องพึ่ง library writer):
+  `<c t="str"><f>=WEBSERVICE(...)</f><v>CACHED-OK</v></c>`
+- `workbook_with_formula_cells_is_rejected_fail_closed`: success=false,
+  errors มีคำว่า 'สูตร', 0 rows persisted
+- `ole_binary_renamed_to_xlsx_fails_closed`: OLE magic bytes → error 'อ่านไฟล์ Excel ไม่ได้'
+- cleanup ช่วง citizen_id `11001002990%` เหมือน ImportServiceTest
+
+## Acceptance criteria
+- [x] composer.lock อยู่ที่ phpspreadsheet ≥ 2.4.7, `composer audit` clean
+- [x] `toArray()` calculateFormulas=false + comment อธิบายเหตุผล
+- [x] ไฟล์มีสูตรถูก reject ทั้งไฟล์ (all-or-nothing) ด้วยข้อความเห็นชัด
+- [x] OLE/binary ปลอม .xlsx fail closed
+- [x] ImportServiceTest เดิมยังเขียว (พฤติกรรม import ปกติไม่เปลี่ยน)
+
+## Verification
+- `bash backend/tests/run.sh --filter "ImportFormulaHardeningTest|ImportServiceTest"`
+- `bash backend/tests/run.sh` (full suite)
+- `scripts/ci-local.ps1 -SkipInstall`


### PR DESCRIPTION
Closes #111

## Summary
- `ImportService::parseWorkbook()` เคยส่ง `calculateFormulas=true` ให้ `toArray()` → สูตรในไฟล์ที่อัปโหลดถูก evaluate จริง (class ของ CVE-2026-59931 เช่น `=WEBSERVICE()` → SSRF/outbound request จากเซิร์ฟเวอร์)
- แก้เป็น `toArray(null, false, false, false)` — ใช้ cached value เท่านั้น + `setReadDataOnly(true)` และ `setLoadSheetsOnly()` ลด attack surface
- `validate()` reject fail-closed ถ้าพบค่าขึ้นต้นด้วย `=` (สูตรเหลืออยู่) พร้อมข้อความไทยเห็นชัด
- upgrade phpspreadsheet 2.4.6 → 2.4.7 (แก้ CVE-2026-59931/59932/59933), `composer audit` clean
- OLE/binary ปลอมนามสกุล .xlsx fail closed ด้วยข้อความที่เข้าใจง่าย

## Tests
- เพิ่ม `ImportFormulaHardeningTest` (สร้าง malicious OOXML ด้วย ZipArchive): ไฟล์มีสูตรถูก reject ทั้งไฟล์ + 0 rows persisted, OLE ปลอม fail closed
- Full backend suite: 336 tests OK (1 pre-existing skip)

## Verification
- `bash backend/tests/run.sh` — passed
- `scripts/ci-local.ps1 -SkipInstall` — all jobs passed (770s)

Plan: `docs/superpowers/plans/2026-08-15-issue-111-xlsx-import-hardening-prp-plan.md`