### PR TITLE
fix(security): rate-limit public endpoints (DB-free) + sanitize CSP log values

### DIFF
--- a/backend/api.php
+++ b/backend/api.php
@@ -112,6 +112,16 @@ $isPublicReadyz = $path[0] === 'readyz' && $method === 'GET';
 // Issue #113: browser ส่ง CSP violation report เอง — ไม่มี JWT/CSRF แนบมาด้วย
 $isPublicCspReport = $path[0] === 'csp-report' && $method === 'POST';
 
+// Issue #122: rate limit เส้นทาง public แบบไม่แตะ DB — กัน unauthenticated
+// amplification (readyz ยิง DB ทุกคำขอ, csp-report เขียน log, uploads อ่าน DB ต่อรูป)
+if ($isPublicPhotoAsset) {
+    checkRateLimitPublic('uploads', 300, 60);
+} elseif ($isPublicReadyz) {
+    checkRateLimitPublic('readyz', 30, 60);
+} elseif ($isPublicCspReport) {
+    checkRateLimitPublic('csp-report', 60, 60);
+}
+
 // login/refresh/logout เป็น public; auth endpoint อื่นต้องมี JWT เช่นเดียวกับ API ปกติ
 if (!$isPublicAuth && !$isPublicPhotoAsset && !$isPublicReadyz && !$isPublicCspReport && $method !== 'OPTIONS') {
     if (!$token || !validateJWT($token)) {
@@ -228,7 +238,8 @@ switch ($path[0]) {
             $directive = (string) ($body['effective-directive'] ?? $body['violated-directive'] ?? 'unknown');
             $blocked = parse_url((string) ($body['blocked-uri'] ?? ''), PHP_URL_HOST) ?: 'self';
             // log เฉพาะ directive + host ของ blocked URI — ไม่มี PII
-            error_log("[csp-report] violation directive={$directive} blocked-host={$blocked}");
+            // Issue #122: sanitize ก่อนเข้า log — ค่ามาจาก body ที่ attacker คุมได้ (กัน CRLF ปลอม log line)
+            error_log('[csp-report] violation directive=' . sanitizeLogValue($directive) . ' blocked-host=' . sanitizeLogValue($blocked));
         }
         http_response_code(204);
         break;

--- a/backend/helpers.php
+++ b/backend/helpers.php
@@ -200,6 +200,16 @@ function sanitizeHtml(?string $input): ?string
 }
 
 /**
+ * Issue #122: ทำค่าที่ attacker คุมได้ให้ปลอดภัยก่อนเข้า error_log()
+ * — strip control chars (CRLF ปลอม log line ได้) + truncate กัน log บวม
+ */
+function sanitizeLogValue(?string $input, int $maxLength = 100): string
+{
+    $clean = preg_replace('/[\x00-\x1F\x7F]/', '', (string) $input) ?? '';
+    return substr($clean, 0, $maxLength);
+}
+
+/**
  * ตรวจว่า personnel_id มีอยู่จริง (soft-link enforcement แทน FK)
  */
 function personnelExists(PDO $pdo, int $personnelId): bool

--- a/backend/middleware/rate_limit.php
+++ b/backend/middleware/rate_limit.php
@@ -157,3 +157,74 @@ function rateLimitGlobal(): void
 
     checkRateLimit($user['user_id'], $method, $limit, $window);
 }
+
+// ============================================================================
+// Issue #122: rate limit สำหรับ endpoint public (readyz / csp-report / uploads)
+// — key ด้วย IP ไม่ใช่ user_id และไม่แตะ DB เลย:
+//   การ probe DB ตอน outage คือ amplification vector ที่ต้องการกัน
+// ============================================================================
+
+/**
+ * IP ของ client — first hop ของ X-Forwarded-For (Render/nginx ตั้งให้)
+ * fallback REMOTE_ADDR; sanitize ให้เหลือแค่รูปของ IPv4/IPv6
+ */
+function publicClientIp(): string
+{
+    $forwarded = (string) ($_SERVER['HTTP_X_FORWARDED_FOR'] ?? '');
+    $first = trim(explode(',', $forwarded)[0]);
+    if ($first !== '' && preg_match('/^[0-9a-fA-F:.]{7,45}$/', $first) === 1) {
+        return $first;
+    }
+
+    return (string) ($_SERVER['REMOTE_ADDR'] ?? 'unknown');
+}
+
+/**
+ * File-based sliding window สำหรับ public endpoint — คืน bool (ไม่ exit) เพื่อ test ได้
+ * บันทึก hit เฉพาะตอนยังไม่เกิน limit — ช่วงถูก flood window จะได้ไม่บวมไปเรื่อย
+ */
+function publicRateLimitWithin(string $bucket, int $limit, int $windowSeconds, ?string $ip = null): bool
+{
+    if (!is_dir(RATE_LIMIT_DIR)) {
+        mkdir(RATE_LIMIT_DIR, 0775, true);
+    }
+
+    $key = 'public_' . ($ip ?? publicClientIp()) . '_' . $bucket;
+    $file = RATE_LIMIT_DIR . md5($key) . '.json';
+    $now = time();
+
+    $handle = fopen($file, 'c+');
+    if ($handle === false) {
+        error_log("[RateLimit] cannot open {$file}");
+        return true; // fail-open — ปิด rate limit ดีกว่าปิด service ทั้งก้อน
+    }
+    flock($handle, LOCK_EX);
+
+    $content = stream_get_contents($handle);
+    $data = $content ? (json_decode($content, true) ?: []) : [];
+    $data['hits'] = array_filter($data['hits'] ?? [], fn($ts) => $ts > $now - $windowSeconds);
+
+    $within = count($data['hits']) < $limit;
+    if ($within) {
+        $data['hits'][] = $now;
+    }
+
+    ftruncate($handle, 0);
+    rewind($handle);
+    fwrite($handle, json_encode($data));
+    fflush($handle);
+    flock($handle, LOCK_UN);
+    fclose($handle);
+
+    return $within;
+}
+
+/**
+ * Wrapper ที่ exit 429 เมื่อเกิน limit (เรียกจาก api.php สำหรับเส้นทาง public)
+ */
+function checkRateLimitPublic(string $bucket, int $limit, int $windowSeconds): void
+{
+    if (!publicRateLimitWithin($bucket, $limit, $windowSeconds)) {
+        rateLimitExceededResponse($windowSeconds);
+    }
+}

--- a/backend/tests/Unit/PublicRateLimitTest.php
+++ b/backend/tests/Unit/PublicRateLimitTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../middleware/rate_limit.php';
+
+/**
+ * Issue #122: unit tests สำหรับ public endpoint rate limiter
+ * (publicClientIp / publicRateLimitWithin) และ sanitizeLogValue
+ * เขียนไฟล์จริงใต้ RATE_LIMIT_DIR ด้วย IP/bucket ทดสอบ แล้วลบไฟล์ทิ้งใน tearDown เสมอ
+ */
+final class PublicRateLimitTest extends TestCase
+{
+    private const TEST_IP = '203.0.113.122';
+    private const BUCKET = 't122_bucket';
+
+    private function fileFor(): string
+    {
+        return RATE_LIMIT_DIR . md5('public_' . self::TEST_IP . '_' . self::BUCKET) . '.json';
+    }
+
+    protected function tearDown(): void
+    {
+        $file = $this->fileFor();
+        if (file_exists($file)) {
+            unlink($file);
+        }
+        unset($_SERVER['HTTP_X_FORWARDED_FOR'], $_SERVER['REMOTE_ADDR']);
+    }
+
+    #[Test]
+    public function it_allows_requests_below_the_limit_and_blocks_over_it(): void
+    {
+        for ($i = 0; $i < 3; $i++) {
+            self::assertTrue(publicRateLimitWithin(self::BUCKET, 3, 60, self::TEST_IP));
+        }
+
+        self::assertFalse(publicRateLimitWithin(self::BUCKET, 3, 60, self::TEST_IP));
+    }
+
+    #[Test]
+    public function it_recovers_when_window_hits_expire(): void
+    {
+        file_put_contents($this->fileFor(), json_encode([
+            'hits' => [time() - 120, time() - 110],
+        ]));
+
+        self::assertTrue(publicRateLimitWithin(self::BUCKET, 2, 60, self::TEST_IP));
+    }
+
+    #[Test]
+    public function it_uses_first_hop_of_forwarded_for(): void
+    {
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '198.51.100.7, 10.0.0.1';
+
+        self::assertSame('198.51.100.7', publicClientIp());
+    }
+
+    #[Test]
+    public function it_falls_back_to_remote_addr_on_garbage_forwarded_for(): void
+    {
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = "evil\r\nX-Injected: 1";
+        $_SERVER['REMOTE_ADDR'] = '192.0.2.9';
+
+        self::assertSame('192.0.2.9', publicClientIp());
+    }
+
+    #[Test]
+    public function it_falls_back_to_remote_addr_when_no_forwarded_for(): void
+    {
+        $_SERVER['REMOTE_ADDR'] = '192.0.2.55';
+
+        self::assertSame('192.0.2.55', publicClientIp());
+    }
+
+    #[Test]
+    public function sanitize_log_value_strips_control_chars_and_truncates(): void
+    {
+        self::assertSame(
+            'script-srcX-Fake: 1self',
+            sanitizeLogValue("script-src\r\nX-Fake: 1\rself")
+        );
+        self::assertSame(str_repeat('a', 100), sanitizeLogValue(str_repeat('a', 500)));
+        self::assertSame('', sanitizeLogValue(null));
+    }
+}

--- a/docs/superpowers/plans/2026-08-15-issue-122-public-endpoint-hardening-prp-plan.md
+++ b/docs/superpowers/plans/2026-08-15-issue-122-public-endpoint-hardening-prp-plan.md
@@ -1,0 +1,62 @@
+# PRP Plan — Issue #122: Public endpoint hardening (rate limiting + log sanitization)
+
+**Date:** 2026-08-15 · **Issue:** #122 · **Branch:** `issue-122-public-endpoint-hardening`
+**Parent:** post-merge audit ของลูป #110–#115 (range `720dda6..a1fafa1`)
+
+## Problem
+
+1. **Public endpoints อยู่นอก rate limiting** — `rateLimitGlobal()` ใน `backend/api.php`
+   รันเฉพาะ branch ที่ authenticated และ `backend/middleware/rate_limit.php` key ด้วย user_id:
+   - `GET /api/readyz` — public + ยิง DB 2 queries/ครั้ง; ตอน TiDB ล่ม `config.php`
+     เพิ่ม 3 connection attempts + ~0.6s sleep/คำขอ → amplification/worker-exhaustion
+     แบบ unauthenticated ตรงช่วง outage พอดี
+   - `POST /api/csp-report` — เขียน `error_log` ไม่จำกัด (log flooding) ที่ body cap 10KB
+   - `GET /uploads/*` — กลายเป็น DB read ต่อรูป (เดิม static)
+2. **CSP-report log injection** — `$directive` จาก body ที่ attacker คุมได้ถูก interpolate
+   ตรงเข้า `error_log()` → CRLF ปลอม log line ได้
+
+## Plan
+
+### 1. Public rate limiter แบบ DB-free (`backend/middleware/rate_limit.php`)
+- `publicClientIp()` — อ่าน IP: first hop ของ `X-Forwarded-For` (Render/nginx ตั้งให้)
+  fallback `REMOTE_ADDR`; sanitize ให้เหลืออักขระ IP ที่ถูกต้อง
+- `publicRateLimitWithin(string $bucket, int $limit, int $windowSeconds): bool` —
+  file-based sliding window (reuse logic เดียวกับ `checkRateLimitFile`)
+  key = `public_{ip}_{bucket}`; **คืน bool ไม่ exit** เพื่อ test ได้
+- `checkRateLimitPublic(string $bucket, int $limit, int $windowSeconds): void` —
+  wrapper ที่ exit 429 เมื่อเกิน (เหมือน `rateLimitExceededResponse()`)
+- **ใช้ file storage เสมอสำหรับ public** — ไม่ probe DB เลย (DB probe ตอน outage
+  คือปัญหาที่ต้องการเลี่ยง; rate limit แบบ eventual ก็พอสำหรับ anti-abuse)
+
+### 2. บังคับใช้กับ public trio (`backend/api.php`)
+- หลังคำนวณ public flags / ก่อน JWT gate:
+  - `uploads` → bucket `uploads`, 300 req/60s/IP (หน้า profile โหลดรูปหลายใบ — เผื่อไว้กว้าง)
+  - `readyz` → bucket `readyz`, 30 req/60s/IP (monitoring poll ความถี่ต่ำก็พอ)
+  - `csp-report` → bucket `csp-report`, 60 req/60s/IP (กัน log flooding)
+- authenticated routes ไม่เปลี่ยนพฤติกรรม
+
+### 3. Log sanitization (`backend/api.php` csp-report case)
+- `$directive`/`$blocked`: strip อักขระ control (`/[\x00-\x1F\x7F]/` → '') + truncate 100 chars
+  ก่อนเข้า `error_log()`
+
+### 4. Tests (`backend/tests/Unit/PublicRateLimitTest.php`)
+- `public_rate_limit_trips_after_limit_and_recovers_after_window`:
+  เรียก `publicRateLimitWithin()` ด้วย bucket unique เกิน limit → false; window สั้น
+  (1–2s) รอแล้วคืน true; cleanup ไฟล์ rate-limit ที่สร้าง (bucket prefix)
+- `public_client_ip_sanitizes_forwarded_for`: X-Forwarded-For มี CRLF/comma chain →
+  ได้ first hop ที่ clean
+- CSP sanitization: unit-test pattern เดียวกับที่ใช้ใน api.php (strip control chars)
+
+## Acceptance criteria
+- [x] `readyz` / `csp-report` / `uploads` ถูก rate limit แบบไม่ต้องพึ่ง DB connection
+- [x] log line ของ CSP-report ไม่มี CR/LF/control char ที่ attacker คุมได้
+- [x] authenticated rate limiting เดิมไม่เปลี่ยน; tests เดิมเขียวยกชุด
+- [x] `scripts/ci-local.ps1` ผ่าน
+
+## Verification
+- `bash backend/tests/run.sh` (Docker PHPUnit)
+- smoke: `curl` ถล่ม `readyz` เกิน 30 ครั้ง/นาทีใน dev container → 429
+  (ผลจริง: 30×200 แล้ว 5×429 พอดี)
+- smoke: POST `/api/csp-report` ด้วย directive ที่มี `\r\n` → log บรรทัดเดียว
+  (`directive=script-srcFAKE-LOG-LINE`) ไม่มีบรรทัดปลอม
+- `scripts/ci-local.ps1 -SkipInstall`


### PR DESCRIPTION
Closes #122

## Summary

Closes both hardening findings from the post-merge audit of the #110–#115 loop:

1. **Public endpoints were outside rate limiting** — `rateLimitGlobal()` only runs in the authenticated branch and keys limits by user ID. The public trio now has DB-free, IP-keyed limiting:

   | Endpoint | Limit |
   | --- | --- |
   | `GET /uploads/*` | 300 req / 60s / IP |
   | `GET /api/readyz` | 30 req / 60s / IP |
   | `POST /api/csp-report` | 60 req / 60s / IP |

2. **CSP-report log injection** — attacker-controlled `effective-directive`/`blocked-uri` values were interpolated raw into `error_log()`; both now pass through `sanitizeLogValue()` (control chars stripped, truncated to 100 chars).

## Changes

- `backend/middleware/rate_limit.php` — `publicClientIp()` (first hop of `X-Forwarded-For`, IP-shape validated, fallback `REMOTE_ADDR`), `publicRateLimitWithin()` (file-based sliding window keyed `public_{ip}_{bucket}`, returns bool for testability, records a hit only when within limit, fail-open on file errors), `checkRateLimitPublic()` (429 wrapper). File storage is deliberate: no DB probe, so limiting still works during the DB outage it protects against.
- `backend/api.php` — applies the three limits before the JWT gate; csp-report case logs sanitized values.
- `backend/helpers.php` — `sanitizeLogValue()`.
- `backend/tests/Unit/PublicRateLimitTest.php` — 6 tests (limit trip, window expiry/recovery, XFF first-hop, garbage-XFF fallback, REMOTE_ADDR fallback, control-char stripping + truncation).

Authenticated route rate limiting is unchanged.

## Verification

- PHP lint clean on all 4 touched files (Docker PHPUnit image)
- `bash backend/tests/run.sh --filter "PublicRateLimitTest|RateLimitTest|AuditSanitizeTest"` → **16 tests, 34 assertions OK**
- Live smoke (dev container): 35 requests to `/api/readyz` → exactly **30×200 then 5×429**
- Live smoke: `POST /api/csp-report` with `"\r\n"` in the directive → `204`, single log line `directive=script-srcFAKE-LOG-LINE blocked-host=evil.example` (no forged line)
- Full local CI gate (`ci-local.ps1 -SkipInstall`): **all jobs passed (842s)**

Plan: `docs/superpowers/plans/2026-08-15-issue-122-public-endpoint-hardening-prp-plan.md`