### PR TITLE
test(harness): make integration runs migration-aware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,8 +182,11 @@ jobs:
 
       - name: Wait for schema init to finish
         run: |
+          # -h 127.0.0.1 สำคัญ: ระหว่าง init mysql:8.0 รัน temporary server แบบ
+          # socket-only (--skip-networking) — probe ผ่าน socket จะผ่านก่อน init จบ
+          # แล้ว step migrations จะชน TCP refused (Issue #129)
           for i in $(seq 1 60); do
-            if docker exec ci-mysql mysql -uroot -prootpassword --silent \
+            if docker exec ci-mysql mysql -h 127.0.0.1 -uroot -prootpassword --silent \
               -e "SELECT 1 FROM personnel LIMIT 1" civil_service_mgmt >/dev/null 2>&1; then
               echo "schema ready"; exit 0
             fi
@@ -194,6 +197,24 @@ jobs:
       - name: Build PHPUnit test image
         run: docker build -t smartport-phpunit:ci -f backend/tests/Dockerfile.test backend/tests
 
+      # Issue #129: init mounts ไม่ได้สร้าง schema_migrations → ต้องรัน migration runner
+      # ก่อน suite (baseline 03–30 ข้าม test-seed) ไม่งั้น readyz pending===0 ว่างเปล่า
+      # retry 3 ครั้งกัน race ชั่วคราว (TCP ยังไม่เปิด/init ยังไม่จบ) — error จริงจะพังครบทั้ง 3
+      - name: Run migrations against CI MySQL
+        run: |
+          for i in 1 2 3; do
+            docker run --rm --network host \
+              -e MYSQL_HOST=127.0.0.1 \
+              -e MYSQL_DATABASE=civil_service_mgmt \
+              -e MYSQL_USER=root \
+              -e MYSQL_PASSWORD=rootpassword \
+              -v "$PWD/backend:/app" -v "$PWD/database:/database" -w /app smartport-phpunit:ci \
+              php scripts/run-migrations.php && exit 0
+            echo "migration attempt $i failed, retrying in 10s..."
+            sleep 10
+          done
+          echo "migrations failed after 3 attempts"; exit 1
+
       - name: Run PHPUnit (unit + integration)
         run: |
           docker run --rm --network host \
@@ -201,7 +222,7 @@ jobs:
             -e MYSQL_DATABASE=civil_service_mgmt \
             -e MYSQL_USER=root \
             -e MYSQL_PASSWORD=rootpassword \
-            -v "$PWD/backend:/app" -w /app smartport-phpunit:ci \
+            -v "$PWD/backend:/app" -v "$PWD/database:/database" -w /app smartport-phpunit:ci \
             sh -c 'composer install --no-interaction --no-progress --ignore-platform-req=ext-gd 2>/dev/null \
               || composer update --no-interaction --no-progress --ignore-platform-req=ext-gd; \
               php vendor/bin/phpunit'

--- a/backend/scripts/migration-lib.php
+++ b/backend/scripts/migration-lib.php
@@ -11,10 +11,12 @@ declare(strict_types=1);
 
 /**
  * Last migration assumed already applied when the DB was provisioned by
- * docker-compose init mounts or tidb-init (both include through 25).
- * Fresh volumes must not re-run non-idempotent files such as 22.
+ * docker-compose init mounts, CI init mounts, or tidb-init (all include through 30).
+ * Fresh volumes must not re-run non-idempotent files such as 22 or 30
+ * (Issue #129: baseline เดิมตัดที่ 25 ทำให้ fresh volume โดน re-apply 30
+ *  ซึ่งเป็น ALTER TABLE ADD COLUMN ล้วน ๆ → Duplicate column แล้ว runner พัง)
  */
-const MIGRATION_BASELINE_THROUGH = '25-ensure-multiplier-tables.sql';
+const MIGRATION_BASELINE_THROUGH = '30-photo-blob-storage.sql';
 
 function migrationEnv(string $key, string $default = ''): string
 {
@@ -78,9 +80,11 @@ function migrationDirectory(): string
 
     // migration อยู่ใน database/ ที่เดียว (ดู scripts/validate-schema-parity.mjs)
     // ในภาพ production คือ /var/www/database ส่วนตอนรันจาก checkout คือ <repo>/database
+    // rtrim: test harness mount backend/ ที่ /app → dirname(__DIR__, 2) คืน '/'
+    // ไม่ตัดจะได้ '//database' ซึ่งทำให้ assert path แบบ exact-match ในเทสพัง
     $candidates = [
         '/var/www/database',
-        dirname(__DIR__, 2) . '/database',
+        rtrim(dirname(__DIR__, 2), '/\\') . '/database',
     ];
 
     $emptyDirs = [];

--- a/backend/scripts/run-migrations.php
+++ b/backend/scripts/run-migrations.php
@@ -5,8 +5,9 @@
  *
  * Safety for existing TiDB/prod / fresh docker-compose volumes:
  * - If schema_migrations is empty but core tables already exist, seed a baseline
- *   for migrations through 25-* (already applied via init mounts / tidb-init)
- *   and only execute newer files. test-seed files are never baselined.
+ *   for migrations through 30-* (already applied via init mounts / tidb-init;
+ *   cut-off constant lives in migration-lib.php), and only execute newer files.
+ *   test-seed files are never baselined.
  * - DDL is not wrapped in a multi-statement transaction (TiDB/MySQL auto-commit DDL).
  * - Uses GET_LOCK when available to reduce multi-instance races.
  *

--- a/backend/tests/Integration/ReadyzTest.php
+++ b/backend/tests/Integration/ReadyzTest.php
@@ -34,20 +34,57 @@ final class ReadyzTest extends TestCase
     {
         $report = readyzReport(self::$pdo);
 
-        // Issue #124: assert เข้มตามชื่อ test — หมายเหตุ: harness (run.sh/CI) mount เฉพาะ
-        // backend/ → migrationDirectory() หา database/ ไม่เจอ → bundled=[] → pending เป็น 0 เสมอ
-        // ใน automated run (ตรวจจริงต้องดู live /readyz; harness limitation นี้ tracked เป็น follow-up)
+        // Issue #129: harness (run.sh/CI) mount database/ เข้า /database และรัน
+        // migration runner ก่อน suite แล้ว → bundled/pending วัดจาก state จริง ไม่ว่างเปล่า
         $this->assertSame('ready', $report['status']);
         $this->assertSame('ok', $report['db']);
         $this->assertSame(0, $report['migrations_pending']);
         $this->assertArrayHasKey('release', $report);
-        $this->assertIsInt($report['migrations_bundled']);
+
+        // bundled ต้องเห็นไฟล์จริง (กัน regression กลับไป bundled=[]) —
+        // readyzReport นับทุกไฟล์ในโฟลเดอร์ (ไม่กรอง test-seed; การกรองมีเฉพาะฝั่ง pending)
+        $expectedBundled = count(listMigrationFiles(migrationDirectory()));
+        $this->assertGreaterThan(0, $report['migrations_bundled']);
+        $this->assertSame($expectedBundled, $report['migrations_bundled']);
 
         // minimal disclosure: มีแค่ key สถานะ/ตัวเลข — ไม่มีรายการ schema/migration รั่วออกมา
         $this->assertSame(
             ['status', 'release', 'db', 'migrations_bundled', 'migrations_pending'],
             array_keys($report)
         );
+    }
+
+    public function test_report_detects_missing_migration_row(): void
+    {
+        // Issue #129: negative case — row หายจาก schema_migrations ต้องถูกจับจริง
+        // (ดึง migration สุดท้ายที่ไม่ใช่ test-seed ตาม natural order)
+        $files = array_values(array_filter(
+            listMigrationFiles(migrationDirectory()),
+            static fn (string $path): bool => !str_contains(basename($path), 'test-seed')
+        ));
+        if ($files === []) {
+            $this->markTestSkipped('no non-test-seed migrations bundled');
+        }
+        $name = basename(end($files));
+
+        $stmt = self::$pdo->prepare('SELECT 1 FROM schema_migrations WHERE migration_name = ?');
+        $stmt->execute([$name]);
+        if (!$stmt->fetchColumn()) {
+            $this->markTestSkipped("{$name} not applied in this environment");
+        }
+
+        self::$pdo->prepare('DELETE FROM schema_migrations WHERE migration_name = ?')
+            ->execute([$name]);
+        try {
+            $report = readyzReport(self::$pdo);
+            $this->assertSame('migrations_pending', $report['status']);
+            $this->assertSame(1, $report['migrations_pending']);
+        } finally {
+            // restore แถวที่ลบ — ตารางนี้ share กับ suite อื่น/การรันซ้ำ
+            // (applied_at ถูก reset เป็น now — ไม่มี consumer ของคอลัมน์นี้)
+            self::$pdo->prepare('INSERT INTO schema_migrations (migration_name) VALUES (?)')
+                ->execute([$name]);
+        }
     }
 
     public function test_release_falls_back_to_dev_without_render_env(): void

--- a/backend/tests/Unit/MigrationBaselineTest.php
+++ b/backend/tests/Unit/MigrationBaselineTest.php
@@ -11,11 +11,13 @@ require_once __DIR__ . '/../../scripts/migration-lib.php';
 
 /**
  * Guards the baseline cut-off used by scripts/run-migrations.php.
- * docker-compose init + tidb-init already apply through 25; only newer files execute.
+ * docker-compose init + CI init + tidb-init already apply through 30;
+ * only newer files execute (Issue #129 — ตัดที่ 25 ไม่ได้แล้ว เพราะ init mounts
+ * ครอบถึง 30 และ 30 เป็น ALTER TABLE ADD COLUMN ที่ re-apply ซ้ำไม่ได้)
  */
 final class MigrationBaselineTest extends TestCase
 {
-    private const BASELINE_THROUGH = '25-ensure-multiplier-tables.sql';
+    private const BASELINE_THROUGH = '30-photo-blob-storage.sql';
 
     #[Test]
     public function baseline_cut_off_matches_runner_constant(): void
@@ -28,7 +30,7 @@ final class MigrationBaselineTest extends TestCase
     {
         self::assertGreaterThan(
             0,
-            strnatcasecmp('26-placeholder-next.sql', self::BASELINE_THROUGH)
+            strnatcasecmp('31-placeholder-next.sql', self::BASELINE_THROUGH)
         );
     }
 
@@ -42,6 +44,8 @@ final class MigrationBaselineTest extends TestCase
             '15-api-rate-limit-hits.sql',
             '22-unify-person-identity.sql',
             '25-ensure-multiplier-tables.sql',
+            '27-superadmin-permission-overrides.sql',
+            '30-photo-blob-storage.sql',
         ];
 
         foreach ($historical as $name) {

--- a/backend/tests/Unit/MigrationDirectoryTest.php
+++ b/backend/tests/Unit/MigrationDirectoryTest.php
@@ -117,10 +117,17 @@ final class MigrationDirectoryTest extends TestCase
     #[Test]
     public function it_reports_which_directories_were_tried_when_no_fallback_exists(): void
     {
-        // ไม่ตั้ง MIGRATIONS_DIR → ไล่ fallback; ในคอนเทนเนอร์เทส backend/ ถูก mount เป็น /app
-        // จึงไม่มีทั้ง /var/www/database และ <repo>/database → ต้องบอกว่าลองที่ไหนไปบ้าง
+        // ไม่ตั้ง MIGRATIONS_DIR → ไล่ fallback
+        // - harness ใหม่ (Issue #129) mount database/ เป็น /database → fallback เจอจริง:
+        //   ต้องคืน /database ไม่ใช่ throw
+        // - ถ้าทั้งสอง candidate ไม่มีอยู่จริง → ต้องบอกว่าลองที่ไหนไปบ้าง
         putenv('MIGRATIONS_DIR');
         unset($_ENV['MIGRATIONS_DIR'], $_SERVER['MIGRATIONS_DIR']);
+
+        if (is_dir('/database') && listMigrationFiles('/database') !== []) {
+            self::assertSame('/database', migrationDirectory());
+            return;
+        }
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('No migrations directory found');

--- a/backend/tests/run.sh
+++ b/backend/tests/run.sh
@@ -24,11 +24,13 @@ IMAGE="smartport-phpunit:local"
 # เป็นรูป Windows (D:/...) — ป้องกัน /app กลายเป็น C:/Program Files/Git/app
 DOCKER_SCRIPT_DIR="${SCRIPT_DIR}"
 DOCKER_BACKEND_DIR="${BACKEND_DIR}"
+DOCKER_ROOT_DIR="${ROOT_DIR}"
 case "$(uname -s)" in
   MINGW*|MSYS*|CYGWIN*)
     export MSYS_NO_PATHCONV=1
     DOCKER_SCRIPT_DIR="$(cd "${SCRIPT_DIR}" && pwd -W)"
     DOCKER_BACKEND_DIR="$(cd "${BACKEND_DIR}" && pwd -W)"
+    DOCKER_ROOT_DIR="$(cd "${ROOT_DIR}" && pwd -W)"
     ;;
 esac
 
@@ -71,17 +73,34 @@ else
   echo "[run.sh] (ถ้าต้องการ integration: docker compose up -d --build db backend)"
 fi
 
-# ---- 3) composer install + phpunit ใน container ----------------------------
+# ---- 3) composer install + migrate + phpunit ใน container -------------------
 # ครั้งแรก lock ยังไม่มี phpunit → install ล้มเหลว → fallback เป็น update (เขียน lock ใหม่)
+# Issue #129: mount database/ เข้า /database ด้วย แล้วรัน migration runner ก่อน suite —
+# ถ้าไม่ทำ readyzReport() จะเห็น bundled=[] → migrations_pending เป็น 0 เสมอแบบว่างเปล่า
+# (migrationDirectory() candidate คือ /var/www/database กับ dirname(__DIR__,2).'/database'
+#  ซึ่งตัวหลังชี้ /database พอดีเมื่อ backend ถูก mount ที่ /app)
 docker run --rm \
   "${NET_ARGS[@]}" \
   "${ENV_ARGS[@]}" \
   -v "${DOCKER_BACKEND_DIR}:/app" \
+  -v "${DOCKER_ROOT_DIR}/database:/database" \
   -w /app \
   "${IMAGE}" \
   sh -c '
     set -e
     composer install --no-interaction --no-progress --ignore-platform-req=ext-gd 2>/dev/null \
       || composer update --no-interaction --no-progress --ignore-platform-req=ext-gd
+    # มี DB ต่ออยู่เท่านั้นถึง migrate (ไม่มี = unit suite อย่างเดียว) —
+    # ล้มเหลวให้พังตรงนี้เลย: DB ที่ migrate ไม่ครบต้องหยุด suite ไม่ใช่ผ่านเงียบ ๆ
+    # retry 3 ครั้งเฉพาะ race ชั่วคราว (db กำลัง init/restart); error จริงจะพังครบทั้ง 3
+    if [ -n "${MYSQL_HOST:-}" ]; then
+      tries=0
+      until php scripts/run-migrations.php; do
+        tries=$((tries + 1))
+        if [ "$tries" -ge 3 ]; then exit 1; fi
+        echo "[run.sh] migrate attempt $tries failed — retrying in 10s (db อาจยัง init อยู่)"
+        sleep 10
+      done
+    fi
     php vendor/bin/phpunit "$@"
   ' -- "$@"

--- a/docs/render-tidb-production.md
+++ b/docs/render-tidb-production.md
@@ -121,7 +121,7 @@ while the schema stayed frozen. Now a resolved directory must actually contain `
 explicitly-set `MIGRATIONS_DIR` that is missing or empty aborts the start instead of silently falling back
 to another directory.
 
-**Existing TiDB / already-initialized DBs:** if `schema_migrations` is empty but `personnel` or `users` already exists, the runner **baselines** migrations through `14-multiplier-area-admin.sql` (marks them applied, does not re-run non-idempotent `ALTER`s). Only newer files such as `15-api-rate-limit-hits.sql` are executed.
+**Existing TiDB / already-initialized DBs:** if `schema_migrations` is empty but `personnel` or `users` already exists, the runner **baselines** migrations through `30-photo-blob-storage.sql` (marks them applied, does not re-run non-idempotent `ALTER`s; files containing `test-seed` are never baselined). Only newer files are executed. ⚠️ The committed dumps (`database/export-*.sql`, `reimport-data.sql`) predate migrations 27–30 — restoring one and running the runner will baseline 27–30 **without applying them**; delete `schema_migrations` rows ≥ 26 first (or use a current dump).
 
 **TEST_SEED migrations:** files whose name contains `test-seed` (e.g. `16-multiplier-test-seed-expand.sql`) are **skipped by default** so provisional data does not land on production. To apply them on a dedicated UAT/dev database, set `APPLY_TEST_SEED_MIGRATIONS=1` on the backend service. Local Docker can set the same env when you intentionally want TEST_SEED rows.
 

--- a/docs/superpowers/plans/2026-08-16-issue-129-migration-aware-harness-prp-plan.md
+++ b/docs/superpowers/plans/2026-08-16-issue-129-migration-aware-harness-prp-plan.md
@@ -1,0 +1,113 @@
+# PRP Plan — Issue #129: Test harness ให้ integration run เป็น migration-aware
+
+วันที่: 2026-08-16 · Branch: `issue-129-migration-aware-harness` · Severity: Low (test-harness accuracy)
+
+## Problem
+
+จาก review ของ #124: assertion `migrations_pending === 0` ใน
+`backend/tests/Integration/ReadyzTest.php` ว่างเปล่าเชิงโครงสร้างใน automated run ทุกที่:
+
+1. `run.sh` และ `ci.yml` mount เฉพาะ `backend/` เข้า `/app` → ทั้งสอง candidate ของ
+   `migrationDirectory()` (`/var/www/database`, `/database`) พลาด → throw →
+   `readyzReport()` catch แล้วตั้ง `bundled = []` → `pending` เป็น **0 เสมอ**
+2. CI MySQL ไม่มี `schema_migrations` (provision ผ่าน init mounts อย่างเดียว)
+
+ผล: test จับ DB ที่ยัง migrate ไม่ครบไม่ได้เลย
+
+## Context ที่ตรวจแล้ว
+
+- `migrationDirectory()` รองรับ env override `MIGRATIONS_DIR` และเลือก candidate
+  `/var/www/database` หรือ `dirname(__DIR__,2).'/database'` (= `/database` เมื่อ backend อยู่ที่ `/app`)
+- `run-migrations.php` มี baseline seeding: DB ที่ provision แล้ว (มี `personnel`/`users`)
+  จะได้ baseline rows ถึง `25-ensure-multiplier-tables.sql` แล้ว apply เฉพาะไฟล์ใหม่กว่า (26–30)
+- **DB state ที่ตรวจจริง:**
+  - Local dev DB (`db-data` volume): มี `schema_migrations` ครบ 03–30 แล้ว → runner จะ
+    "No pending migrations." ไม่มี re-apply risk
+  - CI MySQL (fresh ทุก run): init mounts 01–25, 27–30 → baseline 03–25 + apply 26–30 → pending 0 จริง
+- `26-e2e-admin-test-seed.sql` ไม่มีคำว่า `test-seed` ในชื่อ? — **มี** (`e2e-admin-test-seed`)
+  → runner ไม่ gate (ไม่มี substring `test-seed`... ตรวจ: `str_contains('26-e2e-admin-test-seed.sql','test-seed')` = **true**)
+  → runner จะ SKIP เว้นแต่ `APPLY_TEST_SEED_MIGRATIONS=1` และ readyz ก็นับข้ามด้วยเงื่อนไขเดียวกัน
+  → ทั้งสองฝั่ง consistent เสมอไม่ว่าจะเปิด env หรือไม่
+
+## Changes
+
+### 1. `backend/tests/run.sh`
+
+- คำนวณ `DOCKER_ROOT_DIR` (รูป Windows เมื่อ MSYS เหมือน `DOCKER_BACKEND_DIR`)
+- เพิ่ม mount `-v "${DOCKER_ROOT_DIR}/database:/database"`
+- ใน `sh -c` block: ถ้ามี DB (`[ -n "$MYSQL_HOST" ]`) รัน
+  `php scripts/run-migrations.php` ก่อน phpunit — ล้มเหลว = fail ทั้ง run (fail-fast
+  คือจุดประสงค์ของ issue นี้)
+
+### 2. `.github/workflows/ci.yml` (backend-tests job)
+
+- เพิ่ม step "Run migrations" หลัง build image: `docker run smartport-phpunit:ci`
+  แบบ `--network host` + env เดียวกับ step phpunit + mount `$PWD/database:/database` +
+  `$PWD/backend:/app` → `php scripts/run-migrations.php`
+  (ไม่ต้อง composer install — runner ใช้แค่ PDO)
+- step phpunit เองก็ต้อง mount `$PWD/database:/database` ด้วย (ไม่อย่างนั้น
+  ReadyzTest เรียก `migrationDirectory()` ตรง ๆ แล้ว throw — reviewer finding C2)
+
+### 2b. `backend/scripts/migration-lib.php` (แก้ตาม review)
+
+- **C1/I1:** ขยับ `MIGRATION_BASELINE_THROUGH` จาก `25-ensure-multiplier-tables.sql`
+  เป็น `30-photo-blob-storage.sql` — init mounts (compose + CI + tidb-init) ครอบถึง 30
+  แล้ว ถ้า baseline ตัดที่ 25 runner จะ re-apply 30 (ALTER TABLE ADD COLUMN ล้วน ๆ)
+  บน fresh volume → Duplicate column → gate พัง ตรวจพิสูจน์แล้ว: ลบ row 30 จำลอง →
+  runner "Baselined 1 historical migration(s)" + "No pending migrations." (ไม่ re-apply)
+- candidate path: `rtrim(dirname(__DIR__, 2), '/\\')` กัน `//database` เมื่อ backend
+  ถูก mount ที่ `/app` (test container)
+- `MigrationBaselineTest.php` ขยับตาม (ค่าคงที่ + placeholder 31 + เพิ่ม 27/30 ใน historical list)
+
+### 2c. แก้ตาม deep review รอบสอง
+
+- **I-1:** CI wait probe เพิ่ม `-h 127.0.0.1` (ระหว่าง init mysql:8.0 รัน socket-only
+  temporary server — probe socket ผ่านก่อน init จบ) + step "Run migrations" มี retry 3 ครั้ง
+- **I-2:** docs/render-tidb-production.md — อัปเดต baseline เป็น through 30 + ⚠️ dumps
+  เก่าใน repo (export-*.sql/reimport-data.sql) predates 27–30: restore แล้ว runner จะ
+  baseline ทับโดยไม่ apply — ต้องลบ rows ≥26 หรือใช้ dump ปัจจุบัน
+- **M-1:** docblock run-migrations.php (25-* → 30-*)
+- **M-3:** run.sh — migrate มี retry 3 ครั้ง (db กำลัง init/restart) กัน foot-gun
+- **N-1/N-2/N-3:** empty-list guard ใน negative test + comment applied_at + คำอธิบาย rtrim
+- ไม่แก้: M-2 (APPLY_TEST_SEED forward — ทั้งสองฝั่ง consistent เมื่อ unset), N-4 (ย้าย
+  test-seed skip ลง lib), N-5 (array expansion — bash ≥4.4 บนเครื่องนี้/CI พอ)
+
+### 3. `backend/tests/Integration/ReadyzTest.php`
+
+- ลบ comment เรื่อง harness limitation (หมดจริงแล้ว)
+- เพิ่ม assert: `migrations_bundled > 0` และเท่ากับ `count(listMigrationFiles(migrationDirectory()))`
+  (กัน bundled=[] regression ตรง ๆ)
+- เพิ่ม negative test `test_report_detects_missing_migration_row`:
+  DELETE row สุดท้าย (natural order) จาก `schema_migrations` →
+  assert `status === 'migrations_pending'` + `migrations_pending === 1` →
+  INSERT คืน (try/finally กันค้างถ้า assert พังกลางทาง)
+
+### ไม่แก้
+
+- `Dockerfile.test` — ไม่เกี่ยว (mount ระดับ `docker run`)
+- `readyz.php` — พฤติกรรมถูกแล้ว ช่องว่างอยู่ที่ harness
+
+## Acceptance criteria
+
+- [x] `bash backend/tests/run.sh` → integration suite รัน, ReadyzTest ผ่านด้วย
+      `migrations_bundled > 0`, `migrations_pending === 0` จริง (ไม่ว่างเปล่า)
+- [x] Negative test ผ่าน: ลบ row → pending 1 / status migrations_pending → restore
+- [x] `ci.yml` backend-tests: step migrations ใหม่ + `pending === 0` มีความหมาย
+      (ตรวจด้วยตา; GH Actions ไม่ถูก dispatch — local gate เท่านั้น)
+- [x] Unit suite ยังเขียว, full suite 354 tests / 951 assertions เขียว (1 skip เดิม)
+- [x] C1/I1 simulation: ลบ row 30 → runner baseline คืน ไม่ re-apply ALTER
+- [ ] Full local CI gate ผ่าน
+
+## Risks
+
+- DB ที่ provision เก่ากว่า init set ปัจจุบัน (ไม่มีคอลัมน์ของ 30 แต่ถูก baseline ครอบ):
+  เกิดได้เฉพาะ volume ที่สร้างก่อนยุค #112 แล้วไม่เคยรัน runner — runner จะไม่ apply 30
+  (baseline) แต่คอลัมน์ไม่มีจริง → readyz ยัง ready. ยอมรับ: ทุก env จริง (compose/CI/TiDB)
+  ผ่าน init ที่ครอบถึง 30 หรือมี row ครบแล้ว
+- Negative test แตะตาราง shared → try/finally restore + ใช้ migration สุดท้ายที่ไม่ใช่ test-seed
+
+## Skills ที่ใช้ (per `.claude/skill-collections-20260815.md`)
+
+`ecc:plan-prd` (plan นี้) · `ecc:database-migrations` + `ecc:mysql-patterns` (migration runner/baseline) ·
+`addyosmani:ci-cd-and-automation` (run.sh/ci.yml) · `superpowers:test-driven-development` (negative test) ·
+`superpowers:requesting-code-review` + `ecc:php-review` (reviewer subagent)


### PR DESCRIPTION
## Summary

- readyz's `migrations_pending === 0` assertion was vacuous in every automated run: `run.sh`/`ci.yml` mounted only `backend/`, so `migrationDirectory()` never found `database/` (`bundled=[]` → pending forced to 0), and CI MySQL never had `schema_migrations`
- `run.sh` + `ci.yml` now mount `database/` at `/database` and run the migration runner before the suite (fail-fast, 3-attempt retry for init races; CI wait-probe moved to TCP `-h 127.0.0.1` so it cannot pass while mysql:8.0's socket-only init server is still running)
- `MIGRATION_BASELINE_THROUGH` raised from `25-ensure-multiplier-tables.sql` to `30-photo-blob-storage.sql` — init mounts (compose/CI/tidb-init) cover through 30 and migration 30 is a non-idempotent `ALTER TABLE ADD COLUMN` (verified by simulating a missing row: runner re-baselined instead of re-applying)
- ReadyzTest now asserts real `migrations_bundled` counts plus a negative test (deleted `schema_migrations` row → `migrations_pending` status + `pending === 1`, restored in finally)
- Docs: baseline through 30 + stale-dump caveat (committed `export-*.sql` dumps predate 27–30)

## Verification

- Full backend suite: 354 tests / 951 assertions green (1 pre-existing skip)
- Full local CI gate: all jobs passed (1304s)
- Two reviewer rounds (incl. deep review): all Critical/Important findings fixed and documented in the plan doc

Closes #129