### PR TITLE
test(scripts): external live-header smoke gate (issue #131 Part 2)

### DIFF
--- a/docs/frontend-security-headers.md
+++ b/docs/frontend-security-headers.md
@@ -64,6 +64,16 @@ report-uri /api/csp-report     ← เฉพาะ render.yaml (report-only phas
 ไม่มี header จาก render.yaml เลย → **code-push auto-deploy ไม่ re-sync blueprint
 config** (ใช้ config ของ last-synced blueprint) ต้อง manual Sync จาก dashboard เท่านั้น
 
+**ผลตรวจ 2026-08-16 รอบที่ 3 (~18:04–18:11 UTC) ด้วย `scripts/verify-live-headers.mjs`:**
+ยังเป็น default เหมือนเดิมทุกจุด — `/` และ `/assets/index-B1YyXcfC.js` (ชื่อ asset
+เดิมตั้งแต่รอบ 1 = ไม่มี build ใหม่หลัง 10:28 UTC) คืน `Cache-Control: public,
+max-age=0, s-maxage=300` และไม่มี CSP-Report-Only / X-Frame-Options / Referrer-Policy /
+Permissions-Policy หลักฐานเสริมว่า header ที่เห็นมาจาก edge layer ไม่ใช่ render.yaml:
+HSTS จริงเป็น `max-age=315360000; includeSubdomains; preload` ซึ่งไม่ใช่ค่าที่ render.yaml
+ประกาศ (`max-age=31536000; includeSubDomains`) และ `x-content-type-options: nosniff`
+ก็มีอยู่แล้วก่อน sync — สองตัวนี้จึง**ไม่ใช่**สัญญาณว่า blueprint ถูก apply (สคริปต์
+จึงถือ HSTS ค่า-ไม่-ตรงเป็น warning ไม่ใช่ fail)
+
 **ผลตรวจรอบแรก (เช้าวันเดียวกัน):** ทั้ง `/` และ `/assets/index-B1YyXcfC.js` คืนค่า
 default ของ Render และไม่มี header อื่นจาก render.yaml เลย (ไม่มี CSP-Report-Only/
 X-Frame-Options ฯลฯ) ทั้งที่ site ถูก deploy ใหม่ → header จาก blueprint ยังไม่มีผลจริง
@@ -108,6 +118,11 @@ default คือ [auto-sync ทุกครั้งที่ push blueprint ch
 
 - `frontend/src/__tests__/securityHeaders.test.js` — assert header set ข้างต้นในทั้ง
   render.yaml และ nginx.conf กัน drift/regression
+- `scripts/verify-live-headers.mjs` — external smoke gate (issue #131): curl
+  production จริงแล้ว assert กับ header set ที่ parse จาก render.yaml ตรง ๆ (single
+  source of truth — แก้ render.yaml แล้ว gate ตามอัตโนมัติ) exit 1 เมื่อพบ drift;
+  regression อยู่ที่ `scripts/tests/verify-live-headers.test.mjs` (mock origin บน
+  127.0.0.1 ไม่พึ่งเครือข่าย) เสียบใน `scripts/ci-local.sh` / `.ps1` แล้ว
 - ตรวจจากภายนอกหลัง deploy:
   ```bash
   curl -sI https://smart-port.onrender.com/ | grep -i "content-security\|x-frame\|referrer\|permissions\|strict-transport"

--- a/scripts/ci-local.ps1
+++ b/scripts/ci-local.ps1
@@ -114,6 +114,16 @@ if ($LASTEXITCODE -eq 0) {
   $failed += 'multiplier-validator-regression'
 }
 
+# mock-server regression — ไม่ยิง production จริง (issue #131 Part 2)
+Write-Step 'Live Header Smoke Regression'
+& node --test (Join-Path $Root 'scripts\tests\verify-live-headers.test.mjs')
+if ($LASTEXITCODE -eq 0) {
+  Write-Ok 'live header smoke regression'
+} else {
+  Write-Fail 'live header smoke regression'
+  $failed += 'live-header-smoke-regression'
+}
+
 # ---- 1) Frontend Build & Test ----------------------------------------------
 if (-not $SkipFrontend) {
   Write-Step 'Frontend Build & Test'

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -71,6 +71,14 @@ else
   fail 'multiplier validator regression'
 fi
 
+# mock-server regression — ไม่ยิง production จริง (issue #131 Part 2)
+step 'Live Header Smoke Regression'
+if node --test "${ROOT}/scripts/tests/verify-live-headers.test.mjs"; then
+  ok 'live header smoke regression'
+else
+  fail 'live header smoke regression'
+fi
+
 # ---- 1) Frontend -----------------------------------------------------------
 if [[ "${SKIP_FRONTEND}" -eq 0 ]]; then
   step 'Frontend Build & Test'

--- a/scripts/tests/verify-live-headers.test.mjs
+++ b/scripts/tests/verify-live-headers.test.mjs
@@ -1,0 +1,160 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:http';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { parseRenderHeaders } from '../verify-live-headers.mjs';
+
+// Issue #131 Part 2 — regression ของ live header smoke check
+// เทสแบบ end-to-end ผ่าน CLI (เหมือน validate-multiplier) แต่ชี้ --base-url
+// ไปที่ mock origin บน 127.0.0.1 — CI ไม่ต้องพึ่งเครือข่าย/production
+//
+// หมายเหตุ: ต้องใช้ spawn แบบ async ไม่ใช่ spawnSync เพราะ mock server อยู่ใน
+// process นี้ — spawnSync จะบล็อก event loop จน server รับ request ไม่ได้เลย
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const SCRIPT = resolve(ROOT, 'scripts', 'verify-live-headers.mjs');
+const ASSET = '/assets/index-TEST1234.js';
+const SHELL_HTML = `<!doctype html><html><head><script type="module" src="${ASSET}"></script></head><body>ok</body></html>`;
+
+function run(baseUrl) {
+  return new Promise((resolveRun, rejectRun) => {
+    const child = spawn(process.execPath, [SCRIPT, '--base-url', baseUrl], { cwd: ROOT });
+    let output = '';
+    child.stdout.on('data', (chunk) => (output += chunk));
+    child.stderr.on('data', (chunk) => (output += chunk));
+    const timer = setTimeout(() => {
+      child.kill();
+      rejectRun(new Error('verify-live-headers.mjs ไม่จบภายใน 60s'));
+    }, 60_000);
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      rejectRun(err);
+    });
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      resolveRun({ status: code, output });
+    });
+  });
+}
+
+function startServer({ shell, asset }) {
+  const server = createServer((req, res) => {
+    const headers = req.url === '/' ? shell : req.url === ASSET ? asset : null;
+    if (!headers) {
+      res.statusCode = 404;
+      res.end('not found');
+      return;
+    }
+    for (const [name, value] of Object.entries(headers)) res.setHeader(name, value);
+    res.end(req.method === 'HEAD' ? undefined : SHELL_HTML);
+  });
+  return new Promise((ready) => {
+    server.listen(0, '127.0.0.1', () => {
+      ready({ server, baseUrl: `http://127.0.0.1:${server.address().port}` });
+    });
+  });
+}
+
+test('ผ่านเมื่อ origin ส่ง header ครบตามที่ render.yaml ประกาศ', async () => {
+  // mock origin ที่ "ถูกต้อง" = ส่งทุก header ตาม entries ที่ parse ได้จาก render.yaml จริง
+  const entries = parseRenderHeaders(readFileSync(resolve(ROOT, 'render.yaml'), 'utf8'));
+  const headers = { shell: {}, asset: {} };
+  for (const e of entries) {
+    headers[e.path === '/assets/*' ? 'asset' : 'shell'][e.name] = e.value;
+  }
+  const { server, baseUrl } = await startServer(headers);
+  try {
+    const { status, output } = await run(baseUrl);
+    assert.equal(status, 0, output);
+    assert.match(output, /PASS/);
+  } finally {
+    server.close();
+  }
+});
+
+test('parser แกะได้เฉพาะ block headers: ของ static site (ไม่ชบักไป service อื่น)', () => {
+  const entries = parseRenderHeaders(readFileSync(resolve(ROOT, 'render.yaml'), 'utf8'));
+  const shellNames = entries.filter((e) => e.path === '/*').map((e) => e.name).sort();
+  assert.deepEqual(shellNames, [
+    'Cache-Control',
+    'Content-Security-Policy-Report-Only',
+    'Permissions-Policy',
+    'Referrer-Policy',
+    'Strict-Transport-Security',
+    'X-Content-Type-Options',
+    'X-Frame-Options',
+  ]);
+  const asset = entries.filter((e) => e.path === '/assets/*');
+  assert.equal(asset.length, 1);
+  assert.equal(asset[0].name, 'Cache-Control');
+  assert.equal(asset[0].value, 'public, max-age=31536000, immutable');
+});
+
+test('CSP ถูกผ่อนหรือ HSTS อ่อนกว่าต้อง fail แม้จะมี header ครบทุกตัว', async () => {
+  // reviewer round: substring-match จะมองไม่เห็น directive ที่ถูกเติม source อ่อนกว่า
+  // และ HSTS warn-only ต้องยอมเฉพาะค่าที่แรงกว่า — เคสนี้ต้อง fail ทั้งคู่
+  const entries = parseRenderHeaders(readFileSync(resolve(ROOT, 'render.yaml'), 'utf8'));
+  const headers = { shell: {}, asset: {} };
+  for (const e of entries) {
+    headers[e.path === '/assets/*' ? 'asset' : 'shell'][e.name] = e.value;
+  }
+  headers.shell['Content-Security-Policy-Report-Only'] = headers.shell['Content-Security-Policy-Report-Only'].replace(
+    "script-src 'self'",
+    "script-src 'self' 'unsafe-eval'"
+  );
+  headers.shell['Strict-Transport-Security'] = 'max-age=100';
+  headers.asset['Strict-Transport-Security'] = 'max-age=100';
+
+  const { server, baseUrl } = await startServer(headers);
+  try {
+    const { status, output } = await run(baseUrl);
+    assert.equal(status, 1, output);
+    // CSP ที่ถูกแก้ต้องถูกจับ (directive ที่ผ่อนแล้วไม่ match อีก)
+    assert.ok(output.includes("script-src 'self'"), output);
+    // HSTS อ่อนกว่าต้องเป็น ✗ ไม่ใช่ warning [~]
+    assert.match(output, /✗\] Strict-Transport-Security/);
+    assert.doesNotMatch(output, /~\] Strict-Transport-Security/);
+  } finally {
+    server.close();
+  }
+});
+
+test('ต้อง fail เมื่อเจอ Render/Cloudflare defaults (drift ที่เป็นต้นเหตุของ issue #131)', async () => {
+  // fixture จาก live probe จริง 2026-08-16 ~18:04 UTC ของ smart-port.onrender.com
+  const defaults = {
+    shell: {
+      'Cache-Control': 'public, max-age=0, s-maxage=300',
+      'Strict-Transport-Security': 'max-age=315360000; includeSubdomains; preload',
+      'X-Content-Type-Options': 'nosniff',
+    },
+    asset: {
+      'Cache-Control': 'public, max-age=0, s-maxage=300',
+      'Strict-Transport-Security': 'max-age=315360000; includeSubdomains; preload',
+      'X-Content-Type-Options': 'nosniff',
+    },
+  };
+  const { server, baseUrl } = await startServer(defaults);
+  try {
+    const { status, output } = await run(baseUrl);
+    assert.equal(status, 1, output);
+    assert.match(output, /FAIL/);
+    // header ที่ drift จริงใน production ต้องถูกจับและระบุชื่อครบ
+    for (const name of [
+      'Cache-Control',
+      'Content-Security-Policy-Report-Only',
+      'X-Frame-Options',
+      'Referrer-Policy',
+      'Permissions-Policy',
+    ]) {
+      assert.ok(output.includes(name), `output ต้องระบุ ${name}:\n${output}`);
+    }
+    // X-Content-Type-Options มีค่าถูกอยู่แล้วจึงผ่าน — และ HSTS ค่าที่แรงกว่า (preload)
+    // ต้องเป็นแค่ warning [~] ไม่ใช่สาเหตุของการ fail
+    assert.match(output, /~\] Strict-Transport-Security/);
+  } finally {
+    server.close();
+  }
+});

--- a/scripts/verify-live-headers.mjs
+++ b/scripts/verify-live-headers.mjs
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+// Live header smoke check — issue #131 Part 2 (external drift gate)
+//
+// ทำไมต้องมี: headers ของ render.yaml เคย drift เงียบ ๆ ใน production (issue #113/#125)
+// — live site คืน default ของ Render ทั้งที่ไฟล์ประกาศไว้ครบ พบเจอตอนที่มีคน curl เอง
+// สคริปต์นี้ curl จากภายนอกแล้ว assert กับ header set ที่ "ประกาศจริงใน render.yaml"
+// (parse จากไฟล์ตรง ๆ — expected set จึงไม่ drift จาก render.yaml)
+//
+// Usage: node scripts/verify-live-headers.mjs [--base-url https://smart-port.onrender.com]
+//   --base-url  ใช้ตอนเทสกับ mock server (default = production)
+// Exit 0 = header set ครบตาม render.yaml, Exit 1 = ขาด/ค่าผิด/network fail
+//
+// หมายเหตุ edge layer: production อยู่หลัง Cloudflare ซึ่งอาจเติม header ของตัวเอง
+// (cf-*, และ HSTS ค่าที่แรงกว่า เช่น preload) — เรา assert เฉพาะชุดที่ประกาศใน render.yaml
+// ส่วน HSTS ถ้าค่าจริง "แรงกว่าหรือเท่ากัน" ที่ประกาศ (max-age ≥ และครอบทุก directive)
+// จะเป็นแค่ warning — อ่อนกว่าถือว่า drift และ fail ตัวอย่างจริง: platform default ส่ง
+// max-age=315360000; preload ซึ่งแรงกว่าจึงผ่านเป็น warning
+
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const RENDER_YAML = resolve(ROOT, 'render.yaml');
+const DEFAULT_BASE = 'https://smart-port.onrender.com';
+const FETCH_TIMEOUT_MS = 30_000;
+const FETCH_ATTEMPTS = 2; // gateway DNS เคยหน่วง/ตายเป็นพัก ๆ (handoff 2026-08-16) — retry หนึ่งครั้ง
+
+function parseArgs(argv) {
+  const args = { baseUrl: DEFAULT_BASE };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--base-url' && argv[i + 1]) {
+      args.baseUrl = argv[i + 1].replace(/\/+$/, '');
+      i++;
+    }
+  }
+  return args;
+}
+
+/**
+ * แกะ block `headers:` ของ static site ใน render.yaml เป็นรายการ {path, name, value}
+ * จบ block ด้วยการเทียบ indent กับบรรทัด `headers:` เอง (ระดับ indent เดียวกัน = key
+ * ระดับ service เช่น `routes:` หรือ service ถัดไป) — ถ้าเขียนเป็น regex ตายตัวจะเพี้ยน
+ * ทันทีที่ indent เปลี่ยน แล้วชบักไปกิน name/value ของ service อื่น (เคยเกิดแล้ว:
+ * กิน `name: smartport-backend` + envVar ของ backend) — ถ้าโครงสร้างเปลี่ยนจน parse
+ * ไม่ได้ gate จะ fail-closed พร้อมข้อความชี้จุด ดีกว่าผ่านเงียบ ๆ
+ */
+function parseRenderHeaders(yaml) {
+  const entries = [];
+  let headersIndent = null;
+  let current = null;
+  for (const rawLine of yaml.split(/\r?\n/)) {
+    if (headersIndent === null) {
+      const found = /^(\s*)headers:\s*$/.exec(rawLine);
+      if (found) headersIndent = found[1].length;
+      continue;
+    }
+    const indented = /^(\s*)\S/.exec(rawLine);
+    if (indented && indented[1].length <= headersIndent) {
+      if (current) entries.push(current);
+      current = null;
+      headersIndent = null;
+      continue;
+    }
+    const item = /^(\s*)- path:\s*(\S+)\s*$/.exec(rawLine);
+    if (item) {
+      if (current) entries.push(current);
+      current = { path: item[2] };
+      continue;
+    }
+    const name = /^\s*name:\s*(.+?)\s*$/.exec(rawLine);
+    if (name && current) {
+      current.name = name[1];
+      continue;
+    }
+    const value = /^\s*value:\s*(.+?)\s*$/.exec(rawLine);
+    if (value && current) {
+      current.value = value[1].replace(/^"(.*)"$/, '$1');
+      continue;
+    }
+  }
+  if (current) entries.push(current);
+  return entries.filter((e) => e.name && e.value);
+}
+
+/** สร้างชุดตรวจจาก entries ของ render.yaml — แยกตาม path pattern */
+function buildExpectations(entries) {
+  const byPath = (p) => entries.filter((e) => e.path === p);
+  return {
+    shell: byPath('/*'),
+    asset: byPath('/assets/*'),
+  };
+}
+
+async function fetchWithRetry(url, method) {
+  let lastError;
+  for (let attempt = 1; attempt <= FETCH_ATTEMPTS; attempt++) {
+    try {
+      return await fetch(url, { method, redirect: 'follow', signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+    } catch (err) {
+      lastError = err;
+      if (attempt < FETCH_ATTEMPTS) console.error(`  (retry ${attempt}/${FETCH_ATTEMPTS - 1} หลังจาก: ${err.message})`);
+    }
+  }
+  throw lastError;
+}
+
+/** แยก HSTS เป็น max-age (ตัวเลข) + ชุด directives พิมพ์เล็ก — ใช้เทียบว่าค่าจริง "แรงกว่า" ได้ */
+function parseHsts(value) {
+  const parts = value.split(';').map((p) => p.trim().toLowerCase()).filter(Boolean);
+  const maxAgePart = parts.find((p) => /^max-age=\d+$/.test(p));
+  return {
+    maxAge: maxAgePart ? Number(maxAgePart.split('=')[1]) : NaN,
+    // max-age เทียบเป็นตัวเลขแล้ว จึงไม่รวมในชุด directives (ไม่งั้นค่าที่มากกว่าจะ
+    // กลายเป็น "directive ไม่ match" ทั้งที่จริงคือแรงกว่า)
+    directives: new Set(parts.filter((p) => p !== maxAgePart)),
+  };
+}
+
+/**
+ * เทียบ header จริงกับ expected — คืน array ของผลตรวจ {ok, warn, name, detail}
+ * - exact: ตรงเป๊ะ
+ * - directives (CSP): เทียบเป็นชุด directive หลัง split ';' — tolerant ต่อการเรียง
+ *   ใหม่/whitespace แต่จับได้ว่า directive ไหนถูกผ่อน (เช่น script-src 'self' โดนเติม
+ *   'unsafe-eval' = ไม่ match อีกต่อไป) ส่วน directive ที่มาเกินประกาศเป็น warning
+ * - HSTS: ยอมเป็น warning เฉพาะเมื่อค่าจริง "แรงกว่าหรือเท่ากัน" (max-age ≥ และครอบ
+ *   คลุมทุก directive ของที่ประกาศ) — อ่อนกว่า = fail
+ */
+function checkHeaders(expected, headers, { url }) {
+  const results = [];
+  for (const exp of expected) {
+    if (exp.name === 'Strict-Transport-Security') {
+      const actual = headers.get(exp.name);
+      if (!actual) {
+        results.push({ ok: false, name: exp.name, detail: `ขาดหาย (expected: ${exp.value})` });
+        continue;
+      }
+      const expectedHsts = parseHsts(exp.value);
+      if (Number.isNaN(expectedHsts.maxAge)) {
+        results.push({ ok: false, name: exp.name, detail: `parse ค่า HSTS จาก render.yaml ไม่ได้: "${exp.value}"` });
+        continue;
+      }
+      const actualHsts = parseHsts(actual);
+      const coversAll = [...expectedHsts.directives].every((d) => actualHsts.directives.has(d));
+      const exact = actualHsts.maxAge === expectedHsts.maxAge && actualHsts.directives.size === expectedHsts.directives.size;
+      if (actualHsts.maxAge >= expectedHsts.maxAge && coversAll) {
+        results.push({
+          ok: true,
+          warn: !exact,
+          name: exp.name,
+          detail: exact ? actual : `ค่าจริง "${actual}" แรงกว่า render.yaml "${exp.value}" — ยอมรับได้`,
+        });
+      } else {
+        results.push({
+          ok: false,
+          name: exp.name,
+          detail: `จริง "${actual}" อ่อนกว่า render.yaml "${exp.value}" (max-age น้อยกว่า หรือ directive หาย)`,
+        });
+      }
+      continue;
+    }
+    const actual = headers.get(exp.name);
+    if (!actual) {
+      results.push({ ok: false, name: exp.name, detail: `ขาดหาย (expected: ${exp.value})` });
+      continue;
+    }
+    const mode = exp.name === 'Content-Security-Policy-Report-Only' ? 'directives' : 'exact';
+    if (mode === 'directives') {
+      const actualSet = new Set(actual.split(';').map((d) => d.trim()).filter(Boolean));
+      const expectedList = exp.value.split(';').map((d) => d.trim()).filter(Boolean);
+      const missing = expectedList.filter((d) => !actualSet.has(d));
+      const extra = [...actualSet].filter((d) => !expectedList.includes(d));
+      if (missing.length > 0) {
+        results.push({ ok: false, name: exp.name, detail: `ขาด/ถูกแก้ directives: ${missing.join('; ')}` });
+      } else if (extra.length > 0) {
+        results.push({ ok: true, warn: true, name: exp.name, detail: `มี directives เกินที่ไม่ได้ประกาศ: ${extra.join('; ')}` });
+      } else {
+        results.push({ ok: true, name: exp.name, detail: 'ครบทุก directive ตาม render.yaml' });
+      }
+    } else if (actual.trim() !== exp.value) {
+      results.push({ ok: false, name: exp.name, detail: `จริง "${actual}" ≠ expected "${exp.value}"` });
+    } else {
+      results.push({ ok: true, name: exp.name, detail: actual });
+    }
+  }
+  return results.map((r) => ({ ...r, url }));
+}
+
+function printResults(title, results) {
+  console.log(`\n${title}`);
+  for (const r of results) {
+    const mark = r.ok ? (r.warn ? '~' : '✓') : '✗';
+    console.log(`  [${mark}] ${r.name} — ${r.detail}`);
+  }
+  return results.filter((r) => !r.ok).length;
+}
+
+async function main() {
+  const { baseUrl } = parseArgs(process.argv.slice(2));
+
+  // ใช้ process.exitCode + return (ไม่ใช่ process.exit) — บน Windows process.exit()
+  // ทับกับการเขียน stdout/stderr ที่ยังค้างใน pipe ได้ (เคย crash 0xC0000409 ในเทส)
+  let entries;
+  try {
+    entries = parseRenderHeaders(readFileSync(RENDER_YAML, 'utf8'));
+  } catch (err) {
+    console.error(`✗ อ่าน/parse render.yaml ไม่ได้: ${err.message}`);
+    console.error('  (gate นี้ fail-closed — ถ้า render.yaml เปลี่ยนโครงสร้าง headers: ให้แก้ parseRenderHeaders)');
+    process.exitCode = 1;
+    return;
+  }
+  const expectations = buildExpectations(entries);
+  if (expectations.shell.length === 0 || expectations.asset.length === 0) {
+    console.error('✗ parse render.yaml ได้ header ไม่ครบ (ต้องมีทั้ง path /* และ /assets/*)');
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`Live header smoke check — issue #131`);
+  console.log(`base URL: ${baseUrl}`);
+
+  // 1) app shell: ต้อง GET เพื่อเอา body ไปหาชื่อ asset ปัจจุบัน
+  const shellRes = await fetchWithRetry(baseUrl + '/', 'GET');
+  if (!shellRes.ok) {
+    console.error(`✗ GET / ได้ status ${shellRes.status}`);
+    process.exitCode = 1;
+    return;
+  }
+  const body = await shellRes.text();
+  let shellFailures = printResults(`— App shell (/) —`, checkHeaders(expectations.shell, shellRes.headers, { url: baseUrl + '/' }));
+
+  // 2) hashed asset: ดึงชื่อจาก <script src> ของ shell แล้วตรวจ cache header
+  const assetMatch = /assets\/[\w.-]+\.js/.exec(body);
+  if (!assetMatch) {
+    console.error(`\n✗ หาชื่อ hashed asset (assets/*.js) ใน HTML ไม่ได้ — ตรวจว่า build ยัง emit Vite chunk ปกติ`);
+    process.exitCode = 1;
+    return;
+  }
+  const assetUrl = `${baseUrl}/${assetMatch[0]}`;
+  const assetRes = await fetchWithRetry(assetUrl, 'HEAD');
+  if (!assetRes.ok) {
+    console.error(`✗ HEAD ${assetMatch[0]} ได้ status ${assetRes.status}`);
+    process.exitCode = 1;
+    return;
+  }
+  const assetFailures = printResults(`— Hashed asset (${assetMatch[0]}) —`, checkHeaders(expectations.asset, assetRes.headers, { url: assetUrl }));
+
+  const failures = shellFailures + assetFailures;
+  if (failures > 0) {
+    console.error(`\n✗ FAIL: ${failures} รายการไม่ผ่าน — header จริงไม่ตรงกับ render.yaml`);
+    console.error('  ถ้าเพิ่งแก้ render.yaml: blueprint ต้องถูก Sync จาก Render dashboard ก่อน (auto-deploy ไม่ re-sync)');
+    process.exitCode = 1;
+    return;
+  }
+  console.log(`\n✓ PASS: header set ครบตามที่ประกาศใน render.yaml`);
+}
+
+// export ให้ scripts/tests/verify-live-headers.test.mjs ใช้ parser ตัวเดียวกัน
+export { parseRenderHeaders, buildExpectations };
+
+// รันเป็น CLI เมื่อถูกเรียกตรง ๆ (ไม่ใช่ถูก import)
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    console.error(`✗ ${err.message}`);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary

Implements **Part 2 of issue #131** — an external smoke gate that curls production and asserts the live header set against what `render.yaml` declares, so this class of drift is caught without manual curling (Part 1 — manual Render blueprint Sync — remains blocked on user action).

- `scripts/verify-live-headers.mjs` — fetches `/` + the current hashed asset, asserts the header set **parsed directly from `render.yaml`** (single source of truth: editing render.yaml updates the gate automatically):
  - exact match for X-Frame-Options / Referrer-Policy / Permissions-Policy / X-Content-Type-Options / Cache-Control (both `no-cache` shell and `immutable` asset)
  - CSP compared as a directive set — catches weakened directives (e.g. `script-src 'self'` gaining `'unsafe-eval'`), warns on undeclared extras
  - HSTS: warn-only when the live value is **equal or stronger** (e.g. Cloudflare's `max-age=315360000; preload`); **weaker = fail**
  - fail-closed if the render.yaml structure changes such that parsing fails
- `scripts/tests/verify-live-headers.test.mjs` — 4 regression cases against a mock origin on `127.0.0.1` (no network in CI): pass path, real-world Render/Cloudflare-defaults drift (fixture captured 2026-08-16), parser scope (must not bleed into the backend service block), weakened-CSP + weaker-HSTS must fail
- Wired into `scripts/ci-local.sh` / `.ps1` as an offline gate (the live probe itself is manual/post-deploy — running it in CI would be permanently red until the blueprint is synced)
- `docs/frontend-security-headers.md` — round-3 live verification results (blueprint still not applied; HSTS/XCTO seen today come from the edge layer, not render.yaml)

## Issue

Refs #131 (does **not** close — Part 1 post-sync verification still awaits the manual Render dashboard Sync)

## Verification

- `node --test scripts/tests/verify-live-headers.test.mjs` → 4/4 pass (also run 3× consecutively to rule out flakiness after two Windows-specific fixes: spawnSync blocking the mock server's event loop, and `process.exit()` crashing on pending pipe writes → `process.exitCode` instead)
- `node scripts/verify-live-headers.mjs` against production right now → exits 1 with the expected diagnostics: 5 missing headers on `/` + both Cache-Control precedence violations; stronger HSTS correctly reported as warning
- Reviewer subagent verdict: YES — 2 Important findings (HSTS weaker-value acceptance, CSP substring matching) both fixed in this PR with new regression coverage
- Pre-push vitest hook passed