### PR TITLE
fix(deploy): order assets Cache-Control rule first — Render applies first match

### DIFF
--- a/docs/frontend-security-headers.md
+++ b/docs/frontend-security-headers.md
@@ -74,6 +74,16 @@ HSTS จริงเป็น `max-age=315360000; includeSubdomains; preload` �
 ก็มีอยู่แล้วก่อน sync — สองตัวนี้จึง**ไม่ใช่**สัญญาณว่า blueprint ถูก apply (สคริปต์
 จึงถือ HSTS ค่า-ไม่-ตรงเป็น warning ไม่ใช่ fail)
 
+**ผลตรวจ 2026-08-17 รอบที่ 4 (~06:35 UTC) หลังสร้าง Blueprint instance (associate existing):**
+header ทั้งชุดขึ้นจริงครั้งแรก — CSP-Report-Only / X-Frame-Options / Referrer-Policy /
+Permissions-Policy / XCTO และ `Cache-Control: no-cache` บน shell (backend ยืนที่ `075483f`,
+`/api/*` rewrite ยังใช้ได้) root cause ของรอบ 1–3: **บัญชี Render ไม่เคยมี Blueprint instance
+เลย** — render.yaml ไม่เคยถูกอ่าน ต้องสร้าง instance แบบ *Associate existing services*
+(PR #137 reconcile ให้ config ตรงของจริงก่อน) กุญแจที่ได้มาพร้อมรอบนี้: **precedence
+ของ path ที่ทับกัน = กฎที่เรียงก่อนหน้าชนะ** (กฎ `/*` ที่ขึ้นก่อนกลบกฎ `/assets/*` ที่เฉพาะกว่า
+จน asset ได้ `no-cache` แทน `immutable`) → ต้องเรียงกฎ immutable ของ assets ไว้ก่อนกฎ
+`no-cache` ของ shell (docs ของ Render ไม่ระบุเรื่องนี้ สรุปจากการวัดจริงเท่านั้น)
+
 **ผลตรวจรอบแรก (เช้าวันเดียวกัน):** ทั้ง `/` และ `/assets/index-B1YyXcfC.js` คืนค่า
 default ของ Render และไม่มี header อื่นจาก render.yaml เลย (ไม่มี CSP-Report-Only/
 X-Frame-Options ฯลฯ) ทั้งที่ site ถูก deploy ใหม่ → header จาก blueprint ยังไม่มีผลจริง

--- a/render.yaml
+++ b/render.yaml
@@ -37,14 +37,15 @@ services:
       - path: /*
         name: Strict-Transport-Security
         value: max-age=31536000; includeSubDomains
+      # ลำดับสำคัญ — Render ใช้กฎแรกที่ match (วัดจริง 2026-08-17: กฎ /* ขึ้นก่อนจะกลบ /assets/*)
+      # hashed assets ต้องเรียงไว้ก่อน: URL ผูกกับ hash จึง cache ถาวรได้ปลอดภัย
+      - path: /assets/*
+        name: Cache-Control
+        value: public, max-age=31536000, immutable
       # app shell: revalidate ทุกครั้ง — กัน stale shell ที่ชี้ hashed chunk หาย (เหตุผลเดียวกับ nginx.conf)
       - path: /*
         name: Cache-Control
         value: no-cache
-      # Vite hashed assets — cache ถาวรได้ปลอดภัย
-      - path: /assets/*
-        name: Cache-Control
-        value: public, max-age=31536000, immutable
     routes:
       - type: rewrite
         source: /api/*


### PR DESCRIPTION
## Summary

หลัง blueprint adopt สำเร็จ (PR #137) gate ตรวจได้ 7/8 — เหลือเดียว: `/assets/*` ได้ `no-cache` จากกฎ `/*` แทนที่จะเป็น `immutable`

**สิ่งที่วัดได้จาก production (round 4):** precedence ของ Render static-site headers เมื่อหลายกฎ match path เดียวกัน = **กฎที่เรียงก่อนชนะ** ไม่ใช่กฎที่ specific กว่า (docs ไม่ระบุเรื่องนี้ — สรุปจากการวัดจริงเท่านั้น) กฎ `/*` ที่เขียนไว้ก่อนจึงกลบ `/assets/*`

**แก้:** สลับลำดับ — `/assets/*` (immutable) ขึ้นก่อน `/*` (no-cache) → assets โดน match ที่กูล immutable ก่อน ส่วน shell ตกไปที่กูล `/*` = no-cache เหมือนเดิม + จดหลักฐาน precedence ลง comment และ `docs/frontend-security-headers.md` (round 4)

## Linked issue

#131 — เป็น fix ปลายทางหลัง blueprint adopt สำเร็จ

## Verification

- `node scripts/tests/verify-live-headers.test.mjs` — 5/5 ผ่าน
- `npx vitest run src/__tests__/securityHeaders.test.js` — 9/9 ผ่าน (เทสไม่ผูกลำดับ ไม่กระทบ)
- pre-push vitest เต็มชุด 560/560 ผ่าน
- หลัง merge: auto-sync deploy แล้วรัน `node scripts/verify-live-headers.mjs` ต้อง PASS เต็ม 8/8 (จะยืนยันใน #131)