### PR TITLE
fix(security): seed admin ต้องไม่เขียนทับรหัสผ่านที่ production ตั้งเอง

### DIFF
--- a/backend/tests/Integration/AdminSeedUpsertTest.php
+++ b/backend/tests/Integration/AdminSeedUpsertTest.php
@@ -18,11 +18,14 @@ use RuntimeException;
  *
  * เทสอ่านคำสั่ง ON DUPLICATE KEY UPDATE จากไฟล์ .sql จริง (anti-drift) แล้วรันกับ
  * ผู้ใช้ทดสอบแยกแถว เพื่อไม่ไปแตะแถว admin ที่เทสอื่นและ e2e ใช้ล็อกอิน
+ *
+ * คลาสนี้เก็บเฉพาะเทส "พฤติกรรมบน DB จริง" เท่านั้น — guard แบบ static
+ * (clause ของสองไฟล์ตรงกัน, ไม่มีรหัสผ่าน plaintext) อยู่ที่
+ * scripts/tests/admin-seed-guards.test.mjs ซึ่งรันได้โดยไม่ต้องมี MySQL
  */
 final class AdminSeedUpsertTest extends TestCase
 {
     private const MIGRATION_FILE = __DIR__ . '/../../../database/09-auth-users.sql';
-    private const TIDB_INIT_FILE = __DIR__ . '/../../../database/tidb-init.sql';
     private const TEST_USERNAME = 'seed-upsert-probe-999';
 
     private static ?PDO $pdo = null;
@@ -32,6 +35,11 @@ final class AdminSeedUpsertTest extends TestCase
         self::$pdo = testPdo();
     }
 
+    /**
+     * ทุกเทสในคลาสนี้ต้องใช้ DB จริง — ถ้าจะเพิ่มเทสที่ไม่ต้องใช้ DB
+     * อย่าใส่ที่นี่ เพราะ setUp() skip ทั้งคลาสเมื่อต่อ MySQL ไม่ได้
+     * ให้ไปเพิ่มที่ scripts/tests/admin-seed-guards.test.mjs แทน
+     */
     protected function setUp(): void
     {
         if (self::$pdo === null) {
@@ -130,7 +138,7 @@ final class AdminSeedUpsertTest extends TestCase
     }
 
     #[Test]
-    public function seedsAdminOnFreshInstall(): void
+    public function seeds_admin_row_when_none_exists(): void
     {
         $seedHash = self::extractSeedHash(self::MIGRATION_FILE);
 
@@ -143,7 +151,7 @@ final class AdminSeedUpsertTest extends TestCase
     }
 
     #[Test]
-    public function rerunDoesNotResetPasswordThatOperatorAlreadyChanged(): void
+    public function rerun_does_not_reset_password_that_operator_already_changed(): void
     {
         $seedHash = self::extractSeedHash(self::MIGRATION_FILE);
         $this->runSeedUpsert($seedHash);
@@ -169,7 +177,7 @@ final class AdminSeedUpsertTest extends TestCase
     }
 
     #[Test]
-    public function fillsPasswordWhenExistingRowHasNoUsableHash(): void
+    public function fills_password_when_existing_row_has_no_usable_hash(): void
     {
         $seedHash = self::extractSeedHash(self::MIGRATION_FILE);
 
@@ -192,7 +200,7 @@ final class AdminSeedUpsertTest extends TestCase
     }
 
     #[Test]
-    public function rerunReactivatesDisabledAdminByDesign(): void
+    public function rerun_reactivates_disabled_admin_by_design(): void
     {
         $seedHash = self::extractSeedHash(self::MIGRATION_FILE);
         $this->runSeedUpsert($seedHash);
@@ -210,42 +218,4 @@ final class AdminSeedUpsertTest extends TestCase
         );
     }
 
-    #[Test]
-    public function bothSqlFilesShareTheSameGuardedClause(): void
-    {
-        $normalize = static function (string $s): string {
-            $withoutComments = preg_replace('/--[^\n]*/', '', $s) ?? '';
-
-            return trim(preg_replace('/\s+/', ' ', $withoutComments) ?? '');
-        };
-
-        $migration = $normalize(self::extractUpsertClause(self::MIGRATION_FILE));
-        $tidbInit = $normalize(self::extractUpsertClause(self::TIDB_INIT_FILE));
-
-        $this->assertSame(
-            $migration,
-            $tidbInit,
-            'tidb-init.sql คือ bootstrap ตัวจริงของ production — ถ้า clause ไม่ตรงกับ migration แปลว่าแก้ไปแล้วไม่มีผลกับ prod'
-        );
-        $this->assertStringContainsString(
-            'users.password_hash IS NULL OR users.password_hash',
-            $migration,
-            'ต้องยังมี guard ที่กันการเขียนทับรหัสผ่านเดิม'
-        );
-    }
-
-    #[Test]
-    public function sqlFilesDoNotPublishTheBootstrapPasswordInPlaintext(): void
-    {
-        // ประกอบสตริงเพื่อไม่ให้ค่าดังกล่าวปรากฏเป็นคำเดียวในไฟล์เทสเอง
-        $plaintext = 'admin' . '123';
-
-        foreach ([self::MIGRATION_FILE, self::TIDB_INIT_FILE] as $path) {
-            $this->assertStringNotContainsString(
-                $plaintext,
-                self::readSql($path),
-                basename($path) . ' ต้องไม่เขียนรหัสผ่าน bootstrap เป็น plaintext ลงใน repo สาธารณะ'
-            );
-        }
-    }
 }

--- a/backend/tests/Integration/AdminSeedUpsertTest.php
+++ b/backend/tests/Integration/AdminSeedUpsertTest.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration;
+
+use PDO;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * คุม invariant ของ seed admin ใน database/09-auth-users.sql และ database/tidb-init.sql
+ *
+ * บั๊กที่เทสชุดนี้กันไม่ให้กลับมา: เดิม upsert เขียน password_hash ทับทุกครั้ง
+ * แปลว่า "รัน migration ซ้ำ = รีเซ็ตรหัสผ่าน admin ของ production กลับไปเป็นค่า
+ * bootstrap ที่อยู่ใน repo สาธารณะ" โดยไม่มีสัญญาณเตือนใด ๆ
+ *
+ * เทสอ่านคำสั่ง ON DUPLICATE KEY UPDATE จากไฟล์ .sql จริง (anti-drift) แล้วรันกับ
+ * ผู้ใช้ทดสอบแยกแถว เพื่อไม่ไปแตะแถว admin ที่เทสอื่นและ e2e ใช้ล็อกอิน
+ */
+final class AdminSeedUpsertTest extends TestCase
+{
+    private const MIGRATION_FILE = __DIR__ . '/../../../database/09-auth-users.sql';
+    private const TIDB_INIT_FILE = __DIR__ . '/../../../database/tidb-init.sql';
+    private const TEST_USERNAME = 'seed-upsert-probe-999';
+
+    private static ?PDO $pdo = null;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$pdo = testPdo();
+    }
+
+    protected function setUp(): void
+    {
+        if (self::$pdo === null) {
+            self::markTestSkipped('ต่อ MySQL ไม่ได้ — รัน: docker compose up -d db');
+        }
+        $this->deleteProbeRow();
+    }
+
+    protected function tearDown(): void
+    {
+        if (self::$pdo !== null) {
+            $this->deleteProbeRow();
+        }
+    }
+
+    private function deleteProbeRow(): void
+    {
+        $stmt = self::$pdo->prepare('DELETE FROM users WHERE username = ?');
+        $stmt->execute([self::TEST_USERNAME]);
+    }
+
+    /** อ่านไฟล์ .sql แล้วคืนค่าเป็น LF เสมอ (ไฟล์ในโปรเจกต์เป็น CRLF) */
+    private static function readSql(string $path): string
+    {
+        $raw = file_get_contents($path);
+        if ($raw === false) {
+            throw new RuntimeException("อ่านไฟล์ไม่ได้: {$path}");
+        }
+
+        return str_replace("\r\n", "\n", $raw);
+    }
+
+    /** ดึงคำสั่งหลัง ON DUPLICATE KEY UPDATE ของ seed admin ออกมาจากไฟล์จริง */
+    private static function extractUpsertClause(string $path): string
+    {
+        $sql = self::readSql($path);
+        $matched = preg_match(
+            '/INSERT INTO users \(username, password_hash.*?ON DUPLICATE KEY UPDATE(.*?);/s',
+            $sql,
+            $m
+        );
+        if ($matched !== 1) {
+            throw new RuntimeException("หา seed admin ใน {$path} ไม่เจอ — โครงไฟล์เปลี่ยนไป");
+        }
+
+        return trim($m[1]);
+    }
+
+    /** ดึง hash ที่ไฟล์ seed ใช้จริง แทนการ hardcode ในเทส */
+    private static function extractSeedHash(string $path): string
+    {
+        $sql = self::readSql($path);
+        $matched = preg_match(
+            "/INSERT INTO users \(username, password_hash.*?VALUES \('admin', '([^']+)'/s",
+            $sql,
+            $m
+        );
+        if ($matched !== 1) {
+            throw new RuntimeException("หา seed hash ใน {$path} ไม่เจอ");
+        }
+
+        return $m[1];
+    }
+
+    /**
+     * รัน upsert เดียวกับ migration แต่เปลี่ยน username เป็นแถวทดสอบ
+     * คำสั่งส่วน ON DUPLICATE KEY UPDATE มาจากไฟล์ .sql จริงทั้งดุ้น
+     */
+    private function runSeedUpsert(string $hash, string $fullName = 'ผู้ดูแลระบบ'): void
+    {
+        $clause = self::extractUpsertClause(self::MIGRATION_FILE);
+        $sql = 'INSERT INTO users (username, password_hash, full_name, role, is_active, must_change_password)'
+            . " VALUES (:username, :hash, :full_name, 'admin', 1, 1)\n"
+            . "ON DUPLICATE KEY UPDATE\n" . $clause;
+
+        $stmt = self::$pdo->prepare($sql);
+        $stmt->execute([
+            ':username'  => self::TEST_USERNAME,
+            ':hash'      => $hash,
+            ':full_name' => $fullName,
+        ]);
+    }
+
+    /** @return array<string, mixed> */
+    private function fetchProbeRow(): array
+    {
+        $stmt = self::$pdo->prepare(
+            'SELECT password_hash, full_name, is_active, must_change_password
+             FROM users WHERE username = ?'
+        );
+        $stmt->execute([self::TEST_USERNAME]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        $this->assertIsArray($row, 'ไม่พบแถวทดสอบหลังรัน upsert');
+
+        return $row;
+    }
+
+    #[Test]
+    public function seedsAdminOnFreshInstall(): void
+    {
+        $seedHash = self::extractSeedHash(self::MIGRATION_FILE);
+
+        $this->runSeedUpsert($seedHash);
+
+        $row = $this->fetchProbeRow();
+        $this->assertSame($seedHash, $row['password_hash'], 'ติดตั้งใหม่ต้องได้รหัส bootstrap เพื่อกัน lock-out');
+        $this->assertSame(1, (int) $row['must_change_password'], 'ติดตั้งใหม่ต้องถูกบังคับให้เปลี่ยนรหัส');
+        $this->assertSame(1, (int) $row['is_active']);
+    }
+
+    #[Test]
+    public function rerunDoesNotResetPasswordThatOperatorAlreadyChanged(): void
+    {
+        $seedHash = self::extractSeedHash(self::MIGRATION_FILE);
+        $this->runSeedUpsert($seedHash);
+
+        // จำลองผู้ดูแลเปลี่ยนรหัสผ่านเองหลัง deploy
+        $operatorHash = password_hash('rotated-by-operator-' . bin2hex(random_bytes(6)), PASSWORD_BCRYPT);
+        $update = self::$pdo->prepare(
+            'UPDATE users SET password_hash = ?, must_change_password = 0, full_name = ? WHERE username = ?'
+        );
+        $update->execute([$operatorHash, 'ชื่อที่ผู้ดูแลตั้งเอง', self::TEST_USERNAME]);
+
+        // รัน migration ซ้ำ (เช่น re-deploy / import ทับ)
+        $this->runSeedUpsert($seedHash);
+
+        $row = $this->fetchProbeRow();
+        $this->assertSame(
+            $operatorHash,
+            $row['password_hash'],
+            'รัน migration ซ้ำต้องไม่รีเซ็ตรหัสผ่านกลับไปเป็นค่า bootstrap สาธารณะ'
+        );
+        $this->assertSame(0, (int) $row['must_change_password'], 'ต้องไม่ปลุกธงบังคับเปลี่ยนรหัสซ้ำ');
+        $this->assertSame('ชื่อที่ผู้ดูแลตั้งเอง', $row['full_name'], 'ต้องไม่เขียนทับชื่อที่ผู้ดูแลตั้งเอง');
+    }
+
+    #[Test]
+    public function fillsPasswordWhenExistingRowHasNoUsableHash(): void
+    {
+        $seedHash = self::extractSeedHash(self::MIGRATION_FILE);
+
+        foreach ([null, ''] as $emptyValue) {
+            $this->deleteProbeRow();
+            $insert = self::$pdo->prepare(
+                "INSERT INTO users (username, password_hash, full_name, role, is_active, must_change_password)
+                 VALUES (?, ?, NULL, 'admin', 1, 0)"
+            );
+            $insert->execute([self::TEST_USERNAME, $emptyValue]);
+
+            $this->runSeedUpsert($seedHash);
+
+            $row = $this->fetchProbeRow();
+            $label = $emptyValue === null ? 'NULL' : 'ว่าง';
+            $this->assertSame($seedHash, $row['password_hash'], "แถวที่ hash เป็น {$label} ต้องถูกเติมรหัส bootstrap (กัน lock-out)");
+            $this->assertSame(1, (int) $row['must_change_password'], "แถวที่ hash เป็น {$label} ต้องถูกบังคับเปลี่ยนรหัส");
+            $this->assertSame('ผู้ดูแลระบบ', $row['full_name'], 'ชื่อที่ยังว่างต้องถูกเติมให้');
+        }
+    }
+
+    #[Test]
+    public function rerunReactivatesDisabledAdminByDesign(): void
+    {
+        $seedHash = self::extractSeedHash(self::MIGRATION_FILE);
+        $this->runSeedUpsert($seedHash);
+
+        $disable = self::$pdo->prepare('UPDATE users SET is_active = 0 WHERE username = ?');
+        $disable->execute([self::TEST_USERNAME]);
+
+        $this->runSeedUpsert($seedHash);
+
+        $row = $this->fetchProbeRow();
+        $this->assertSame(
+            1,
+            (int) $row['is_active'],
+            'is_active = 1 เสมอเป็นพฤติกรรมที่ตั้งใจ (กัน lock-out) — ถ้าจะเปลี่ยนต้องเป็นการตัดสินใจโดยรู้ตัว'
+        );
+    }
+
+    #[Test]
+    public function bothSqlFilesShareTheSameGuardedClause(): void
+    {
+        $normalize = static function (string $s): string {
+            $withoutComments = preg_replace('/--[^\n]*/', '', $s) ?? '';
+
+            return trim(preg_replace('/\s+/', ' ', $withoutComments) ?? '');
+        };
+
+        $migration = $normalize(self::extractUpsertClause(self::MIGRATION_FILE));
+        $tidbInit = $normalize(self::extractUpsertClause(self::TIDB_INIT_FILE));
+
+        $this->assertSame(
+            $migration,
+            $tidbInit,
+            'tidb-init.sql คือ bootstrap ตัวจริงของ production — ถ้า clause ไม่ตรงกับ migration แปลว่าแก้ไปแล้วไม่มีผลกับ prod'
+        );
+        $this->assertStringContainsString(
+            'users.password_hash IS NULL OR users.password_hash',
+            $migration,
+            'ต้องยังมี guard ที่กันการเขียนทับรหัสผ่านเดิม'
+        );
+    }
+
+    #[Test]
+    public function sqlFilesDoNotPublishTheBootstrapPasswordInPlaintext(): void
+    {
+        // ประกอบสตริงเพื่อไม่ให้ค่าดังกล่าวปรากฏเป็นคำเดียวในไฟล์เทสเอง
+        $plaintext = 'admin' . '123';
+
+        foreach ([self::MIGRATION_FILE, self::TIDB_INIT_FILE] as $path) {
+            $this->assertStringNotContainsString(
+                $plaintext,
+                self::readSql($path),
+                basename($path) . ' ต้องไม่เขียนรหัสผ่าน bootstrap เป็น plaintext ลงใน repo สาธารณะ'
+            );
+        }
+    }
+}

--- a/backend/tests/Integration/AdminSeedUpsertTest.php
+++ b/backend/tests/Integration/AdminSeedUpsertTest.php
@@ -173,7 +173,12 @@ final class AdminSeedUpsertTest extends TestCase
             'รัน migration ซ้ำต้องไม่รีเซ็ตรหัสผ่านกลับไปเป็นค่า bootstrap สาธารณะ'
         );
         $this->assertSame(0, (int) $row['must_change_password'], 'ต้องไม่ปลุกธงบังคับเปลี่ยนรหัสซ้ำ');
-        $this->assertSame('ชื่อที่ผู้ดูแลตั้งเอง', $row['full_name'], 'ต้องไม่เขียนทับชื่อที่ผู้ดูแลตั้งเอง');
+        $this->assertSame(
+            'ผู้ดูแลระบบ',
+            $row['full_name'],
+            'full_name ถูกเขียนทับเสมอโดยตั้งใจ — เป็นตัวซ่อมชื่อที่เพี้ยนจาก dump เก่าตอน import ทับ '
+            . 'ถ้าจะเปลี่ยนให้ปกป้องชื่อที่ผู้ดูแลตั้งเอง ต้องเป็นงานแยกที่ตัดสินใจโดยรู้ตัว'
+        );
     }
 
     #[Test]

--- a/database/09-auth-users.sql
+++ b/database/09-auth-users.sql
@@ -57,7 +57,7 @@ ON DUPLICATE KEY UPDATE
     -- ไปแล้ว เงื่อนไขจะอ่านค่าใหม่และกลายเป็นเท็จเสมอ
     must_change_password = IF(users.password_hash IS NULL OR users.password_hash = '', VALUES(must_change_password), users.must_change_password),
     password_hash = IF(users.password_hash IS NULL OR users.password_hash = '', VALUES(password_hash), users.password_hash),
-    full_name = IF(users.full_name IS NULL OR users.full_name = '', VALUES(full_name), users.full_name),
+    full_name = VALUES(full_name),
     -- Do not reset role: migration 27 may promote username=admin → superadmin
     -- is_active = 1 เสมอโดยตั้งใจ — เป็นตัวกัน lock-out (คงพฤติกรรมเดิม)
     is_active = VALUES(is_active);

--- a/database/09-auth-users.sql
+++ b/database/09-auth-users.sql
@@ -35,15 +35,29 @@ CREATE TABLE login_attempts (
     KEY idx_login_attempts_user_time (username, attempted_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
--- Seed admin คนแรก (กัน lock-out) — รหัสผ่านชั่วคราว 'admin123'
--- ต้องเปลี่ยนทันทีหลัง deploy production (must_change_password = 1)
+-- Seed admin คนแรก (กัน lock-out)
+--
+-- คำเตือนด้านความปลอดภัย: รหัสผ่านเริ่มต้นด้านล่างเป็น credential สำหรับ dev/local
+-- เท่านั้น และถือว่าเป็น "ค่าสาธารณะ" เพราะ hash อยู่ใน repo ที่เปิดสาธารณะ
+-- ระบบ production ต้องเปลี่ยนรหัสผ่านบัญชี admin ทันทีหลัง deploy ครั้งแรก
+-- must_change_password = 1 เป็นเพียงสัญญาณให้ frontend พาไปหน้าเปลี่ยนรหัส
+-- มันไม่ได้บล็อกการออก JWT ที่ backend (ดู loginUser() ใน backend/routes/auth.php)
+--
 -- ใช้ upsert เพราะ dump เก่า (export-tidb.sql / reimport-data.sql) seed แถว
 -- (1,'admin') ไว้แล้วทั้งบน local และ TiDB production
 INSERT INTO users (username, password_hash, full_name, role, is_active, must_change_password)
 VALUES ('admin', '$2y$10$Vrl20xAh4dvfwpDt/pWnTOcMuCzjj8353VKy348pb80StKqkENMcm', 'ผู้ดูแลระบบ', 'admin', 1, 1)
 ON DUPLICATE KEY UPDATE
-    password_hash = VALUES(password_hash),
-    full_name = VALUES(full_name),
+    -- ตั้งรหัสผ่านให้เฉพาะแถวที่ "ยังไม่มีรหัสใช้งานได้" (dump เก่าที่ hash เป็น NULL/ว่าง)
+    -- ห้ามเขียนทับรหัสที่ผู้ดูแลตั้งเองแล้ว มิฉะนั้นการรัน migration ซ้ำ = รีเซ็ตรหัสผ่าน
+    -- ของ production กลับไปเป็นค่า bootstrap สาธารณะโดยไม่มีใครรู้ตัว
+    --
+    -- ลำดับสำคัญ: must_change_password ต้องอยู่ "ก่อน" password_hash เพราะ MySQL/TiDB
+    -- ประเมิน assignment เรียงซ้ายไปขวา ถ้าสลับลำดับ users.password_hash จะถูกเขียนทับ
+    -- ไปแล้ว เงื่อนไขจะอ่านค่าใหม่และกลายเป็นเท็จเสมอ
+    must_change_password = IF(users.password_hash IS NULL OR users.password_hash = '', VALUES(must_change_password), users.must_change_password),
+    password_hash = IF(users.password_hash IS NULL OR users.password_hash = '', VALUES(password_hash), users.password_hash),
+    full_name = IF(users.full_name IS NULL OR users.full_name = '', VALUES(full_name), users.full_name),
     -- Do not reset role: migration 27 may promote username=admin → superadmin
-    is_active = VALUES(is_active),
-    must_change_password = VALUES(must_change_password);
+    -- is_active = 1 เสมอโดยตั้งใจ — เป็นตัวกัน lock-out (คงพฤติกรรมเดิม)
+    is_active = VALUES(is_active);

--- a/database/tidb-init.sql
+++ b/database/tidb-init.sql
@@ -1299,7 +1299,7 @@ ON DUPLICATE KEY UPDATE
     -- ไปแล้ว เงื่อนไขจะอ่านค่าใหม่และกลายเป็นเท็จเสมอ
     must_change_password = IF(users.password_hash IS NULL OR users.password_hash = '', VALUES(must_change_password), users.must_change_password),
     password_hash = IF(users.password_hash IS NULL OR users.password_hash = '', VALUES(password_hash), users.password_hash),
-    full_name = IF(users.full_name IS NULL OR users.full_name = '', VALUES(full_name), users.full_name),
+    full_name = VALUES(full_name),
     -- Do not reset role on reimport (matches 09-auth-users.sql)
     -- is_active = 1 เสมอโดยตั้งใจ — เป็นตัวกัน lock-out (คงพฤติกรรมเดิม)
     is_active = VALUES(is_active);

--- a/database/tidb-init.sql
+++ b/database/tidb-init.sql
@@ -1278,17 +1278,31 @@ CREATE TABLE login_attempts (
     KEY idx_login_attempts_user_time (username, attempted_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
--- Seed admin คนแรก (กัน lock-out) — รหัสผ่านชั่วคราว 'admin123'
--- ต้องเปลี่ยนทันทีหลัง deploy production (must_change_password = 1)
+-- Seed admin คนแรก (กัน lock-out)
+--
+-- คำเตือนด้านความปลอดภัย: รหัสผ่านเริ่มต้นด้านล่างเป็น credential สำหรับ dev/local
+-- เท่านั้น และถือว่าเป็น "ค่าสาธารณะ" เพราะ hash อยู่ใน repo ที่เปิดสาธารณะ
+-- ระบบ production ต้องเปลี่ยนรหัสผ่านบัญชี admin ทันทีหลัง deploy ครั้งแรก
+-- must_change_password = 1 เป็นเพียงสัญญาณให้ frontend พาไปหน้าเปลี่ยนรหัส
+-- มันไม่ได้บล็อกการออก JWT ที่ backend (ดู loginUser() ใน backend/routes/auth.php)
+--
 -- ใช้ upsert เผื่อกรณี import ทับ dump เก่าที่ seed แถว (1,'admin') ไว้แล้ว
 INSERT INTO users (username, password_hash, full_name, role, is_active, must_change_password)
 VALUES ('admin', '$2y$10$Vrl20xAh4dvfwpDt/pWnTOcMuCzjj8353VKy348pb80StKqkENMcm', 'ผู้ดูแลระบบ', 'superadmin', 1, 1)
 ON DUPLICATE KEY UPDATE
-    password_hash = VALUES(password_hash),
-    full_name = VALUES(full_name),
+    -- ตั้งรหัสผ่านให้เฉพาะแถวที่ "ยังไม่มีรหัสใช้งานได้" (dump เก่าที่ hash เป็น NULL/ว่าง)
+    -- ห้ามเขียนทับรหัสที่ผู้ดูแลตั้งเองแล้ว มิฉะนั้นการรัน migration ซ้ำ = รีเซ็ตรหัสผ่าน
+    -- ของ production กลับไปเป็นค่า bootstrap สาธารณะโดยไม่มีใครรู้ตัว
+    --
+    -- ลำดับสำคัญ: must_change_password ต้องอยู่ "ก่อน" password_hash เพราะ MySQL/TiDB
+    -- ประเมิน assignment เรียงซ้ายไปขวา ถ้าสลับลำดับ users.password_hash จะถูกเขียนทับ
+    -- ไปแล้ว เงื่อนไขจะอ่านค่าใหม่และกลายเป็นเท็จเสมอ
+    must_change_password = IF(users.password_hash IS NULL OR users.password_hash = '', VALUES(must_change_password), users.must_change_password),
+    password_hash = IF(users.password_hash IS NULL OR users.password_hash = '', VALUES(password_hash), users.password_hash),
+    full_name = IF(users.full_name IS NULL OR users.full_name = '', VALUES(full_name), users.full_name),
     -- Do not reset role on reimport (matches 09-auth-users.sql)
-    is_active = VALUES(is_active),
-    must_change_password = VALUES(must_change_password);
+    -- is_active = 1 เสมอโดยตั้งใจ — เป็นตัวกัน lock-out (คงพฤติกรรมเดิม)
+    is_active = VALUES(is_active);
 
 -- ============================================
 -- FILE: 27-superadmin-permission-overrides.sql

--- a/docs/render-tidb-production.md
+++ b/docs/render-tidb-production.md
@@ -189,23 +189,39 @@ The endpoint is public but discloses only counts/status — no table or migratio
 
 ```bash
 # พิมพ์รหัสผ่าน admin ของ production ตอนรัน — ไม่ต้องเขียนรหัสลงในเอกสารนี้
-read -rs ADMIN_PASSWORD
-curl -i \
-  -H "Content-Type: application/json" \
-  --data-binary "$(printf '{"email":"admin","password":"%s"}' "$ADMIN_PASSWORD")" \
-  https://smartport-backend.onrender.com/api/auth/login
+# ส่ง body ทาง stdin เพื่อไม่ให้รหัสผ่านไปโผล่ใน argv ของ curl
+# (printf เป็น builtin ของ bash จึงไม่เกิด process แยก)
+read -rsp 'admin password: ' ADMIN_PASSWORD; echo
+printf '{"email":"admin","password":"%s"}' "$ADMIN_PASSWORD" \
+  | curl -i \
+      -H "Content-Type: application/json" \
+      --data-binary @- \
+      https://smartport-backend.onrender.com/api/auth/login
 ```
 
 Expected result: JSON token payload, not a database connection error.
+(ถ้ารหัสผ่านมีอักขระ `"` หรือ `\` ต้อง escape ก่อน เพราะบรรทัดนี้ประกอบ JSON ตรง ๆ)
 
-> รหัสผ่าน bootstrap ของบัญชี `admin` เป็นค่าสาธารณะ (hash อยู่ใน repo ที่เปิด
-> สาธารณะ) บน production แถวนี้มาจาก `database/tidb-init.sql` ซึ่งเป็น bootstrap
-> ตัวจริงเพราะ prod ตั้ง `RUN_MIGRATIONS=0` ส่วน `database/09-auth-users.sql` คือ
-> migration ที่ใช้กับ local/CI — ทั้งสองไฟล์ seed ค่าเดียวกันและมี gate คุมให้ตรงกัน
->
-> production ต้องเปลี่ยนรหัสของบัญชี `admin` ทันทีหลัง deploy ครั้งแรก — ธง
+> **รหัสผ่าน bootstrap ของบัญชี `admin` เป็นค่าสาธารณะ** — hash อยู่ใน repo ที่เปิด
+> สาธารณะ production ต้องเปลี่ยนรหัสของบัญชีนี้ทันทีหลัง deploy ครั้งแรก ธง
 > `must_change_password` เป็นแค่การพาไปหน้าเปลี่ยนรหัสที่ frontend
-> ไม่ได้บล็อกการออก JWT ที่ backend
+> **ไม่ได้บล็อกการออก JWT ที่ backend** (ดู `loginUser()` ใน `backend/routes/auth.php`)
+>
+> แถว `admin` บน production มาได้สองทาง และ **ทั้งสองทางทำงานจริง**:
+>
+> - `render.yaml` ใช้ `dockerfilePath: ./Dockerfile` (ตัวที่ root) ซึ่งตั้ง
+>   `ENV RUN_MIGRATIONS=1` → **migration รันบน production จริง** ไม่ใช่ไม่รัน
+>   (`backend/Dockerfile` ที่ตั้ง `RUN_MIGRATIONS=0` ไม่ได้ถูกใช้)
+>   แต่ละไฟล์รันได้ครั้งเดียวต่อฐานข้อมูล เพราะ `run-migrations.php` บันทึกชื่อที่รันแล้ว
+>   ไว้ในตาราง `schema_migrations` แล้วรันเฉพาะตัวที่ยังไม่เคยรัน
+> - `database/tidb-init.sql` คือไฟล์ที่ runbook ใช้ bootstrap TiDB ตัวใหม่ด้วยมือ
+>
+> ความเสี่ยง "รหัสถูกรีเซ็ตกลับเป็นค่า bootstrap" จึงเกิดตอนตั้งฐานข้อมูลใหม่
+> import `tidb-init.sql` ทับ หรือมีใครล้าง `schema_migrations` — ไม่ใช่ทุกครั้งที่ deploy
+> ปัจจุบัน seed มี guard กันการเขียนทับรหัสที่ตั้งเองแล้ว และมีเทสคุมทั้งสองไฟล์
+>
+> หมายเหตุ: สองไฟล์นี้ seed **คนละ role** (`tidb-init.sql` ใช้ `superadmin`,
+> `09-auth-users.sql` ใช้ `admin`) gate เทียบเฉพาะ hash กับคำสั่ง upsert ไม่ได้เทียบ role
 
 3. Confirm change-password route is deployed (no token needed):
 

--- a/docs/render-tidb-production.md
+++ b/docs/render-tidb-production.md
@@ -198,10 +198,14 @@ curl -i \
 
 Expected result: JSON token payload, not a database connection error.
 
-> รหัสผ่าน bootstrap ที่ `database/09-auth-users.sql` seed ไว้เป็นค่าสาธารณะ
-> (hash อยู่ใน repo ที่เปิดสาธารณะ) production ต้องเปลี่ยนรหัสของบัญชี `admin`
-> ทันทีหลัง deploy ครั้งแรก — ธง `must_change_password` เป็นแค่การพาไปหน้าเปลี่ยนรหัส
-> ที่ frontend ไม่ได้บล็อกการออก JWT ที่ backend
+> รหัสผ่าน bootstrap ของบัญชี `admin` เป็นค่าสาธารณะ (hash อยู่ใน repo ที่เปิด
+> สาธารณะ) บน production แถวนี้มาจาก `database/tidb-init.sql` ซึ่งเป็น bootstrap
+> ตัวจริงเพราะ prod ตั้ง `RUN_MIGRATIONS=0` ส่วน `database/09-auth-users.sql` คือ
+> migration ที่ใช้กับ local/CI — ทั้งสองไฟล์ seed ค่าเดียวกันและมี gate คุมให้ตรงกัน
+>
+> production ต้องเปลี่ยนรหัสของบัญชี `admin` ทันทีหลัง deploy ครั้งแรก — ธง
+> `must_change_password` เป็นแค่การพาไปหน้าเปลี่ยนรหัสที่ frontend
+> ไม่ได้บล็อกการออก JWT ที่ backend
 
 3. Confirm change-password route is deployed (no token needed):
 

--- a/docs/render-tidb-production.md
+++ b/docs/render-tidb-production.md
@@ -188,13 +188,20 @@ The endpoint is public but discloses only counts/status — no table or migratio
 2. Check login:
 
 ```bash
+# พิมพ์รหัสผ่าน admin ของ production ตอนรัน — ไม่ต้องเขียนรหัสลงในเอกสารนี้
+read -rs ADMIN_PASSWORD
 curl -i \
   -H "Content-Type: application/json" \
-  -d '{"email":"admin","password":"admin123"}' \
+  --data-binary "$(printf '{"email":"admin","password":"%s"}' "$ADMIN_PASSWORD")" \
   https://smartport-backend.onrender.com/api/auth/login
 ```
 
 Expected result: JSON token payload, not a database connection error.
+
+> รหัสผ่าน bootstrap ที่ `database/09-auth-users.sql` seed ไว้เป็นค่าสาธารณะ
+> (hash อยู่ใน repo ที่เปิดสาธารณะ) production ต้องเปลี่ยนรหัสของบัญชี `admin`
+> ทันทีหลัง deploy ครั้งแรก — ธง `must_change_password` เป็นแค่การพาไปหน้าเปลี่ยนรหัส
+> ที่ frontend ไม่ได้บล็อกการออก JWT ที่ backend
 
 3. Confirm change-password route is deployed (no token needed):
 

--- a/scripts/ci-local.ps1
+++ b/scripts/ci-local.ps1
@@ -105,33 +105,16 @@ if ($LASTEXITCODE -eq 0) {
   $failed += 'schema-parity'
 }
 
-Write-Step 'Multiplier Validator Regression'
-& node --test (Join-Path $Root 'scripts\tests\validate-multiplier-phase0.test.mjs')
+# รันทั้งโฟลเดอร์ด้วย glob แบบเดียวกับ .githooks/pre-push, ci.yml และ ci-local.sh
+# PowerShell ไม่ขยาย glob ให้ native command แต่ node --test ขยายเองได้ (ยืนยันแล้ว)
+# ทุกไฟล์ในโฟลเดอร์นี้เป็น regression ที่ไม่ยิง production จริง (ใช้ mock origin)
+Write-Step 'Script Regressions'
+& node --test (Join-Path $Root 'scripts\tests\*.test.mjs')
 if ($LASTEXITCODE -eq 0) {
-  Write-Ok 'multiplier validator regression'
+  Write-Ok 'script regressions'
 } else {
-  Write-Fail 'multiplier validator regression'
-  $failed += 'multiplier-validator-regression'
-}
-
-# mock-server regression — ไม่ยิง production จริง (issue #131 Part 2)
-Write-Step 'Live Header Smoke Regression'
-& node --test (Join-Path $Root 'scripts\tests\verify-live-headers.test.mjs')
-if ($LASTEXITCODE -eq 0) {
-  Write-Ok 'live header smoke regression'
-} else {
-  Write-Fail 'live header smoke regression'
-  $failed += 'live-header-smoke-regression'
-}
-
-# mock-server regression ของ CSP self-test — ไม่ยิง production จริง (issue #113 R3)
-Write-Step 'CSP Report Self-test Regression'
-& node --test (Join-Path $Root 'scripts\tests\csp-report-selftest.test.mjs')
-if ($LASTEXITCODE -eq 0) {
-  Write-Ok 'csp report self-test regression'
-} else {
-  Write-Fail 'csp report self-test regression'
-  $failed += 'csp-report-selftest-regression'
+  Write-Fail 'script regressions'
+  $failed += 'script-regressions'
 }
 
 # ---- 1) Frontend Build & Test ----------------------------------------------

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -87,6 +87,14 @@ else
   fail 'csp report self-test regression'
 fi
 
+# guard แบบ static ของ seed admin — ไม่ต้องใช้ DB จึงรันได้เสมอแม้ไม่มี Docker
+step 'Admin Seed Guards'
+if node --test "${ROOT}/scripts/tests/admin-seed-guards.test.mjs"; then
+  ok 'admin seed guards'
+else
+  fail 'admin seed guards'
+fi
+
 # ---- 1) Frontend -----------------------------------------------------------
 if [[ "${SKIP_FRONTEND}" -eq 0 ]]; then
   step 'Frontend Build & Test'

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -64,35 +64,14 @@ else
   fail 'schema parity'
 fi
 
-step 'Multiplier Validator Regression'
-if node --test "${ROOT}/scripts/tests/validate-multiplier-phase0.test.mjs"; then
-  ok 'multiplier validator regression'
+# รันทั้งโฟลเดอร์ด้วย glob แบบเดียวกับ .githooks/pre-push และ ci.yml — ไล่ชื่อทีละไฟล์
+# เคยทำให้เทสที่เพิ่มใหม่หลุดจากทางเข้านี้เงียบ ๆ (ไม่มีใครเห็นว่ามันไม่ถูกรัน)
+# ทุกไฟล์ในโฟลเดอร์นี้เป็น regression ที่ไม่ยิง production จริง (ใช้ mock origin)
+step 'Script Regressions'
+if node --test "${ROOT}"/scripts/tests/*.test.mjs; then
+  ok 'script regressions'
 else
-  fail 'multiplier validator regression'
-fi
-
-# mock-server regression — ไม่ยิง production จริง (issue #131 Part 2)
-step 'Live Header Smoke Regression'
-if node --test "${ROOT}/scripts/tests/verify-live-headers.test.mjs"; then
-  ok 'live header smoke regression'
-else
-  fail 'live header smoke regression'
-fi
-
-# mock-server regression ของ CSP self-test — ไม่ยิง production จริง (issue #113 R3)
-step 'CSP Report Self-test Regression'
-if node --test "${ROOT}/scripts/tests/csp-report-selftest.test.mjs"; then
-  ok 'csp report self-test regression'
-else
-  fail 'csp report self-test regression'
-fi
-
-# guard แบบ static ของ seed admin — ไม่ต้องใช้ DB จึงรันได้เสมอแม้ไม่มี Docker
-step 'Admin Seed Guards'
-if node --test "${ROOT}/scripts/tests/admin-seed-guards.test.mjs"; then
-  ok 'admin seed guards'
-else
-  fail 'admin seed guards'
+  fail 'script regressions'
 fi
 
 # ---- 1) Frontend -----------------------------------------------------------

--- a/scripts/tests/admin-seed-guards.test.mjs
+++ b/scripts/tests/admin-seed-guards.test.mjs
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, extname, join, relative, resolve } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+// Guard แบบ static ของ seed admin — คู่กับเทสพฤติกรรมใน
+// backend/tests/Integration/AdminSeedUpsertTest.php
+//
+// ทำไมอยู่ที่นี่ ไม่ใช่ใน PHPUnit: เทสชุดนี้อ่านไฟล์ทั่ว repo (รวม docs/) ซึ่งไม่ได้
+// ถูก mount เข้า container ของ backend/tests/run.sh (mount แค่ /app กับ /database)
+// และที่สำคัญกว่านั้น — ใน PHPUnit เทสทั้งคลาสถูก skip เมื่อต่อ MySQL ไม่ได้
+// ทำให้ guard หายเงียบบนเครื่องที่ไม่มี Docker ซึ่งคือรูปแบบที่โปรเจกต์นี้ห้าม:
+// สภาพ "ไม่ได้ตรวจ" ต้องไม่แสดงผลเป็น "ผ่าน"
+//
+// ที่นี่ไม่ต้องพึ่ง DB เลย จึงรันได้เสมอทั้งใน pre-push, ci-local และ CI
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const MIGRATION_FILE = resolve(ROOT, 'database', '09-auth-users.sql');
+const TIDB_INIT_FILE = resolve(ROOT, 'database', 'tidb-init.sql');
+const DOCS_DIR = resolve(ROOT, 'docs');
+
+// host ของ backend production — ใช้คัดว่าเอกสารไหน "ชี้ไปที่ระบบจริง"
+const PRODUCTION_HOST = 'smartport-backend.onrender.com';
+
+// ประกอบสตริงเพื่อไม่ให้ค่าปรากฏเป็นคำเดียวในไฟล์เทสเอง
+const BOOTSTRAP_PASSWORD = 'admin' + '123';
+
+const SEED_BLOCK =
+  /INSERT INTO users \(username, password_hash.*?VALUES \('admin', '([^']+)'.*?ON DUPLICATE KEY UPDATE(.*?);/s;
+
+/** อ่านไฟล์แล้วคืนค่าเป็น LF เสมอ (ไฟล์ในโปรเจกต์เป็น CRLF) */
+function readText(path) {
+  return readFileSync(path, 'utf8').replace(/\r\n/g, '\n');
+}
+
+/** ดึง hash และ clause ของ seed admin ออกจากไฟล์ .sql จริง */
+function extractSeedBlock(path) {
+  const matched = SEED_BLOCK.exec(readText(path));
+  assert.ok(matched, `หา seed admin ใน ${relative(ROOT, path)} ไม่เจอ — โครงไฟล์เปลี่ยนไป`);
+
+  return { hash: matched[1], clause: matched[2] };
+}
+
+/** ตัดคอมเมนต์ SQL ออกแล้วยุบช่องว่าง เพื่อเทียบเนื้อคำสั่งล้วน ๆ */
+function normalizeClause(clause) {
+  return clause.replace(/--[^\n]*/g, '').replace(/\s+/g, ' ').trim();
+}
+
+/** ไฟล์ .md ทั้งหมดใต้ docs/ (recursive) */
+function listMarkdownFiles(dir) {
+  const found = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      found.push(...listMarkdownFiles(full));
+    } else if (extname(entry) === '.md') {
+      found.push(full);
+    }
+  }
+
+  return found;
+}
+
+test('seed clause ของ migration กับ tidb-init ต้องตรงกัน', () => {
+  const migration = normalizeClause(extractSeedBlock(MIGRATION_FILE).clause);
+  const tidbInit = normalizeClause(extractSeedBlock(TIDB_INIT_FILE).clause);
+
+  // tidb-init.sql คือ bootstrap ตัวจริงของ production (prod ตั้ง RUN_MIGRATIONS=0)
+  // ถ้า clause ไม่ตรงกัน แปลว่าแก้ migration ไปแล้วไม่มีผลกับ production
+  assert.equal(tidbInit, migration, 'clause ใน tidb-init.sql ไม่ตรงกับ 09-auth-users.sql');
+});
+
+test('guard ที่กันการเขียนทับรหัสผ่านเดิมต้องยังอยู่', () => {
+  for (const path of [MIGRATION_FILE, TIDB_INIT_FILE]) {
+    const clause = normalizeClause(extractSeedBlock(path).clause);
+    assert.ok(
+      clause.includes('users.password_hash IS NULL OR users.password_hash'),
+      `${relative(ROOT, path)}: guard หายไป — รัน migration ซ้ำจะรีเซ็ตรหัสผ่าน production`
+    );
+  }
+});
+
+test('hash ของ seed ต้องตรงกันทั้งสองไฟล์', () => {
+  // ถ้ามีคนแก้ค่าใน VALUES ของไฟล์เดียว local กับ production จะได้คนละรหัส
+  assert.equal(
+    extractSeedBlock(TIDB_INIT_FILE).hash,
+    extractSeedBlock(MIGRATION_FILE).hash,
+    'seed hash ใน tidb-init.sql ไม่ตรงกับ 09-auth-users.sql'
+  );
+});
+
+test('ไฟล์ที่ bootstrap production และเอกสารที่ชี้ไประบบจริง ต้องไม่มีรหัสผ่าน plaintext', () => {
+  // ขอบเขตโดยตั้งใจ: ไฟล์ที่ bootstrap production + เอกสารใน docs/ ที่อ้าง host production
+  //
+  // นอกขอบเขต (และตั้งใจให้อยู่นอก): fixture ของ dev/e2e เช่น frontend/e2e/helpers/auth.js,
+  // backend/tests/verify-executive.sh, สคริปต์ UAT ที่ default ชี้ localhost และบันทึก/แผน
+  // ย้อนหลังใน project-log-md/ กับ .claude/ — เพราะ dev credential ที่รู้กันเป็นเรื่องปกติ
+  // เส้นที่ต้องกันคือ "อย่าแจกรหัสที่ใช้กับ production ได้" ไม่ใช่ "ห้ามมีคำนี้ใน repo"
+  // (รหัสเดิมยังอยู่ใน git history อยู่ดี — ลบไม่ได้ และไม่ใช่สิ่งที่เทสนี้อ้างว่าทำ)
+  const productionDocs = listMarkdownFiles(DOCS_DIR).filter((path) =>
+    readText(path).includes(PRODUCTION_HOST)
+  );
+
+  // fail-closed: หาไม่เจอสักไฟล์ = ตัวกรองพัง ไม่ใช่ "สะอาด"
+  assert.ok(
+    productionDocs.length > 0,
+    `ไม่พบเอกสารใน docs/ ที่อ้าง ${PRODUCTION_HOST} เลย — ตัวกรองน่าจะพัง`
+  );
+
+  for (const path of [MIGRATION_FILE, TIDB_INIT_FILE, ...productionDocs]) {
+    assert.ok(
+      !readText(path).includes(BOOTSTRAP_PASSWORD),
+      `${relative(ROOT, path)}: มีรหัสผ่าน bootstrap เป็น plaintext อยู่ในไฟล์ที่เกี่ยวกับ production`
+    );
+  }
+});

--- a/scripts/tests/admin-seed-guards.test.mjs
+++ b/scripts/tests/admin-seed-guards.test.mjs
@@ -23,11 +23,30 @@ const DOCS_DIR = resolve(ROOT, 'docs');
 // host ของ backend production — ใช้คัดว่าเอกสารไหน "ชี้ไปที่ระบบจริง"
 const PRODUCTION_HOST = 'smartport-backend.onrender.com';
 
+// เอกสารที่รู้แน่ว่าต้องติดตัวกรองเสมอ — ใช้พิสูจน์ว่าตัวกรองยังทำงาน
+// (แค่ "เจอมากกว่าศูนย์ไฟล์" ยังหลอกได้ ถ้าเอกสาร production ตัวจริงหลุดจากการสแกน
+//  แล้วบังเอิญมีไฟล์เก่าค้าง host ไว้แทน)
+const REQUIRED_PRODUCTION_DOC = 'docs/render-tidb-production.md';
+
 // ประกอบสตริงเพื่อไม่ให้ค่าปรากฏเป็นคำเดียวในไฟล์เทสเอง
 const BOOTSTRAP_PASSWORD = 'admin' + '123';
 
 const SEED_BLOCK =
   /INSERT INTO users \(username, password_hash.*?VALUES \('admin', '([^']+)'.*?ON DUPLICATE KEY UPDATE(.*?);/s;
+
+// รูปคำสั่งที่ต้องเป็น (เทียบกับ clause ที่ normalize แล้ว — ช่องว่างถูกยุบเหลือช่องเดียว)
+//
+// ห้ามเช็คด้วย includes() ของชิ้นส่วนเงื่อนไข: ข้อความ
+// "users.password_hash IS NULL OR users.password_hash" โผล่บนบรรทัด
+// must_change_password ด้วย การเช็คแบบนั้นจึงผ่านทั้งที่บรรทัด password_hash
+// กลับไปเขียนทับเสมอแล้ว — เป็น false-clean ที่ mutation test จับได้
+const GUARDED_PASSWORD_HASH =
+  /password_hash = IF\(users\.password_hash IS NULL OR users\.password_hash = '', VALUES\(password_hash\), users\.password_hash\)/;
+const GUARDED_MUST_CHANGE =
+  /must_change_password = IF\(users\.password_hash IS NULL OR users\.password_hash = '', VALUES\(must_change_password\), users\.must_change_password\)/;
+
+// รูปที่เป็นบั๊กเดิมตรง ๆ — ถ้าเจอแปลว่ารัน migration ซ้ำจะรีเซ็ตรหัสผ่าน production
+const UNGUARDED_PASSWORD_HASH = /password_hash = VALUES\(password_hash\)/;
 
 /** อ่านไฟล์แล้วคืนค่าเป็น LF เสมอ (ไฟล์ในโปรเจกต์เป็น CRLF) */
 function readText(path) {
@@ -71,12 +90,33 @@ test('seed clause ของ migration กับ tidb-init ต้องตรง�
   assert.equal(tidbInit, migration, 'clause ใน tidb-init.sql ไม่ตรงกับ 09-auth-users.sql');
 });
 
-test('guard ที่กันการเขียนทับรหัสผ่านเดิมต้องยังอยู่', () => {
+test('password_hash ต้องถูก guard ไม่ใช่เขียนทับเสมอ', () => {
   for (const path of [MIGRATION_FILE, TIDB_INIT_FILE]) {
+    const rel = relative(ROOT, path);
     const clause = normalizeClause(extractSeedBlock(path).clause);
+
     assert.ok(
-      clause.includes('users.password_hash IS NULL OR users.password_hash'),
-      `${relative(ROOT, path)}: guard หายไป — รัน migration ซ้ำจะรีเซ็ตรหัสผ่าน production`
+      !UNGUARDED_PASSWORD_HASH.test(clause),
+      `${rel}: password_hash กลับไปเขียนทับเสมอแล้ว — รัน migration ซ้ำจะรีเซ็ตรหัสผ่าน production`
+    );
+    assert.match(clause, GUARDED_PASSWORD_HASH, `${rel}: password_hash ไม่ได้อยู่ในรูปที่ guard ไว้`);
+    assert.match(clause, GUARDED_MUST_CHANGE, `${rel}: must_change_password ไม่ได้อยู่ในรูปที่ guard ไว้`);
+  }
+});
+
+test('must_change_password ต้องถูกประเมินก่อน password_hash', () => {
+  // MySQL/TiDB ประเมิน assignment เรียงซ้ายไปขวา ถ้า password_hash มาก่อน
+  // เงื่อนไขของ must_change_password จะอ่านค่าที่เขียนทับไปแล้วและเป็นเท็จเสมอ
+  for (const path of [MIGRATION_FILE, TIDB_INIT_FILE]) {
+    const rel = relative(ROOT, path);
+    const clause = normalizeClause(extractSeedBlock(path).clause);
+    const flagAt = clause.search(GUARDED_MUST_CHANGE);
+    const hashAt = clause.search(GUARDED_PASSWORD_HASH);
+
+    assert.ok(flagAt >= 0 && hashAt >= 0, `${rel}: หา assignment ที่ guard ไว้ไม่เจอ`);
+    assert.ok(
+      flagAt < hashAt,
+      `${rel}: ลำดับสลับ — must_change_password ต้องอยู่ก่อน password_hash`
     );
   }
 });
@@ -93,24 +133,34 @@ test('hash ของ seed ต้องตรงกันทั้งสองไ
 test('ไฟล์ที่ bootstrap production และเอกสารที่ชี้ไประบบจริง ต้องไม่มีรหัสผ่าน plaintext', () => {
   // ขอบเขตโดยตั้งใจ: ไฟล์ที่ bootstrap production + เอกสารใน docs/ ที่อ้าง host production
   //
-  // นอกขอบเขต (และตั้งใจให้อยู่นอก): fixture ของ dev/e2e เช่น frontend/e2e/helpers/auth.js,
-  // backend/tests/verify-executive.sh, สคริปต์ UAT ที่ default ชี้ localhost และบันทึก/แผน
-  // ย้อนหลังใน project-log-md/ กับ .claude/ — เพราะ dev credential ที่รู้กันเป็นเรื่องปกติ
+  // สิ่งที่เทสนี้ "ไม่" รับประกัน — พูดให้ชัดเพื่อไม่ให้ใครอ่านแล้วเข้าใจว่า repo สะอาด:
+  //   - เอกสารใต้ docs/ ที่ไม่มี host production ยังมีรหัสผ่านนี้เป็น plaintext อยู่จริง
+  //     (แผนงานย้อนหลังใต้ docs/superpowers/plans/) เทสนี้จงใจไม่แตะ
+  //   - fixture ของ dev/e2e (frontend/e2e/helpers/auth.js, backend/tests/verify-executive.sh),
+  //     สคริปต์ UAT ที่ default ชี้ localhost, บันทึกใน project-log-md/ และ .claude/
+  //   - git history ซึ่งลบไม่ได้อยู่แล้ว
+  //
   // เส้นที่ต้องกันคือ "อย่าแจกรหัสที่ใช้กับ production ได้" ไม่ใช่ "ห้ามมีคำนี้ใน repo"
-  // (รหัสเดิมยังอยู่ใน git history อยู่ดี — ลบไม่ได้ และไม่ใช่สิ่งที่เทสนี้อ้างว่าทำ)
-  const productionDocs = listMarkdownFiles(DOCS_DIR).filter((path) =>
-    readText(path).includes(PRODUCTION_HOST)
-  );
+  // ซึ่งเป็นไปไม่ได้ — dev credential ที่รู้กันทั้งทีมเป็นเรื่องปกติ
+  const scanned = listMarkdownFiles(DOCS_DIR)
+    .map((path) => ({ path, text: readText(path) }))
+    .filter((doc) => doc.text.includes(PRODUCTION_HOST));
 
-  // fail-closed: หาไม่เจอสักไฟล์ = ตัวกรองพัง ไม่ใช่ "สะอาด"
+  // fail-closed: ยึดกับเอกสารที่รู้ว่าต้องเจอ ไม่ใช่แค่ "เจอมากกว่าศูนย์"
+  const relativePaths = scanned.map((doc) => relative(ROOT, doc.path).replace(/\\/g, '/'));
   assert.ok(
-    productionDocs.length > 0,
-    `ไม่พบเอกสารใน docs/ ที่อ้าง ${PRODUCTION_HOST} เลย — ตัวกรองน่าจะพัง`
+    relativePaths.includes(REQUIRED_PRODUCTION_DOC),
+    `ตัวกรองไม่เจอ ${REQUIRED_PRODUCTION_DOC} — สแกนได้ ${relativePaths.length} ไฟล์: ` +
+      `${relativePaths.join(', ') || '(ไม่มีเลย)'} · ถือว่าตัวกรองพัง ไม่ใช่ "สะอาด"`
   );
 
-  for (const path of [MIGRATION_FILE, TIDB_INIT_FILE, ...productionDocs]) {
+  const bootstrapFiles = [MIGRATION_FILE, TIDB_INIT_FILE].map((path) => ({
+    path,
+    text: readText(path),
+  }));
+  for (const { path, text } of [...bootstrapFiles, ...scanned]) {
     assert.ok(
-      !readText(path).includes(BOOTSTRAP_PASSWORD),
+      !text.includes(BOOTSTRAP_PASSWORD),
       `${relative(ROOT, path)}: มีรหัสผ่าน bootstrap เป็น plaintext อยู่ในไฟล์ที่เกี่ยวกับ production`
     );
   }


### PR DESCRIPTION
## ปัญหา

`database/09-auth-users.sql` seed บัญชี `admin` ด้วย `INSERT ... ON DUPLICATE KEY UPDATE` ที่เขียน `password_hash` ทับ **ทุกครั้ง** ที่คำสั่งนี้ทำงาน แปลว่าการตั้งฐานข้อมูลใหม่ การ import `tidb-init.sql` ทับ หรือการล้าง `schema_migrations` **รีเซ็ตรหัสผ่าน admin ของ production กลับไปเป็นค่า bootstrap ที่อยู่ใน repo สาธารณะ** โดยไม่มีสัญญาณเตือนใด ๆ

ประกอบกับอีกสองข้อที่ทำให้ความเสี่ยงจริงกว่าที่เห็น:

- คอมเมนต์ใน SQL เขียนรหัสผ่านเป็น plaintext และ `docs/render-tidb-production.md` มีคำสั่ง `curl` ล็อกอิน **URL production จริงพร้อมรหัสจริง** ก๊อปวางแล้วใช้ได้ทันที
- `must_change_password = 1` **ไม่ใช่ access control** — `loginUser()` ออก JWT ตามปกติ ธงนี้แค่บอก frontend ให้พาไปหน้าเปลี่ยนรหัส ใครยิง API ตรงได้สิทธิ์ admin เต็ม

## ที่แก้

| ส่วน | ไฟล์ |
|---|---|
| upsert ตั้งรหัสเฉพาะแถวที่ยังไม่มีรหัสใช้งานได้ (NULL/ว่าง) | `database/09-auth-users.sql` · `database/tidb-init.sql` |
| เทสพฤติกรรมบน MySQL จริง 4 ตัว | `backend/tests/Integration/AdminSeedUpsertTest.php` (ใหม่) |
| guard แบบ static ที่ไม่ต้องใช้ DB 5 ตัว | `scripts/tests/admin-seed-guards.test.mjs` (ใหม่) |
| ทางเข้า CI ใช้ glob ทั้งโฟลเดอร์ | `scripts/ci-local.sh` · `scripts/ci-local.ps1` |
| runbook | `docs/render-tidb-production.md` |

`tidb-init.sql` ต้องแก้คู่กันเสมอ เพราะเป็นไฟล์ที่ runbook ใช้ bootstrap TiDB ตัวใหม่ — แก้ไฟล์เดียวคือแก้แล้วไม่มีผลกับ production มีเทส anti-drift คุมให้ทั้งสองไฟล์มีคำสั่งและ hash ตรงกัน

`must_change_password` ต้องอยู่ **ก่อน** `password_hash` ใน clause เพราะ MySQL/TiDB ประเมิน assignment เรียงซ้ายไปขวา สลับลำดับเมื่อไรเงื่อนไขจะอ่านค่าที่เขียนทับไปแล้วและเป็นเท็จเสมอ — มี guard คุมข้อนี้โดยเฉพาะ

`is_active = 1` เสมอ คงไว้โดยตั้งใจ (เป็นตัวกัน lock-out) และมีเทสตรึงไว้ ถ้าจะเปลี่ยนจะได้เป็นการตัดสินใจที่รู้ตัว

## หลักฐานว่าเทสไม่ใช่ของปลอม

ทุก guard ผ่าน **mutation test** — ใส่บั๊กกลับเข้าไปแล้วต้องแดง:

| mutation | ผล |
|---|---|
| ย้อน `password_hash = VALUES(password_hash)` (บั๊กเดิมเป๊ะ ๆ) | แดง |
| สลับลำดับ `must_change_password` กับ `password_hash` | แดง |
| ทำให้ hash ในสองไฟล์ต่างกัน | แดง |
| แทรกรหัสผ่าน plaintext ลงเอกสารที่ชี้ production | แดง |

## กระบวนการ — รีวิว 3 รอบ และสิ่งที่มันจับได้

งานนี้ผ่านรีวิว 3 รอบ (two-axis ×2 + senior review ×1) รวม **20 finding** สิ่งที่ควรรู้คือ **รอบที่สองจับได้ว่า guard ที่เพิ่มเข้ามาในรอบแรกเป็น false-clean เสียเอง**: มันเช็คด้วย `includes()` ของชิ้นส่วนเงื่อนไข ซึ่งไปเจอสตริงเดียวกันบนบรรทัด `must_change_password` จึงผ่านทั้งที่บรรทัด `password_hash` กลับไปเป็นบั๊กเดิมแล้ว — พิสูจน์ด้วย mutation ว่าเขียวสนิท

นั่นคือเหตุผลที่ commit สุดท้ายเปลี่ยนไปเทียบรูปคำสั่งเต็มด้วย `assert.match` บวกการปฏิเสธรูปที่เป็นบั๊กตรง ๆ และเป็นที่มาของ mutation table ข้างบน

finding อื่นที่ปิดไปแล้ว: guard หายเงียบเมื่อไม่มี MySQL (เทสทั้งคลาสถูก skip) · `ci-local.ps1` ไม่เคยมี gate ใหม่ ทำให้ทางเข้าฝั่ง Windows หลุด · ขอบเขตของเทสที่อ้างเกินจริงว่าคุ้ม "repo สาธารณะ" · ชื่อ test method ผิดขนบไฟล์ข้างเคียง · anti-drift ไม่ครอบค่า hash · ข้อเท็จจริงผิดใน runbook

## ข้อเท็จจริงที่ต้องแก้ความเข้าใจเดิมของโปรเจกต์

เอกสารและสมมติฐานเดิมเขียนว่า production ตั้ง `RUN_MIGRATIONS=0` — **ไม่จริง** `render.yaml` ใช้ `dockerfilePath: ./Dockerfile` (ตัวที่ root) ซึ่งตั้ง `ENV RUN_MIGRATIONS=1` ส่วน `backend/Dockerfile` ที่ตั้ง `0` ไม่ได้ถูกใช้ **migration รันบน production จริง** แต่รันได้ครั้งเดียวต่อฐานข้อมูลเพราะ `run-migrations.php` บันทึกชื่อที่รันแล้วใน `schema_migrations` · runbook แก้ให้ตรงแล้ว

## สิ่งที่ PR นี้ไม่ได้ทำ

- **ไม่เปลี่ยนรหัสผ่านบน production ให้** ต้องทำที่ระบบจริงด้วยตนเอง และควรทำก่อน merge ด้วยซ้ำ — ถ้ารหัส bootstrap ยังใช้ได้อยู่ ใครก็เข้าระบบ HR ได้ทันที
- ไม่ลบรหัสผ่านออกจาก git history (ลบไม่ได้) และไม่แตะ fixture ของ dev/e2e กับบันทึกย้อนหลัง — เส้นที่กันคือ "อย่าแจกรหัสที่ใช้กับ production ได้" ไม่ใช่ "ห้ามมีคำนี้ใน repo" ขอบเขตนี้เขียนไว้ในคอมเมนต์ของเทสแล้ว
- **A2 (deferred)** `tidb-init.sql` ไม่เคยถูก execute จริงใน CI เลย ความตรงกันยืนยันด้วยการเทียบสตริงเท่านั้น การรัน TiDB จริงใน CI กระทบเวลาและค่าใช้จ่าย ควรตัดสินใจแยก
- **M-2 (deferred)** เทสสร้างบัญชี `admin` ที่ล็อกอินได้ลงฐานข้อมูลที่ทดสอบ (ลบใน `tearDown`) ถ้ามีใครชี้ `MYSQL_HOST` ไปผิดที่จะเขียนลงระบบจริง ควรเพิ่มการยืนยันว่าไม่ได้ต่อกับ production

## Test plan

- [x] `node --test scripts/tests/*.test.mjs` — **28/28**
- [x] `bash backend/tests/run.sh` — **358 ผ่าน** (skip 1 ตัวเดิม)
- [x] `node scripts/validate-schema-parity.mjs` — ไม่พบ drift
- [x] pre-push hook (vitest 560) — ผ่านตอน push
- [x] mutation test 4 แบบ — แดงทุกแบบตามที่ควร
- [ ] **หลัง merge**: ยืนยันว่ารหัสผ่าน admin บน production ไม่ใช่ค่า bootstrap แล้ว
