### PR TITLE
fix(deploy): reconcile render.yaml with live services for blueprint adoption

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -6,13 +6,15 @@ services:
     rootDir: frontend
     buildCommand: npm ci && npm run build
     staticPublishPath: dist
+    autoDeployTrigger: commit
     buildFilter:
       paths:
         - frontend/**
         - render.yaml
+    # ค่าจริงตั้งไว้บน Render service แล้ว (dashboard) — sync: false = sync ข้าม ไม่แตะค่าเดิม
     envVars:
       - key: VITE_API_URL
-        value: /api
+        sync: false
     # Issue #113: Render static site ไม่ได้ใช้ frontend/nginx.conf — ต้องประกาศ headers ที่นี่
     # นโยบายเต็ม + cache decision อยู่ใน docs/frontend-security-headers.md
     # CSP เริ่มแบบ report-only เพื่อ inventory ก่อน enforce (report ไปที่ backend /api/csp-report)
@@ -55,41 +57,46 @@ services:
     name: smartport-backend
     runtime: docker
     branch: main
+    # plan/region จาก dashboard export 2026-08-17 — ต้องระบุ ไม่งั้น sync ใช้ค่า default ที่ไม่ตรงของจริง
+    region: singapore
+    plan: free
     # Build จาก repo root เพื่อให้ database/ (ไฟล์ migration) ติดไปกับ image และ
     # docker-entrypoint.sh รัน run-migrations.php ได้เอง — ตัว Dockerfile ที่ root มี
     # production hardening ครบเท่ากับ backend/Dockerfile ทุกข้อ ต่างแค่ COPY database/
     # และตั้ง RUN_MIGRATIONS=1
     #
-    # ⚠️ ต้องเคลียร์ "Root Directory" ในหน้า Render dashboard ของ service นี้ให้ว่าง
-    #    ถ้า dashboard ยังตั้งเป็น backend อยู่ ค่าจะทับ blueprint แล้ว build จะกลับไปใช้
-    #    backend/Dockerfile (ยังทำงานได้ แต่ไม่มี migration = schema ต้อง apply มือ)
-    #    วิธีเช็คว่าใช้ตัวไหน: GET / ของ backend จะคืน migrations_available
+    # (ยืนยันกับ dashboard export 2026-08-17: service จริงใช้ Dockerfile root และ
+    # ไม่ได้ตั้ง Root Directory ทับ — เช็คซ้ำได้ด้วย GET / ของ backend ที่คืน migrations_available)
     rootDir: .
     dockerfilePath: ./Dockerfile
     dockerContext: .
     healthCheckPath: /
+    autoDeployTrigger: commit
     buildFilter:
       paths:
         - backend/**
         - database/**
         - render.yaml
         - Dockerfile
+    # env ทั้ง 8 ตัว (ค่า TiDB + JWT_SECRET) มีค่าจริงอยู่บน Render service แล้ว —
+    # sync: false ทุกตัวเพื่อ adoption แบบไม่ขยับค่าเดิม (รวม JWT_SECRET ไม่โดน regenerate)
+    # ค่าที่ไม่ใช่ความลับที่ควรมีบน service (จดกันหาย): MYSQL_SSL=true,
+    # MYSQL_SSL_CA=/etc/ssl/certs/ca-certificates.crt (CA สาธารณะใน image ใช้ยืนยัน TiDB),
+    # MYSQL_PORT=4000, MYSQL_DATABASE=civil_service_mgmt — เหตุผลเต็ม docs/render-tidb-production.md
     envVars:
       - key: MYSQL_HOST
         sync: false
       - key: MYSQL_PORT
-        value: "4000"
+        sync: false
       - key: MYSQL_DATABASE
-        value: civil_service_mgmt
+        sync: false
       - key: MYSQL_USER
         sync: false
       - key: MYSQL_PASSWORD
         sync: false
       - key: MYSQL_SSL
-        value: "true"
-      # TiDB Serverless chain จบที่ public root CA ซึ่งอยู่ใน /etc/ssl/certs/ca-certificates.crt
-      # ของ image php:8.3-apache อยู่แล้ว — config.php fail-closed ถ้า MYSQL_SSL=true แต่ไม่มี CA (issue #114)
+        sync: false
       - key: MYSQL_SSL_CA
-        value: /etc/ssl/certs/ca-certificates.crt
+        sync: false
       - key: JWT_SECRET
-        generateValue: true
+        sync: false


### PR DESCRIPTION
## Summary

ต้นตอของ #131 Part 1: บัญชี Render **ไม่มี Blueprint instance** — `render.yaml` ใน repo ไม่เคยถูก Render อ่าน เลย headers/buildFilter ไม่มีผลกับ production เลย (แก้ไฟล์แล้ว sync ไม่เกิด เพราะไม่มี blueprint ให้ sync)

PR นี้ reconcile `render.yaml` กับ **config จริงของ service ที่รันอยู่** (dashboard exports 2026-08-17) เพื่อให้การสร้าง Blueprint instance ครั้งถัดไป **adopt service เดิม** แทนการสร้างตัวซ้ำ (docs: name match → apply to existing resource; ถ้า field ไหนไม่ระบุ sync จะใช้ default ที่ไม่ตรงของจริง)

### สิ่งที่เปลี่ยน

- backend: เพิ่ม `plan: free` + `region: singapore` (จาก export — เดิมไม่ระบุ sync จะเปลี่ยน plan/region พัง)
- env vars ทั้ง 9 ตัว → `sync: false` หมด (docs: sync ข้ามตัวที่ sync:false = ค่าบน service จริงอยู่ครบ ไม่ถูกแตะ) — รวม `JWT_SECRET` ที่เดิมเป็น `generateValue: true` → ไม่มีทางโดน regenerate ตอน adoption
- ย้ายค่า non-secret (MYSQL_SSL/CA/PORT/DATABASE) ไปอยู่ใน comment กันหาย + ชี้ไป docs/render-tidb-production.md
- `autoDeployTrigger: commit` ระบุตรงตาม export (default เดียวกัน แต่ระบุชัด)
- คงไว้: `buildCommand: npm ci` (พิสูจน์แล้วใน CI/Docker/ci-local), buildFilter, headers ทั้งชุด (ไม่แตะ) — headers จะมีผลจริงเมื่อ blueprint adopt

## Linked issue

Closes #131 (เมื่อ Blueprint instance ถูกสร้างและ header ตรวจผ่าน — มี step ยืนยันแยกด้านล่าง)

## Schema/API notes

ไม่มี — แตะไฟล์เดียวคือ `render.yaml`

## Verification

- `node scripts/tests/verify-live-headers.test.mjs` — 5/5 ผ่าน (parser อ่าน render.yaml ใหม่ได้, fail-closed ยังอยู่)
- `npm test` — 560/560 ผ่าน (รวม `securityHeaders.test.js` 9/9)
- Reviewer subagent: **Ship**, 0 Critical / 0 Important (Minor 3 ข้อ — แก้ข้อค่า env หายแล้ว 1, อีก 2 เป็น informational)

## หลัง merge — ขั้นตอน adoption (ต้องกดใน Render dashboard)

1. **New > Blueprint** → connect repo นี้ → branch `main` → path `render.yaml`
2. **ดูหน้า review ก่อนกด Deploy Blueprint**: ต้องเป็นการ apply เข้า `smart-port` / `smartport-backend` ตัวเดิม — ถ้าเห็นชื่อมี suffix (`smart-port-xxxx`) = กำลังจะสร้างตัวซ้ำ ให้หยุด
3. Sync แรกจะ trigger rebuild ทั้งสอง service (buildCommand/buildFilter/headers เปลี่ยน) — คาดว่าผ่าน
4. ยืนยัน: `node scripts/verify-live-headers.mjs` ต้อง ✓ PASS + `curl -s https://smart-port.onrender.com/api/readyz` ยังตอบ 200