### PR TITLE
fix(photos): stop inserting phantom thumbnail rows; CSPRNG filenames

### DIFF
--- a/backend/api.php
+++ b/backend/api.php
@@ -102,7 +102,7 @@ $isPasswordChange = $path[0] === 'auth' && ($path[1] ?? '') === 'change-password
 $isPublicAuth = $isPublicLogin || $isPublicRefresh || $isPublicLogout;
 
 // Issue #112: asset รูป (GET /uploads/{file}) เป็น public เหมือนตอน Apache เสิร์ฟ static
-// (<img> ไม่ส่ง Authorization header) — ชื่อไฟล์ uniqid เดาไม่ได้ทำหน้าที่เป็น capability URL
+// (<img> ไม่ส่ง Authorization header) — ชื่อไฟล์ CSPRNG เดาไม่ได้ทำหน้าที่เป็น capability URL
 $isPublicPhotoAsset = $path[0] === 'uploads' && $method === 'GET';
 
 // Issue #114: readiness endpoint เปิด public สำหรับ monitoring — คืนเฉพาะตัวเลข/สถานะ
@@ -312,8 +312,8 @@ switch ($path[0]) {
                 break;
             }
 
-            // Generate safe filename
-            $safeFileName = uniqid('photo_', true) . '.' . $ext;
+            // Generate safe filename — CSPRNG; uniqid เป็น time+LCG เดาได้ (issue #127)
+            $safeFileName = 'photo_' . bin2hex(random_bytes(16)) . '.' . $ext;
 
             // Issue #112: เก็บ bytes ลงฐานข้อมูล (TiDB persist ข้าม deploy) —
             // ห้ามเขียนลง filesystem ของ container เพราะหายตอน redeploy (ADR-0001/0003)
@@ -337,7 +337,6 @@ switch ($path[0]) {
                     'success' => true,
                     'photo_id' => $stored['photo_id'],
                     'path' => $web_path,
-                    'versions' => $stored['versions'],
                 ]);
             } catch (Throwable $e) {
                 error_log('[photos] store failed: ' . $e->getMessage());

--- a/backend/helpers.php
+++ b/backend/helpers.php
@@ -129,46 +129,6 @@ function getLevelName(string $code): string
 }
 
 /**
- * Create photo version records in the application layer instead of a DB routine.
- *
- * @param PDO $pdo
- * @param int $photoId
- * @param string|null $fileName
- * @return array<int, array<string, mixed>>
- */
-function createPhotoVersions(PDO $pdo, int $photoId, ?string $fileName = null): array
-{
-    if ($photoId <= 0) {
-        throw new InvalidArgumentException('Photo id is required');
-    }
-
-    if ($fileName === null || $fileName === '') {
-        $stmt = $pdo->prepare('SELECT file_name FROM civil_servant_photos WHERE photo_id = ?');
-        $stmt->execute([$photoId]);
-        $fileName = $stmt->fetchColumn() ?: '';
-    }
-
-    if ($fileName === '') {
-        throw new RuntimeException('Photo file name not found');
-    }
-
-    $thumbnailFileName = 'thumb_' . $fileName;
-
-    $deleteStmt = $pdo->prepare('DELETE FROM photo_versions WHERE photo_id = ? AND version_type = ?');
-    $deleteStmt->execute([$photoId, 'thumbnail']);
-
-    $insertStmt = $pdo->prepare(
-        'INSERT INTO photo_versions (photo_id, version_type, file_name) VALUES (?, ?, ?)'
-    );
-    $insertStmt->execute([$photoId, 'thumbnail', $thumbnailFileName]);
-
-    return [[
-        'version_type' => 'thumbnail',
-        'file_name' => $thumbnailFileName,
-    ]];
-}
-
-/**
  * Sanitize text input to prevent XSS
  *
  * @param string|null $input Raw user input

--- a/backend/routes/photos.php
+++ b/backend/routes/photos.php
@@ -8,21 +8,24 @@ declare(strict_types=1);
 // ของ container — filesystem ของ Render ไม่ persist ข้าม deploy (ADR-0001/0003)
 //
 // การอ่าน (GET /uploads/{file}) เป็น public เหมือนเดิมที่ Apache เคยเสิร์ฟ static —
-// ชื่อไฟล์สร้างจาก uniqid (เดาไม่ได้) จึงทำหน้าที่เป็น capability URL
+// ชื่อไฟล์สร้างจาก CSPRNG (เดาไม่ได้) จึงทำหน้าที่เป็น capability URL
 // ============================================================================
 
 require_once __DIR__ . '/../helpers.php';
 
-/** ชื่อไฟล์รูปที่รับได้ — กัน path traversal (ของจริงคือ photo_<uniqid>.<ext>) */
+/** ชื่อไฟล์รูปที่รับได้ — กัน path traversal (ของจริงคือ photo_<hex32>.<ext> จาก CSPRNG) */
 function isValidPhotoFileName(string $name): bool
 {
     return (bool) preg_match('/^[A-Za-z0-9][A-Za-z0-9._-]{0,254}$/', $name);
 }
 
 /**
- * บันทึกแถวรูป + bytes + thumbnail version ใน transaction เดียว (all-or-nothing)
+ * บันทึกแถวรูป + bytes ใน transaction เดียว (all-or-nothing)
  *
- * @return array{photo_id: int, versions: array<int, array<string, mixed>>}
+ * Issue #127: ไม่สร้างแถว photo_versions แล้ว — ของเดิมแทรก thumb_<file> ที่ไม่มี bytes
+ * ทำให้ GET /uploads/thumb_<file> 404 เสมอ (โฆษณา asset ที่เข้าไม่ถึง)
+ *
+ * @return array{photo_id: int}
  */
 function storePhotoRecord(PDO $pdo, int $servantId, string $fileName, string $webPath, string $bytes, string $mime): array
 {
@@ -35,10 +38,9 @@ function storePhotoRecord(PDO $pdo, int $servantId, string $fileName, string $we
         $stmt->execute([$servantId, $fileName, $webPath, $bytes, $mime, strlen($bytes)]);
         $photoId = (int) $pdo->lastInsertId();
 
-        $versions = createPhotoVersions($pdo, $photoId, $fileName);
         $pdo->commit();
 
-        return ['photo_id' => $photoId, 'versions' => $versions];
+        return ['photo_id' => $photoId];
     } catch (Throwable $e) {
         if ($pdo->inTransaction()) {
             $pdo->rollBack();
@@ -90,7 +92,7 @@ function handleUploadsAsset(PDO $pdo, string $method, array $path): void
 
     $photo = fetchActivePhoto($pdo, $fileName);
     if ($photo === null) {
-        // log เฉพาะ file_name (uniqid-generated, ไม่มี PII) — ใช้ตามหา missing objects
+        // log เฉพาะ file_name (CSPRNG-generated, ไม่มี PII) — ใช้ตามหา missing objects
         error_log('[photos] asset not found or inactive: ' . $fileName);
         http_response_code(404);
         echo json_encode(['error' => 'Not found']);

--- a/backend/tests/Integration/PhotoStorageTest.php
+++ b/backend/tests/Integration/PhotoStorageTest.php
@@ -48,7 +48,12 @@ final class PhotoStorageTest extends TestCase
         $stored = storePhotoRecord(self::$pdo, 1, $name, 'uploads/' . $name, $bytes, 'image/jpeg');
 
         $this->assertGreaterThan(0, $stored['photo_id']);
-        $this->assertSame('thumb_' . $name, $stored['versions'][0]['file_name'] ?? null);
+        $this->assertArrayNotHasKey('versions', $stored);
+
+        // Issue #127: ต้องไม่มีแถว phantom ใน photo_versions (thumb_ ที่ไร้ bytes → 404)
+        $stmt = self::$pdo->prepare('SELECT COUNT(*) FROM photo_versions WHERE photo_id = ?');
+        $stmt->execute([$stored['photo_id']]);
+        $this->assertSame(0, (int) $stmt->fetchColumn());
 
         $fetched = fetchActivePhoto(self::$pdo, $name);
         $this->assertNotNull($fetched);
@@ -98,6 +103,7 @@ final class PhotoStorageTest extends TestCase
     public function test_file_name_validation_rejects_traversal_and_accepts_generated_names(): void
     {
         $this->assertTrue(isValidPhotoFileName('photo_65e1c8a0b1f2a3.45678901.jpg'));
+        $this->assertTrue(isValidPhotoFileName('photo_' . str_repeat('0a1b2c3d', 4) . '.jpg')); // CSPRNG shape (#127)
         $this->assertTrue(isValidPhotoFileName('thumb_photo_abc.png'));
 
         $this->assertFalse(isValidPhotoFileName('../etc/passwd'));

--- a/docs/adr/0003-photo-storage-tidb-blob.md
+++ b/docs/adr/0003-photo-storage-tidb-blob.md
@@ -27,9 +27,14 @@ redeploy/restart รูปทั้งหมดหาย ขณะที่แ�
    URL เดิมที่ frontend ใช้ (`apiAssetUrl('uploads/...')`) ทำงานต่อโดยไม่ต้องแก้ frontend
    เพราะ `.htaccess` rewrite ไฟล์ที่ไม่มีอยู่จริงเข้า `api.php`
 4. การอ่านเป็น **public** เหมือนตอน Apache เสิร์ฟ static file — ชื่อไฟล์สร้างจาก
-   `uniqid(..., true)` (entropy สูง เดาไม่ได้) จึงทำหน้าที่เป็น capability URL
+   `'photo_' . bin2hex(random_bytes(16)) . '.' . $ext` (CSPRNG เดาไม่ได้) จึงทำหน้าที่เป็น capability URL
+   (issue #127: เดิมใช้ `uniqid(..., true)` ซึ่งเป็น time+LCG — predictable)
 5. อัปโหลดยังคง validation เดิม: extension/MIME/`getimagesize`/size ≤ 5MB +
    `requirePermission('create', 'photos')`
+6. Issue #127: **เลิกแทรกแถว `photo_versions` ตอนอัปโหลด** — ของเดิมแทรก
+   `thumb_<file>` โดยไม่สร้าง bytes ทำให้ `GET /uploads/thumb_<file>` 404 เสมอ
+   (โฆษณา asset ที่เข้าไม่ถึง) ตาราง `photo_versions` คงอยู่เผื่อทำ thumbnail จริงในอนาคต
+   (ต้องติดตั้ง GD ใน image ก่อน — ยังไม่มีใน `backend/Dockerfile`)
 
 ## Consequences
 
@@ -55,7 +60,7 @@ redeploy/restart รูปทั้งหมดหาย ขณะที่แ�
 - INSERT ล้มเหลว → rollback ทั้งแถว (ไม่มีแถว DB ที่ไร้ bytes) + log
   `[photos] store failed: ...` (ไม่มี PII)
 - อ่านรูปที่ไม่พบ/inactive → 404 + log `[photos] asset not found or inactive: <file_name>`
-  (file_name เป็น uniqid ไม่มี PII)
+  (file_name เป็นชื่อสุ่ม CSPRNG/uniqid ไม่มี PII)
 
 **Migration/reconciliation สำหรับแถวเก่า** (ไฟล์สูญหายจาก ephemeral disk ไปแล้ว
 ตั้งแต่ก่อน migration นี้ — กู้คืนไม่ได้):
@@ -72,6 +77,6 @@ WHERE is_active = 1 AND file_data IS NULL;
 
 ## References
 
-- Issue #112 · Migration: `database/30-photo-blob-storage.sql`
+- Issue #112 · Issue #127 · Migration: `database/30-photo-blob-storage.sql`
 - Code: `backend/routes/photos.php`, `backend/api.php` (case 'uploads', 'photos')
 - ADR-0001 (filesystem ไม่ persist) · ADR-0002 (schema parity gate)

--- a/docs/superpowers/plans/2026-08-16-issue-127-photo-storage-polish-prp-plan.md
+++ b/docs/superpowers/plans/2026-08-16-issue-127-photo-storage-polish-prp-plan.md
@@ -45,11 +45,11 @@ WHERE pv.version_type = 'thumbnail' AND pv.file_name LIKE 'thumb\_%';
 
 ## Acceptance criteria
 
-- [ ] ไม่มี phantom `photo_versions` row ถูกสร้างตอนอัปโหลด (test ครอบ)
-- [ ] ชื่อไฟล์ใหม่มาจาก CSPRNG (`random_bytes`)
-- [ ] รูปเดิม (ชื่อ uniqid เก่า) ยังเสิร์ฟได้ — lookup ตาม file_name ที่เก็บไว้
-- [ ] Upload response ไม่มี `versions`
-- [ ] Backend suite เขียว + CI gate ผ่าน
+- [x] ไม่มี phantom `photo_versions` row ถูกสร้างตอนอัปโหลด (test ครอบ)
+- [x] ชื่อไฟล์ใหม่มาจาก CSPRNG (`random_bytes`)
+- [x] รูปเดิม (ชื่อ uniqid เก่า) ยังเสิร์ฟได้ — lookup ตาม file_name ที่เก็บไว้
+- [x] Upload response ไม่มี `versions`
+- [x] Backend suite เขียว (354 tests) — รอ CI gate เต็ม
 
 ## Risks
 

--- a/docs/superpowers/plans/2026-08-16-issue-127-photo-storage-polish-prp-plan.md
+++ b/docs/superpowers/plans/2026-08-16-issue-127-photo-storage-polish-prp-plan.md
@@ -1,0 +1,57 @@
+# PRP Plan — Issue #127: Photo storage polish (phantom thumbnails + CSPRNG filenames)
+
+- **Branch:** `issue-127-photo-storage-polish`
+- **Date:** 2026-08-16
+- **Decision:** Option (a) — remove the phantom thumbnail row insertion (issue ให้เลือก a/b)
+
+## Why option (a)
+
+1. GD ไม่ถูกติดตั้งทั้ง production image (`backend/Dockerfile` ใช้ `--ignore-platform-req=ext-gd`)
+   และ test image (`Dockerfile.test` ไม่มี GD เลย) → option (b) "สร้าง thumbnail จริง"
+   ต้องแก้ image ทั้งสอง + โค้ด resize ใหม่ = blast radius ใหญ่เกินจำเป็น
+2. Frontend ไม่เคยอ่าน `versions` — grep `versions|thumb_` ใน `frontend/src/` ไม่พบ match
+3. แถว `thumb_<file>` ที่ไม่มี bytes ทำให้ `GET /uploads/thumb_<file>` 404 เสมอ — โฆษณา asset ที่เข้าไม่ถึง
+
+## Changes
+
+### 1. `backend/helpers.php`
+- ลบ `createPhotoVersions()` ทั้งฟังก์ชัน (เรียกจากที่เดียวคือ `storePhotoRecord`)
+
+### 2. `backend/routes/photos.php`
+- `storePhotoRecord()`: เอา `createPhotoVersions()` ออกจาก transaction, return `['photo_id' => ...]` ล้วน
+- อัปเดต docblock/comment ที่อ้าง `uniqid` → CSPRNG (`bin2hex(random_bytes(16))`)
+
+### 3. `backend/api.php` (case 'photos' POST)
+- `$safeFileName = uniqid('photo_', true) . '.' . $ext;` → `'photo_' . bin2hex(random_bytes(16)) . '.' . $ext;`
+  (drop-in: `fetchActivePhoto()` lookup ตาม `file_name` ที่เก็บไว้ — ชื่อเก่ายังเสิร์ฟได้)
+- Response: เอา `'versions'` ออก (เหลือ `success/photo_id/path`)
+
+### 4. `backend/tests/Integration/PhotoStorageTest.php`
+- roundtrip test: แทน assert `thumb_...` ด้วย assert ว่า **ไม่มี** แถว `photo_versions` ถูกสร้าง
+- cleanup() คงเดิม (กันแถวค้างเก่า)
+
+### 5. `docs/adr/0003-photo-storage-tidb-blob.md`
+- Decision ข้อ 4: `uniqid(..., true)` → `bin2hex(random_bytes(16))` (CSPRNG จริง; uniqid เป็น time+LCG)
+- เพิ่มหมายเหตุ: ไม่สร้างแถว `photo_versions` แล้ว (issue #127)
+
+### 6. แถว phantom เดิมใน DB (operational, ไม่บังคับ)
+```sql
+-- ทำครั้งเดียวถ้าต้องการล้างแถว thumb_* ที่ไม่มี bytes จริง
+DELETE pv FROM photo_versions pv
+JOIN civil_servant_photos p ON p.photo_id = pv.photo_id
+WHERE pv.version_type = 'thumbnail' AND pv.file_name LIKE 'thumb\_%';
+```
+ตาราง `photo_versions` คงอยู่ (เผื่อทำ thumbnail จริงในอนาคต)
+
+## Acceptance criteria
+
+- [ ] ไม่มี phantom `photo_versions` row ถูกสร้างตอนอัปโหลด (test ครอบ)
+- [ ] ชื่อไฟล์ใหม่มาจาก CSPRNG (`random_bytes`)
+- [ ] รูปเดิม (ชื่อ uniqid เก่า) ยังเสิร์ฟได้ — lookup ตาม file_name ที่เก็บไว้
+- [ ] Upload response ไม่มี `versions`
+- [ ] Backend suite เขียว + CI gate ผ่าน
+
+## Risks
+
+- Client ภายนอกที่อ่าน `versions` จาก upload response → ไม่มี (grep frontend ไม่พบ)
+- ชื่อใหม่ยาวขึ้น (photo_ + 32 hex + ext ≈ 43 ตัว) — ยังอยู่ในขีดจำกัด `isValidPhotoFileName` (≤255) และคอลัมน์ file_name


### PR DESCRIPTION
## Summary
- Issue #127 option (a): remove `createPhotoVersions()` — it inserted `photo_versions` rows advertising `thumb_<file>` whose bytes were never generated, so `GET /uploads/thumb_<file>` always 404'd (unreachable advertised asset). GD is absent from both backend images and the frontend never consumes `versions`, so no real thumbnails were generated instead.
- Replace predictable `uniqid('photo_', true)` filenames (time+LCG) with CSPRNG `'photo_' . bin2hex(random_bytes(16))`; photo filenames double as capability URLs (ADR-0003). Existing uploads keep serving — lookup is by stored `file_name`.
- Upload response no longer includes `versions`; ADR-0003 updated.

Closes #127

## Verification
- Backend suite: 354 tests / 953 assertions green (`backend/tests/run.sh`)
- New integration asserts: no `versions` key in store return + zero `photo_versions` rows after upload; CSPRNG name shape accepted by validator
- Reviewer subagent: YES, 0 Critical / 0 Important (3 minor comment nits fixed)
- Local CI gate (`ci-local.ps1 -SkipInstall`): all jobs PASS (1072s)

## Operational note (optional, one-time)
Legacy phantom rows can be cleaned with:
```sql
DELETE pv FROM photo_versions pv
JOIN civil_servant_photos p ON p.photo_id = pv.photo_id
WHERE pv.version_type = 'thumbnail' AND pv.file_name LIKE 'thumb\_%';
```