### PR TITLE
fix(api): readyz emits documented not_ready shape via non-exiting DB probe

### DIFF
--- a/backend/api.php
+++ b/backend/api.php
@@ -246,8 +246,9 @@ switch ($path[0]) {
 
     case 'readyz':
         // Issue #114: readiness (DB + migration state) — ต่างจาก `/` ที่เป็น liveness ไม่แตะ DB
+        // Issue #124: ใช้ tryGetDB() (ไม่ exit) เพื่อให้ handler คืน documented not_ready shape ได้จริง
         include_once __DIR__ . '/routes/readyz.php';
-        handleReadyz(getDB(), $method);
+        handleReadyz(tryGetDB(), $method);
         break;
 
     case 'uploads':

--- a/backend/config.php
+++ b/backend/config.php
@@ -44,12 +44,7 @@ define('JWT_SECRET', $jwtSecret);
 // ============================================================================
 $pdo = null;
 
-function getDB(): PDO {
-    global $pdo;
-    if ($pdo !== null) {
-        return $pdo;
-    }
-
+function attemptDbConnection(): ?PDO {
     $host     = env('MYSQL_HOST', 'db');
     $port     = env('MYSQL_PORT', '3306');
     $dbname   = env('MYSQL_DATABASE', 'civil_service_mgmt');
@@ -77,9 +72,10 @@ function getDB(): PDO {
     // Retry on transient connection failure (TiDB Cloud Serverless cold start)
     $maxRetries = 3;
     $lastException = null;
+    $connection = null;
     for ($attempt = 1; $attempt <= $maxRetries; $attempt++) {
         try {
-            $pdo = new PDO($dsn, $username, $password, $options);
+            $connection = new PDO($dsn, $username, $password, $options);
             $lastException = null;
             break;
         } catch (PDOException $e) {
@@ -92,14 +88,36 @@ function getDB(): PDO {
 
     if ($lastException !== null) {
         error_log('[db] Connection failed after ' . $maxRetries . ' attempts: ' . $lastException->getMessage());
-        $isLocal = in_array($host, ['db', 'localhost', '127.0.0.1'], true);
-        $msg = $isLocal
-            ? 'Database connection failed (check docker compose db service)'
-            : 'Database connection failed';
-        http_response_code(503);
-        echo json_encode(['error' => $msg]);
-        exit;
+        return null;
     }
 
+    return $connection;
+}
+
+// Issue #124: probe แบบไม่ exit — readyz ใช้เพื่อคืน documented not_ready shape
+// เองเมื่อ DB ต่อไม่ได้ (getDB() จะ exit ก่อนถึง handler เสมอ)
+function tryGetDB(): ?PDO {
+    global $pdo;
+    if ($pdo !== null) {
+        return $pdo;
+    }
+
+    $pdo = attemptDbConnection();
     return $pdo;
+}
+
+function getDB(): PDO {
+    $db = tryGetDB();
+    if ($db !== null) {
+        return $db;
+    }
+
+    $host = env('MYSQL_HOST', 'db');
+    $isLocal = in_array($host, ['db', 'localhost', '127.0.0.1'], true);
+    $msg = $isLocal
+        ? 'Database connection failed (check docker compose db service)'
+        : 'Database connection failed';
+    http_response_code(503);
+    echo json_encode(['error' => $msg]);
+    exit;
 }

--- a/backend/routes/readyz.php
+++ b/backend/routes/readyz.php
@@ -66,11 +66,31 @@ function readyzReport(PDO $pdo): array
     ];
 }
 
+/**
+ * DB-down response ที่ monitor เห็นจริง (Issue #124): api.php ส่ง tryGetDB()
+ * ที่คืน null แทนการ exit แบบ getDB() — shape นี้ต้องตรงกับ
+ * docs/render-tidb-production.md
+ */
+function emitNotReady(): void
+{
+    http_response_code(503);
+    echo json_encode([
+        'status' => 'not_ready',
+        'release' => releaseSha(),
+        'db' => 'unreachable',
+    ], JSON_UNESCAPED_UNICODE);
+}
+
 /** GET /readyz — 200 เมื่อ DB พร้อมและไม่มี migration ค้าง, มิฉะนั้น 503 */
-function handleReadyz(PDO $pdo, string $method): void
+function handleReadyz(?PDO $pdo, string $method): void
 {
     if ($method !== 'GET') {
         respondMethodNotAllowed();
+        return;
+    }
+
+    if ($pdo === null) {
+        emitNotReady();
         return;
     }
 
@@ -79,12 +99,7 @@ function handleReadyz(PDO $pdo, string $method): void
     } catch (Throwable $e) {
         // log เฉพาะข้อความ error ของ DB driver — ไม่มี PII
         error_log('[readyz] db check failed: ' . $e->getMessage());
-        http_response_code(503);
-        echo json_encode([
-            'status' => 'not_ready',
-            'release' => releaseSha(),
-            'db' => 'unreachable',
-        ], JSON_UNESCAPED_UNICODE);
+        emitNotReady();
         return;
     }
 

--- a/backend/tests/Integration/ReadyzTest.php
+++ b/backend/tests/Integration/ReadyzTest.php
@@ -34,11 +34,14 @@ final class ReadyzTest extends TestCase
     {
         $report = readyzReport(self::$pdo);
 
+        // Issue #124: assert เข้มตามชื่อ test — หมายเหตุ: harness (run.sh/CI) mount เฉพาะ
+        // backend/ → migrationDirectory() หา database/ ไม่เจอ → bundled=[] → pending เป็น 0 เสมอ
+        // ใน automated run (ตรวจจริงต้องดู live /readyz; harness limitation นี้ tracked เป็น follow-up)
+        $this->assertSame('ready', $report['status']);
         $this->assertSame('ok', $report['db']);
+        $this->assertSame(0, $report['migrations_pending']);
         $this->assertArrayHasKey('release', $report);
         $this->assertIsInt($report['migrations_bundled']);
-        $this->assertIsInt($report['migrations_pending']);
-        $this->assertGreaterThanOrEqual(0, $report['migrations_pending']);
 
         // minimal disclosure: มีแค่ key สถานะ/ตัวเลข — ไม่มีรายการ schema/migration รั่วออกมา
         $this->assertSame(

--- a/backend/tests/Unit/ReadyzHandlerTest.php
+++ b/backend/tests/Unit/ReadyzHandlerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../routes/readyz.php';
+
+/**
+ * Issue #124 — readyz DB-down contract:
+ * api.php ส่ง tryGetDB() (คืน null เมื่อต่อ DB ไม่ได้ แทนการ exit แบบ getDB())
+ * handler ต้องคืน documented not_ready shape จริง — ไม่ใช่ dead code เหมือนก่อน
+ */
+final class ReadyzHandlerTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        // http_response_code() เป็น process-global — reset กัน test ถัดไป false-pass
+        http_response_code(200);
+    }
+
+    public function test_null_pdo_emits_documented_not_ready_shape(): void
+    {
+        ob_start();
+        try {
+            handleReadyz(null, 'GET');
+        } finally {
+            $output = (string) ob_get_clean();
+        }
+
+        $this->assertSame(503, http_response_code());
+
+        $json = json_decode($output, true);
+        $this->assertIsArray($json);
+        $this->assertSame('not_ready', $json['status']);
+        $this->assertSame('unreachable', $json['db']);
+        $this->assertArrayHasKey('release', $json);
+        // minimal disclosure: มีแค่ 3 key สถานะ — ไม่มีชื่อตาราง/migration
+        $this->assertSame(['status', 'release', 'db'], array_keys($json));
+    }
+
+    public function test_null_pdo_still_rejects_non_get_before_db_check(): void
+    {
+        ob_start();
+        try {
+            handleReadyz(null, 'POST');
+        } finally {
+            $output = (string) ob_get_clean();
+        }
+
+        $this->assertSame(405, http_response_code());
+        $this->assertJson($output);
+    }
+}

--- a/docs/render-tidb-production.md
+++ b/docs/render-tidb-production.md
@@ -176,8 +176,13 @@ curl -i https://smartport-backend.onrender.com/readyz
 ```
 
 Expected result: `200` with `{"status":"ready","release":"...","db":"ok","migrations_bundled":N,"migrations_pending":0}`.
-A `503` with `migrations_pending > 0` means the image is ahead of the schema;
-`db:"unreachable"` (or a `503` from the connection layer) means TiDB env values are wrong.
+A `503` with `migrations_pending > 0` means the image is ahead of the schema.
+DB down / wrong TiDB env: `503` with `{"status":"not_ready","release":"...","db":"unreachable"}`
+(Issue #124 — readyz probes via a non-exiting connection, so this shape is what
+monitors actually receive; the generic connection-layer 503 only applies to other routes).
+Caution: `ready` with `migrations_bundled: 0` means the image shipped without the
+`database/` folder — nothing was checked against the schema; cross-check the
+`migrations_available` field on the `/` liveness endpoint before trusting it.
 The endpoint is public but discloses only counts/status — no table or migration names.
 
 2. Check login:

--- a/docs/superpowers/plans/2026-08-16-issue-124-readyz-contract-prp-plan.md
+++ b/docs/superpowers/plans/2026-08-16-issue-124-readyz-contract-prp-plan.md
@@ -1,0 +1,72 @@
+# PRP Plan — Issue #124: readyz contract accuracy
+
+วันที่: 2026-08-16 · Branch: `issue-124-readyz-contract` · Parent audit: review ของ #110–#115 (range `720dda6..a1fafa1`), findings 2 + 8
+
+## Problem
+
+1. **DB-down shape เป็น dead code:** `handleReadyz()` จับ DB failure เพื่อคืน
+   `{"status":"not_ready","db":"unreachable"}` (503) แต่ `getDB()` ใน config.php
+   `exit` ด้วย `{"error":"Database connection failed"}` ก่อนถึง handler เสมอ —
+   monitor ที่ parse ฟิลด์ `status` ไม่เคยเห็น `not_ready` จริง
+2. **ReadyzTest assert อ่อนกว่าชื่อ:** test "ready with zero pending" assert แค่
+   `migrations_pending >= 0` ไม่ใช่ `0` และ runbook ไม่เตือนว่า `ready` +
+   `migrations_bundled: 0` อาจแปลว่า image ไม่ได้ bundle `database/` ไว้
+
+## Decision: Option (a) — ทำให้ readyz ผลิต documented shape จริง
+
+เหตุผล: contract ที่เอกสาร/runbook ระบุไว้มีประโยชน์ต่อ monitor (ฟิลด์ `status`
+เสถียร) การยอมให้ config.php exit ทับ shape = ลดคุณภาพ monitoring โดยไม่มี gain;
+การเพิ่ม non-exiting probe เปลี่ยนแปลงน้อยและ backward-compatible กับทุก route อื่น
+
+## Changes
+
+### 1. `backend/config.php` — แยก connection attempt ออกจาก exit
+
+- แตก `getDB()` เป็น:
+  - `attemptDbConnection(): ?PDO` — env/DSN/options/retry loop เดิมทั้งหมด คืน
+    `PDO|null` (log error เดิมอยู่ที่นี่) ไม่ exit ไม่ echo
+  - `tryGetDB(): ?PDO` — lazy cache ใน `$pdo` global เหมือนเดิม คืน null เมื่อต่อไม่ได้
+  - `getDB(): PDO` — เรียก `tryGetDB()`; null → พฤติกรรมเดิมทุกประการ
+    (error message แยก local/prod, 503, `exit`)
+- ทุก route เดิมเรียก `getDB()` = พฤติกรรมไม่เปลี่ยน
+
+### 2. `backend/routes/readyz.php` — รับ nullable PDO
+
+- `handleReadyz(?PDO $pdo, string $method)`: `$pdo === null` → 503
+  `{"status":"not_ready","release":...,"db":"unreachable"}` (shape เดิมที่เคย dead)
+- ดึง emitter ร่วม `emitNotReady()` ใช้ทั้ง null case และ catch case (query fail กลางทาง)
+
+### 3. `backend/api.php` — readyz ใช้ probe
+
+- `case 'readyz': handleReadyz(tryGetDB(), $method);`
+
+### 4. Tests
+
+- `tests/Integration/ReadyzTest.php`: migrated-DB test assert
+  `migrations_pending === 0` และ `status === 'ready'` (strict ตามชื่อ test)
+- ใหม่ `tests/Unit/ReadyzHandlerTest.php` (ไม่ต้องมี DB): `handleReadyz(null, 'GET')`
+  → ob_start จับ output, assert 503 + shape `not_ready`/`db:"unreachable"`/มี `release`;
+  method อื่นไม่ใช่ GET ยัง 405
+
+### 5. `docs/render-tidb-production.md`
+
+- แก้บรรทัด DB-down: ระบุ shape จริง `503 {"status":"not_ready","release":"...","db":"unreachable"}`
+  (ลบ "(or a 503 from the connection layer)" ที่ไม่จริงอีกต่อไป)
+- เพิ่ม note: `ready` + `migrations_bundled: 0` = image อาจไม่ได้ bundle `database/` —
+  เช็ค `migrations_available` จาก `/` ประกอบ
+
+## Verification
+
+1. `php -l` ทุกไฟล์ที่แก้ (docker smartport-phpunit:local)
+2. `bash backend/tests/run.sh --filter "Readyz"` — integration (ต้องต่อ DB ได้) + unit
+3. Live smoke: `docker compose up -d db backend` → `curl -i localhost:8000/readyz`
+   (happy path); DB-down path ตรวจผ่าน unit test (stop db = slow, unit พอ)
+4. Full CI gate: `scripts/ci-local.ps1 -SkipInstall`
+
+## Acceptance
+
+- [ ] readyz คืน `{"status":"not_ready","db":"unreachable"}` 503 เมื่อ DB ต่อไม่ได้จริง (unit test + code path)
+- [ ] ทุก route อื่นยังได้พฤติกรรม 503/exit เดิมจาก `getDB()`
+- [ ] ReadyzTest assert `migrations_pending === 0` และ `status === 'ready'` และเขียวบน migrated DB
+- [ ] Runbook ระบุ DB-down shape จริง + caveat `migrations_bundled: 0`
+- [ ] CI gate ผ่าน


### PR DESCRIPTION
## Summary

- readyz's documented DB-down shape was dead code: `getDB()` exited with a generic `{"error":"Database connection failed"}` before `handleReadyz()` ran, so monitors never saw `{"status":"not_ready","db":"unreachable"}`.
- Fixes by splitting `config.php` into `attemptDbConnection()` / non-exiting `tryGetDB()` / original `getDB()` (all other routes keep the identical 503-exit behavior), routing readyz through `tryGetDB()`, and sharing one `emitNotReady()` across both failure paths.
- Tightens `ReadyzTest` to assert `status === 'ready'` and `migrations_pending === 0`; adds a DB-free unit test pinning the exact `not_ready` shape and 405 handling; documents the real DB-down shape and the `migrations_bundled: 0` caveat in the runbook. Harness gap filed as follow-up #129.

## Verification

- `bash backend/tests/run.sh` - full suite OK (353 tests, 945 assertions).
- Readyz filter: 5/5 pass; new unit test pins the 503 shape without a DB.
- Live smoke: `curl /readyz` -> `200 {"status":"ready","release":"dev","db":"ok","migrations_bundled":28,"migrations_pending":0}`.
- Code review (subagent): Ready to merge - behavior preservation verified line-by-line against base.
- Full local CI gate (`scripts/ci-local.ps1 -SkipInstall`): all selected jobs passed (767s).

Closes #124