### PR TITLE
fix(security): add object-src 'none' to CSP and record Render header verification

### DIFF
--- a/docs/frontend-security-headers.md
+++ b/docs/frontend-security-headers.md
@@ -1,6 +1,6 @@
 # Frontend Security Headers & Cache Policy (issue #113 — ระยะที่ 1)
 
-อัปเดต: 2026-08-15
+อัปเดต: 2026-08-16
 
 ## Deploy paths และที่ที่ headers ถูกประกาศ
 
@@ -33,6 +33,7 @@ style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
 font-src https://fonts.gstatic.com;
 img-src 'self' data:;
 connect-src 'self';
+object-src 'none';              ← Issue #125: ไม่ใช้ plugin/embed
 frame-ancestors 'none';
 base-uri 'self';
 form-action 'self';
@@ -54,6 +55,40 @@ report-uri /api/csp-report     ← เฉพาะ render.yaml (report-only phas
 - **Hashed assets (`/assets/*`):** `public, max-age=31536000, immutable` — เนื้อหาผูกกับ
   hash ในชื่อไฟล์ เปลี่ยนเมื่อไหร่ URL เปลี่ยนเมื่อนั้น
 - ข้อมูล auth ไม่เคยถูก cache (มาทาง `/api/*` ของ backend)
+
+## Live verification — Render Cache-Control precedence (issue #125)
+
+**ผลตรวจ 2026-08-16 (curl smart-port.onrender.com):** ทั้ง `/` และ
+`/assets/index-B1YyXcfC.js` คืนค่า default ของ Render
+(`Cache-Control: public, max-age=0, s-maxage=300`) และไม่มี header อื่นจาก
+render.yaml เลย (ไม่มี CSP-Report-Only/X-Frame-Options ฯลฯ) ทั้งที่ site ถูก deploy
+ใหม่ในวันเดียวกัน → header จาก blueprint ยังไม่มีผลจริง สาเหตุที่เป็นไปได้:
+(1) blueprint นี้ปิด auto-sync ไว้ หรือ (2) static site นี้ไม่ได้ถูก manage โดย
+blueprint นี้ตั้งแต่แรก (เช่น สร้างก่อนรับ render.yaml เข้ามา) — Render ค่า default
+คือ [auto-sync ทุกครั้งที่ push blueprint changes](https://render.com/docs/infrastructure-as-code)
+และ [docs ของ static-site headers](https://render.com/docs/static-site-headers)
+ไม่ระบุ precedence สำหรับ path pattern ที่ทับกัน จึงต้องวัดจริงเท่านั้น
+
+**Checklist หลังทำให้ blueprint sync จริง + deploy ใหม่:**
+
+0. ที่ Render dashboard → Blueprint: ตรวจ sync status / auto-sync setting ว่าเปิดอยู่
+1. ตรวจว่า header set ออกครบ (คำสั่งเดียวกับ section "การทดสอบ" ข้างล่าง):
+   ```bash
+   curl -sI https://smart-port.onrender.com/ | grep -i "content-security\|x-frame\|referrer\|permissions\|strict-transport"
+   ```
+2. ตรวจ Cache-Control precedence:
+   ```bash
+   curl -sI https://smart-port.onrender.com/ | grep -i cache-control
+   # ต้องได้: no-cache
+   curl -sI https://smart-port.onrender.com/assets/index-B1YyXcfC.js | grep -i cache-control
+   # (แทนชื่อ asset ปัจจุบันจาก <script src> ในหน้าเว็บ) ต้องได้: public, max-age=31536000, immutable
+   ```
+
+- ถ้า step 1 ยังไม่มี header เลยแม้ sync แล้ว → ตรวจว่า static site ถูก manage โดย
+  blueprint นี้จริงหรือไม่ (dashboard ของ service ต้องชี้มาที่ render.yaml นี้)
+- ถ้า `/assets/*` ได้ค่าถูกต้อง → บันทึกผลจริงแทน section นี้, ปิดประเด็น precedence
+- ถ้า `no-cache` ชนะบน assets (worst case ของ issue) → restructure: ยกเลิกกฎ `/*`
+  แล้วตั้ง `no-cache` เฉพาะ path เอกสาร (หรือแนวทางอื่นตาม behavior ที่วัดได้)
 
 ## CSP monitoring ก่อน enforce
 

--- a/docs/superpowers/plans/2026-08-16-issue-125-render-headers-object-src-prp-plan.md
+++ b/docs/superpowers/plans/2026-08-16-issue-125-render-headers-object-src-prp-plan.md
@@ -1,0 +1,58 @@
+# PRP Plan — Issue #125: Render header precedence + object-src 'none'
+
+วันที่: 2026-08-16 · Branch: `issue-125-render-headers-object-src` · Parent audit: review ของ #110–#115 (range `720dda6..a1fafa1`), finding 4 + promotion recommendation
+
+## Problem
+
+1. **Render Cache-Control overlap ยังไม่ถูก verify:** render.yaml ตั้ง `Cache-Control: no-cache`
+   บน `/*` และ `public, max-age=31536000, immutable` บน `/assets/*` — docs ของ Render
+   ไม่ระบุ precedence เมื่อสอง pattern ทับกัน
+2. **CSP ทั้งสอง path ไม่มี `object-src 'none'`** — app ไม่ได้ใช้ plugin/embed เลย
+   เพิ่ม `'none'` เป็น belt-and-braces ได้ฟรี
+
+## Live observation (2026-08-16, curl smart-port.onrender.com)
+
+ทั้ง `/` และ `/assets/index-B1YyXcfC.js` คืนค่า default ของ Render:
+`Cache-Control: public, max-age=0, s-maxage=300` — **header set จาก render.yaml
+ยังไม่ถูก apply เลย** (ไม่มี CSP-Report-Only / X-Frame-Options ฯลฯ) ทั้งที่ site ถูก
+deploy ใหม่แล้ว (last-modified วันนี้) → blueprint ยังไม่ได้ "Sync" ใน Render dashboard
+ตั้งแต่ #113; การ sync เป็น manual action บน dashboard
+
+ผลต่อ acceptance ข้อ 1: บันทึกผลจริงที่วัดได้ + เงื่อนไขที่ต้องทำต่อ (sync blueprint →
+deploy → curl ใหม่) ลง docs — การ verify สมบูรณ์เกิดหลัง sync ซึ่งอยู่นอก repo
+
+[Render static-site headers docs](https://render.com/docs/static-site-headers) ยืนยันว่า
+ไม่มีกฎ precedence สำหรับ pattern ทับกัน → ต้องวัดจริงหลัง deploy เท่านั้น
+
+## Changes
+
+### 1. เพิ่ม `object-src 'none'` ทั้งสอง CSP
+
+- `render.yaml` — report-only policy (เพิ่มต่อจาก `form-action 'self'`)
+- `frontend/nginx-security-headers.conf` — enforced policy (docker path)
+- `docs/frontend-security-headers.md` — CSP block ใน doc
+
+### 2. Tests
+
+- `frontend/src/__tests__/securityHeaders.test.js`: เพิ่ม `"object-src 'none'"` ใน
+  `CSP_CORE` → ครอบทั้ง render.yaml + snippet อัตโนมัติ; เพิ่ม explicit assertion
+
+### 3. บันทึก live verification ลง docs
+
+- `docs/frontend-security-headers.md`: เพิ่ม section "Live verification (#125)" —
+  ผล curl วันนี้ (default ของ Render = blueprint ยังไม่ sync), checklist หลัง sync:
+  curl `/` ต้องได้ `no-cache`, curl `/assets/*` ต้องได้ `public, max-age=31536000, immutable`;
+  ถ้า `no-cache` ชนะบน assets → restructure ตามแผนใน issue
+
+## Verification
+
+1. `npx vitest run src/__tests__/securityHeaders.test.js` (threads pool) — เขียว
+2. Full CI gate: `scripts/ci-local.ps1 -SkipInstall` (build frontend image = ตรวจ
+   snippet syntax ทางอ้อมผ่าน nginx.conf include)
+3. Live re-check ทำหลัง blueprint sync (นอกรอบ PR นี้)
+
+## Acceptance
+
+- [ ] `object-src 'none'` อยู่ใน render.yaml (report-only), nginx snippet (enforced), doc และ tests เขียว
+- [ ] ผล live observation + เงื่อนไข verify ต่อ ถูกบันทึกใน docs/frontend-security-headers.md
+- [ ] CI gate ผ่าน

--- a/frontend/nginx-security-headers.conf
+++ b/frontend/nginx-security-headers.conf
@@ -5,4 +5,4 @@ add_header X-Frame-Options "DENY" always;
 add_header X-Content-Type-Options "nosniff" always;
 add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 add_header Permissions-Policy "camera=(), geolocation=(), microphone=(), payment=()" always;
-add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;

--- a/frontend/src/__tests__/securityHeaders.test.js
+++ b/frontend/src/__tests__/securityHeaders.test.js
@@ -22,6 +22,8 @@ const CSP_CORE = [
   'font-src https://fonts.gstatic.com',
   "img-src 'self' data:",
   "connect-src 'self'",
+  // Issue #125: app ไม่ใช้ plugin/embed — 'none' เป็น defense-in-depth ฟรี
+  "object-src 'none'",
   "frame-ancestors 'none'",
   "base-uri 'self'",
   "form-action 'self'",

--- a/render.yaml
+++ b/render.yaml
@@ -19,7 +19,7 @@ services:
     headers:
       - path: /*
         name: Content-Security-Policy-Report-Only
-        value: "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; report-uri /api/csp-report"
+        value: "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; report-uri /api/csp-report"
       - path: /*
         name: X-Frame-Options
         value: DENY


### PR DESCRIPTION
## Summary

- Adds `object-src 'none'` to both CSP policies - render.yaml (report-only, production path) and `frontend/nginx-security-headers.conf` (enforced, docker path) - plus the `CSP_CORE` drift-guard in `securityHeaders.test.js`. Nothing in the app uses plugins/embeds, so `'none'` is free defense-in-depth.
- Finding 1 outcome: live curl of `smart-port.onrender.com` shows **neither** Cache-Control rule applied - both `/` and `/assets/*` serve Render's default (`public, max-age=0, s-maxage=300`) and none of the #113 headers, despite a same-day redeploy. The blueprint is evidently out of sync (auto-sync disabled, or the service isn't managed by this blueprint). Render's docs document no precedence for overlapping header paths, so the `/*` vs `/assets/*` question stays empirical.
- Records the observation and a post-sync verification checklist (dashboard sync-status check, full header curl, Cache-Control curl, remediation branch if `no-cache` wins on assets) in `docs/frontend-security-headers.md`. Follow-up #131 tracks the dashboard action + optional live header smoke check.

## Verification

- `vitest run src/__tests__/securityHeaders.test.js` - 9/9 pass.
- Fresh image build: `nginx -t` OK; container GET `/` serves the enforced CSP with `object-src 'none'`.
- `render.yaml` parses cleanly (js-yaml); diff touches only the CSP value line.
- Code review (subagent): Ready with fixes - both Important items addressed (doc wording corrected against Render's auto-sync default; plan doc committed).
- Full local CI gate (`scripts/ci-local.ps1 -SkipInstall`): all selected jobs passed (739s).

Closes #125