### PR TITLE
fix(deps): clear high-severity frontend advisories + audit gate

### DIFF
--- a/docs/superpowers/plans/2026-08-15-issue-115-frontend-dep-advisories-prp-plan.md
+++ b/docs/superpowers/plans/2026-08-15-issue-115-frontend-dep-advisories-prp-plan.md
@@ -1,0 +1,55 @@
+# PRP Plan — Issue #115: Remediate high-severity frontend dependency advisories
+
+**Date:** 2026-08-15 · **Issue:** #115 · **Branch:** `issue-115-frontend-dep-advisories`
+**Parent audit:** #109
+
+## Problem
+
+`npm audit --omit=dev` รายงาน 2 high advisories ใน build chain ของ Vue compiler:
+
+1. **nanoid ≤ 3.3.17** (installed: 3.3.11)
+   - GHSA-28wg-ghj8-5hjv — non-secure generators loop indefinitely เมื่อ size ติดลบ
+   - GHSA-2v37-7h3g-55p8 — custom generators loop เมื่อ size เป็นศูนย์
+2. **postcss ≤ 8.5.22** (installed: 8.5.8)
+   - GHSA-qx2v-qp2m-jg93 — XSS ผ่าน `</style>` ที่ไม่ escape ใน CSS stringify
+   - GHSA-6g55-p6wh-862q — arbitrary file read ผ่าน attacker-controlled sourceMappingURL
+   - GHSA-fxqj-rqcc-2cmp — fix ของตัวก่อนหน้าไม่สมบูรณ์
+   - GHSA-r28c-9q8g-f849 — path traversal ใน previous-source-map auto-loading
+
+Dependency path: `vue@3.5.30 → @vue/compiler-sfc@3.5.30 → postcss → nanoid`
+เป็น build-time path เป็นหลัก (ลด browser-runtime exposure) แต่ production artifacts
+ต้องไม่ build จาก dependency set ที่มี known high-severity advisory
+
+## Plan
+
+### 1. Update เฉพาะ lockfile (smallest compatible set)
+- `npm audit fix` ใน `frontend/` — อัปเดตเฉพาะ transitive deps ที่ resolve ใหม่ใน lockfile
+  ไม่แตะ `package.json` ranges ของโปรเจกต์
+- ผลลัพธ์: `postcss 8.5.8 → 8.5.26`, `nanoid 3.3.11 → 3.3.18`
+  ทั้งคู่อยู่ใน semver range เดิม (8.5.x / 3.3.x) → ไม่มี API/behavior change ตาม semver;
+  changelog ของช่วงนี้เป็น security fix ล้วน (ตาม GHSA ข้างต้น) ไม่มีการเปลี่ยน
+  behavior ของ Vue compiler, PostCSS stringify หรือ nanoid API
+
+### 2. Gate ใน local CI (`scripts/ci-local.ps1`)
+- เพิ่ม `npm audit --omit=dev --audit-level=high` ใน Frontend gate (หลัง npm ci, ก่อน vitest)
+- **Severity policy:** prod deps ต้องไม่มี advisory ระดับ high/critical —
+  moderate และ dev-only advisories ไม่บล็อก CI (triage ด้วยมือเป็นกรณีไป)
+- เหตุผลที่ local CI เท่านั้น: GitHub Actions ถูก hold ไว้ (workflow_dispatch-only)
+  และนโยบายลูปคือรัน gate ในเครื่องเท่านั้น
+
+### 3. Verification
+- `npm audit --omit=dev` = 0 vulnerabilities
+- Frontend vitest suite + production build ผ่าน (ผ่าน ci-local gate)
+- CSS/source-map smoke: build สำเร็จและ assets ถูก generate (CI build ครอบคลุม),
+  E2E all-menus gate ผ่าน = เส้นทางหลัก render ได้จาก bundle ใหม่
+
+## Acceptance criteria
+- [x] `npm audit --omit=dev` ไม่มี high/critical advisory (พบ 0 vulnerabilities)
+- [x] Frontend unit tests และ production build ผ่าน
+- [x] CSS/source-map + representative routes ถูก smoke-test (E2E all-menus ใน ci-local)
+- [x] เวอร์ชันที่แก้ถูกล็อกและบันทึกใน PR: `postcss@8.5.26`, `nanoid@3.3.18`
+- [x] `npm audit --omit=dev` อยู่ใน local CI path พร้อม severity policy ที่ documented
+
+## Verification
+- `npm audit --omit=dev` ใน `frontend/`
+- `scripts/ci-local.ps1 -SkipInstall` (frontend tests/build + audit gate + E2E + backend + docker)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1998,9 +1998,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2528,14 +2528,11 @@
       }
     },
     "node_modules/js-cookie": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.8.tgz",
+      "integrity": "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "10.0.0",
@@ -2954,9 +2951,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -3085,9 +3082,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3166,9 +3163,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -3185,7 +3182,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -3620,9 +3617,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.5.tgz",
-      "integrity": "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3630,9 +3627,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/scripts/ci-local.ps1
+++ b/scripts/ci-local.ps1
@@ -6,7 +6,7 @@
 .DESCRIPTION
   Local gates:
     0) Fast gates: schema parity + multiplier validator regression
-    1) Frontend:  npm ci (optional) + npm test + npm run build
+    1) Frontend:  npm ci (optional) + npm audit (prod, high+) + npm test + npm run build
     2) E2E:       Playwright Chromium checks all sidebar menus (Docker db + backend)
     3) Backend:   bash backend/tests/run.sh  (Docker PHPUnit; needs Git Bash)
     4) Docker:    build frontend + backend images (no push)
@@ -58,7 +58,7 @@ Usage: .\scripts\ci-local.ps1 [-SkipInstall] [-SkipFrontend] [-SkipE2E] [-SkipBa
 
 Mirrors .github/workflows/ci.yml locally (no GitHub Actions minutes):
   0) Fast gates schema parity + multiplier validator regression
-  1) Frontend   npm ci + vitest (forks/2) + build
+  1) Frontend   npm ci + npm audit (prod, high+) + vitest (forks/2) + build
   2) E2E        Docker db/backend + Playwright Chromium (all sidebar menus)
   3) Backend    bash backend/tests/run.sh
   4) Docker     build frontend + backend images
@@ -126,6 +126,12 @@ if (-not $SkipFrontend) {
     } else {
       Write-Host 'skip npm ci (-SkipInstall)'
     }
+
+    # Severity policy: prod deps ต้องไม่มี advisory ระดับ high/critical
+    # (moderate และ dev-only advisories ไม่บล็อก — triage ด้วยมือเป็นกรณีไป)
+    Write-Host 'npm audit --omit=dev --audit-level=high ...'
+    npm audit --omit=dev --audit-level=high
+    if ($LASTEXITCODE -ne 0) { throw "npm audit found high/critical prod vulnerabilities - run 'npm audit fix' or triage and document the exception" }
 
     # pool/maxWorkers come from frontend/vitest.config.js (forks + 2 workers)
     Write-Host 'npm test (vitest) ...'


### PR DESCRIPTION
Closes #115

## Summary

`npm audit fix` (lockfile-only — no `package.json` range changes) clears the 2 high advisories in the Vue compiler build chain (`vue@3.5.30 -> @vue/compiler-sfc@3.5.30 -> postcss -> nanoid`).

### Locked fixed versions

| Package | Before | After | Advisories fixed |
| --- | --- | --- | --- |
| `postcss` | 8.5.8 | **8.5.26** | GHSA-qx2v-qp2m-jg93 (XSS via unescaped `</style>` in stringify), GHSA-6g55-p6wh-862q (arbitrary file read via sourceMappingURL), GHSA-fxqj-rqcc-2cmp (incomplete fix), GHSA-r28c-9q8g-f849 (path traversal in previous-source-map auto-loading) |
| `nanoid` | 3.3.11 | **3.3.18** | GHSA-28wg-ghj8-5hjv (negative-size generator loop), GHSA-2v37-7h3g-55p8 (zero-size custom generator loop) |

Other same-major patch bumps in the lockfile: `brace-expansion`, `js-cookie`, `picomatch`, `undici`, `vite`.

`npm audit --omit=dev` now reports **0 vulnerabilities**.

### New CI gate + severity policy

`scripts/ci-local.ps1` frontend gate now runs `npm audit --omit=dev --audit-level=high`:

- **Blocks** on high/critical advisories in production dependencies
- **Tolerates** moderate and dev-only advisories (manual triage, case by case)

(Note: the audit `throw` message is ASCII-only — PowerShell 5.1 reads this BOM-less script as CP1252 and an em-dash decodes as a smart quote that terminates the string.)

## Verification

- `npm audit --omit=dev` → 0 vulnerabilities
- Full local CI gate (`ci-local.ps1 -SkipInstall`): schema parity, multiplier regression, **npm audit**, vitest, production build, Playwright all-menus E2E (CSS/source-map + representative routes smoke), backend PHPUnit, Docker image builds — all passed (763s)

Plan: `docs/superpowers/plans/2026-08-15-issue-115-frontend-dep-advisories-prp-plan.md`
Parent audit: #109