### PR TITLE
fix(deploy): single no-cache rule — Render header overlap is non-deterministic

### DIFF
--- a/docs/frontend-security-headers.md
+++ b/docs/frontend-security-headers.md
@@ -50,10 +50,13 @@ report-uri /api/csp-report     ← เฉพาะ render.yaml (report-only phas
 
 ## Cache behavior (app shell) — decision
 
-- **Shell (`index.html`, path อื่น ๆ):** `Cache-Control: no-cache` (render.yaml) /
-  `no-store` (nginx) — revalidate ทุกครั้ง กัน stale shell ที่อ้างอิง hashed chunk ที่หายไปแล้ว
-- **Hashed assets (`/assets/*`):** `public, max-age=31536000, immutable` — เนื้อหาผูกกับ
-  hash ในชื่อไฟล์ เปลี่ยนเมื่อไหร่ URL เปลี่ยนเมื่อนั้น
+- **Render (production) — กฎเดียวทั้ง site (shell + hashed assets):** `Cache-Control: no-cache`
+  — revalidate ทุกครั้ง (ETag ทำให้ได้ 304 เมื่อเนื้อหาไม่เปลี่ยน) กัน stale shell ที่อ้างอิง
+  hashed chunk ที่หายไปแล้ว เหตุผลที่ไม่แยกกฎ `immutable` ให้ assets บน Render:
+  engine จัดกฎ Cache-Control ซ้อนทับ (`/*` + `/assets/*`) แบบ non-deterministic
+  (วัดจริง 2026-08-17 รอบ 5 — ด้านล่าง)
+- **nginx (Docker local):** shell `no-store` แต่ `/assets/*` ยังเป็น `public, immutable`
+  ได้ เพราะ location matching ของ nginx เป็น longest-prefix deterministic
 - ข้อมูล auth ไม่เคยถูก cache (มาทาง `/api/*` ของ backend)
 
 ## Live verification — Render Cache-Control precedence (issue #125)
@@ -79,10 +82,19 @@ header ทั้งชุดขึ้นจริงครั้งแรก —
 Permissions-Policy / XCTO และ `Cache-Control: no-cache` บน shell (backend ยืนที่ `075483f`,
 `/api/*` rewrite ยังใช้ได้) root cause ของรอบ 1–3: **บัญชี Render ไม่เคยมี Blueprint instance
 เลย** — render.yaml ไม่เคยถูกอ่าน ต้องสร้าง instance แบบ *Associate existing services*
-(PR #137 reconcile ให้ config ตรงของจริงก่อน) กุญแจที่ได้มาพร้อมรอบนี้: **precedence
-ของ path ที่ทับกัน = กฎที่เรียงก่อนหน้าชนะ** (กฎ `/*` ที่ขึ้นก่อนกลบกฎ `/assets/*` ที่เฉพาะกว่า
-จน asset ได้ `no-cache` แทน `immutable`) → ต้องเรียงกฎ immutable ของ assets ไว้ก่อนกฎ
-`no-cache` ของ shell (docs ของ Render ไม่ระบุเรื่องนี้ สรุปจากการวัดจริงเท่านั้น)
+(PR #137 reconcile ให้ config ตรงของจริงก่อน) จุดที่ยังไม่ผ่านรอบนี้: asset ได้ `no-cache`
+จากกฎ `/*` แทน `immutable` จากกฎ `/assets/*`
+
+**ผลตรวจ 2026-08-17 รอบที่ 5 (~07:04–07:45 UTC) — precedence ของกฎซ้อนทับคือ
+non-deterministic:** สมมติฐานแรกคือ "กฎแรกที่ match ชนะ" เลยสลับลำดับให้กฎ `/assets/*`
+ขึ้นก่อน (PR #138) — แต่หลัง sync จริง (deploy 07:04 UTC + manual sync) ค่ายังแกว่ง
+~90/10 ต่อ request: ยิง URL asset เดิมซ้ำ 3 ครั้งติดกันได้ทั้ง `immutable` และ `no-cache`,
+HEAD ตรง origin (cf MISS) ก็สลับค่าเช่นกัน (ไม่ใช่ edge cache) สรุป: **engine ของ Render
+จัดกฎ Cache-Control สองตัวที่ path ทับกันแบบไม่ deterministic** (สลับลำดับก็ไม่ช่วย —
+docs ของ Render ไม่ระบุเรื่องนี้ สรุปจากการวัดจริงเท่านั้น) → **decision รอบปลาย: ตัดกฎ
+`/assets/*` ออก เหลือ `no-cache` เดียวทั้ง site** (PR #139) ยอมแลก asset caching กับความ
+deterministic เพราะ stale shell ที่ชี้ chunk หาย แพงกว่า perf ที่เสียจาก revalidate
+(ETag ยังทำให้ได้ 304 เมื่อเนื้อหาไม่เปลี่ยน)
 
 **ผลตรวจรอบแรก (เช้าวันเดียวกัน):** ทั้ง `/` และ `/assets/index-B1YyXcfC.js` คืนค่า
 default ของ Render และไม่มี header อื่นจาก render.yaml เลย (ไม่มี CSP-Report-Only/
@@ -93,26 +105,10 @@ default คือ [auto-sync ทุกครั้งที่ push blueprint ch
 และ [docs ของ static-site headers](https://render.com/docs/static-site-headers)
 ไม่ระบุ precedence สำหรับ path pattern ที่ทับกัน จึงต้องวัดจริงเท่านั้น
 
-**Checklist หลังทำให้ blueprint sync จริง + deploy ใหม่:**
-
-0. ที่ Render dashboard → Blueprint: ตรวจ sync status / auto-sync setting ว่าเปิดอยู่
-1. ตรวจว่า header set ออกครบ (คำสั่งเดียวกับ section "การทดสอบ" ข้างล่าง):
-   ```bash
-   curl -sI https://smart-port.onrender.com/ | grep -i "content-security\|x-frame\|referrer\|permissions\|strict-transport"
-   ```
-2. ตรวจ Cache-Control precedence:
-   ```bash
-   curl -sI https://smart-port.onrender.com/ | grep -i cache-control
-   # ต้องได้: no-cache
-   curl -sI https://smart-port.onrender.com/assets/index-B1YyXcfC.js | grep -i cache-control
-   # (แทนชื่อ asset ปัจจุบันจาก <script src> ในหน้าเว็บ) ต้องได้: public, max-age=31536000, immutable
-   ```
-
-- ถ้า step 1 ยังไม่มี header เลยแม้ sync แล้ว → ตรวจว่า static site ถูก manage โดย
-  blueprint นี้จริงหรือไม่ (dashboard ของ service ต้องชี้มาที่ render.yaml นี้)
-- ถ้า `/assets/*` ได้ค่าถูกต้อง → บันทึกผลจริงแทน section นี้, ปิดประเด็น precedence
-- ถ้า `no-cache` ชนะบน assets (worst case ของ issue) → restructure: ยกเลิกกฎ `/*`
-  แล้วตั้ง `no-cache` เฉพาะ path เอกสาร (หรือแนวทางอื่นตาม behavior ที่วัดได้)
+**Checklist นี้จบแล้ว (resolved รอบ 4–5, 2026-08-17):** blueprint adopt สำเร็จ header
+ครบ และ Cache-Control ใช้กฎเดียว `no-cache` ทั้ง site — การตรวจประจำวันใช้
+`node scripts/verify-live-headers.mjs` อย่างเดียว (gate อ่าน render.yaml เป็น source of
+truth และ fail-closed เมื่อโครงสร้างเปลี่ยน)
 
 ## CSP monitoring ก่อน enforce
 

--- a/frontend/src/__tests__/securityHeaders.test.js
+++ b/frontend/src/__tests__/securityHeaders.test.js
@@ -49,10 +49,13 @@ describe('render.yaml security headers (Render static-site path)', () => {
     expect(renderYaml).toContain('max-age=31536000; includeSubDomains')
   })
 
-  it('documents the cache decision: shell revalidates, hashed assets immutable', () => {
+  it('documents the cache decision: single deterministic no-cache rule for the whole site', () => {
     expect(renderYaml).toMatch(/Cache-Control\s*\n\s*value:\s*no-cache/)
-    expect(renderYaml).toContain('/assets/*')
-    expect(renderYaml).toContain('public, max-age=31536000, immutable')
+    // 2026-08-17: ตัดกฎ /assets/* immutable ออก — Render จัดกฎ Cache-Control ซ้อนทับ
+    // แบบ non-deterministic (วัดจริง) เหลือกฎเดียว no-cache ทั้ง site
+    // (คำว่า immutable ยังได้อยู่ใน comment อธิบายเหตุผล — เลยยืนที่ path rule + value)
+    expect(renderYaml).not.toMatch(/- path: \/assets\//)
+    expect(renderYaml).not.toMatch(/value:\s*public, max-age=\d+, immutable/)
   })
 
   it('does not reintroduce the old broad CSP allowances', () => {

--- a/render.yaml
+++ b/render.yaml
@@ -37,12 +37,11 @@ services:
       - path: /*
         name: Strict-Transport-Security
         value: max-age=31536000; includeSubDomains
-      # ลำดับสำคัญ — Render ใช้กฎแรกที่ match (วัดจริง 2026-08-17: กฎ /* ขึ้นก่อนจะกลบ /assets/*)
-      # hashed assets ต้องเรียงไว้ก่อน: URL ผูกกับ hash จึง cache ถาวรได้ปลอดภัย
-      - path: /assets/*
-        name: Cache-Control
-        value: public, max-age=31536000, immutable
-      # app shell: revalidate ทุกครั้ง — กัน stale shell ที่ชี้ hashed chunk หาย (เหตุผลเดียวกับ nginx.conf)
+      # Cache-Control กฎเดียวทั้ง site: no-cache — browser revalidate ทุกครั้ง (ETag ทำให้ได้ 304)
+      # อดีตเคยแยกกฎ immutable ให้ assets แต่วัดจริง 2026-08-17: engine ของ Render จัดกฎ
+      # Cache-Control สองตัวที่ path ทับกันแบบไม่ deterministic (ค่าแกว่ง ~90/10 ต่อ request
+      # แม้สลับลำดับกฎ) — เลือกกฎเดียวที่ deterministic เพราะความเสี่ยง stale shell แพงกว่า
+      # ผลได้จาก asset caching — ทางกลับมาใช้ immutable: docs/frontend-security-headers.md
       - path: /*
         name: Cache-Control
         value: no-cache

--- a/scripts/tests/verify-live-headers.test.mjs
+++ b/scripts/tests/verify-live-headers.test.mjs
@@ -60,11 +60,13 @@ function startServer({ shell, asset }) {
 
 test('ผ่านเมื่อ origin ส่ง header ครบตามที่ render.yaml ประกาศ', async () => {
   // mock origin ที่ "ถูกต้อง" = ส่งทุก header ตาม entries ที่ parse ได้จาก render.yaml จริง
+  // (กฎเดียว /* ครอบทั้ง site — asset จึงได้ชุดเดียวกับ shell ตาม fallback ของ buildExpectations)
   const entries = parseRenderHeaders(readFileSync(resolve(ROOT, 'render.yaml'), 'utf8'));
   const headers = { shell: {}, asset: {} };
   for (const e of entries) {
-    headers[e.path === '/assets/*' ? 'asset' : 'shell'][e.name] = e.value;
+    headers.shell[e.name] = e.value;
   }
+  headers.asset = { ...headers.shell };
   const { server, baseUrl } = await startServer(headers);
   try {
     const { status, output } = await run(baseUrl);
@@ -87,10 +89,12 @@ test('parser แกะได้เฉพาะ block headers: ของ static s
     'X-Content-Type-Options',
     'X-Frame-Options',
   ]);
-  const asset = entries.filter((e) => e.path === '/assets/*');
-  assert.equal(asset.length, 1);
-  assert.equal(asset[0].name, 'Cache-Control');
-  assert.equal(asset[0].value, 'public, max-age=31536000, immutable');
+  // 2026-08-17: ตัดกฎ /assets/* (immutable) ออก — Render จัดกฎ Cache-Control ซ้อนทับ
+  // แบบ non-deterministic เหลือกฎเดียว no-cache ทั้ง site ถ้ามี /assets/* โผล่มาอีก
+  // = มีคนกลับไปใช้กฎซ้อนทับ ซึ่ง gate จะเริ่มตรวจไม่ deterministic อีก — ต้องรู้ตัว
+  assert.equal(entries.filter((e) => e.path === '/assets/*').length, 0);
+  const cacheControl = entries.find((e) => e.name === 'Cache-Control');
+  assert.equal(cacheControl.value, 'no-cache');
 });
 
 test('buildExpectations ต้อง fail-closed เมื่อเจอ path group ที่ยังไม่รองรับ (review follow-up)', () => {
@@ -110,6 +114,11 @@ test('buildExpectations ต้อง fail-closed เมื่อเจอ path g
   ]);
   assert.equal(ok.shell.length, 1);
   assert.equal(ok.asset.length, 1);
+  // 2026-08-17: เมื่อไม่มีกฎ /assets/* เลย (โครงสร้างปัจจุบัน) ให้ asset ตรวจด้วยชุดของ /*
+  const single = buildExpectations([{ path: '/*', name: 'X-Frame-Options', value: 'DENY' }]);
+  assert.equal(single.shell.length, 1);
+  assert.equal(single.asset.length, 1);
+  assert.equal(single.asset[0].name, 'X-Frame-Options');
 });
 
 test('CSP ถูกผ่อนหรือ HSTS อ่อนกว่าต้อง fail แม้จะมี header ครบทุกตัว', async () => {
@@ -118,8 +127,9 @@ test('CSP ถูกผ่อนหรือ HSTS อ่อนกว่าต้�
   const entries = parseRenderHeaders(readFileSync(resolve(ROOT, 'render.yaml'), 'utf8'));
   const headers = { shell: {}, asset: {} };
   for (const e of entries) {
-    headers[e.path === '/assets/*' ? 'asset' : 'shell'][e.name] = e.value;
+    headers.shell[e.name] = e.value;
   }
+  headers.asset = { ...headers.shell };
   headers.shell['Content-Security-Policy-Report-Only'] = headers.shell['Content-Security-Policy-Report-Only'].replace(
     "script-src 'self'",
     "script-src 'self' 'unsafe-eval'"

--- a/scripts/verify-live-headers.mjs
+++ b/scripts/verify-live-headers.mjs
@@ -98,10 +98,12 @@ function buildExpectations(entries) {
         `ขยาย buildExpectations (และเทส) ให้รองรับ path นี้ก่อน ไม่เช่นนั้น header ของ path นั้นจะไม่ถูกตรวจ`
     );
   }
-  return {
-    shell: entries.filter((e) => e.path === '/*'),
-    asset: entries.filter((e) => e.path === '/assets/*'),
-  };
+  const shell = entries.filter((e) => e.path === '/*');
+  const asset = entries.filter((e) => e.path === '/assets/*');
+  // 2026-08-17: render.yaml ใช้กฎ Cache-Control เดียว (/*) ทั้ง site เพราะ engine ของ Render
+  // จัดกฎซ้อนทับ (/* + /assets/*) แบบไม่ deterministic — เมื่อไม่มีกฎ /assets/* ให้ตรวจ
+  // asset ด้วยชุดของ /* เพื่อยืนยันว่าทุก path ได้ค่าเดียวกัน deterministic
+  return { shell, asset: asset.length > 0 ? asset : shell };
 }
 
 async function fetchWithRetry(url, method) {
@@ -222,8 +224,8 @@ async function main() {
     return;
   }
   const expectations = buildExpectations(entries);
-  if (expectations.shell.length === 0 || expectations.asset.length === 0) {
-    console.error('✗ parse render.yaml ได้ header ไม่ครบ (ต้องมีทั้ง path /* และ /assets/*)');
+  if (expectations.shell.length === 0) {
+    console.error('✗ parse render.yaml ไม่ได้ header ของ path /* (ต้องมีอย่างน้อยกฎของ /*)');
     process.exitCode = 1;
     return;
   }


### PR DESCRIPTION
## Summary

ต่อจาก PR #138 — สมมติฐาน "first-match-wins" ผิด: หลัง sync จริง (manual sync ยืนยัน commit) ค่า Cache-Control ของ asset **ยังแกว่ง ~90/10 ต่อ request** แม้ HEAD ตรง origin (cf MISS) ไม่ใช่ edge cache — engine ของ Render จัดกฎ Cache-Control สองตัวที่ path ทับกันแบบ **non-deterministic** (สลับลำดับแล้วก็ไม่ช่วย)

**Decision:** ตัดกฎ `/assets/*` (immutable) ออก เหลือกฎเดียว `no-cache` ทั้ง site — deterministic 100% ยอมแลก asset caching (ETag ยังทำให้ได้ 304) เพราะ stale shell ที่ชี้ chunk หายแพงกว่า nginx path (Docker local) เก็บ immutable ได้เพราะ location matching ของ nginx เป็น longest-prefix deterministic

**แก้พร้อมกัน:**
- `verify-live-headers.mjs` — เมื่อ render.yaml ไม่มีกลุ่ม `/assets/*` ให้ตรวจ asset ด้วยชุดของ `/*` (ยืนยันค่าเดียวกันทุก path)
- เทส: mock origin ใช้ชุดเดียวทั้ง site + เคส fallback ใหม่ + ห้ามมีกฎ `/assets/*` โผล่มาอีก (จะไปเปิดช่อง non-deterministic ซ้ำ)
- doc: round 4–5 บันทึกผลวัดจริง (แก้ข้อสรุป first-match-wins ที่ผิด) + cache decision + checklist จบแล้ว

## Linked issue

Closes #131

## Verification

- `node scripts/tests/verify-live-headers.test.mjs` — 5/5 ผ่าน
- `npx vitest run src/__tests__/securityHeaders.test.js` — 9/9 ผ่าน
- pre-push vitest เต็มชุด 560/560 ผ่าน
- หลัง merge + sync: จะยืนยันด้วย gate (`node scripts/verify-live-headers.mjs`) และ poll ความ stable ของค่าจริง