### PR TITLE
docs: บันทึก baseline ของ CSP report-only ก่อนตัดสินใจ enforce

### DIFF
--- a/docs/frontend-security-headers.md
+++ b/docs/frontend-security-headers.md
@@ -1,6 +1,6 @@
 # Frontend Security Headers & Cache Policy (issue #113 — ระยะที่ 1)
 
-อัปเดต: 2026-08-16
+อัปเดต: 2026-08-17
 
 ## Deploy paths และที่ที่ headers ถูกประกาศ
 
@@ -121,6 +121,62 @@ truth และ fail-closed เมื่อโครงสร้างเปล�
 3. วิธี enforce: ใน `render.yaml` เปลี่ยน key `Content-Security-Policy-Report-Only`
    เป็น `Content-Security-Policy` (ค่าเดิม ตัด `report-uri` หรือไว้ต่อก็ได้)
    แล้วอัปเดตเทส `securityHeaders.test.js`
+
+### Baseline check 2026-08-17 (~14:24–14:45 UTC) — วันที่ headers live วันแรก
+
+หน้าต่าง 7 วันเพิ่งเริ่มนับวันนี้ (`last-modified` ของ `/` = 08:18 UTC 17 ส.ค. — เวลา deploy
+ของ PR #139; header ขึ้นจริงตั้งแต่รอบ 4 ~06:35 UTC ใช้ค่าที่ช้ากว่าเพื่อความอนุรักษ์นิยม)
+→ **จุดตัดสินใจ enforce เร็วที่สุดคือ 24 ส.ค. 2026** วันนี้เก็บได้แค่ baseline
+
+- **pipeline ส่งถึง endpoint ได้จริง**: POST self-test ไป `https://smart-port.onrender.com/api/csp-report`
+  (ผ่าน rewrite `/api/*` แบบเดียวกับที่ browser ใช้) → **HTTP 204** ตามสัญญาของ handler
+  marker ที่ใช้คือ `blocked-host=csp-selftest.invalid` (directive `img-src`) — **เวลา ~14:45 UTC
+  17 ส.ค. เป็นของทีม ไม่ใช่ violation จริง ให้ตัดทิ้งตอนอ่าน log** (ความสำคัญ: ถ้าไม่ยืนยันข้อนี้
+  "log ว่าง" จะแยกไม่ออกระหว่าง "ไม่มี violation" กับ "report ไม่เคยส่งถึง")
+  - **log อยู่ที่ service `smartport-backend` ไม่ใช่ static site `smart-port`** — `error_log()`
+    ที่ handler เรียกออก stderr ของ container backend (`Dockerfile:64` ตั้ง `error_log = /dev/stderr`)
+    เปิด log ผิด service จะเห็นว่างเสมอ และ hop สุดท้าย (`error_log` → Render log stream)
+    ยังไม่เคยถูกยืนยันด้วยตา เพราะ session นี้เข้าถึง Render log ไม่ได้
+  - **ข้อควรระวังที่ยังทำให้ "log ว่าง" ตีความไม่ได้ 100%:** POST นัดแรก timeout ที่ 30 วินาที
+    ต้อง warm up ด้วย `GET /api/readyz` (ตอบ 200 ใน 1.1s) ก่อนจึงยิงผ่าน — สาเหตุยังสรุปไม่ได้
+    ระหว่าง network hiccup ของ gateway (เคยเจอ 16 ส.ค.) กับ cold start แต่ **backend เป็น
+    `plan: free` ที่ spin down เมื่อไม่มี traffic** ซึ่งเป็นกลไกจริง และ CSP report เป็น
+    fire-and-forget ไม่มี retry → report ที่ browser ยิงตอน backend หลับหายเงียบได้
+    ในแอป HR ที่ traffic ต่ำ การเปิดหน้าแรกของวัน (จุดที่ violation จะโผล่พอดี) คือจุดที่
+    backend หลับพอดี นอกจากนี้ handler ยัง rate limit ที่ 60 req/นาที ต่อ IP
+    (`api.php:122`) — หน้าที่มี subresource ถูกบล็อกเยอะอาจชนเพดานจนบาง report ถูกทิ้ง
+  - **ก่อนอ่าน log วันที่ 24 ให้ยิง self-test ใหม่ 1 นัดเพื่อให้ได้ marker สด** (Render retention
+    ของ plan ที่ไม่ใช่ Enterprise ราว 7 วัน = marker ของ 17 ส.ค. จะอยู่ริมขอบพอดีหรือหลุดไปแล้ว)
+    **decision rule: เจอ marker สด → pipeline ครบวงจร ตัด marker ทิ้งแล้วดูที่เหลือ;
+    ไม่เจอ marker → สรุปไม่ได้ ห้าม enforce**
+- **ต้องมี traffic จริงในหน้าต่าง 7 วันด้วย** — เกณฑ์ข้อ 2 มีความหมายก็ต่อเมื่อมีคนเปิดใช้จริง
+  แอปมี ~24 route แต่ audit ด้านล่างครอบคลุมแค่ 6 chunk ถ้าไม่มีใครเปิดหน้าที่เหลือเลย
+  "log ว่าง" แปลว่า "ยังไม่มีใครลอง" ไม่ใช่ "ปลอดภัย" → ก่อน enforce ให้เดินคลิกครบหน้าหลัก
+  (dashboard / personnel / profile ที่มีรูป / import / ocr) โดยเปิด DevTools console ดู
+  violation ตรง ๆ อย่างน้อย 1 รอบ — วิธีนี้ไม่ต้องพึ่ง Render log เลย
+- **static audit ของ bundle production จริง** (entry + **6 จาก ~24** route chunks + CSS
+  ที่ดึงจาก production ไม่ใช่ build ในเครื่อง) ไม่พบสิ่งที่จะชน policy:
+
+  | Directive | ที่วัดได้ |
+  |---|---|
+  | `connect-src 'self'` | API base compile เป็น `"/api"` relative ล้วน ไม่มี absolute URL ใน chunk ที่ตรวจ — หลักฐานที่แข็งกว่า: `grep -rE "https?://" frontend/src` (ไม่นับ tests) ไม่เจออะไรเลย และ API base ประกอบจาก `import.meta.env.VITE_API_URL \|\| '/api'` แค่ 3 จุด (`useApi.js`, `auth.js` ×2) |
+  | `script-src 'self'` | ไม่มี inline `<script>` / `eval(` / `new Function(` / `new Worker` |
+  | `style-src` + `font-src` | external มีแค่ `fonts.googleapis.com` + `fonts.gstatic.com`; CSS bundle ไม่มี `url()` และ build ไม่มีไฟล์ font local |
+  | `img-src 'self' data:` | blob URL ตัวเดียวในโค้ดคือ `OcrPage.vue` (`URL.createObjectURL`) ซึ่งใช้กับ `<a download>` = download ไม่ใช่ subresource จึงไม่อยู่ใต้ directive ใดเลย |
+
+**ความเสี่ยงที่ต้องกันไว้ก่อน enforce (คนละเรื่องกับจำนวน violation ใน log):**
+
+1. `VITE_API_URL` เป็น `sync: false` = ค่าจริงอยู่บน dashboard เท่านั้น bundle ที่ deploy
+   อยู่ตอนนี้ใช้ `/api` (same-origin) จึงผ่าน แต่ยังมีค่าแบบ absolute
+   (`https://smartport-backend.onrender.com/api` — origin เดียวกับ `destination` ของ rewrite
+   ใน render.yaml) จดไว้ในบันทึกค่าคอนฟิกของทีม — **ถ้าใครตั้งค่านั้นกลับเข้า dashboard
+   หลัง enforce จะพังสองชั้นพร้อมกัน**: `connect-src 'self'` บล็อก API call ทั้งหมด **และ**
+   `img-src 'self' data:` บล็อกรูปข้าราชการทุกใบด้วย เพราะ `apiAssetUrl()` ประกอบ URL รูป
+   จาก API base เดียวกัน (`useApi.js:112` → `useProfile.js:43` → `<img :src>` ที่
+   `ProfilePage.vue:63`) — คนที่แก้โดยเติม backend origin เข้า `connect-src` อย่างเดียว
+   จะได้ API กลับมาแต่รูปยังพังทั้งระบบ เช็ค bundle จริงอีกครั้งก่อนกดสวิตช์
+2. `font-src https://fonts.gstatic.com` ไม่มี `'self'` — วันนี้ไม่พังเพราะไม่มี font ใน
+   bundle แต่ถ้าย้ายมา self-host font เมื่อไร จะพังทันทีทั้งที่ดูเหมือนแค่เปลี่ยน asset
 
 ## การทดสอบ
 


### PR DESCRIPTION
## ทำอะไร

บันทึกผลตรวจ CSP report-only วันแรกที่ headers ขึ้น production จริง (#131 ปิดไปเมื่อเช้า) ลง `docs/frontend-security-headers.md` §CSP monitoring — เพื่อให้คนที่มาตัดสินใจ enforce วันที่ **24 ส.ค.** มีข้อมูลพอและไม่ตีความผิด

หน้าต่าง 7 วันเพิ่งเริ่มนับวันนี้ ดังนั้นวันนี้เก็บได้แค่ baseline เท่านั้น

## ทำไมไม่ใช่การอ่าน log ตรง ๆ

Render log เข้าถึงไม่ได้จาก checkout นี้ — ไม่มี `render` CLI และไม่มี API key ที่ไหนเลย จึงใช้การตรวจ 3 ชั้นที่ทำได้จริงแทน แล้วบันทึกทั้งผลและ **ขอบเขตของสิ่งที่ยังพิสูจน์ไม่ได้**

1. **liveness** — `HEAD /` คืน `content-security-policy-report-only` ครบพร้อม `report-uri /api/csp-report`
2. **self-test ของ report pipeline** — `POST /api/csp-report` ผ่าน rewrite `/api/*` เส้นเดียวกับที่ browser ใช้ → **HTTP 204** marker คือ `blocked-host=csp-selftest.invalid` (`.invalid` เป็น reserved TLD จึงชนกับ host จริงไม่ได้)
3. **static audit ของ bundle production จริง** — ดึง entry + 6 route chunks + CSS จาก production (ไม่ใช่ build ในเครื่อง) ไม่พบสิ่งที่ชน policy

## Guard rail ที่ใส่ไว้ให้คนตัดสินใจวันที่ 24

- **log อยู่ที่ service `smartport-backend` ไม่ใช่ static site** (`Dockerfile:64` ส่ง `error_log` ออก stderr) — เปิดผิด service จะเห็นว่างแล้วสรุปผิดทันที
- **"log ว่าง" ยังไม่ใช่หลักฐานว่าไม่มี violation** — self-test ผ่านหลัง warm up `/api/readyz` เท่านั้น (สาเหตุ timeout นัดแรกยังสรุปไม่ได้ระหว่าง gateway hiccup กับ cold start) แต่ backend เป็น `plan: free` ที่ spin down จริง และ CSP report เป็น fire-and-forget ไม่มี retry + rate limit 60 req/นาที ก็ทิ้ง report ได้อีกทาง
- **ยิง self-test ใหม่ก่อนอ่าน log** — Render retention ~7 วัน marker ของวันนี้จะอยู่ริมขอบพอดี **decision rule: เจอ marker สด → ตัดทิ้งแล้วดูที่เหลือ / ไม่เจอ → สรุปไม่ได้ ห้าม enforce**
- **ต้องมี traffic จริงหนุนด้วย** — แอปมี ~24 route แต่ audit ครอบคลุม 6 chunk ให้เดินคลิกหน้าหลักโดยเปิด DevTools console แทนการเชื่อความเงียบของ log

## ความเสี่ยงที่จดเพิ่ม (คนละเรื่องกับจำนวน violation)

1. `VITE_API_URL` เป็น `sync: false` — ถ้าตั้งกลับเป็น absolute URL หลัง enforce จะพัง **สองชั้น**: `connect-src` บล็อก API call ทั้งหมด และ `img-src` บล็อกรูปข้าราชการทุกใบ (เพราะ `apiAssetUrl()` ประกอบ URL รูปจาก API base เดียวกัน: `useApi.js:112` → `useProfile.js:43` → `ProfilePage.vue:63`) คนที่แก้เฉพาะ `connect-src` จะได้ API กลับมาแต่รูปยังพัง
2. `font-src https://fonts.gstatic.com` ไม่มี `'self'` — ไม่พังวันนี้เพราะไม่มี font ใน bundle แต่พังทันทีถ้าย้ายมา self-host

## Test plan

- [x] `frontend/src/__tests__/securityHeaders.test.js` — 9/9 ผ่าน (ยืนยันว่า `render.yaml`/`nginx.conf` ไม่ถูกแตะ)
- [x] pre-push gate เต็ม — **560/560 ผ่าน (74 ไฟล์)**
- [x] ตรวจ claim ทุกข้อกับโค้ดจริง: `Dockerfile:64`, router มี 27 dynamic import, `grep -rE "https?://" frontend/src` ไม่เจออะไรเลย, `ProfilePage.vue:63` ผูก `<img :src>` กับ `apiAssetUrl()` จริง
- [x] ผ่าน code review (reviewer subagent): แก้ครบ 1 Critical + 6 Important + 4 Minor
- n/a GitHub Actions ปิด auto-trigger ตาม `.github/workflows/ci.yml` (quota)

## ยังไม่ทำในนี้ (เสนอไว้จาก review)

เกณฑ์ enforce ทั้งหมดยังผูกกับการ "เปิด Render log ดูด้วยตา" ซึ่ง automation ในโปรเจกต์เข้าถึงไม่ได้เลย — ทางแก้ที่คุ้มกว่าคือให้ handler persist counter แล้วเปิด endpoint อ่านสรุป (เกณฑ์จะ query ได้และเขียนเป็นเทสได้), ยก static audit เป็นสคริปต์ที่ไล่ import graph ครบทุก chunk เสียบ `ci-local.*`, และทำ `scripts/csp-report-selftest.mjs` ที่ warm up ก่อนยิง marker ผูกวันที่ — ทั้งสามเป็น scope ใหม่ ไม่รวมใน PR นี้
