### PR TITLE
fix(security): add security headers to nginx static-asset responses

### DIFF
--- a/docs/frontend-security-headers.md
+++ b/docs/frontend-security-headers.md
@@ -7,7 +7,7 @@
 | Path | ใช้ตอน | Headers ประกาศที่ |
 |---|---|---|
 | Render static site (`smart-port.onrender.com`) | **production** | `render.yaml` → `headers:` (ไม่ใช่ nginx.conf!) |
-| Docker/Nginx (`localhost:8081`) | local/compose | `frontend/nginx.conf` |
+| Docker/Nginx (`localhost:8081`) | local/compose | `frontend/nginx-security-headers.conf` (snippet ที่ `nginx.conf` include — Issue #126) |
 | Vite dev (`localhost:5174`) | dev | ไม่มี security headers (ไม่เป็นไร — dev only) |
 
 บทเรียน: repo เคยมี headers เฉพาะใน `nginx.conf` ซึ่ง production ไม่ได้ใช้เลย

--- a/docs/superpowers/plans/2026-08-16-issue-126-nginx-asset-security-headers-prp-plan.md
+++ b/docs/superpowers/plans/2026-08-16-issue-126-nginx-asset-security-headers-prp-plan.md
@@ -1,0 +1,37 @@
+# PRP Plan — Issue #126: nginx static-asset location gets the security headers
+
+**Date:** 2026-08-16 · **Issue:** #126 · **Branch:** `issue-126-nginx-asset-security-headers`
+
+## Problem
+
+`frontend/nginx.conf` — regex location สำหรับ static assets (`*.js/.css/.png/...`)
+มี `add_header` ของตัวเอง (Cache-Control) ดังนั้นตาม semantics ของ nginx มัน
+**ไม่ inherit** server-level headers → asset responses จาก Docker path ไม่มี
+security headers เลย (รวมถึง enforced CSP ที่เพิ่มใน #113)
+
+## Plan
+
+### 1. Single source: include snippet
+- ไฟล์ใหม่ `frontend/nginx-security-headers.conf` — add_header 5 ตัว
+  (X-Frame-Options DENY, nosniff, Referrer-Policy, Permissions-Policy, enforced CSP ชุด CSP_CORE)
+- `location /` และ asset location ใช้ `include /etc/nginx/snippets/security-headers.conf;`
+  แทนการคัดลอก header block (กัน drift ระหว่างสอง location)
+- server-level headers คงเดิม (cover deny location / 50x fallback)
+- `frontend/Dockerfile` เพิ่ม `COPY nginx-security-headers.conf /etc/nginx/snippets/security-headers.conf`
+
+### 2. Drift-guard test (`frontend/src/__tests__/securityHeaders.test.js`)
+- อ่าน snippet file; assert CSP_CORE + header lines ครบใน snippet
+- assert nginx.conf: ทั้ง `location /` และ asset location include snippet,
+  asset location ยังมี `Cache-Control "public, immutable"`,
+  และไม่มี broad CSP เก่า
+
+### 3. Verification
+- `npm test` (vitest) ใน frontend
+- build image แล้ว `nginx -t` + `curl -sI` asset ใน container ตรวจ headers จริง
+- `scripts/ci-local.ps1 -SkipInstall`
+
+## Acceptance criteria
+- [ ] Asset responses จาก Docker nginx มี security headers เท่ากับ document responses
+- [ ] Header set มีแหล่งเดียว (snippet) — location ไหนต้องการก็ include
+- [ ] securityHeaders.test.js ครอบ asset-location case และเขียว
+- [ ] CI gate ผ่าน

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -43,6 +43,10 @@ RUN rm /etc/nginx/conf.d/default.conf
 # **สำคัญ**: ตรวจสอบให้แน่ใจว่าคุณมีไฟล์ nginx.conf อยู่ในโฟลเดอร์ frontend
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 
+# Security headers snippet — nginx.conf include ไฟล์นี้ใน location ที่ตั้ง add_header เอง
+# (add_header ไม่ inherit จาก server level เมื่อ location มี add_header ของตัวเอง; Issue #126)
+COPY nginx-security-headers.conf /etc/nginx/snippets/security-headers.conf
+
 # คัดลอกไฟล์ที่ buildเสร็จแล้วจาก stage 'builder' มายัง web root ของ Nginx
 COPY --from=builder /app/dist /usr/share/nginx/html
 

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -7,6 +7,9 @@ COPY . /usr/share/nginx/html
 # Copy nginx configuration for SPA
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 
+# nginx.conf include ไฟล์นี้ (Issue #126) — ไม่มีไฟล์นี้ nginx จะไม่ start
+COPY nginx-security-headers.conf /etc/nginx/snippets/security-headers.conf
+
 # Expose port
 EXPOSE 80
 

--- a/frontend/nginx-security-headers.conf
+++ b/frontend/nginx-security-headers.conf
@@ -1,0 +1,8 @@
+# Issue #126: security header ชุดเดียวที่ใช้ทุก location ของ nginx.conf
+# (nginx add_header ไม่ inherit จาก server level เมื่อ location มี add_header ของตัวเอง —
+#  ต้อง include ไฟล์นี้ในแต่ละ location ที่ตั้ง header; ดู docs/frontend-security-headers.md)
+add_header X-Frame-Options "DENY" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+add_header Permissions-Policy "camera=(), geolocation=(), microphone=(), payment=()" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -8,11 +8,8 @@ server {
 
     # Security headers (ชุดเดียวกับ render.yaml — ดู docs/frontend-security-headers.md)
     # Docker path นี้ enforce CSP เลย (render.yaml เริ่ม report-only เพื่อ inventory ก่อน)
-    add_header X-Frame-Options "DENY" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Permissions-Policy "camera=(), geolocation=(), microphone=(), payment=()" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
+    # แหล่งเดียวอยู่ที่ nginx-security-headers.conf (copy ไป /etc/nginx/snippets/ ใน Dockerfile)
+    include /etc/nginx/snippets/security-headers.conf;
 
     # Gzip compression
     gzip on;
@@ -28,11 +25,7 @@ server {
         try_files $uri $uri/ /index.html;
         add_header Cache-Control "no-store, no-cache, must-revalidate, max-age=0" always;
         add_header Pragma "no-cache" always;
-        add_header X-Frame-Options "DENY" always;
-        add_header X-Content-Type-Options "nosniff" always;
-        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Permissions-Policy "camera=(), geolocation=(), microphone=(), payment=()" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
+        include /etc/nginx/snippets/security-headers.conf;
     }
 
     # API proxy to backend
@@ -44,10 +37,12 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    # Static assets caching
+    # Static assets caching — include snippet เพราะ add_header ใน location นี้
+    # ทำให้ server-level headers ไม่ inherit ลงมา (Issue #126)
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";
+        include /etc/nginx/snippets/security-headers.conf;
     }
 
     # Prevent access to hidden files

--- a/frontend/src/__tests__/securityHeaders.test.js
+++ b/frontend/src/__tests__/securityHeaders.test.js
@@ -4,12 +4,15 @@ import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
 
 // Issue #113 — automated header assertions: กัน drift ของ security headers ที่ประกาศใน
-// render.yaml (Render static site path จริง) และ frontend/nginx.conf (docker path)
+// render.yaml (Render static site path จริง), frontend/nginx.conf (docker path) และ
+// frontend/nginx-security-headers.conf (snippet ที่ nginx.conf include ในทุก location
+// ที่ตั้ง add_header เอง — Issue #126)
 // นโยบายเต็มอยู่ใน docs/frontend-security-headers.md
 
 const here = dirname(fileURLToPath(import.meta.url))
 const renderYaml = readFileSync(resolve(here, '../../../render.yaml'), 'utf8')
 const nginxConf = readFileSync(resolve(here, '../../nginx.conf'), 'utf8')
+const nginxHeadersSnippet = readFileSync(resolve(here, '../../nginx-security-headers.conf'), 'utf8')
 
 // CSP ชุดที่ตกลงกัน — Vite build: script/style ไฟล์ภายนอก, Noto Sans Thai จาก Google Fonts
 const CSP_CORE = [
@@ -55,22 +58,82 @@ describe('render.yaml security headers (Render static-site path)', () => {
   })
 })
 
-describe('nginx.conf security headers (docker path)', () => {
-  it('enforces the same CSP (not report-only) without the old broad allowances', () => {
-    expect(nginxConf).toContain('add_header Content-Security-Policy')
-    expect(nginxConf).not.toContain('Content-Security-Policy-Report-Only')
+describe('nginx security-headers snippet (docker path, Issue #126)', () => {
+  it('enforces the agreed CSP and header set (not report-only) without the old broad allowances', () => {
+    expect(nginxHeadersSnippet).toContain('add_header Content-Security-Policy')
+    expect(nginxHeadersSnippet).not.toContain('Content-Security-Policy-Report-Only')
     for (const directive of CSP_CORE) {
-      expect(nginxConf).toContain(directive)
+      expect(nginxHeadersSnippet).toContain(directive)
     }
-    expect(nginxConf).not.toContain("http: https: data: blob:")
+    expect(nginxHeadersSnippet).not.toContain("http: https: data: blob:")
   })
 
   it('uses DENY framing, strict referrer, permissions policy, and nosniff', () => {
-    expect(nginxConf).toContain('X-Frame-Options "DENY"')
-    expect(nginxConf).not.toContain('X-Frame-Options "SAMEORIGIN"')
-    expect(nginxConf).toContain('Referrer-Policy "strict-origin-when-cross-origin"')
-    expect(nginxConf).toContain('Permissions-Policy "camera=(), geolocation=(), microphone=(), payment=()"')
-    expect(nginxConf).toContain('X-Content-Type-Options "nosniff"')
-    expect(nginxConf).not.toContain('X-XSS-Protection')
+    expect(nginxHeadersSnippet).toContain('X-Frame-Options "DENY"')
+    expect(nginxHeadersSnippet).not.toContain('X-Frame-Options "SAMEORIGIN"')
+    expect(nginxHeadersSnippet).toContain('Referrer-Policy "strict-origin-when-cross-origin"')
+    expect(nginxHeadersSnippet).toContain('Permissions-Policy "camera=(), geolocation=(), microphone=(), payment=()"')
+    expect(nginxHeadersSnippet).toContain('X-Content-Type-Options "nosniff"')
+    expect(nginxHeadersSnippet).not.toContain('X-XSS-Protection')
+  })
+})
+
+describe('nginx.conf wiring (docker path)', () => {
+  const SNIPPET_INCLUDE = 'include /etc/nginx/snippets/security-headers.conf;'
+
+  const stripComments = (conf) =>
+    conf.split('\n').map((line) => line.replace(/#.*$/, '')).join('\n')
+
+  // แตก nginx.conf เป็น location blocks (brace-matching) เพื่อ scan ทีละ block
+  const locationBlocks = (conf) => {
+    const blocks = []
+    const re = /location\b[^{]*\{/g
+    let match
+    while ((match = re.exec(conf)) !== null) {
+      let depth = 1
+      let i = re.lastIndex
+      while (i < conf.length && depth > 0) {
+        if (conf[i] === '{') depth++
+        else if (conf[i] === '}') depth--
+        i++
+      }
+      blocks.push({ header: match[0], body: conf.slice(re.lastIndex, i - 1) })
+      re.lastIndex = i
+    }
+    return blocks
+  }
+
+  // add_header ไม่ inherit จาก server level เมื่อ location มี add_header ของตัวเอง —
+  // ทุก location ที่ตั้ง header เองต้อง include snippet (location / และ static assets)
+  it('every location that sets add_header includes the security-headers snippet', () => {
+    const conf = stripComments(nginxConf)
+    expect(conf).toContain(SNIPPET_INCLUDE) // server-level include
+
+    const blocks = locationBlocks(conf)
+    expect(blocks.length).toBeGreaterThanOrEqual(4)
+    for (const { header, body } of blocks) {
+      expect(
+        !body.includes('add_header') || body.includes(SNIPPET_INCLUDE),
+        `${header.trim()} sets add_header without ${SNIPPET_INCLUDE} — headers จะไม่ออก response`,
+      ).toBe(true)
+    }
+  })
+
+  it('static assets keep the immutable cache policy and both Dockerfiles ship the snippet', () => {
+    const conf = stripComments(nginxConf)
+    const asset = locationBlocks(conf).find(({ header }) => header.includes('(js|css|png'))
+    expect(asset?.body).toContain('Cache-Control "public, immutable"')
+    expect(asset?.body).toContain(SNIPPET_INCLUDE)
+
+    const dockerfile = readFileSync(resolve(here, '../../Dockerfile'), 'utf8')
+    expect(dockerfile).toContain('COPY nginx-security-headers.conf /etc/nginx/snippets/security-headers.conf')
+    const devDockerfile = readFileSync(resolve(here, '../../Dockerfile.dev'), 'utf8')
+    expect(devDockerfile).toContain('nginx-security-headers.conf')
+  })
+
+  it('does not reintroduce duplicated literal header blocks or the old broad CSP', () => {
+    expect(nginxConf).not.toContain('add_header Content-Security-Policy ')
+    expect(nginxConf).not.toContain('add_header X-Frame-Options')
+    expect(nginxConf).not.toContain("http: https: data: blob:")
   })
 })


### PR DESCRIPTION
## Summary

- Fixes the docker/nginx path: nginx `add_header` does not inherit from server level into a location that declares its own `add_header`, so the static-asset location (`*.js|css|png|...`) silently lost all five security headers (X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy, CSP).
- Extracts the header set into `frontend/nginx-security-headers.conf` (single source of truth), included at server level and in every header-setting location; both `Dockerfile` and `Dockerfile.dev` ship the snippet.
- Generalizes the drift-guard in `securityHeaders.test.js`: parses every `location` block and fails if any block sets `add_header` without including the snippet, plus pins the Dockerfile COPYs.

## Verification

- Live Docker smoke (`smartport-frontend:issue126`): `nginx -t` OK; `GET /assets/<hashed>.js` returns all 5 security headers + `Cache-Control: public, immutable`; `GET /` returns no-store + all 5 headers.
- `vitest run src/__tests__/securityHeaders.test.js` - 9/9 pass.
- Full local CI gate (`scripts/ci-local.ps1 -SkipInstall`): all jobs passed (1656s).
- Code review (subagent): Ready with fixes - both Important items addressed before commit.

Closes #126