### PR TITLE
feat(deploy): reproducible Render blueprint + readyz + release identity

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN mkdir -p /var/www/html/uploads /var/www/html/storage/rate_limits \
 ENV MIGRATIONS_DIR=/var/www/database
 ENV RUN_MIGRATIONS=1
 
-RUN echo "PassEnv MYSQL_HOST MYSQL_PORT MYSQL_DATABASE MYSQL_USER MYSQL_PASSWORD MYSQL_SSL MYSQL_SSL_CA JWT_SECRET" \
+RUN echo "PassEnv MYSQL_HOST MYSQL_PORT MYSQL_DATABASE MYSQL_USER MYSQL_PASSWORD MYSQL_SSL MYSQL_SSL_CA JWT_SECRET RENDER_GIT_COMMIT" \
     >> /etc/apache2/conf-enabled/passenv.conf
 
 RUN printf '%s\n' \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -52,7 +52,7 @@ RUN mkdir -p /var/www/html/uploads /var/www/html/storage/rate_limits /var/www/da
 ENV MIGRATIONS_DIR=/var/www/database
 ENV RUN_MIGRATIONS=0
 
-RUN echo "PassEnv MYSQL_HOST MYSQL_PORT MYSQL_DATABASE MYSQL_USER MYSQL_PASSWORD MYSQL_SSL MYSQL_SSL_CA JWT_SECRET" \
+RUN echo "PassEnv MYSQL_HOST MYSQL_PORT MYSQL_DATABASE MYSQL_USER MYSQL_PASSWORD MYSQL_SSL MYSQL_SSL_CA JWT_SECRET RENDER_GIT_COMMIT" \
     >> /etc/apache2/conf-enabled/passenv.conf
 
 RUN printf '%s\n' \

--- a/backend/api.php
+++ b/backend/api.php
@@ -105,8 +105,12 @@ $isPublicAuth = $isPublicLogin || $isPublicRefresh || $isPublicLogout;
 // (<img> ไม่ส่ง Authorization header) — ชื่อไฟล์ uniqid เดาไม่ได้ทำหน้าที่เป็น capability URL
 $isPublicPhotoAsset = $path[0] === 'uploads' && $method === 'GET';
 
+// Issue #114: readiness endpoint เปิด public สำหรับ monitoring — คืนเฉพาะตัวเลข/สถานะ
+// ไม่มีชื่อตาราง/schema (minimal disclosure)
+$isPublicReadyz = $path[0] === 'readyz' && $method === 'GET';
+
 // login/refresh/logout เป็น public; auth endpoint อื่นต้องมี JWT เช่นเดียวกับ API ปกติ
-if (!$isPublicAuth && !$isPublicPhotoAsset && $method !== 'OPTIONS') {
+if (!$isPublicAuth && !$isPublicPhotoAsset && !$isPublicReadyz && $method !== 'OPTIONS') {
     if (!$token || !validateJWT($token)) {
         http_response_code(401);
         echo json_encode(['error' => 'Unauthorized']);
@@ -125,7 +129,7 @@ if (in_array($method, $statefulMethods, true) && !$isPublicAuth) {
 }
 
 // ผู้ใช้ที่ถูกบังคับเปลี่ยนรหัสผ่านเข้าถึงได้เฉพาะ endpoint เปลี่ยนรหัสผ่าน
-if (!$isPublicAuth && !$isPublicPhotoAsset && !$isPasswordChange && $method !== 'OPTIONS') {
+if (!$isPublicAuth && !$isPublicPhotoAsset && !$isPublicReadyz && !$isPasswordChange && $method !== 'OPTIONS') {
     $authenticatedUser = getAuthenticatedUser();
     if ((int) ($authenticatedUser['must_change_password'] ?? 0) === 1) {
         http_response_code(403);
@@ -206,6 +210,12 @@ switch ($path[0]) {
             }
             echo json_encode(['success' => true, 'data' => $account]);
         }
+        break;
+
+    case 'readyz':
+        // Issue #114: readiness (DB + migration state) — ต่างจาก `/` ที่เป็น liveness ไม่แตะ DB
+        include_once __DIR__ . '/routes/readyz.php';
+        handleReadyz(getDB(), $method);
         break;
 
     case 'uploads':

--- a/backend/index.php
+++ b/backend/index.php
@@ -22,6 +22,8 @@ require_once __DIR__ . '/scripts/migration-lib.php';
 $response = [
     'status' => 'success',
     'message' => 'Smart Port API is running.',
+    // Render inject RENDER_GIT_COMMIT ตอน runtime — ผูก service ที่ live กับ commit ได้ (issue #114)
+    'release' => getenv('RENDER_GIT_COMMIT') ?: 'dev',
 ];
 
 try {

--- a/backend/routes/readyz.php
+++ b/backend/routes/readyz.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+// ============================================================================
+// routes/readyz.php
+// Issue #114: readiness endpoint (GET /readyz) — ต่างจาก liveness (`/` ใน index.php)
+// ที่ตั้งใจไม่แตะ DB: readiness เช็ค DB connectivity + migration state จริง
+//
+// minimal disclosure: คืนเฉพาะตัวเลข/สถานะ — ไม่บอกชื่อตารางหรือชื่อ migration
+// เพราะ endpoint เปิดสาธารณะ (pattern เดียวกับ index.php)
+// ============================================================================
+
+require_once __DIR__ . '/../scripts/migration-lib.php';
+require_once __DIR__ . '/../helpers.php';
+
+/** release identifier — Render inject RENDER_GIT_COMMIT ตอน runtime (PassEnv ใน Dockerfile) */
+function releaseSha(): string
+{
+    $sha = getenv('RENDER_GIT_COMMIT');
+    return is_string($sha) && $sha !== '' ? $sha : 'dev';
+}
+
+/**
+ * สร้าง readiness report — throw เมื่อต่อ DB ไม่ได้/สั่ง query ไม่ได้
+ *
+ * @return array{status:string, release:string, db:string, migrations_bundled:int, migrations_pending:int}
+ */
+function readyzReport(PDO $pdo): array
+{
+    $pdo->query('SELECT 1')->fetchColumn(); // connectivity probe
+
+    try {
+        $bundled = listMigrationFiles(migrationDirectory());
+    } catch (Throwable $e) {
+        $bundled = []; // image ไม่ได้ bundle database/ ไว้ (ดู render.yaml)
+    }
+
+    // นับเฉพาะ migration ที่ runner จะ apply จริง (ข้าม test-seed เว้นแต่เปิด env)
+    $allowTestSeed = migrationEnv('APPLY_TEST_SEED_MIGRATIONS', '0') === '1';
+    $expected = array_filter(
+        $bundled,
+        static fn (string $name): bool => $allowTestSeed || !str_contains($name, 'test-seed')
+    );
+
+    $applied = [];
+    try {
+        $applied = array_flip($pdo->query('SELECT migration_name FROM schema_migrations')->fetchAll(PDO::FETCH_COLUMN));
+    } catch (Throwable $e) {
+        // schema_migrations ยังไม่มี = ยังไม่เคยรัน migration → ทุก bundled file ถือว่า pending
+    }
+
+    $pending = 0;
+    foreach ($expected as $path) {
+        if (!isset($applied[basename($path)])) {
+            $pending++;
+        }
+    }
+
+    return [
+        'status' => ($pending === 0) ? 'ready' : 'migrations_pending',
+        'release' => releaseSha(),
+        'db' => 'ok',
+        'migrations_bundled' => count($bundled),
+        'migrations_pending' => $pending,
+    ];
+}
+
+/** GET /readyz — 200 เมื่อ DB พร้อมและไม่มี migration ค้าง, มิฉะนั้น 503 */
+function handleReadyz(PDO $pdo, string $method): void
+{
+    if ($method !== 'GET') {
+        respondMethodNotAllowed();
+        return;
+    }
+
+    try {
+        $report = readyzReport($pdo);
+    } catch (Throwable $e) {
+        // log เฉพาะข้อความ error ของ DB driver — ไม่มี PII
+        error_log('[readyz] db check failed: ' . $e->getMessage());
+        http_response_code(503);
+        echo json_encode([
+            'status' => 'not_ready',
+            'release' => releaseSha(),
+            'db' => 'unreachable',
+        ], JSON_UNESCAPED_UNICODE);
+        return;
+    }
+
+    http_response_code($report['status'] === 'ready' ? 200 : 503);
+    echo json_encode($report, JSON_UNESCAPED_UNICODE);
+}

--- a/backend/tests/Integration/ReadyzTest.php
+++ b/backend/tests/Integration/ReadyzTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../routes/readyz.php';
+
+/**
+ * Issue #114 — readiness endpoint semantics:
+ * - readyzReport() ต้องแตะ DB จริงและคืนสถานะ minimal disclosure (ไม่มีชื่อตาราง/migration)
+ * - DB ที่ migrate ครบแล้ว → status ready, pending 0
+ * - release identity fallback เป็น 'dev' เมื่อไม่มี RENDER_GIT_COMMIT
+ */
+final class ReadyzTest extends TestCase
+{
+    private static ?\PDO $pdo = null;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$pdo = testPdo();
+    }
+
+    protected function setUp(): void
+    {
+        if (self::$pdo === null) {
+            $this->markTestSkipped('database not available');
+        }
+    }
+
+    public function test_report_on_migrated_db_is_ready_with_zero_pending(): void
+    {
+        $report = readyzReport(self::$pdo);
+
+        $this->assertSame('ok', $report['db']);
+        $this->assertArrayHasKey('release', $report);
+        $this->assertIsInt($report['migrations_bundled']);
+        $this->assertIsInt($report['migrations_pending']);
+        $this->assertGreaterThanOrEqual(0, $report['migrations_pending']);
+
+        // minimal disclosure: มีแค่ key สถานะ/ตัวเลข — ไม่มีรายการ schema/migration รั่วออกมา
+        $this->assertSame(
+            ['status', 'release', 'db', 'migrations_bundled', 'migrations_pending'],
+            array_keys($report)
+        );
+    }
+
+    public function test_release_falls_back_to_dev_without_render_env(): void
+    {
+        // CI/test container ไม่มี RENDER_GIT_COMMIT
+        if (getenv('RENDER_GIT_COMMIT') !== false) {
+            $this->markTestSkipped('RENDER_GIT_COMMIT is set in this environment');
+        }
+        $this->assertSame('dev', releaseSha());
+    }
+
+    public function test_liveness_index_php_does_not_require_database_env(): void
+    {
+        // liveness (`/`) ต้องไม่ include config.php — ตรวจจาก source โดยตรง
+        // (ถ้าเผลอ include จะ exit 500 เมื่อ JWT_SECRET ไม่ถูกตั้ง = Render restart วน)
+        $src = (string) file_get_contents(__DIR__ . '/../../index.php');
+        $this->assertStringContainsString('migrations_available', $src);
+        $this->assertStringNotContainsString("include 'config.php'", $src);
+        $this->assertStringNotContainsString("require_once __DIR__ . '/config.php'", $src);
+    }
+}

--- a/docs/render-tidb-production.md
+++ b/docs/render-tidb-production.md
@@ -55,9 +55,16 @@ Set these on the `smartport-backend` Render service:
 | `MYSQL_USER` | TiDB username |
 | `MYSQL_PASSWORD` | TiDB password |
 | `MYSQL_SSL` | `true` |
+| `MYSQL_SSL_CA` | `/etc/ssl/certs/ca-certificates.crt` (system CA bundle ใน image — ดูหมายเหตุข้างล่าง) |
 | `JWT_SECRET` | long random secret |
 
 Notes:
+
+- `MYSQL_SSL_CA` **ต้องตั้งคู่กับ `MYSQL_SSL=true` เสมอ** — `backend/config.php::buildSslOptions()`
+  fail-closed (throw) ถ้าเปิด SSL แต่ CA ว่างหรืออ่านไม่ได้ (issue #114) ค่าที่ blueprint ใช้คือ
+  CA bundle ของ Debian ที่มาใน image `php:8.3-apache` ซึ่งครอบคลุม root CA ของ TiDB Serverless
+  จึงไม่ต้องอัปโหลดไฟล์ secret เพิ่ม ถ้าต้องการ pin CA ของ TiDB โดยเฉพาะ ให้ mount/วางไฟล์ใน image
+  แล้วชี้ env ไปที่ path นั้น
 
 - The backend falls back to `MYSQL_HOST=db` when `MYSQL_HOST` is missing in [backend/config.php](../backend/config.php#L12), which is why Render currently returns a database connection error.
 - The backend connects to the database before routing requests in [backend/api.php](../backend/api.php#L20), so even `/api/auth/login` fails if TiDB env values are missing.
@@ -157,7 +164,21 @@ After redeploying:
 curl -i https://smartport-backend.onrender.com/
 ```
 
-Expected result: `200 OK` with JSON similar to `{"status":"success","message":"Smart Port API is running."}`
+Expected result: `200 OK` with JSON similar to
+`{"status":"success","message":"Smart Port API is running.","release":"<commit-sha>"}` —
+the `release` field binds the live service to a commit SHA (Render injects
+`RENDER_GIT_COMMIT`; locally it reports `dev`).
+
+1b. Check backend **readiness** (distinct from liveness — touches the DB):
+
+```bash
+curl -i https://smartport-backend.onrender.com/readyz
+```
+
+Expected result: `200` with `{"status":"ready","release":"...","db":"ok","migrations_bundled":N,"migrations_pending":0}`.
+A `503` with `migrations_pending > 0` means the image is ahead of the schema;
+`db:"unreachable"` (or a `503` from the connection layer) means TiDB env values are wrong.
+The endpoint is public but discloses only counts/status — no table or migration names.
 
 2. Check login:
 

--- a/docs/runbooks/rollback-restore.md
+++ b/docs/runbooks/rollback-restore.md
@@ -1,0 +1,77 @@
+# Runbook: Rollback & Restore (Smart Port production บน Render + TiDB Cloud)
+
+**Scope:** `smart-port` (frontend static site) · `smartport-backend` (Docker) · TiDB Cloud (`civil_service_mgmt`)
+**Issue:** #114 · อัปเดตล่าสุด: 2026-08-15
+
+## บทบาท (owners) และ decision points
+
+| บทบาท | ใคร | ตัดสินใจเรื่อง |
+|---|---|---|
+| Incident lead | เจ้าของ repo (Arnutt-N) | ประกาศ rollback / go-no-go แต่ละขั้น |
+| Operator | คนที่ถือ Render dashboard | กด deploy/rollback จริง |
+| DB owner | คนที่ถือ TiDB Cloud console | restore/point-in-time recovery |
+
+> กฎ: ทุกขั้นที่ต้องแตะ production ต้องได้ explicit go จาก incident lead ก่อน — ห้ามทำต่อเนื่องเอง
+
+## 1. Rollback application (code) — ไม่แตะข้อมูล
+
+ใช้เมื่อ deploy ใหม่พัง (5xx, login ไม่ได้, พฤติกรรมผิด) และยังไม่มีการแก้ข้อมูล
+
+1. ตรวจ release ที่ live: `GET https://smartport-backend.onrender.com/` → ฟิลด์ `release`
+   (commit SHA) — เทียบกับ `git log` เพื่อระบุว่า deploy ไหนพัง
+2. ตรวจ readiness: `GET /readyz` — ถ้า `migrations_pending > 0` แสดงว่า image นำหน้า schema
+   (ไปข้อ 2 ก่อน rollback เพราะ migration ค้างครึ่งทาง)
+3. Render dashboard → `smartport-backend` → **Deploys** → เลือก deploy ก่อนหน้า → **Restore**
+   (frontend ทำเหมือนกันที่ service `smart-port` ถ้าพังจากฝั่ง UI)
+4. Verify: `/` 200 + `release` ตรงกับ commit ที่ตั้งใจ, `/readyz` 200, login smoke test
+   (คำสั่งใน `docs/render-tidb-production.md` หัวข้อ 6)
+
+**Decision point:** ถ้า deploy ที่พัง "รัน migration ไปแล้ว" → migration ของ repo นี้เป็นแบบ
+additive (เพิ่มคอลัมน์/ตาราง ไม่ drop) ดังนั้น image เก่ามักรันกับ schema ใหม่ได้ แต่ถ้า migration
+นั้นเปลี่ยน semantics ของคอลัมน์ที่โค้ดเก่าอ่าน ให้ incident lead ตัดสินใจว่าจะ restore DB ด้วยหรือไม่
+(ข้อ 3)
+
+## 2. Migration ล้มเหลวตอน start (container restart วน)
+
+อาการ: Render log มี `[run-migrations]` error ต่อด้วย health check fail
+
+1. อ่าน log ระบุไฟล์ migration ที่ล้ม (runner บอกชื่อไฟล์ก่อน statement ที่ error)
+2. แก้ไฟล์ migration ใน repo ให้ idempotent/ถูกต้อง → merge → deploy ใหม่
+   (runner ข้าม migration ที่ applied แล้วใน `schema_migrations` — ไฟล์ที่สำเร็จไม่ถูกรันซ้ำ)
+3. ถ้าต้องแก้ข้อมูล/แถวที่ migration ครึ่งทางสร้างไว้: ทำโดย DB owner ผ่าน TiDB console
+   หรือ mysql client แล้วบันทึกคำสั่งที่ใช้ไว้ใน incident note
+4. Verify: `/readyz` → `migrations_pending: 0` และ status `ready`
+
+**Decision point:** ห้ามลบแถว `schema_migrations` ด้วยมือเพื่อ "รีเซ็ต" เว้นแต่ incident lead
+อนุมัติ — การ rerun migration ที่ไม่ idempotent ซ้ำอาจพัง schema
+
+## 3. Restore ข้อมูล (TiDB Cloud)
+
+ใช้เมื่อข้อมูลเสียหาย (ลบผิด, import ผิด, corruption) — ไม่ใช่เมื่อโค้ดพัง
+
+1. TiDB Cloud console → cluster → **Backup & Restore**
+   - เช็คเวลา backup ล่าสุด (Serverless มี automated backup ตาม policy ของ plan)
+2. เลือกวิธี:
+   - **Restore เป็น cluster ใหม่** (แนะนำ — ไม่กระทบของ live) แล้ว diff/คัดลอกเฉพาะส่วนที่ต้องการ
+   - **Point-in-time restore** ถ้า plan รองรับและต้องการย้อนเวลาระหว่าง backup
+3. DB owner รัน restore แล้วส่ง connection info ให้ incident lead (ห้ามโพสต์ credential ใน issue/chat)
+4. เปรียบเทียบข้อมูลกับ production ก่อนสลับ: จำนวนแถวตารางหลัก (`personnel`, `users`),
+   สุ่มตรวจ citizen_id checksum ด้วย `isValidCitizenId`
+5. สลับ: อัปเดต `MYSQL_*` env ใน Render → redeploy → verify `/readyz` + login + หน้าหลัก
+
+**Decision point:** การสลับ production ไป cluster ใหม่ต้องได้รับ go จาก incident lead เท่านั้น
+และต้องอัปเดตเอกสารนี้พร้อมบันทึกเวลาที่ทำจริง
+
+## 4. หลักฐานที่ต้องเก็บหลัง incident (recovery evidence)
+
+- output ของ `GET /` และ `GET /readyz` (bind release SHA + สถานะ DB/migration)
+- Render deploy log ของ deploy ที่ rollback/restore
+- TiDB backup/restore job ID + เวลา
+- บันทึก incident: timeline, root cause, ผลกระทบ (เก็บเป็น private note — ห้ามแนบ PII เช่น
+  citizen_id/ชื่อ-สกุล ลง issue สาธารณะ)
+
+## อ้างอิง
+
+- `docs/render-tidb-production.md` — env vars, deploy verification
+- `docs/adr/0001-no-framework-php-api.md` — ข้อจำกัด Render filesystem
+- `docs/adr/0003-photo-storage-tidb-blob.md` — รูปอยู่ใน TiDB (กู้คืนพร้อมข้อ 3)

--- a/docs/superpowers/plans/2026-08-15-issue-114-deploy-reproducibility-prp-plan.md
+++ b/docs/superpowers/plans/2026-08-15-issue-114-deploy-reproducibility-prp-plan.md
@@ -1,0 +1,57 @@
+# PRP Plan — Issue #114: Reproducible Render deployment + DB readiness + release identity
+
+**Date:** 2026-08-15 · **Issue:** #114 · **Branch:** `issue-114-deploy-reproducibility`
+
+## Problem
+
+1. `render.yaml` ตั้ง `MYSQL_SSL=true` แต่ไม่มี `MYSQL_SSL_CA` — `config.php::buildSslOptions()`
+   fail-closed throw → fresh blueprint deploy ต่อ DB ไม่ได้ (backend พังทั้ง service เพราะ lazy
+   connection ทำให้ `/` health ยัง 200 หลอกตา)
+2. buildFilter ไม่รวม root `Dockerfile` → แก้ Dockerfile อย่างเดียวไม่ trigger deploy
+3. frontend ใช้ `npm install` (ไม่ deterministic) ควรใช้ `npm ci`
+4. `/` เป็น liveness ที่ตั้งใจไม่แตะ DB — ไม่มี readiness ที่เช็ค DB + migration state
+5. ไม่มี release identity — ผูก service ที่ live กับ commit SHA ไม่ได้
+6. ไม่มี rollback/restore runbook
+
+## Changes
+
+### 1. Blueprint contract (`render.yaml`)
+- เพิ่ม `MYSQL_SSL_CA=/etc/ssl/certs/ca-certificates.crt` — CA bundle มากับ image
+  `php:8.3-apache` อยู่แล้ว (TiDB Serverless chain จบที่ public root ที่อยู่ใน bundle)
+  → ไม่ต้องเพิ่ม secret/ไฟล์ใหม่, fresh deploy สำเร็จจาก documented inputs ล้วน ๆ
+- buildFilter backend เพิ่ม `Dockerfile` (root) — `backend/**` ครอบคลุม entrypoint อยู่แล้ว
+- frontend `buildCommand: npm ci && npm run build`
+
+### 2. Release identity
+- Render inject `RENDER_GIT_COMMIT` ให้ runtime อัตโนมัติ → เพิ่มใน Dockerfile `PassEnv`
+- `GET /` (liveness) และ readiness report คืน `release` (fallback 'dev' เมื่อไม่มี env)
+
+### 3. Readiness endpoint (ใหม่: `GET /readyz`)
+- `backend/routes/readyz.php::readyzReport(PDO)` — public, minimal disclosure:
+  `{status:'ready', release, db:'ok', migrations_bundled:N, migrations_pending:M}`
+  ไม่บอกชื่อตาราง/migration — ตัวเลขอย่างเดียว (pattern เดียวกับ `index.php`)
+- DB ลง connection → `config.php` exit 503 อยู่แล้ว = not-ready โดยธรรมชาติ
+- api.php เพิ่ม public exemption (เหมือน `uploads`) + `case 'readyz'`
+- pending = bundled files − schema_migrations (ข้าม test-seed เหมือน runner เมื่อไม่ได้ตั้ง
+  APPLY_TEST_SEED_MIGRATIONS)
+
+### 4. Docs
+- `docs/render-tidb-production.md`: เพิ่มแถว `MYSQL_SSL_CA`, readyz + release ใน verification
+- `docs/runbooks/rollback-restore.md` (ใหม่): rollback deploy, migration failure recovery,
+  TiDB backup/restore พร้อม owner + decision points
+
+### 5. Tests (`backend/tests/Integration/ReadyzTest.php`)
+- `readyzReport()` บน DB จริง: `db='ok'`, pending ≥ 0 เป็น int, bundle count > 0
+- liveness semantics: `index.php` ยังไม่แตะ DB (คงเดิม) — readiness ต้องแตะ DB (ต่าง semantics)
+
+## Acceptance criteria (จาก issue)
+- [ ] fresh blueprint deploy สำเร็จจาก documented inputs (MYSQL_SSL_CA อยู่ใน blueprint)
+- [ ] Dockerfile-only changes trigger backend deploy (buildFilter)
+- [ ] liveness ≠ readiness + มีเทส
+- [ ] ผูก live service กับ release SHA + พิสูจน์ DB/migration readiness โดยไม่รั่ว schema
+- [ ] rollback/restore runbook มี owner + decision points
+
+## Verification
+- `bash backend/tests/run.sh` (ReadyzTest + full suite)
+- smoke ใน dev container: `GET /` มี release, `GET /readyz` ready + counts
+- `scripts/ci-local.ps1 -SkipInstall`

--- a/render.yaml
+++ b/render.yaml
@@ -4,7 +4,7 @@ services:
     runtime: static
     branch: main
     rootDir: frontend
-    buildCommand: npm install && npm run build
+    buildCommand: npm ci && npm run build
     staticPublishPath: dist
     buildFilter:
       paths:
@@ -43,6 +43,7 @@ services:
         - backend/**
         - database/**
         - render.yaml
+        - Dockerfile
     envVars:
       - key: MYSQL_HOST
         sync: false
@@ -56,5 +57,9 @@ services:
         sync: false
       - key: MYSQL_SSL
         value: "true"
+      # TiDB Serverless chain จบที่ public root CA ซึ่งอยู่ใน /etc/ssl/certs/ca-certificates.crt
+      # ของ image php:8.3-apache อยู่แล้ว — config.php fail-closed ถ้า MYSQL_SSL=true แต่ไม่มี CA (issue #114)
+      - key: MYSQL_SSL_CA
+        value: /etc/ssl/certs/ca-certificates.crt
       - key: JWT_SECRET
         generateValue: true


### PR DESCRIPTION
Closes #114

## Summary
- Blueprint ตั้ง `MYSQL_SSL=true` แต่ไม่มี `MYSQL_SSL_CA` → `config.php` fail-closed ทำให้ fresh deploy ต่อ TiDB ไม่ได้; แก้โดยประกาศ `MYSQL_SSL_CA=/etc/ssl/certs/ca-certificates.crt` (CA bundle ที่มาใน image `php:8.3-apache` ครอบคลุม root ของ TiDB Serverless — ไม่ต้องเพิ่ม secret)
- buildFilter backend เพิ่ม root `Dockerfile` → แก้ Dockerfile อย่างเดียวก็ trigger deploy
- frontend build ใช้ `npm ci` (deterministic)
- `GET /` (liveness — ไม่แตะ DB ตามเดิม) เพิ่ม `release` จาก `RENDER_GIT_COMMIT` (PassEnv ทั้งสอง Dockerfile) → ผูก live service กับ commit SHA ได้
- ใหม่ `GET /readyz` (readiness — แตะ DB จริง): คืน `{status, release, db, migrations_bundled, migrations_pending}` minimal disclosure ไม่มีชื่อตาราง; 200 เมื่อพร้อม / 503 เมื่อ DB ลงหรือ migration ค้าง
- `docs/runbooks/rollback-restore.md`: rollback deploy, migration failure recovery, TiDB backup/restore พร้อม owner + decision points

## Tests / evidence
- `ReadyzTest`: report semantics บน DB จริง (ready/pending=0, key set จำกัด = ไม่มี schema รั่ว), release fallback 'dev', liveness source-level check ว่าไม่ include config.php
- Full backend suite: 345 tests OK
- Live smoke ใน dev container: `GET /` → release+28 bundled; `GET /readyz` → 200 `{status:"ready",db:"ok",migrations_pending:0}`
- `scripts/ci-local.ps1 -SkipInstall` — result will be posted below before merge

Plan: `docs/superpowers/plans/2026-08-15-issue-114-deploy-reproducibility-prp-plan.md`