### PR TITLE
feat(scripts): CSP report self-test ยิง marker สดก่อนอ่าน log

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -25,6 +25,12 @@ if [[ ! -d "${FRONTEND}/node_modules" ]]; then
   exit 1
 fi
 
+# Script regressions (mock server ในเครื่อง ไม่ออกเน็ต) — ~15s เร็วกว่า vitest มาก
+# รันก่อนเพื่อ fail เร็ว และเพราะ Actions ปิด auto-trigger อยู่ hook นี้คือที่เดียวที่
+# gate พวกนี้ถูกบังคับจริงทุกครั้ง (schema parity validator / live header / CSP self-test)
+echo "[pre-push] script regressions (node --test scripts/tests) ..."
+node --test "${ROOT}"/scripts/tests/*.test.mjs
+
 echo "[pre-push] frontend vitest (forks pool from vitest.config.js) ..."
 cd "${FRONTEND}"
 npx vitest run --reporter=dot

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,10 @@ jobs:
       # และกัน migration ใหม่ที่ลืม mount ใน docker-compose / ไฟล์นี้
       - name: Validate schema parity
         run: node scripts/validate-schema-parity.mjs
+      # regression ของสคริปต์ใน scripts/ — mock server บน 127.0.0.1 ทั้งหมด ไม่ออกเน็ต
+      # (gate ที่บังคับจริงทุกครั้งคือ .githooks/pre-push เพราะ workflow นี้ปิด auto-trigger อยู่)
+      - name: Script regressions (offline mock servers)
+        run: node --test scripts/tests/*.test.mjs
 
   backend-tests:
     name: Backend PHPUnit (Unit + Integration)

--- a/docs/frontend-security-headers.md
+++ b/docs/frontend-security-headers.md
@@ -138,15 +138,38 @@ truth และ fail-closed เมื่อโครงสร้างเปล�
     เปิด log ผิด service จะเห็นว่างเสมอ และ hop สุดท้าย (`error_log` → Render log stream)
     ยังไม่เคยถูกยืนยันด้วยตา เพราะ session นี้เข้าถึง Render log ไม่ได้
   - **ข้อควรระวังที่ยังทำให้ "log ว่าง" ตีความไม่ได้ 100%:** POST นัดแรก timeout ที่ 30 วินาที
-    ต้อง warm up ด้วย `GET /api/readyz` (ตอบ 200 ใน 1.1s) ก่อนจึงยิงผ่าน — สาเหตุยังสรุปไม่ได้
-    ระหว่าง network hiccup ของ gateway (เคยเจอ 16 ส.ค.) กับ cold start แต่ **backend เป็น
-    `plan: free` ที่ spin down เมื่อไม่มี traffic** ซึ่งเป็นกลไกจริง และ CSP report เป็น
+    ต้อง warm up ด้วย `GET /api/readyz` (ตอบ 200 ใน 1.1s) ก่อนจึงยิงผ่าน — ตอนนั้นสรุปสาเหตุ
+    ไม่ได้ระหว่าง network hiccup ของ gateway (เคยเจอ 16 ส.ค.) กับ cold start
+    **หลักฐานเพิ่ม 2026-08-18 05:00 UTC:** รอบนั้น request แรกคือ `GET /api/readyz` เอง
+    และใช้เวลา **23.1 วินาที** ส่วน POST ถัดมาเร็วปกติ — รูปแบบ "request แรกที่ชน container
+    ที่หลับช้ามาก ถัดไปเร็ว" ตรงกันทั้งสองรอบ จึงอธิบายได้ด้วย spin down อย่างเดียวโดยไม่ต้อง
+    พึ่ง network hiccup (ยังเป็นการวัดครั้งเดียว ไม่ใช่ข้อพิสูจน์ปิดตาย) และยิ่งตอกย้ำว่า
+    **backend เป็น `plan: free` ที่ spin down เมื่อไม่มี traffic** ซึ่งเป็นกลไกจริง และ CSP report เป็น
     fire-and-forget ไม่มี retry → report ที่ browser ยิงตอน backend หลับหายเงียบได้
     ในแอป HR ที่ traffic ต่ำ การเปิดหน้าแรกของวัน (จุดที่ violation จะโผล่พอดี) คือจุดที่
     backend หลับพอดี นอกจากนี้ handler ยัง rate limit ที่ 60 req/นาที ต่อ IP
     (`api.php:122`) — หน้าที่มี subresource ถูกบล็อกเยอะอาจชนเพดานจนบาง report ถูกทิ้ง
   - **ก่อนอ่าน log วันที่ 24 ให้ยิง self-test ใหม่ 1 นัดเพื่อให้ได้ marker สด** (Render retention
     ของ plan ที่ไม่ใช่ Enterprise ราว 7 วัน = marker ของ 17 ส.ค. จะอยู่ริมขอบพอดีหรือหลุดไปแล้ว)
+    คำสั่งเดียวจบ — warm up `/api/readyz` ให้เองก่อน แล้วพิมพ์บรรทัดที่ต้องเอาไปค้นใน log:
+
+    ```bash
+    node scripts/csp-report-selftest.mjs
+    ```
+
+    marker ผูกวันที่ UTC + nonce (`csp-selftest-YYYYMMDD-xxxx.invalid`) จึงแยก "marker ที่เพิ่งยิง"
+    ออกจากรอบก่อน ๆ ได้แม้รันหลายรอบในวันเดียวกัน — **ใช้ค่าที่สคริปต์พิมพ์ออกมาไปค้นเท่านั้น
+    อย่าค้นด้วย prefix `csp-selftest-` ลอย ๆ** เพราะจะไปเจอ marker ของรอบเก่า
+    **อ่านผลของสคริปต์ให้ครบสองทิศ:**
+    - `exit 1` = ยังไม่มี marker สดในรอบนี้ → ห้ามข้ามไปอ่าน log
+    - `exit 0` = request ถึงปลายทางและได้ 204 เท่านั้น **ไม่ใช่หลักฐานว่า marker ถูก log**
+      (handler ตอบ 204 แม้แกะ body ไม่ได้ และ `error_log()` อาจเขียนไม่ลง) — ยังต้องเห็นด้วยตา
+    - marker ที่เป็นของทีมและมีอยู่แล้วใน log (ตัดทิ้งตอนอ่าน ไม่ใช่ violation จริง):
+      `csp-selftest.invalid` (17 ส.ค. ~14:45 UTC, ยิงด้วยมือ) ·
+      `csp-selftest-20260818.invalid` (18 ส.ค. 05:00 UTC) ·
+      `csp-selftest-20260818-ecc9.invalid` (18 ส.ค. 05:10 UTC) — สองตัวหลังคือรอบ validate
+      สคริปต์กับ production ทั้งคู่ได้ 204 และ **จะหลุด retention ~7 วันพอดีช่วง 24–25 ส.ค.**
+
     **decision rule: เจอ marker สด → pipeline ครบวงจร ตัด marker ทิ้งแล้วดูที่เหลือ;
     ไม่เจอ marker → สรุปไม่ได้ ห้าม enforce**
 - **ต้องมี traffic จริงในหน้าต่าง 7 วันด้วย** — เกณฑ์ข้อ 2 มีความหมายก็ต่อเมื่อมีคนเปิดใช้จริง
@@ -187,6 +210,12 @@ truth และ fail-closed เมื่อโครงสร้างเปล�
   source of truth — แก้ render.yaml แล้ว gate ตามอัตโนมัติ) exit 1 เมื่อพบ drift;
   regression อยู่ที่ `scripts/tests/verify-live-headers.test.mjs` (mock origin บน
   127.0.0.1 ไม่พึ่งเครือข่าย) เสียบใน `scripts/ci-local.sh` / `.ps1` แล้ว
+- `scripts/csp-report-selftest.mjs` — ยิง CSP report marker สดเข้า pipeline จริง (issue #113):
+  warm up `/api/readyz` ก่อน แล้ว POST `/api/csp-report` ผ่าน rewrite เส้นเดียวกับที่ browser ใช้
+  exit 0 เมื่อได้ 204 พร้อมพิมพ์บรรทัด log ที่ต้องไปค้นหา (ผูกกับข้อความ `error_log()` จริงใน
+  `backend/api.php` — มีเทสกัน drift); regression อยู่ที่ `scripts/tests/csp-report-selftest.test.mjs`
+  (mock origin บน 127.0.0.1) เสียบใน `scripts/ci-local.sh` / `.ps1` แล้ว
+  **ตัวสคริปต์เองไม่ได้อยู่ใน CI gate** เพราะยิง production จริง — เรียกมือตอนจะอ่าน log เท่านั้น
 - ตรวจจากภายนอกหลัง deploy:
   ```bash
   curl -sI https://smart-port.onrender.com/ | grep -i "content-security\|x-frame\|referrer\|permissions\|strict-transport"

--- a/docs/frontend-security-headers.md
+++ b/docs/frontend-security-headers.md
@@ -214,7 +214,9 @@ truth และ fail-closed เมื่อโครงสร้างเปล�
   warm up `/api/readyz` ก่อน แล้ว POST `/api/csp-report` ผ่าน rewrite เส้นเดียวกับที่ browser ใช้
   exit 0 เมื่อได้ 204 พร้อมพิมพ์บรรทัด log ที่ต้องไปค้นหา (ผูกกับข้อความ `error_log()` จริงใน
   `backend/api.php` — มีเทสกัน drift); regression อยู่ที่ `scripts/tests/csp-report-selftest.test.mjs`
-  (mock origin บน 127.0.0.1) เสียบใน `scripts/ci-local.sh` / `.ps1` แล้ว
+  (mock origin บน 127.0.0.1) เสียบใน `scripts/ci-local.sh` / `.ps1` และ `.githooks/pre-push`
+  (`node --test scripts/tests/*.test.mjs` ครอบ regression ของสคริปต์ทั้งโฟลเดอร์ ~17s) —
+  pre-push คือที่เดียวที่ gate พวกนี้ถูกบังคับทุกครั้ง เพราะ GitHub Actions ปิด auto-trigger อยู่
   **ตัวสคริปต์เองไม่ได้อยู่ใน CI gate** เพราะยิง production จริง — เรียกมือตอนจะอ่าน log เท่านั้น
 - ตรวจจากภายนอกหลัง deploy:
   ```bash

--- a/scripts/ci-local.ps1
+++ b/scripts/ci-local.ps1
@@ -124,6 +124,16 @@ if ($LASTEXITCODE -eq 0) {
   $failed += 'live-header-smoke-regression'
 }
 
+# mock-server regression ของ CSP self-test — ไม่ยิง production จริง (issue #113 R3)
+Write-Step 'CSP Report Self-test Regression'
+& node --test (Join-Path $Root 'scripts\tests\csp-report-selftest.test.mjs')
+if ($LASTEXITCODE -eq 0) {
+  Write-Ok 'csp report self-test regression'
+} else {
+  Write-Fail 'csp report self-test regression'
+  $failed += 'csp-report-selftest-regression'
+}
+
 # ---- 1) Frontend Build & Test ----------------------------------------------
 if (-not $SkipFrontend) {
   Write-Step 'Frontend Build & Test'

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -79,6 +79,14 @@ else
   fail 'live header smoke regression'
 fi
 
+# mock-server regression ของ CSP self-test — ไม่ยิง production จริง (issue #113 R3)
+step 'CSP Report Self-test Regression'
+if node --test "${ROOT}/scripts/tests/csp-report-selftest.test.mjs"; then
+  ok 'csp report self-test regression'
+else
+  fail 'csp report self-test regression'
+fi
+
 # ---- 1) Frontend -----------------------------------------------------------
 if [[ "${SKIP_FRONTEND}" -eq 0 ]]; then
   step 'Frontend Build & Test'

--- a/scripts/csp-report-selftest.mjs
+++ b/scripts/csp-report-selftest.mjs
@@ -1,0 +1,326 @@
+#!/usr/bin/env node
+// CSP report self-test — issue #113: ยิง marker สดเข้า pipeline report-only
+//
+// ทำไมต้องมี: เกณฑ์ promote CSP เป็น enforce คือ "ไม่มี violation จากระบบจริง ≥ 7 วัน"
+// ซึ่งอ่านจาก Render log — แต่ "log ว่าง" มีสองความหมายที่แยกกันไม่ออกด้วยตาเปล่า
+//   (ก) ไม่มี violation จริง = พร้อม enforce
+//   (ข) report ไม่เคยส่งถึง backend เลย = สรุปไม่ได้ ห้าม enforce
+// marker ที่ยิงจากสคริปต์นี้คือสิ่งที่แยกสองกรณีออกจากกัน: เจอ marker ใน log = pipeline
+// ครบวงจร (ตัด marker ทิ้งแล้วดู violation ที่เหลือได้) / ไม่เจอ marker = ตกกรณี (ข)
+//
+// **ขอบเขตของสิ่งที่สคริปต์นี้พิสูจน์ได้: จบที่ "handler ตอบ 204"** ไม่ได้พิสูจน์ว่า
+// error_log() เขียนลง log stream สำเร็จ (handler ตอบ 204 แม้ body จะแกะไม่ได้ — api.php)
+// หลักฐานจริงมีทางเดียวคือเห็น marker ในหน้า log ด้วยตา
+//
+// marker ผูกวันที่ (UTC) + nonce เพราะ Render retention ของ plan ที่ไม่ใช่ Enterprise ราว
+// 7 วัน — marker ของรอบก่อนจะหลุดพอดีตอนถึงจุดตัดสินใจ ต้องยิงใหม่ทุกครั้งก่อนอ่าน log
+//
+// Usage: node scripts/csp-report-selftest.mjs [--base-url https://smart-port.onrender.com]
+//   --base-url  ใช้ตอนเทสกับ mock server (default = production static site)
+// Exit 0 = backend ตื่นและรับ report แล้วตอบ 204, Exit 1 = warm up ไม่ติด / ไม่ได้ 204
+//
+// ยิงผ่าน static site (`/api/*` → rewrite ไป backend) ตั้งใจให้เดินเส้นทางเดียวกับที่
+// browser ใช้จริงทุก hop ไม่ใช่ยิงตรงเข้า backend origin — ถ้า rewrite พัง ต้องรู้ตรงนี้
+
+import { randomBytes } from 'node:crypto';
+import { pathToFileURL } from 'node:url';
+
+const DEFAULT_BASE = 'https://smart-port.onrender.com';
+const WARMUP_PATH = '/api/readyz';
+const REPORT_PATH = '/api/csp-report';
+const FETCH_TIMEOUT_MS = 30_000;
+// backend เป็น `plan: free` — ตื่นจาก spin down ใช้เวลาได้หลายสิบวินาที (วัดจริง 2026-08-18:
+// readyz นัดแรก 23.1s) และ gateway เคย DNS หน่วงเป็นพัก ๆ (handoff 2026-08-16)
+// จึงให้โอกาส warm up มากกว่า report
+const WARMUP_ATTEMPTS = 3;
+const WARMUP_RETRY_DELAY_MS = 2_000;
+const REPORT_ATTEMPTS = 2;
+const MARKER_DIRECTIVE = 'img-src';
+
+// ต้องตรงกับ error_log() ใน backend/api.php case 'csp-report' — ถ้าฝั่ง PHP เปลี่ยนข้อความ
+// คำค้นที่พิมพ์ออกไปจะหาไม่เจอ แล้ว "ไม่เจอ marker" จะถูกตีความผิดเป็น "pipeline พัง"
+// เทส `รูปแบบ log ...` ใน scripts/tests/csp-report-selftest.test.mjs กัน drift นี้ไว้
+//
+// หมายเหตุรูปแบบ payload: render.yaml ใช้ `report-uri` (legacy) อย่างเดียว → body เป็น
+// `{"csp-report": {...}}` แบบ kebab-case ตรงกับที่ handler แกะ ถ้าวันไหนย้ายไป Reporting API
+// (`Reporting-Endpoints` + `report-to`) shape จะกลายเป็น camelCase (`effectiveDirective`,
+// `blockedURL`) ต้องแก้ทั้ง handler และ buildReportBody พร้อมกัน
+const LOG_DIRECTIVE_PREFIX = '[csp-report] violation directive=';
+const LOG_BLOCKED_PREFIX = ' blocked-host=';
+
+// error_log() ของ handler ออก stderr ของ container backend (Dockerfile ตั้ง
+// error_log = /dev/stderr) — เปิด log ของ static site จะเห็นว่างเสมอ
+const RENDER_LOG_SERVICE = 'smartport-backend';
+
+const USAGE = `Usage: node scripts/csp-report-selftest.mjs [--base-url <url>]
+
+  --base-url <url>  origin ที่จะยิง (default = ${DEFAULT_BASE})
+                    ใช้ชี้ mock server ตอนเทส — ค่าอื่นที่ไม่ใช่ default จะไม่ผ่าน
+                    rewrite /api/* ของ static site จึงพิสูจน์ pipeline จริงไม่ได้
+  -h, --help        แสดงข้อความนี้
+
+ยิง CSP violation report marker สดเข้า pipeline report-only แล้วบอกบรรทัดที่ต้องไปค้นใน
+Render log ของ service ${RENDER_LOG_SERVICE} — รายละเอียดเกณฑ์ enforce อยู่ที่
+docs/frontend-security-headers.md §CSP monitoring ก่อน enforce`;
+
+const normalizeBase = (value) => {
+  const trimmed = value.trim().replace(/\/+$/, '');
+  // ต้องเป็น URL จริงและเป็น http(s) เท่านั้น — กันทั้ง flag ที่พิมพ์ผิดถูกกลืนมาเป็นค่า
+  // (แล้วไปรายงานผิดว่า "ปลุก backend ไม่ขึ้น") และ scheme แปลก ๆ อย่าง file:/data:
+  let parsed;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new Error(`--base-url ไม่ใช่ URL ที่ใช้ได้: "${value}"`);
+  }
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    throw new Error(`--base-url ต้องเป็น http/https เท่านั้น (ได้ "${parsed.protocol}")`);
+  }
+  return trimmed;
+};
+
+/**
+ * fail-closed กับ argument ที่ไม่รู้จัก — ต่างจาก gate อื่นตรงที่ default ของสคริปต์นี้คือ
+ * "ยิง production จริง" ถ้าข้าม flag ที่พิมพ์ผิดไปเงียบ ๆ คนที่ตั้งใจยิง staging จะไปโดน
+ * production แทนโดยไม่รู้ตัว และค่าที่ขึ้นต้นด้วย -- ก็ห้ามถูกกลืนเป็นค่าของ --base-url
+ */
+function parseArgs(argv) {
+  const args = { baseUrl: DEFAULT_BASE, help: false };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '-h' || arg === '--help') {
+      args.help = true;
+      continue;
+    }
+    if (arg === '--base-url') {
+      const value = argv[i + 1];
+      if (!value || value.startsWith('--')) throw new Error('--base-url ต้องตามด้วย URL (เช่น --base-url https://smart-port.onrender.com)');
+      args.baseUrl = normalizeBase(value);
+      i++;
+      continue;
+    }
+    if (arg.startsWith('--base-url=')) {
+      args.baseUrl = normalizeBase(arg.slice('--base-url='.length));
+      continue;
+    }
+    throw new Error(`อาร์กิวเมนต์ที่ใช้ไม่ได้: "${arg}" — ดู --help`);
+  }
+  return args;
+}
+
+const sleep = (ms) => new Promise((done) => setTimeout(done, ms));
+
+/**
+ * marker host ของรอบนี้ — `csp-selftest-YYYYMMDD-<nonce>.invalid`
+ * - วันที่เป็น UTC ให้ตรงกับ timestamp ใน Render log (ยิงเช้า SEAST จะได้วันที่ก่อนหน้า
+ *   ซึ่งถูกแล้ว สคริปต์พิมพ์ marker ที่ใช้จริงออกมาเสมอ ไม่ให้ผู้ใช้เดาวันที่เอง)
+ * - nonce แยก "marker ที่เพิ่งยิง" ออกจาก marker ของรอบอื่นในวันเดียวกัน (รันซ้ำ/รันจาก
+ *   เครื่องอื่น) — ไม่งั้น marker เก่าที่ค้างใน log จะถูกนับเป็นหลักฐานของรอบนี้
+ * - `.invalid` เป็น TLD สงวนตาม RFC 2606 — resolve ไม่ได้แน่นอน จึงชนกับ host จริงไม่ได้
+ */
+function buildMarkerHost(now = new Date(), nonce = randomBytes(2).toString('hex')) {
+  return `csp-selftest-${now.toISOString().slice(0, 10).replace(/-/g, '')}-${nonce}.invalid`;
+}
+
+/**
+ * payload ตามรูป CSP report ของ browser — handler อ่าน `$report['csp-report'] ?? $report`
+ * แล้วหยิบ effective-directive (fallback violated-directive) + host ของ blocked-uri
+ * blocked-uri ต้องเป็น absolute URL ที่มี host ไม่งั้น parse_url คืน false → log เป็น 'self'
+ */
+function buildReportBody(markerHost, documentUri) {
+  return {
+    'csp-report': {
+      'document-uri': documentUri,
+      referrer: '',
+      'violated-directive': MARKER_DIRECTIVE,
+      'effective-directive': MARKER_DIRECTIVE,
+      'original-policy': `img-src 'self' data:; report-uri ${REPORT_PATH}`,
+      disposition: 'report',
+      'blocked-uri': `https://${markerHost}/probe.png`,
+      'status-code': 200,
+      'script-sample': '',
+    },
+  };
+}
+
+/**
+ * แยก "PHP ตอบเองว่ายังไม่พร้อม" ออกจาก "edge ตอบแทนตอน container ยังไม่ตื่น"
+ * readyz ของเรา (backend/routes/readyz.php) คืน JSON ที่มีคีย์ `status` เสมอ —
+ * 200 ready / 503 not_ready|migrations_pending ส่วน 502/504 หรือ 5xx ที่ body ไม่ใช่รูปนั้น
+ * มาจาก edge ของ Render ระหว่างบูต = **ยังไม่ตื่น ต้อง retry ไม่ใช่นับว่าผ่าน**
+ * (ถ้านับว่าผ่านแล้วยิง report ต่อ marker จะหายไปกับ container ที่ยังไม่รับงาน)
+ */
+function isBackendAwake(status, body) {
+  if (status < 500) return true;
+  try {
+    const parsed = JSON.parse(body);
+    return typeof parsed?.status === 'string';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * ปลุก backend ก่อนยิง report — CSP report เป็น fire-and-forget ไม่มี retry ฝั่ง browser
+ * ถ้ายิงตอน container ยังหลับ marker จะหายเงียบและทำให้ผลรอบนี้ตีความไม่ได้
+ */
+async function warmUp(baseUrl) {
+  let lastDetail = 'ไม่ทราบสาเหตุ';
+  for (let attempt = 1; attempt <= WARMUP_ATTEMPTS; attempt++) {
+    const started = Date.now();
+    try {
+      const res = await fetch(baseUrl + WARMUP_PATH, {
+        method: 'GET',
+        redirect: 'follow',
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      });
+      const body = await res.text().catch(() => '');
+      const ms = Date.now() - started;
+      if (isBackendAwake(res.status, body)) return { status: res.status, ms, attempts: attempt };
+      lastDetail = `HTTP ${res.status} ที่ไม่ใช่รูป JSON ของ readyz — edge ตอบแทนระหว่าง container บูต`;
+    } catch (err) {
+      lastDetail = err.message;
+    }
+    if (attempt < WARMUP_ATTEMPTS) {
+      console.error(`  (warm up ครั้งที่ ${attempt}/${WARMUP_ATTEMPTS} ยังไม่ตื่น: ${lastDetail}) — รอ ${WARMUP_RETRY_DELAY_MS / 1000}s แล้วลองใหม่`);
+      await sleep(WARMUP_RETRY_DELAY_MS);
+    }
+  }
+  throw new Error(lastDetail);
+}
+
+/**
+ * ยิง report — retry เฉพาะตอน network error/timeout เท่านั้น
+ * (ได้ status กลับมาแล้วถือว่าเป็นคำตอบจริง ไม่ยิงซ้ำ) การ retry หลัง timeout อาจทำให้ได้
+ * marker ซ้ำสองบรรทัดใน log ซึ่งไม่เป็นไร — ทั้งคู่เป็นของรอบนี้และถูกตัดทิ้งอยู่แล้ว
+ *
+ * redirect: 'manual' ตั้งใจ — ถ้าตาม redirect (301/302/303) fetch จะแปลง POST เป็น GET
+ * และ **ทิ้ง body** แล้วปลายทางอาจตอบ 204 ทำให้สคริปต์รายงาน PASS ทั้งที่ไม่มี report
+ * ถึง handler เลยสักไบต์ (false-PASS) — ต้องเห็น 3xx แล้ว fail พร้อมบอก Location
+ */
+async function sendReport(baseUrl, body) {
+  let lastError;
+  for (let attempt = 1; attempt <= REPORT_ATTEMPTS; attempt++) {
+    try {
+      const res = await fetch(baseUrl + REPORT_PATH, {
+        method: 'POST',
+        headers: { 'content-type': 'application/csp-report' },
+        body: JSON.stringify(body),
+        redirect: 'manual',
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      });
+      return { status: res.status, attempts: attempt, location: res.headers.get('location'), sentAt: new Date().toISOString() };
+    } catch (err) {
+      lastError = err;
+      if (attempt < REPORT_ATTEMPTS) console.error(`  (retry ${attempt}/${REPORT_ATTEMPTS - 1} หลังจาก: ${err.message})`);
+    }
+  }
+  throw lastError;
+}
+
+/** คำอธิบายเพิ่มเติมของ status ที่ไม่ใช่ 204 — แต่ละตัวมีความหมายต่อการอ่าน log คนละแบบ */
+function explainStatus(status, location) {
+  if (status >= 300 && status < 400) {
+    return `มี redirect ระหว่างทาง (Location: ${location ?? 'ไม่ระบุ'}) — POST จะถูกแปลงเป็น GET และ body ถูกทิ้ง report จึงไม่มีทางถึง handler ตรวจ route/rewrite ที่เพิ่งเพิ่มเข้ามา`;
+  }
+  if (status === 404) {
+    return 'rewrite /api/* ของ static site หรือ case csp-report ใน backend/api.php หายไป — report ของ browser จริงก็ตกทางเดียวกัน';
+  }
+  if (status === 405) {
+    return 'handler ไม่รับ POST — เช็ค case csp-report ใน backend/api.php หรือมี hop ที่แปลง POST เป็น GET ระหว่างทาง';
+  }
+  if (status === 429) {
+    return 'ชน rate limit (60 req/นาที ต่อ IP ที่ backend/api.php) — request นี้ถูกทิ้งก่อนถึง handler จึงไม่มี marker ใน log รอสักครู่แล้วยิงใหม่';
+  }
+  if (status === 502 || status === 503 || status === 504) {
+    return `edge ตอบแทน container (HTTP ${status}) — request ไม่ถึง PHP จึงไม่มี stack trace ใน log ให้ดู ลองใหม่หลัง backend ตื่นเต็มที่`;
+  }
+  if (status >= 500) {
+    return `backend error — เปิด log ของ service ${RENDER_LOG_SERVICE} ดู stack trace ก่อน`;
+  }
+  return 'handler สัญญาว่าจะตอบ 204 เสมอเมื่อรับ report ได้ — status อื่นแปลว่า request ไม่ถึง handler';
+}
+
+/** ขั้นตอนที่ automation ทำแทนไม่ได้ (ไม่มีสิทธิ์อ่าน Render log) — ต้องบอกให้ชัดว่าหาอะไรที่ไหน */
+function printNextSteps(markerHost) {
+  console.log('\n— ขั้นต่อไป (ต้องทำด้วยตา) —');
+  console.log(`  1. เปิด Render log ของ service "${RENDER_LOG_SERVICE}" (ไม่ใช่ static site) แล้วค้นหา:`);
+  console.log(`\n     ${LOG_DIRECTIVE_PREFIX}${MARKER_DIRECTIVE}${LOG_BLOCKED_PREFIX}${markerHost}\n`);
+  console.log('  2. เจอ marker  → pipeline ครบวงจร: ตัดบรรทัด marker ทิ้ง แล้วดู violation ที่เหลือในหน้าต่าง 7 วัน');
+  console.log('  3. ไม่เจอ marker → สรุปไม่ได้ ห้าม enforce (log ว่างอาจแปลว่า report ไม่เคยส่งถึง)');
+  console.log('\n  เตือน: marker เดียวไม่พอสำหรับตัดสินใจ enforce — ต้องมี traffic จริงในหน้าต่าง 7 วันด้วย');
+  console.log('  เกณฑ์เต็มอยู่ที่ docs/frontend-security-headers.md §CSP monitoring ก่อน enforce');
+}
+
+async function main() {
+  const { baseUrl, help } = parseArgs(process.argv.slice(2));
+  if (help) {
+    console.log(USAGE);
+    return;
+  }
+  const markerHost = buildMarkerHost();
+
+  console.log('CSP report self-test — issue #113');
+  console.log(`base URL: ${baseUrl}`);
+  console.log(`marker:   ${markerHost}  (directive ${MARKER_DIRECTIVE})`);
+  if (baseUrl !== DEFAULT_BASE) {
+    console.log(`  [!] ไม่ใช่ production (${DEFAULT_BASE}) — รอบนี้ไม่ได้เดินผ่าน rewrite /api/* ของ static site`);
+    console.log('      marker ที่ได้จึงใช้เป็นหลักฐานของ pipeline จริงไม่ได้');
+  }
+
+  // 1) warm up — ต้องผ่านก่อนเสมอ ไม่งั้น marker อาจหายไปกับ container ที่ยังหลับ
+  console.log(`\n— Warm up (${WARMUP_PATH}) —`);
+  let warm;
+  try {
+    warm = await warmUp(baseUrl);
+  } catch (err) {
+    console.error(`  [✗] ปลุก backend ไม่ขึ้นหลังลอง ${WARMUP_ATTEMPTS} ครั้ง: ${err.message}`);
+    console.error('\n✗ FAIL: ยังไม่ยิง report เพราะพิสูจน์ไม่ได้ว่า backend รับ request อยู่');
+    console.error('  (report เป็น fire-and-forget ไม่มี retry — ยิงตอนนี้เสี่ยง marker หายเงียบแล้วอ่าน log ผิด)');
+    process.exitCode = 1;
+    return;
+  }
+  if (warm.status === 200) {
+    console.log(`  [✓] backend ตื่นแล้ว (HTTP 200 ใน ${warm.ms}ms, ลอง ${warm.attempts} ครั้ง)`);
+  } else {
+    console.log(`  [~] backend ตอบเองแล้วแต่ได้ HTTP ${warm.status} ใน ${warm.ms}ms (ลอง ${warm.attempts} ครั้ง)`);
+    console.log('      ยิง report ต่อได้ — readyz ตอบเป็น JSON ของตัวเอง = PHP รับงานแล้ว และ handler csp-report ไม่แตะ DB');
+  }
+
+  // 2) ยิง marker เข้า pipeline เส้นเดียวกับที่ browser ใช้
+  console.log(`\n— Report (${REPORT_PATH}) —`);
+  let sent;
+  try {
+    sent = await sendReport(baseUrl, buildReportBody(markerHost, `${baseUrl}/`));
+  } catch (err) {
+    console.error(`  [✗] ยิง report ไม่สำเร็จ: ${err.message}`);
+    console.error('\n✗ FAIL: ไม่ได้ 204 — ถือว่ายังไม่มี marker สดในรอบนี้');
+    process.exitCode = 1;
+    return;
+  }
+  if (sent.status !== 204) {
+    console.error(`  [✗] ได้ HTTP ${sent.status} (ต้องเป็น 204)`);
+    console.error(`      ${explainStatus(sent.status, sent.location)}`);
+    console.error('\n✗ FAIL: ไม่ได้ 204 — ถือว่ายังไม่มี marker สดในรอบนี้');
+    process.exitCode = 1;
+    return;
+  }
+  console.log(`  [✓] HTTP 204 ตามสัญญาของ handler (ยิง ${sent.attempts} ครั้ง, ${sent.sentAt})`);
+
+  printNextSteps(markerHost);
+
+  // ระวังการอ่านผลกลับด้าน: exit 0 ไม่เท่ากับ "มี marker ใน log แล้ว" — handler ตอบ 204
+  // แม้ body จะแกะไม่ได้ (api.php ตอบ 204 ท้าย case เสมอ) และ error_log() อาจเขียนไม่ลง
+  console.log('\n✓ PASS: request ถึงปลายทางและได้ 204 ตามสัญญาของ handler');
+  console.log('  แต่ 204 ยังไม่ใช่หลักฐานว่า marker ถูกเขียนลง log — หลักฐานคือขั้นตอนที่ 1 ข้างบนเท่านั้น');
+}
+
+export { buildMarkerHost, buildReportBody, isBackendAwake, LOG_DIRECTIVE_PREFIX, LOG_BLOCKED_PREFIX };
+
+// รันเป็น CLI เมื่อถูกเรียกตรง ๆ (ไม่ใช่ถูก import)
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    console.error(`✗ FAIL: ${err.message}`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/csp-report-selftest.mjs
+++ b/scripts/csp-report-selftest.mjs
@@ -161,6 +161,20 @@ function isBackendAwake(status, body) {
 }
 
 /**
+ * ดึง release SHA จาก body ของ readyz (`RENDER_GIT_COMMIT` หรือ 'dev' — readyz.php:19-23)
+ * ใช้ผูก marker เข้ากับ deployment ที่รับ request จริง เวลาต้องสืบว่า marker หายไปกับ
+ * deploy ไหน — Render log ก็แสดง commit ของ container ทำให้เทียบกันได้
+ */
+function readReleaseSha(body) {
+  try {
+    const release = JSON.parse(body)?.release;
+    return typeof release === 'string' && release !== '' ? release : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * ปลุก backend ก่อนยิง report — CSP report เป็น fire-and-forget ไม่มี retry ฝั่ง browser
  * ถ้ายิงตอน container ยังหลับ marker จะหายเงียบและทำให้ผลรอบนี้ตีความไม่ได้
  */
@@ -176,7 +190,7 @@ async function warmUp(baseUrl) {
       });
       const body = await res.text().catch(() => '');
       const ms = Date.now() - started;
-      if (isBackendAwake(res.status, body)) return { status: res.status, ms, attempts: attempt };
+      if (isBackendAwake(res.status, body)) return { status: res.status, ms, attempts: attempt, release: readReleaseSha(body) };
       lastDetail = `HTTP ${res.status} ที่ไม่ใช่รูป JSON ของ readyz — edge ตอบแทนระหว่าง container บูต`;
     } catch (err) {
       lastDetail = err.message;
@@ -246,6 +260,9 @@ function printNextSteps(markerHost) {
   console.log('\n— ขั้นต่อไป (ต้องทำด้วยตา) —');
   console.log(`  1. เปิด Render log ของ service "${RENDER_LOG_SERVICE}" (ไม่ใช่ static site) แล้วค้นหา:`);
   console.log(`\n     ${LOG_DIRECTIVE_PREFIX}${MARKER_DIRECTIVE}${LOG_BLOCKED_PREFIX}${markerHost}\n`);
+  // สำรอง: ถ้า log filter ตีความ [ หรือ = เป็น syntax หรือ copy ตกไปตัวหนึ่ง ผลจะกลายเป็น
+  // "ไม่เจอ marker" = ห้าม enforce ซึ่งเผาหน้าต่าง 7 วันทิ้งฟรี ๆ — marker มี nonce จึง unique พอ
+  console.log(`     (ถ้า filter ไม่รับอักขระพิเศษ ค้นด้วย marker ล้วน ๆ ก็พอ: ${markerHost})\n`);
   console.log('  2. เจอ marker  → pipeline ครบวงจร: ตัดบรรทัด marker ทิ้ง แล้วดู violation ที่เหลือในหน้าต่าง 7 วัน');
   console.log('  3. ไม่เจอ marker → สรุปไม่ได้ ห้าม enforce (log ว่างอาจแปลว่า report ไม่เคยส่งถึง)');
   console.log('\n  เตือน: marker เดียวไม่พอสำหรับตัดสินใจ enforce — ต้องมี traffic จริงในหน้าต่าง 7 วันด้วย');
@@ -280,11 +297,14 @@ async function main() {
     process.exitCode = 1;
     return;
   }
+  const release = warm.release ? `, release=${warm.release.slice(0, 12)}` : '';
   if (warm.status === 200) {
-    console.log(`  [✓] backend ตื่นแล้ว (HTTP 200 ใน ${warm.ms}ms, ลอง ${warm.attempts} ครั้ง)`);
+    console.log(`  [✓] backend ตื่นแล้ว (HTTP 200 ใน ${warm.ms}ms, ลอง ${warm.attempts} ครั้ง${release})`);
   } else {
-    console.log(`  [~] backend ตอบเองแล้วแต่ได้ HTTP ${warm.status} ใน ${warm.ms}ms (ลอง ${warm.attempts} ครั้ง)`);
-    console.log('      ยิง report ต่อได้ — readyz ตอบเป็น JSON ของตัวเอง = PHP รับงานแล้ว และ handler csp-report ไม่แตะ DB');
+    // ระวังอย่าอ้างเกินที่ตรวจ: isBackendAwake ปล่อยผ่าน status < 500 โดยไม่แตะ body เลย
+    // (เช่น 404 ตอน route หาย) จึงพูดได้แค่ว่า "ไม่ใช่ 5xx ของ edge" ไม่ใช่ "readyz ตอบเอง"
+    console.log(`  [~] ได้คำตอบที่ไม่ใช่ 5xx ของ edge แต่เป็น HTTP ${warm.status} ใน ${warm.ms}ms (ลอง ${warm.attempts} ครั้ง${release})`);
+    console.log('      ยิง report ต่อได้ — มีคนรับงานแล้ว และ handler csp-report ไม่แตะ DB จึง log ได้แม้ readyz จะ not_ready');
   }
 
   // 2) ยิง marker เข้า pipeline เส้นเดียวกับที่ browser ใช้

--- a/scripts/tests/csp-report-selftest.test.mjs
+++ b/scripts/tests/csp-report-selftest.test.mjs
@@ -80,10 +80,12 @@ const ok204 = (req, res) => {
   res.end();
 };
 
+// release = RENDER_GIT_COMMIT ของ container ที่รับ request (readyz.php:19-23)
+const RELEASE_SHA = 'abc123def4567890abc123def4567890abc123de';
 const readyzOk = (req, res) => {
   res.statusCode = 200;
   res.setHeader('content-type', 'application/json');
-  res.end(JSON.stringify({ status: 'ready' }));
+  res.end(JSON.stringify({ status: 'ready', release: RELEASE_SHA }));
 };
 
 test('happy path: warm up แล้วยิง marker ผูกวันที่ ได้ 204 → exit 0 พร้อมบอกคำค้นใน log', async () => {
@@ -109,6 +111,8 @@ test('happy path: warm up แล้วยิง marker ผูกวันที�
 
     // กับดักที่เคยทำให้ "log ว่าง" ตีความผิด: log อยู่ที่ service backend ไม่ใช่ static site
     assert.ok(output.includes('smartport-backend'), `output ต้องบอกว่าให้เปิด log ของ service ไหน:\n${output}`);
+    // release ของ container ที่รับงาน — ใช้เทียบกับ Render log ตอนต้องสืบว่า marker หายไปกับ deploy ไหน
+    assert.ok(output.includes(`release=${RELEASE_SHA.slice(0, 12)}`), `output ต้องบอก release ของ container:\n${output}`);
     // 204 ไม่ใช่หลักฐานว่า error_log() ทำงาน — ห้ามให้ PASS ชวนอ่านกลับด้าน
     assert.match(output, /ยังไม่ใช่หลักฐาน/, `PASS ต้องระบุขอบเขตของสิ่งที่พิสูจน์ได้:\n${output}`);
 
@@ -389,13 +393,14 @@ test('รูปแบบ log ที่สคริปต์บอกให้ค
   // anti-drift: ถ้ามีคนแก้ข้อความ error_log ฝั่ง PHP คำค้นที่สคริปต์พิมพ์จะหาไม่เจอ
   // แล้ว "ไม่เจอ marker" จะถูกตีความผิดเป็น "pipeline พัง" ทั้งที่แค่ข้อความเปลี่ยน
   const php = readFileSync(resolve(ROOT, 'backend', 'api.php'), 'utf8');
-  assert.ok(
-    php.includes(`'${LOG_DIRECTIVE_PREFIX}'`),
-    `backend/api.php ไม่มี literal "${LOG_DIRECTIVE_PREFIX}" แล้ว — อัปเดต LOG_DIRECTIVE_PREFIX ใน csp-report-selftest.mjs`
-  );
-  assert.ok(
-    php.includes(`'${LOG_BLOCKED_PREFIX}'`),
-    `backend/api.php ไม่มี literal "${LOG_BLOCKED_PREFIX}" แล้ว — อัปเดต LOG_BLOCKED_PREFIX ใน csp-report-selftest.mjs`
+  // ต้องอยู่ใน error_log() บรรทัดเดียวกันจริง ๆ — ไม่ใช่แค่ "มี literal ที่ไหนก็ได้ในไฟล์"
+  // (ถ้าเช็คแยกกัน literal ที่ย้ายไป branch อื่นหรือ error_log ตัวที่สองจะทำให้เทสผ่านหลอก ๆ)
+  const escape = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const sameLine = new RegExp(`error_log\\(\\s*'${escape(LOG_DIRECTIVE_PREFIX)}'.*'${escape(LOG_BLOCKED_PREFIX)}'`);
+  assert.match(
+    php,
+    sameLine,
+    `backend/api.php ไม่มี error_log() ที่ประกอบ "${LOG_DIRECTIVE_PREFIX}" + "${LOG_BLOCKED_PREFIX}" ในบรรทัดเดียวแล้ว — อัปเดตค่าคงที่ใน csp-report-selftest.mjs ให้ตรงกับของจริง`
   );
 });
 

--- a/scripts/tests/csp-report-selftest.test.mjs
+++ b/scripts/tests/csp-report-selftest.test.mjs
@@ -1,0 +1,412 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:http';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import {
+  buildMarkerHost,
+  buildReportBody,
+  isBackendAwake,
+  LOG_DIRECTIVE_PREFIX,
+  LOG_BLOCKED_PREFIX,
+} from '../csp-report-selftest.mjs';
+
+// Issue #113 — regression ของ CSP report self-test
+// เทสผ่าน CLI จริงแต่ชี้ --base-url ไปที่ mock origin บน 127.0.0.1 (แบบเดียวกับ
+// verify-live-headers.test.mjs) — CI ไม่ต้องพึ่งเครือข่าย/production
+//
+// สิ่งที่เทสชุดนี้ปกป้องคือ "ความหมายของผลลัพธ์" ไม่ใช่แค่ exit code:
+// self-test นี้เป็นตัวแยก "log ว่างเพราะไม่มี violation" ออกจาก "log ว่างเพราะ report
+// ไม่เคยส่งถึง" — ถ้าสคริปต์รายงาน PASS ทั้งที่ report ไม่ได้ถึง handler จริง
+// decision rule ของวัน enforce จะพังเงียบ ๆ
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const SCRIPT = resolve(ROOT, 'scripts', 'csp-report-selftest.mjs');
+const MARKER_RE = /csp-selftest-\d{8}-[0-9a-f]{4}\.invalid/;
+
+function run(baseUrl, extraArgs = []) {
+  return runArgs(['--base-url', baseUrl, ...extraArgs]);
+}
+
+function runArgs(args) {
+  return new Promise((resolveRun, rejectRun) => {
+    const child = spawn(process.execPath, [SCRIPT, ...args], { cwd: ROOT });
+    let output = '';
+    child.stdout.on('data', (chunk) => (output += chunk));
+    child.stderr.on('data', (chunk) => (output += chunk));
+    const timer = setTimeout(() => {
+      child.kill();
+      rejectRun(new Error('csp-report-selftest.mjs ไม่จบภายใน 60s'));
+    }, 60_000);
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      rejectRun(err);
+    });
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      resolveRun({ status: code, output });
+    });
+  });
+}
+
+/** mock origin: routes คีย์เป็น "METHOD path" — บันทึกทุก request ที่เข้ามาไว้ตรวจ */
+function startServer(routes) {
+  const received = [];
+  const server = createServer((req, res) => {
+    let body = '';
+    req.on('data', (chunk) => (body += chunk));
+    req.on('end', () => {
+      received.push({ method: req.method, url: req.url, headers: req.headers, body });
+      const handler = routes[`${req.method} ${req.url}`];
+      if (!handler) {
+        res.statusCode = 404;
+        res.end('no route');
+        return;
+      }
+      handler(req, res, received);
+    });
+  });
+  return new Promise((ready) => {
+    server.listen(0, '127.0.0.1', () => {
+      ready({ server, received, baseUrl: `http://127.0.0.1:${server.address().port}` });
+    });
+  });
+}
+
+const ok204 = (req, res) => {
+  res.statusCode = 204;
+  res.end();
+};
+
+const readyzOk = (req, res) => {
+  res.statusCode = 200;
+  res.setHeader('content-type', 'application/json');
+  res.end(JSON.stringify({ status: 'ready' }));
+};
+
+test('happy path: warm up แล้วยิง marker ผูกวันที่ ได้ 204 → exit 0 พร้อมบอกคำค้นใน log', async () => {
+  const { server, baseUrl, received } = await startServer({
+    'GET /api/readyz': readyzOk,
+    'POST /api/csp-report': ok204,
+  });
+  try {
+    const { status, output } = await run(baseUrl);
+    assert.equal(status, 0, output);
+    assert.match(output, /PASS/);
+
+    // marker ของรอบนี้มี nonce จึงเดาล่วงหน้าไม่ได้ — ต้องอ่านจาก output แล้วเทียบว่า
+    // marker ที่ยิงจริงกับ marker ในคำค้นเป็นตัวเดียวกัน (ถ้าหลุดจากกัน คนจะค้น log ไม่เจอ)
+    const marker = MARKER_RE.exec(output)?.[0];
+    assert.ok(marker, `output ต้องมี marker:\n${output}`);
+    assert.ok(
+      output.includes(`${LOG_DIRECTIVE_PREFIX}img-src${LOG_BLOCKED_PREFIX}${marker}`),
+      `output ต้องมีบรรทัด log ที่ต้องไปค้นหา:\n${output}`
+    );
+    const post = received.find((r) => r.url === '/api/csp-report');
+    assert.equal(new URL(JSON.parse(post.body)['csp-report']['blocked-uri']).hostname, marker);
+
+    // กับดักที่เคยทำให้ "log ว่าง" ตีความผิด: log อยู่ที่ service backend ไม่ใช่ static site
+    assert.ok(output.includes('smartport-backend'), `output ต้องบอกว่าให้เปิด log ของ service ไหน:\n${output}`);
+    // 204 ไม่ใช่หลักฐานว่า error_log() ทำงาน — ห้ามให้ PASS ชวนอ่านกลับด้าน
+    assert.match(output, /ยังไม่ใช่หลักฐาน/, `PASS ต้องระบุขอบเขตของสิ่งที่พิสูจน์ได้:\n${output}`);
+
+    // warm up ต้องมาก่อน report เสมอ (backend plan free spin down ได้ — report เป็น fire-and-forget)
+    assert.equal(received.length, 2, JSON.stringify(received.map((r) => `${r.method} ${r.url}`)));
+    assert.equal(received[0].url, '/api/readyz');
+    assert.equal(received[1].url, '/api/csp-report');
+  } finally {
+    server.close();
+  }
+});
+
+test('payload ต้องเป็น CSP report shape ที่ handler จริงแกะได้ และ marker เป็นวันที่ UTC วันนี้', async () => {
+  const { server, baseUrl, received } = await startServer({
+    'GET /api/readyz': readyzOk,
+    'POST /api/csp-report': ok204,
+  });
+  try {
+    const { status, output } = await run(baseUrl);
+    assert.equal(status, 0, output);
+
+    const post = received.find((r) => r.url === '/api/csp-report');
+    // handler อ่าน php://input แล้ว json_decode → ต้องเป็น JSON ที่ห่อด้วยคีย์ 'csp-report'
+    // (api.php: $report['csp-report'] ?? $report) และ content-type ตามที่ browser ส่งจริง
+    assert.equal(post.headers['content-type'], 'application/csp-report');
+    const body = JSON.parse(post.body);
+    const inner = body['csp-report'];
+    assert.ok(inner, `body ต้องห่อด้วยคีย์ csp-report: ${post.body}`);
+    assert.equal(inner['effective-directive'], 'img-src');
+    // handler ใช้ parse_url(blocked-uri, PHP_URL_HOST) → ต้องเป็น absolute URL ที่มี host
+    const blockedHost = new URL(inner['blocked-uri']).hostname;
+    assert.match(blockedHost, MARKER_RE);
+    assert.ok(blockedHost.startsWith(`csp-selftest-${new Date().toISOString().slice(0, 10).replace(/-/g, '')}-`), blockedHost);
+    // cap 10KB ของ handler (api.php: file_get_contents ... 10240) — payload ต้องไม่ชนเพดาน
+    assert.ok(Buffer.byteLength(post.body) < 10240, `payload ยาวเกิน cap 10KB ของ handler: ${post.body.length}`);
+  } finally {
+    server.close();
+  }
+});
+
+test('redirect ระหว่างทางต้อง fail — ตาม redirect = POST กลายเป็น GET และ body หายทั้งก้อน', async () => {
+  // false-PASS ที่แพงที่สุด: ถ้าใช้ redirect: 'follow' ปลายทางจะตอบ 204 ให้ GET ที่ไม่มี body
+  // แล้วสคริปต์รายงาน PASS ทั้งที่ไม่มี report ถึง handler เลยสักไบต์
+  const { server, baseUrl, received } = await startServer({
+    'GET /api/readyz': readyzOk,
+    'POST /api/csp-report': (req, res) => {
+      res.statusCode = 302;
+      res.setHeader('location', '/api/csp-report-final');
+      res.end();
+    },
+    'GET /api/csp-report-final': ok204,
+    'POST /api/csp-report-final': ok204,
+  });
+  try {
+    const { status, output } = await run(baseUrl);
+    assert.equal(status, 1, output);
+    assert.match(output, /ได้ HTTP 302/, output);
+    assert.doesNotMatch(output, /PASS/, output);
+    assert.equal(received.filter((r) => r.url === '/api/csp-report-final').length, 0, 'ห้ามเดินตาม redirect ต่อ');
+  } finally {
+    server.close();
+  }
+});
+
+test('ไม่ได้ 204 (404 = rewrite/handler หาย) → exit 1 ไม่ใช่ PASS', async () => {
+  const { server, baseUrl } = await startServer({
+    'GET /api/readyz': readyzOk,
+    // ไม่ประกาศ POST /api/csp-report → mock ตอบ 404 เหมือนตอน rewrite ผิดทาง
+  });
+  try {
+    const { status, output } = await run(baseUrl);
+    assert.equal(status, 1, output);
+    assert.match(output, /FAIL/);
+    // ห้าม assert แค่ includes('404') — ephemeral port ของ mock มีเลข 404 ได้เอง
+    assert.match(output, /ได้ HTTP 404/, output);
+  } finally {
+    server.close();
+  }
+});
+
+test('429 (ชน rate limit 60/นาที) → exit 1 และบอกชัดว่า marker ไม่ได้ถูก log', async () => {
+  const { server, baseUrl } = await startServer({
+    'GET /api/readyz': readyzOk,
+    'POST /api/csp-report': (req, res) => {
+      res.statusCode = 429;
+      res.end('rate limited');
+    },
+  });
+  try {
+    const { status, output } = await run(baseUrl);
+    assert.equal(status, 1, output);
+    assert.match(output, /ได้ HTTP 429/, output);
+    assert.match(output, /rate limit/i);
+  } finally {
+    server.close();
+  }
+});
+
+test('warm up ไม่ติดเลย → exit 1 และต้องไม่ยิง report (กัน marker หายเงียบ)', async () => {
+  const { server, baseUrl, received } = await startServer({
+    // ตัด socket ทิ้งเลียนแบบตอน backend หลับ/gateway ตาย — fetch จะ reject ไม่ใช่ได้ status
+    'GET /api/readyz': (req, res) => res.socket.destroy(),
+    'POST /api/csp-report': ok204,
+  });
+  try {
+    const { status, output } = await run(baseUrl);
+    assert.equal(status, 1, output);
+    assert.equal(
+      received.filter((r) => r.url === '/api/csp-report').length,
+      0,
+      'ห้ามยิง report ทั้งที่ยังไม่รู้ว่า backend ตื่น — report เป็น fire-and-forget ไม่มี retry'
+    );
+  } finally {
+    server.close();
+  }
+});
+
+test('502 จาก edge ระหว่าง container บูต = ยังไม่ตื่น ต้อง retry แล้ว fail ไม่ใช่ยิง report ต่อ', async () => {
+  // cold start ของ plan free คือสถานการณ์ที่ warm up ถูกออกแบบมารับพอดี — ถ้านับ 502
+  // ว่า "ตื่นแล้ว" report จะถูกยิงเข้า container ที่ยังไม่รับงาน แล้ว marker หายเงียบ
+  const { server, baseUrl, received } = await startServer({
+    'GET /api/readyz': (req, res) => {
+      res.statusCode = 502;
+      res.end('<html>Bad Gateway</html>');
+    },
+    'POST /api/csp-report': ok204,
+  });
+  try {
+    const { status, output } = await run(baseUrl);
+    assert.equal(status, 1, output);
+    assert.match(output, /HTTP 502/, output);
+    assert.equal(received.filter((r) => r.url === '/api/readyz').length, 3, 'ต้อง retry ครบ 3 ครั้งก่อนยอมแพ้');
+    assert.equal(received.filter((r) => r.url === '/api/csp-report').length, 0);
+  } finally {
+    server.close();
+  }
+});
+
+test('warm up ล้มครั้งแรกแล้วติดครั้งที่สอง → ยิง report ต่อได้ (retry ต้องทำงานจริง)', async () => {
+  let warmupHits = 0;
+  const { server, baseUrl, received } = await startServer({
+    'GET /api/readyz': (req, res) => {
+      warmupHits++;
+      if (warmupHits === 1) return res.socket.destroy();
+      return readyzOk(req, res);
+    },
+    'POST /api/csp-report': ok204,
+  });
+  try {
+    const { status, output } = await run(baseUrl);
+    assert.equal(status, 0, output);
+    assert.match(output, /ลอง 2 ครั้ง/, output);
+    assert.equal(received.filter((r) => r.url === '/api/csp-report').length, 1);
+  } finally {
+    server.close();
+  }
+});
+
+test('report เจอ network error ครั้งแรกแล้วสำเร็จครั้งที่สอง → exit 0', async () => {
+  let reportHits = 0;
+  const { server, baseUrl } = await startServer({
+    'GET /api/readyz': readyzOk,
+    'POST /api/csp-report': (req, res) => {
+      reportHits++;
+      if (reportHits === 1) return res.socket.destroy();
+      return ok204(req, res);
+    },
+  });
+  try {
+    const { status, output } = await run(baseUrl);
+    assert.equal(status, 0, output);
+    assert.match(output, /retry 1\/1/, output);
+    assert.equal(reportHits, 2);
+  } finally {
+    server.close();
+  }
+});
+
+test('readyz ตอบ 503 not_ready → ถือว่า PHP รับงานแล้ว ยิงต่อได้ (handler ไม่แตะ DB)', async () => {
+  const { server, baseUrl, received } = await startServer({
+    'GET /api/readyz': (req, res) => {
+      res.statusCode = 503;
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ status: 'not_ready' }));
+    },
+    'POST /api/csp-report': ok204,
+  });
+  try {
+    const { status, output } = await run(baseUrl);
+    assert.equal(status, 0, output);
+    assert.match(output, /HTTP 503/, `ต้องเตือนว่า readyz ไม่ 200 แต่ไม่บล็อก:\n${output}`);
+    assert.equal(received.filter((r) => r.url === '/api/csp-report').length, 1);
+  } finally {
+    server.close();
+  }
+});
+
+test('argument ที่ไม่รู้จักต้อง fail ก่อนแตะเครือข่าย ไม่ใช่ falls back ไปยิง production', async () => {
+  const { server, baseUrl, received } = await startServer({
+    'GET /api/readyz': readyzOk,
+    'POST /api/csp-report': ok204,
+  });
+  try {
+    const { status, output } = await run(baseUrl, ['--verbose']);
+    assert.equal(status, 1, output);
+    assert.ok(output.includes('--verbose'), output);
+    assert.equal(received.length, 0, 'ต้องไม่ยิงอะไรเลยเมื่อ argument ผิด');
+
+    // --base-url ที่ไม่มีค่าตามหลัง / มี flag ตามหลัง ต้องไม่กลืนแล้วไปยิง default (production)
+    // assert ว่าไม่เข้าเฟส network เลย — ถ้าวันหนึ่งมีคนแก้ให้ fallback ไป DEFAULT_BASE
+    // เทสชุดนี้จะยิง production จริงจากทุกเครื่องที่รัน ci-local และปลูก marker ปลอมลง log
+    for (const args of [['--base-url'], ['--base-url', '--verbose'], ['--base-url=ftp://x']]) {
+      const bad = await runArgs(args);
+      assert.equal(bad.status, 1, `${args.join(' ')} → ${bad.output}`);
+      assert.doesNotMatch(bad.output, /Warm up/, `ห้ามเข้าเฟส network เมื่อ argument ผิด: ${args.join(' ')}`);
+    }
+  } finally {
+    server.close();
+  }
+});
+
+test('รองรับรูป --base-url=<url> ด้วย (พิมพ์แบบนี้แล้วต้องไม่ถูกมองข้าม)', async () => {
+  const { server, baseUrl, received } = await startServer({
+    'GET /api/readyz': readyzOk,
+    'POST /api/csp-report': ok204,
+  });
+  try {
+    const { status, output } = await runArgs([`--base-url=${baseUrl}/`]);
+    assert.equal(status, 0, output);
+    assert.equal(received.filter((r) => r.url === '/api/csp-report').length, 1);
+    // base URL ที่ไม่ใช่ production ต้องเตือนว่า marker นี้ไม่ได้ผ่าน rewrite จริง
+    assert.match(output, /ไม่ใช่ production/, output);
+  } finally {
+    server.close();
+  }
+});
+
+test('--help ต้อง exit 0 พร้อม usage ไม่ใช่ error', async () => {
+  const { status, output } = await runArgs(['--help']);
+  assert.equal(status, 0, output);
+  assert.match(output, /Usage:/, output);
+  assert.doesNotMatch(output, /Warm up/, 'ห้ามยิงอะไรตอนขอ help');
+});
+
+test('buildMarkerHost ผูกกับวันที่ UTC + nonce และปลอดภัยต่อ parse_url + sanitizeLogValue', () => {
+  // ใช้ UTC เพราะ timestamp ใน Render log เป็น UTC — ยิงตอนเช้า SEAST อาจได้วันที่ก่อนหน้า
+  // ซึ่งถูกต้องแล้ว สคริปต์จึงพิมพ์ marker ที่ใช้จริงออกมาเสมอ ไม่ให้ผู้ใช้เดาเอง
+  assert.equal(buildMarkerHost(new Date('2026-08-24T00:30:00Z'), 'a3f9'), 'csp-selftest-20260824-a3f9.invalid');
+  assert.equal(buildMarkerHost(new Date('2026-08-23T23:00:00Z'), 'a3f9'), 'csp-selftest-20260823-a3f9.invalid');
+  // nonce ต้องสุ่มจริงต่อรอบ ไม่งั้น marker เก่าที่ค้างใน log จะถูกนับเป็นหลักฐานของรอบใหม่
+  assert.notEqual(buildMarkerHost(), buildMarkerHost());
+
+  const host = buildMarkerHost(new Date('2026-08-24T00:30:00Z'));
+  assert.match(host, MARKER_RE);
+  // ต้องเป็น hostname ที่ parse ได้จริง ไม่งั้น parse_url ฝั่ง PHP จะคืน false → log เป็น 'self'
+  assert.equal(new URL(`https://${host}/probe.png`).hostname, host);
+  // sanitizeLogValue ตัดที่ 100 ตัวอักษรและลบ control char — marker ต้องรอดครบทั้งเส้น
+  assert.ok(host.length < 100, `marker ยาวเกินจนถูก sanitizeLogValue ตัด: ${host.length}`);
+  assert.doesNotMatch(host, /[\x00-\x1F\x7F]/);
+  // .invalid = TLD สงวนตาม RFC 2606 — resolve ไม่ได้แน่นอน จึงชนกับ host จริงไม่ได้
+  assert.match(host, /\.invalid$/);
+});
+
+test('isBackendAwake แยก 503 ของ PHP ออกจาก 5xx ของ edge ได้', () => {
+  // readyz จริง (backend/routes/readyz.php) คืน JSON ที่มีคีย์ status เสมอ
+  assert.equal(isBackendAwake(200, JSON.stringify({ status: 'ready' })), true);
+  assert.equal(isBackendAwake(503, JSON.stringify({ status: 'not_ready' })), true);
+  assert.equal(isBackendAwake(503, JSON.stringify({ status: 'migrations_pending' })), true);
+  // edge ของ Render ตอบแทนตอน container ยังไม่ตื่น — ไม่มีทางเป็น JSON ของ readyz
+  assert.equal(isBackendAwake(502, '<html>Bad Gateway</html>'), false);
+  assert.equal(isBackendAwake(504, ''), false);
+  assert.equal(isBackendAwake(500, '<html>PHP fatal</html>'), false);
+  // status ต่ำกว่า 500 แปลว่ามีคนรับงานแล้ว (เช่น 404 จาก route ที่หาย) — คนละปัญหากับ "ยังไม่ตื่น"
+  assert.equal(isBackendAwake(404, 'not found'), true);
+});
+
+test('รูปแบบ log ที่สคริปต์บอกให้ค้นหา ต้องตรงกับ error_log จริงใน backend/api.php', () => {
+  // anti-drift: ถ้ามีคนแก้ข้อความ error_log ฝั่ง PHP คำค้นที่สคริปต์พิมพ์จะหาไม่เจอ
+  // แล้ว "ไม่เจอ marker" จะถูกตีความผิดเป็น "pipeline พัง" ทั้งที่แค่ข้อความเปลี่ยน
+  const php = readFileSync(resolve(ROOT, 'backend', 'api.php'), 'utf8');
+  assert.ok(
+    php.includes(`'${LOG_DIRECTIVE_PREFIX}'`),
+    `backend/api.php ไม่มี literal "${LOG_DIRECTIVE_PREFIX}" แล้ว — อัปเดต LOG_DIRECTIVE_PREFIX ใน csp-report-selftest.mjs`
+  );
+  assert.ok(
+    php.includes(`'${LOG_BLOCKED_PREFIX}'`),
+    `backend/api.php ไม่มี literal "${LOG_BLOCKED_PREFIX}" แล้ว — อัปเดต LOG_BLOCKED_PREFIX ใน csp-report-selftest.mjs`
+  );
+});
+
+test('buildReportBody สร้าง body ที่ handler แกะ directive/host ได้ตรงตามที่ตั้งใจ', () => {
+  const body = buildReportBody('csp-selftest-20260824-a3f9.invalid', 'https://smart-port.onrender.com/');
+  const inner = body['csp-report'];
+  // api.php อ่าน effective-directive ก่อน แล้ว fallback ไป violated-directive — ใส่ทั้งคู่ให้ตรงกัน
+  assert.equal(inner['effective-directive'], 'img-src');
+  assert.equal(inner['violated-directive'], 'img-src');
+  assert.equal(new URL(inner['blocked-uri']).hostname, 'csp-selftest-20260824-a3f9.invalid');
+  assert.equal(inner['document-uri'], 'https://smart-port.onrender.com/');
+  // disposition ต้องเป็น report — ยืนยันในตัว log ว่ามาจาก report-only phase
+  assert.equal(inner.disposition, 'report');
+});


### PR DESCRIPTION
## ทำไมต้องมี

เกณฑ์ promote CSP จาก report-only เป็น enforce (จุดตัดสินใจ **24 ส.ค. 2026**) ผูกกับการเปิด Render log ดูด้วยตา แต่ **"log ว่าง" มีสองความหมายที่แยกกันไม่ออก**:

- (ก) ไม่มี violation จริง = พร้อม enforce
- (ข) report ไม่เคยส่งถึง backend เลย = สรุปไม่ได้ ห้าม enforce

PR นี้ทำให้ขั้นตอน "ยิง self-test ใหม่ก่อนอ่าน log" (ที่เอกสาร baseline สั่งไว้แต่เดิมต้องทำมือ) เหลือ **คำสั่งเดียว**:

```bash
node scripts/csp-report-selftest.mjs
```

สคริปต์ warm up `/api/readyz` ให้เอง → POST marker ผูกวันที่ UTC + nonce ผ่าน rewrite เส้นเดียวกับที่ browser ใช้ → พิมพ์บรรทัดที่ต้องเอาไปค้นใน log ออกมาให้ copy ได้ตรง ๆ

## ที่เปลี่ยน

| ไฟล์ | อะไร |
|---|---|
| `scripts/csp-report-selftest.mjs` | CLI ใหม่ (ไม่อยู่ใน CI gate — ยิง production จริง เรียกมือเท่านั้น) |
| `scripts/tests/csp-report-selftest.test.mjs` | regression 17 เทสผ่าน mock origin บน 127.0.0.1 |
| `scripts/ci-local.sh` / `.ps1` | เสียบ **เฉพาะ regression test** เข้า fast gate |
| `docs/frontend-security-headers.md` | ขั้นตอนวัน 24 ส.ค. + ขอบเขตของสิ่งที่ exit 0 พิสูจน์ได้ + หลักฐาน cold start ใหม่ |

## Guard rails ที่ใส่ไว้ (แต่ละข้อมีเทสคุม)

1. **warm up fail-closed** — ปลุก backend ไม่ขึ้น = **ไม่ยิง report เลย** (CSP report เป็น fire-and-forget ไม่มี retry; ยิงตอน container หลับ = marker หายเงียบ แล้วอ่าน log ผิด)
2. **แยก 503 ของ PHP ออกจาก 502/504 ของ edge** — `readyz` คืน JSON ที่มีคีย์ `status` เสมอ; 5xx ที่ไม่ใช่รูปนั้นแปลว่า container ยังไม่ตื่น → retry ไม่ใช่นับว่าผ่าน
3. **`redirect: 'manual'`** — ถ้าตาม redirect ตัว POST จะกลายเป็น GET และ **body หายทั้งก้อน** แล้วปลายทางอาจตอบ 204 = false-PASS ที่ทำให้ enforce บนหลักฐานปลอม (reproduce ได้จริงตอนรีวิว)
4. **ข้อความ PASS ระบุขอบเขต** — 204 ไม่ใช่หลักฐานว่า `error_log()` ทำงาน (handler ตอบ 204 แม้แกะ body ไม่ได้) หลักฐานจริงมีทางเดียวคือเห็น marker ในหน้า log
5. **argument fail-closed** — default ของสคริปต์คือยิง production ถ้ากลืน flag ที่พิมพ์ผิดเงียบ ๆ คนที่ตั้งใจยิง staging จะไปโดน production; validate URL + scheme + ปฏิเสธค่าที่ขึ้นต้นด้วย `--`
6. **marker มี nonce** — `csp-selftest-YYYYMMDD-xxxx.invalid` แยก "marker ที่เพิ่งยิง" ออกจาก marker เก่าที่ค้างใน log วันเดียวกัน (ไม่งั้นหลักฐานรอบเก่าถูกนับเป็นของรอบใหม่)
7. **เทส anti-drift** — ผูกคำค้นที่สคริปต์พิมพ์เข้ากับ literal ของ `error_log()` ใน `backend/api.php` ถ้าฝั่ง PHP เปลี่ยนข้อความ เทสแตกทันที (ไม่งั้น "ไม่เจอ marker" จะถูกตีความผิดเป็น "pipeline พัง")

## ความเสี่ยงที่ยังเหลือ

1. **สคริปต์นี้ยิง production จริง** — จงใจไม่เสียบเข้า CI gate ใด ๆ (ยืนยันแล้วว่า `ci.yml`, `deploy.yml`, `.githooks/pre-push` ไม่ได้แตะ `scripts/tests/` แบบ glob) ถ้ามีคนย้ายเข้า gate ในอนาคต จะปลูก marker ปลอมลง Render log ทุกครั้งที่ใครรัน CI แล้วทำให้หลักฐานวันตัดสินใจเสีย
2. **hop สุดท้าย (`error_log` → Render log stream) ยังไม่เคยยืนยันด้วยตา** — สคริปต์ปิดช่องว่างได้ถึงแค่ 204 คนที่มีสิทธิ์เปิด dashboard ต้องเป็นคนยืนยันขั้นสุดท้าย

## Test plan

- [x] `node --test scripts/tests/csp-report-selftest.test.mjs` — 17/17 ผ่าน (ไม่แตะเครือข่ายจริง)
- [x] `bash scripts/ci-local.sh --skip-frontend --skip-e2e --skip-backend --skip-docker` — fast gates เขียวครบ (schema parity / multiplier / live header / CSP self-test)
- [x] pre-push vitest — 74 ไฟล์ / 560 เทส ผ่านหมด
- [x] validate กับ production จริง 2 รอบ: `csp-selftest-20260818.invalid` (05:00 UTC) และ `csp-selftest-20260818-ecc9.invalid` (05:10 UTC) ได้ **HTTP 204** ทั้งคู่ — รอบหลังใช้ `redirect: 'manual'` = ยืนยันว่าเส้นทางจริงไม่มี redirect แทรก
- [ ] **ต้องให้คนที่มีสิทธิ์ทำ**: เปิด Render log ของ service `smartport-backend` ค้น `csp-selftest-20260818-ecc9.invalid` — เจอ = ปิดช่องว่าง hop สุดท้ายได้ตั้งแต่วันนี้ ไม่ต้องรอ 24 ส.ค.

## หลักฐานใหม่ที่ได้ระหว่างทาง (บันทึกลงเอกสารแล้ว)

เอกสาร baseline เคยบันทึกว่า "POST นัดแรก timeout 30s แต่ `readyz` ตอบ 200 ใน 1.1s จึงสรุปสาเหตุไม่ได้ระหว่าง network hiccup กับ cold start" — รอบ 05:00 UTC วันนี้ request แรกคือ `readyz` เอง และใช้เวลา **23.1 วินาที** ส่วน request ถัดมาเร็วปกติ รูปแบบ "request แรกที่ชน container ที่หลับช้ามาก ถัดไปเร็ว" ตรงกันทั้งสองรอบ จึงอธิบายได้ด้วย spin down ของ `plan: free` อย่างเดียว โดยไม่ต้องพึ่งสมมติฐาน network hiccup (ยังเป็นการวัดครั้งเดียว ไม่ใช่ข้อพิสูจน์ปิดตาย)

Refs #113
