### PR TITLE
fix(scripts): smoke gate fail-closed on unknown render.yaml path groups

### DIFF
--- a/scripts/tests/verify-live-headers.test.mjs
+++ b/scripts/tests/verify-live-headers.test.mjs
@@ -5,7 +5,7 @@ import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
-import { parseRenderHeaders } from '../verify-live-headers.mjs';
+import { parseRenderHeaders, buildExpectations } from '../verify-live-headers.mjs';
 
 // Issue #131 Part 2 — regression ของ live header smoke check
 // เทสแบบ end-to-end ผ่าน CLI (เหมือน validate-multiplier) แต่ชี้ --base-url
@@ -91,6 +91,25 @@ test('parser แกะได้เฉพาะ block headers: ของ static s
   assert.equal(asset.length, 1);
   assert.equal(asset[0].name, 'Cache-Control');
   assert.equal(asset[0].value, 'public, max-age=31536000, immutable');
+});
+
+test('buildExpectations ต้อง fail-closed เมื่อเจอ path group ที่ยังไม่รองรับ (review follow-up)', () => {
+  // ถ้าข้ามเงียบ ๆ path group ใหม่ใน render.yaml จะผ่าน gate โดยไม่ถูกตรวจ = false-pass
+  assert.throws(
+    () =>
+      buildExpectations([
+        { path: '/*', name: 'X-Frame-Options', value: 'DENY' },
+        { path: '/img/*', name: 'Cache-Control', value: 'public, max-age=86400' },
+      ]),
+    /ไม่รองรับ.*\/img\/\*/
+  );
+  // ชุดที่รองรับทั้งหมดต้องไม่ throw
+  const ok = buildExpectations([
+    { path: '/*', name: 'X-Frame-Options', value: 'DENY' },
+    { path: '/assets/*', name: 'Cache-Control', value: 'public, max-age=31536000, immutable' },
+  ]);
+  assert.equal(ok.shell.length, 1);
+  assert.equal(ok.asset.length, 1);
 });
 
 test('CSP ถูกผ่อนหรือ HSTS อ่อนกว่าต้อง fail แม้จะมี header ครบทุกตัว', async () => {

--- a/scripts/verify-live-headers.mjs
+++ b/scripts/verify-live-headers.mjs
@@ -83,12 +83,24 @@ function parseRenderHeaders(yaml) {
   return entries.filter((e) => e.name && e.value);
 }
 
-/** สร้างชุดตรวจจาก entries ของ render.yaml — แยกตาม path pattern */
+/**
+ * สร้างชุดตรวจจาก entries ของ render.yaml — แยกตาม path pattern
+ * fail-closed: path group ที่ไม่รู้จักต้อง throw ไม่ใช่ข้ามเงียบ ๆ
+ * (ไม่งั้นวันหน้าเพิ่ม tier ใหม่ เช่น /img/* แล้ว header ของ path นั้นจะ
+ * ผ่าน gate โดยไม่ถูกตรวจ — เป็น false-pass ทางเดียวของ gate นี้)
+ */
 function buildExpectations(entries) {
-  const byPath = (p) => entries.filter((e) => e.path === p);
+  const supported = new Set(['/*', '/assets/*']);
+  const unknown = [...new Set(entries.filter((e) => !supported.has(e.path)).map((e) => e.path))];
+  if (unknown.length > 0) {
+    throw new Error(
+      `render.yaml ประกาศ path group ที่ gate นี้ยังไม่รองรับ: ${unknown.join(', ')} — ` +
+        `ขยาย buildExpectations (และเทส) ให้รองรับ path นี้ก่อน ไม่เช่นนั้น header ของ path นั้นจะไม่ถูกตรวจ`
+    );
+  }
   return {
-    shell: byPath('/*'),
-    asset: byPath('/assets/*'),
+    shell: entries.filter((e) => e.path === '/*'),
+    asset: entries.filter((e) => e.path === '/assets/*'),
   };
 }
 


### PR DESCRIPTION
## Summary

Review follow-up to PR #135. The formal code review (per the requesting-code-review skill, range `f45043e..13bcde8`) returned **Yes** with one **Important** finding: `buildExpectations` only recognized `/*` and `/assets/*` and silently skipped any other path group — so a future render.yaml edit adding a new tier (e.g. `/img/*`) would pass the gate **unchecked**, the single false-pass path in an otherwise fail-closed gate.

Fix: unknown path groups now throw with the offending path named (exit 1, extend the gate first). New regression test covers both directions (unknown path throws; supported set passes). 5/5 tests green; behavior against production unchanged (still fails the same 6 drift items).

## Issue

Refs #131

## Verification

- `node --test scripts/tests/verify-live-headers.test.mjs` → 5/5 pass
- `node scripts/verify-live-headers.mjs` → same 6 drift items, exit 1
- Pre-push vitest hook passed