### PR TITLE
feat(security): production security headers + CSP report-only (issue #113 phase 1)

### DIFF
--- a/backend/api.php
+++ b/backend/api.php
@@ -109,8 +109,11 @@ $isPublicPhotoAsset = $path[0] === 'uploads' && $method === 'GET';
 // ไม่มีชื่อตาราง/schema (minimal disclosure)
 $isPublicReadyz = $path[0] === 'readyz' && $method === 'GET';
 
+// Issue #113: browser ส่ง CSP violation report เอง — ไม่มี JWT/CSRF แนบมาด้วย
+$isPublicCspReport = $path[0] === 'csp-report' && $method === 'POST';
+
 // login/refresh/logout เป็น public; auth endpoint อื่นต้องมี JWT เช่นเดียวกับ API ปกติ
-if (!$isPublicAuth && !$isPublicPhotoAsset && !$isPublicReadyz && $method !== 'OPTIONS') {
+if (!$isPublicAuth && !$isPublicPhotoAsset && !$isPublicReadyz && !$isPublicCspReport && $method !== 'OPTIONS') {
     if (!$token || !validateJWT($token)) {
         http_response_code(401);
         echo json_encode(['error' => 'Unauthorized']);
@@ -124,12 +127,12 @@ if (!$isPublicAuth && !$isPublicPhotoAsset && !$isPublicReadyz && $method !== 'O
 // CSRF Protection for state-changing requests
 $statefulMethods = ['POST', 'PUT', 'DELETE'];
 
-if (in_array($method, $statefulMethods, true) && !$isPublicAuth) {
+if (in_array($method, $statefulMethods, true) && !$isPublicAuth && !$isPublicCspReport) {
     requireCSRFToken();
 }
 
 // ผู้ใช้ที่ถูกบังคับเปลี่ยนรหัสผ่านเข้าถึงได้เฉพาะ endpoint เปลี่ยนรหัสผ่าน
-if (!$isPublicAuth && !$isPublicPhotoAsset && !$isPublicReadyz && !$isPasswordChange && $method !== 'OPTIONS') {
+if (!$isPublicAuth && !$isPublicPhotoAsset && !$isPublicReadyz && !$isPublicCspReport && !$isPasswordChange && $method !== 'OPTIONS') {
     $authenticatedUser = getAuthenticatedUser();
     if ((int) ($authenticatedUser['must_change_password'] ?? 0) === 1) {
         http_response_code(403);
@@ -210,6 +213,24 @@ switch ($path[0]) {
             }
             echo json_encode(['success' => true, 'data' => $account]);
         }
+        break;
+
+    case 'csp-report':
+        // Issue #113: รับ CSP violation report จาก browser (report-only phase) — log แล้วทิ้ง
+        if ($method !== 'POST') {
+            respondMethodNotAllowed();
+            break;
+        }
+        $raw = file_get_contents('php://input', false, null, 0, 10240); // cap 10KB กัน abuse
+        $report = json_decode((string) $raw, true);
+        $body = is_array($report) ? ($report['csp-report'] ?? $report) : [];
+        if (is_array($body)) {
+            $directive = (string) ($body['effective-directive'] ?? $body['violated-directive'] ?? 'unknown');
+            $blocked = parse_url((string) ($body['blocked-uri'] ?? ''), PHP_URL_HOST) ?: 'self';
+            // log เฉพาะ directive + host ของ blocked URI — ไม่มี PII
+            error_log("[csp-report] violation directive={$directive} blocked-host={$blocked}");
+        }
+        http_response_code(204);
         break;
 
     case 'readyz':

--- a/docs/frontend-security-headers.md
+++ b/docs/frontend-security-headers.md
@@ -1,0 +1,85 @@
+# Frontend Security Headers & Cache Policy (issue #113 — ระยะที่ 1)
+
+อัปเดต: 2026-08-15
+
+## Deploy paths และที่ที่ headers ถูกประกาศ
+
+| Path | ใช้ตอน | Headers ประกาศที่ |
+|---|---|---|
+| Render static site (`smart-port.onrender.com`) | **production** | `render.yaml` → `headers:` (ไม่ใช่ nginx.conf!) |
+| Docker/Nginx (`localhost:8081`) | local/compose | `frontend/nginx.conf` |
+| Vite dev (`localhost:5174`) | dev | ไม่มี security headers (ไม่เป็นไร — dev only) |
+
+บทเรียน: repo เคยมี headers เฉพาะใน `nginx.conf` ซึ่ง production ไม่ได้ใช้เลย
+เพราะ Render static site ไม่รัน nginx → ต้องประกาศใน blueprint ด้วยเสมอ
+
+## Header set ที่ตกลง
+
+| Header | ค่า | หมายเหตุ |
+|---|---|---|
+| `Content-Security-Policy-Report-Only` (render.yaml) / `Content-Security-Policy` (nginx) | ดูข้างล่าง | Render เริ่ม report-only เพื่อ inventory; nginx enforce เลย |
+| `X-Frame-Options` | `DENY` | + `frame-ancestors 'none'` ใน CSP |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` | |
+| `Permissions-Policy` | `camera=(), geolocation=(), microphone=(), payment=()` | |
+| `X-Content-Type-Options` | `nosniff` | |
+| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` | render.yaml เท่านั้น (nginx local เป็น http) |
+
+### CSP
+
+```
+default-src 'self';
+script-src 'self';
+style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
+font-src https://fonts.gstatic.com;
+img-src 'self' data:;
+connect-src 'self';
+frame-ancestors 'none';
+base-uri 'self';
+form-action 'self';
+report-uri /api/csp-report     ← เฉพาะ render.yaml (report-only phase)
+```
+
+เหตุผลแต่ละ allowance:
+- `style-src 'unsafe-inline'` — Vue runtime set inline style attribute ผ่าน `:style`
+- `https://fonts.googleapis.com` / `fonts.gstatic.com` — Noto Sans Thai (Google Fonts ใน index.html)
+- `img-src data:` — รองรับ data-URI thumbnail เล็ก ๆ
+- `connect-src 'self'` พอเพราะ `/api/*` ถูก rewrite ฝั่ง server ไป backend (same-origin ในสายตา browser)
+
+**ไม่อนุญาต** `unsafe-eval`, wildcard scheme (`http: https:`), หรือ `blob:` ใน default-src อีกต่อไป
+
+## Cache behavior (app shell) — decision
+
+- **Shell (`index.html`, path อื่น ๆ):** `Cache-Control: no-cache` (render.yaml) /
+  `no-store` (nginx) — revalidate ทุกครั้ง กัน stale shell ที่อ้างอิง hashed chunk ที่หายไปแล้ว
+- **Hashed assets (`/assets/*`):** `public, max-age=31536000, immutable` — เนื้อหาผูกกับ
+  hash ในชื่อไฟล์ เปลี่ยนเมื่อไหร่ URL เปลี่ยนเมื่อนั้น
+- ข้อมูล auth ไม่เคยถูก cache (มาทาง `/api/*` ของ backend)
+
+## CSP monitoring ก่อน enforce
+
+1. report-only phase: browser ส่ง violation ไป `POST /api/csp-report` (public, ไม่เก็บ body —
+   log เฉพาะ directive + host ของ blocked URI ผ่าน `error_log`) ดูได้จาก Render log
+2. เกณฑ์ promote เป็น enforce: Render log ไม่มี violation จากระบบจริง ≥ 7 วัน
+   (violation จาก extension ของ user เช่น `chrome-extension:` ตัดทิ้งได้)
+3. วิธี enforce: ใน `render.yaml` เปลี่ยน key `Content-Security-Policy-Report-Only`
+   เป็น `Content-Security-Policy` (ค่าเดิม ตัด `report-uri` หรือไว้ต่อก็ได้)
+   แล้วอัปเดตเทส `securityHeaders.test.js`
+
+## การทดสอบ
+
+- `frontend/src/__tests__/securityHeaders.test.js` — assert header set ข้างต้นในทั้ง
+  render.yaml และ nginx.conf กัน drift/regression
+- ตรวจจากภายนอกหลัง deploy:
+  ```bash
+  curl -sI https://smart-port.onrender.com/ | grep -i "content-security\|x-frame\|referrer\|permissions\|strict-transport"
+  ```
+
+## Follow-up ที่เหลือของ issue #113 (แยก PR)
+
+**ลดการอ่าน token ผ่าน JavaScript** — ปัจจุบัน access/refresh/CSRF token อยู่ใน
+`localStorage` (`frontend/src/stores/auth.js`) ซึ่ง XSS เดียวอ่านได้ทั้งหมด แผนคือย้าย
+refresh token ไป Secure/HttpOnly/SameSite cookie + เก็บ access token ใน memory
+ต้องทำแยกเพราะแตะ:
+- backend `routes/auth.php` (Set-Cookie ใน login/refresh/logout, อ่าน refresh จาก cookie)
+- CSRF design ใหม่หลัง cookie transition (double-submit → SameSite-based หรือ token ผูก session)
+- multi-tab behavior + browser regression suite ด้วยบัญชีทดสอบที่ไม่ใช่ production

--- a/docs/superpowers/plans/2026-08-15-issue-113-security-headers-prp-plan.md
+++ b/docs/superpowers/plans/2026-08-15-issue-113-security-headers-prp-plan.md
@@ -1,0 +1,59 @@
+# PRP Plan — Issue #113 (ระยะที่ 1): Security headers บน Render static site + CSP report-only
+
+**Date:** 2026-08-15 · **Issue:** #113 · **Branch:** `issue-113-security-headers-token-storage`
+
+## Problem (ส่วนที่ทำรอบนี้)
+
+Live frontend บน Render ขาด CSP, frame-ancestors, Referrer-Policy, Permissions-Policy —
+`frontend/nginx.conf` มี headers อยู่แต่ Render static site ไม่ได้ใช้ nginx.conf เลย
+(คนละ deploy path) และ CSP เดิมใน nginx กว้างเกินไป (`default-src 'self' http: https: data: blob: 'unsafe-inline'`)
+
+## Scope decision
+
+**ทำรอบนี้ (headers/cache/CSP):** ข้อ 1, 2, 5 ของ plan ใน issue
+**แยกเป็น follow-up (ต้องออกแบบต่างหาก):** การย้าย refresh token ไป HttpOnly cookie
+(ข้อ 3–4) เพราะแตะ backend auth + CSRF redesign + multi-tab behavior และต้องการ
+browser regression จริง — ทำเป็น PR เฉพาะจะได้รีวิว/ทดสอบถูกจุด (จดใน docs)
+
+## Changes
+
+### 1. Headers บน Render static site จริง (`render.yaml` → `headers:`)
+- `/*`:
+  - `Content-Security-Policy-Report-Only` — เริ่ม report-only เพื่อ inventory ก่อน enforce:
+    `default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;`
+    `font-src https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self';`
+    `frame-ancestors 'none'; base-uri 'self'; form-action 'self'; report-uri /api/csp-report`
+    (Vite build: script/style เป็นไฟล์ภายนอก; `style-src 'unsafe-inline'` เผื่อ Vue inline style attr;
+    Noto Sans Thai โหลดจาก Google Fonts)
+  - `X-Frame-Options: DENY` · `Referrer-Policy: strict-origin-when-cross-origin`
+  - `Permissions-Policy: camera=(), geolocation=(), microphone=(), payment=()`
+  - `X-Content-Type-Options: nosniff` · `Strict-Transport-Security: max-age=31536000; includeSubDomains`
+  - `Cache-Control: no-cache` — app shell revalidate ทุกครั้ง (กัน stale shell ชี้ chunk hash หาย
+    เหตุผลเดียวกับ nginx.conf)
+- `/assets/*`: `Cache-Control: public, max-age=31536000, immutable` (hashed filenames)
+
+### 2. CSP report collector (`backend/api.php` → `POST /csp-report`)
+- public, ไม่ผ่าน JWT/CSRF (browser ส่งเอง), cap body 10KB, log จำนวน violation type ผ่าน
+  `error_log` (ไม่มี PII) แล้วคืน 204 — ทำให้ "monitor ก่อน enforce" วัดผลได้จริงบน Render log
+
+### 3. nginx.conf parity (docker frontend 8081)
+- เปลี่ยน CSP เดิมที่กว้างเกินเป็น enforced policy ชุดเดียวกัน (ตัด `http: https: data: blob:`
+  ออกจาก default-src) + เพิ่ม Referrer-Policy/Permissions-Policy, X-Frame-Options DENY
+
+### 4. Automated header assertions (vitest)
+- `frontend/src/__tests__/securityHeaders.test.js`: assert ว่า render.yaml ประกาศ header ครบชุด
+  ตามข้อตกลง (กัน drift/regression ตอนแก้ blueprint) + assert nginx.conf enforce CSP ชุดเดียวกัน
+
+### 5. Docs
+- `docs/frontend-security-headers.md`: policy set, cache decision, วิธีอ่าน report,
+  เกณฑ์ promote report-only → enforce, และ follow-up cookie migration
+
+## Acceptance (ส่วนนี้)
+- [ ] Render static-site path ประกาศ header ครบชุด (verify จาก blueprint + test)
+- [ ] CSP report-only + collector ทำงาน (monitor ก่อน enforce ไม่พัง Thai UI)
+- [ ] cache behavior ของ app shell ถูก document + test
+- [ ] nginx.conf ไม่มี unsafe allowance เดิม
+
+## Verification
+- `cd frontend && npm test` (securityHeaders.test.js + suite เดิม)
+- `scripts/ci-local.ps1 -SkipInstall`

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -6,12 +6,13 @@ server {
     charset utf-8;
     charset_types text/html text/css text/plain application/javascript application/json application/xml image/svg+xml;
 
-    # Security headers
-    add_header X-Frame-Options "SAMEORIGIN" always;
+    # Security headers (ชุดเดียวกับ render.yaml — ดู docs/frontend-security-headers.md)
+    # Docker path นี้ enforce CSP เลย (render.yaml เริ่ม report-only เพื่อ inventory ก่อน)
+    add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;
-    add_header X-XSS-Protection "1; mode=block" always;
-    add_header Referrer-Policy "no-referrer-when-downgrade" always;
-    add_header Content-Security-Policy "default-src 'self' http: https: data: blob: 'unsafe-inline'" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), geolocation=(), microphone=(), payment=()" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
 
     # Gzip compression
     gzip on;
@@ -27,11 +28,11 @@ server {
         try_files $uri $uri/ /index.html;
         add_header Cache-Control "no-store, no-cache, must-revalidate, max-age=0" always;
         add_header Pragma "no-cache" always;
-        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Frame-Options "DENY" always;
         add_header X-Content-Type-Options "nosniff" always;
-        add_header X-XSS-Protection "1; mode=block" always;
-        add_header Referrer-Policy "no-referrer-when-downgrade" always;
-        add_header Content-Security-Policy "default-src 'self' http: https: data: blob: 'unsafe-inline'" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), geolocation=(), microphone=(), payment=()" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
     }
 
     # API proxy to backend

--- a/frontend/src/__tests__/securityHeaders.test.js
+++ b/frontend/src/__tests__/securityHeaders.test.js
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+// Issue #113 — automated header assertions: กัน drift ของ security headers ที่ประกาศใน
+// render.yaml (Render static site path จริง) และ frontend/nginx.conf (docker path)
+// นโยบายเต็มอยู่ใน docs/frontend-security-headers.md
+
+const here = dirname(fileURLToPath(import.meta.url))
+const renderYaml = readFileSync(resolve(here, '../../../render.yaml'), 'utf8')
+const nginxConf = readFileSync(resolve(here, '../../nginx.conf'), 'utf8')
+
+// CSP ชุดที่ตกลงกัน — Vite build: script/style ไฟล์ภายนอก, Noto Sans Thai จาก Google Fonts
+const CSP_CORE = [
+  "default-src 'self'",
+  "script-src 'self'",
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+  'font-src https://fonts.gstatic.com',
+  "img-src 'self' data:",
+  "connect-src 'self'",
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+]
+
+describe('render.yaml security headers (Render static-site path)', () => {
+  it('declares CSP report-only with the agreed directives and report collector', () => {
+    expect(renderYaml).toContain('Content-Security-Policy-Report-Only')
+    for (const directive of CSP_CORE) {
+      expect(renderYaml).toContain(directive)
+    }
+    expect(renderYaml).toContain('report-uri /api/csp-report')
+  })
+
+  it('sets frame, referrer, permissions, MIME, and HSTS policies', () => {
+    expect(renderYaml).toContain('X-Frame-Options')
+    expect(renderYaml).toMatch(/X-Frame-Options\s*\n\s*value:\s*DENY/)
+    expect(renderYaml).toMatch(/Referrer-Policy\s*\n\s*value:\s*strict-origin-when-cross-origin/)
+    expect(renderYaml).toContain('Permissions-Policy')
+    expect(renderYaml).toContain('camera=()')
+    expect(renderYaml).toMatch(/X-Content-Type-Options\s*\n\s*value:\s*nosniff/)
+    expect(renderYaml).toContain('Strict-Transport-Security')
+    expect(renderYaml).toContain('max-age=31536000; includeSubDomains')
+  })
+
+  it('documents the cache decision: shell revalidates, hashed assets immutable', () => {
+    expect(renderYaml).toMatch(/Cache-Control\s*\n\s*value:\s*no-cache/)
+    expect(renderYaml).toContain('/assets/*')
+    expect(renderYaml).toContain('public, max-age=31536000, immutable')
+  })
+
+  it('does not reintroduce the old broad CSP allowances', () => {
+    expect(renderYaml).not.toContain("default-src 'self' http:")
+  })
+})
+
+describe('nginx.conf security headers (docker path)', () => {
+  it('enforces the same CSP (not report-only) without the old broad allowances', () => {
+    expect(nginxConf).toContain('add_header Content-Security-Policy')
+    expect(nginxConf).not.toContain('Content-Security-Policy-Report-Only')
+    for (const directive of CSP_CORE) {
+      expect(nginxConf).toContain(directive)
+    }
+    expect(nginxConf).not.toContain("http: https: data: blob:")
+  })
+
+  it('uses DENY framing, strict referrer, permissions policy, and nosniff', () => {
+    expect(nginxConf).toContain('X-Frame-Options "DENY"')
+    expect(nginxConf).not.toContain('X-Frame-Options "SAMEORIGIN"')
+    expect(nginxConf).toContain('Referrer-Policy "strict-origin-when-cross-origin"')
+    expect(nginxConf).toContain('Permissions-Policy "camera=(), geolocation=(), microphone=(), payment=()"')
+    expect(nginxConf).toContain('X-Content-Type-Options "nosniff"')
+    expect(nginxConf).not.toContain('X-XSS-Protection')
+  })
+})

--- a/render.yaml
+++ b/render.yaml
@@ -13,6 +13,36 @@ services:
     envVars:
       - key: VITE_API_URL
         value: /api
+    # Issue #113: Render static site ไม่ได้ใช้ frontend/nginx.conf — ต้องประกาศ headers ที่นี่
+    # นโยบายเต็ม + cache decision อยู่ใน docs/frontend-security-headers.md
+    # CSP เริ่มแบบ report-only เพื่อ inventory ก่อน enforce (report ไปที่ backend /api/csp-report)
+    headers:
+      - path: /*
+        name: Content-Security-Policy-Report-Only
+        value: "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; report-uri /api/csp-report"
+      - path: /*
+        name: X-Frame-Options
+        value: DENY
+      - path: /*
+        name: Referrer-Policy
+        value: strict-origin-when-cross-origin
+      - path: /*
+        name: Permissions-Policy
+        value: "camera=(), geolocation=(), microphone=(), payment=()"
+      - path: /*
+        name: X-Content-Type-Options
+        value: nosniff
+      - path: /*
+        name: Strict-Transport-Security
+        value: max-age=31536000; includeSubDomains
+      # app shell: revalidate ทุกครั้ง — กัน stale shell ที่ชี้ hashed chunk หาย (เหตุผลเดียวกับ nginx.conf)
+      - path: /*
+        name: Cache-Control
+        value: no-cache
+      # Vite hashed assets — cache ถาวรได้ปลอดภัย
+      - path: /assets/*
+        name: Cache-Control
+        value: public, max-age=31536000, immutable
     routes:
       - type: rewrite
         source: /api/*


### PR DESCRIPTION
References #113 (phase 1: headers/CSP/cache — ส่วน refresh-token cookie migration แยก PR ตาม `docs/frontend-security-headers.md`)

## Summary
- Production (Render static site) ขาด CSP/frame/referrer/permissions — และ `frontend/nginx.conf` ไม่เคยถูกใช้ใน Render path เลย; แก้โดยประกาศ header set ใน `render.yaml` โดยตรง:
  - `Content-Security-Policy-Report-Only` (inventory ก่อน enforce — ไม่พัง Thai UI) พร้อม `report-uri /api/csp-report`, `frame-ancestors 'none'`
  - `X-Frame-Options: DENY`, `Referrer-Policy: strict-origin-when-cross-origin`, `Permissions-Policy`, `nosniff`, HSTS
  - Cache decision: shell `no-cache` (กัน stale shell ชี้ hashed chunk หาย), `/assets/*` immutable 1 ปี
- ใหม่ `POST /api/csp-report` collector: public, cap 10KB, log เฉพาะ directive + blocked-host (ไม่มี PII) → monitor violation จาก Render log ได้จริงก่อน promote เป็น enforce
- `nginx.conf` (docker path): เลิก CSP กว้างเกินเดิม (`http: https: data: blob: 'unsafe-inline'` ใน default-src) เป็น enforced policy ชุดเดียวกัน, drop X-XSS-Protection ที่ deprecated

## Tests / evidence
- `securityHeaders.test.js` (vitest, 6 tests): assert header set ครบทั้ง render.yaml + nginx.conf กัน drift
- Full frontend vitest + backend suite ผ่านใน CI gate (`ci-local.ps1 -SkipInstall`, exit 0)
- Live smoke: `POST /csp-report` (ไม่มี JWT/CSRF) → 204; `GET /csp-report` → 401 (fail-closed)

## Remaining for #113 (follow-up PR)
- ย้าย refresh/CSRF token ออกจาก localStorage → HttpOnly cookie + access token in-memory (แตะ backend auth + CSRF redesign + multi-tab regression) — รายละเอียดใน docs

Plan: `docs/superpowers/plans/2026-08-15-issue-113-security-headers-prp-plan.md`