### PR TITLE
fix(ocr): ตอบ 503 OCR_NOT_CONFIGURED เมื่อไม่ได้ตั้ง OCR_SERVER_URL

### DIFF
--- a/backend/routes/ocr.php
+++ b/backend/routes/ocr.php
@@ -4,17 +4,46 @@ declare(strict_types=1);
 include_once __DIR__ . '/../authz.php';
 
 /**
+ * Issue #147 — คืน null เมื่อไม่ได้ตั้ง OCR_SERVER_URL
+ * ห้าม fallback เป็น 127.0.0.1:8100 เพราะทำให้ "ยังไม่ได้ติดตั้ง" กับ "ติดตั้งแล้วพัง"
+ * ให้ผลหน้าจอเหมือนกัน (curl ชน localhost ของ container เอง) — "ไม่รู้" ต้องไม่กลายเป็น "สะอาด"
+ */
+function ocrServerBaseUrl(): ?string
+{
+    $raw = getenv('OCR_SERVER_URL');
+    if ($raw === false || trim($raw) === '') {
+        return null;
+    }
+    return rtrim(trim($raw), '/');
+}
+
+/** 503 พร้อมข้อความที่ผู้ใช้อ่านรู้เรื่อง — ใช้ร่วมทั้ง /health และ /convert */
+function respondOcrNotConfigured(): void
+{
+    http_response_code(503);
+    header('Content-Type: application/json');
+    echo json_encode([
+        'error' => 'ยังไม่ได้ติดตั้งบริการแปลงเอกสาร (OCR)',
+        'message' => 'ฟีเจอร์นี้ยังไม่พร้อมใช้งาน กรุณาติดต่อผู้ดูแลระบบ',
+        'code' => 'OCR_NOT_CONFIGURED',
+    ]);
+}
+
+/**
  * POST /ocr/convert — upload PDF, forward to document-ocr FastAPI server.
  * GET  /ocr/health  — check OCR server availability.
  */
 function handleOcr(PDO $pdo, string $method, array $path): void
 {
-    $ocrBase = rtrim(getenv('OCR_SERVER_URL') ?: 'http://127.0.0.1:8100', '/');
-
     $sub = $path[1] ?? '';
 
     if ($method === 'GET' && $sub === 'health') {
         requirePermission('read', 'ocr');
+        $ocrBase = ocrServerBaseUrl();
+        if ($ocrBase === null) {
+            respondOcrNotConfigured();
+            return;
+        }
         $ch = curl_init("$ocrBase/health");
         curl_setopt_array($ch, [
             CURLOPT_RETURNTRANSFER => true,
@@ -31,6 +60,11 @@ function handleOcr(PDO $pdo, string $method, array $path): void
 
     if ($method === 'POST' && $sub === 'convert') {
         requirePermission('create', 'ocr');
+        $ocrBase = ocrServerBaseUrl();
+        if ($ocrBase === null) {
+            respondOcrNotConfigured();
+            return;
+        }
         if (!isset($_FILES['file'])) {
             http_response_code(422);
             echo json_encode(['error' => 'Missing file upload (field: file)']);

--- a/backend/tests/Unit/OcrRouteConfigTest.php
+++ b/backend/tests/Unit/OcrRouteConfigTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../routes/ocr.php';
+
+/**
+ * Issue #147 — เมื่อไม่ได้ตั้ง OCR_SERVER_URL ต้องตอบ 503 ชัดเจนว่า "ยังไม่ได้ติดตั้ง"
+ * ไม่ใช่ปล่อยให้ curl ไปชน localhost ของ container เองแล้วล้มเหลวแบบที่ผู้ใช้อ่านไม่ออก
+ * ("ไม่รู้" ต้องไม่กลายเป็น "สะอาด") — ครอบคลุมทั้ง GET /ocr/health และ POST /ocr/convert
+ */
+final class OcrRouteConfigTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        // เริ่มจากสภาพไม่มีตัวแปรทุกเคส กัน env ของเครื่อง dev ปนเข้ามา
+        putenv('OCR_SERVER_URL');
+    }
+
+    protected function tearDown(): void
+    {
+        putenv('OCR_SERVER_URL');
+        // http_response_code() เป็น process-global — reset กัน test ถัดไป false-pass
+        http_response_code(200);
+    }
+
+    #[Test]
+    public function base_url_is_null_when_env_unset(): void
+    {
+        self::assertNull(ocrServerBaseUrl());
+    }
+
+    #[Test]
+    public function base_url_is_null_when_env_is_blank(): void
+    {
+        foreach (['', '   ', "\t"] as $blank) {
+            putenv("OCR_SERVER_URL=$blank");
+            self::assertNull(ocrServerBaseUrl());
+        }
+    }
+
+    #[Test]
+    public function base_url_trims_whitespace_and_trailing_slash(): void
+    {
+        putenv('OCR_SERVER_URL= http://ocr:8100/ ');
+        self::assertSame('http://ocr:8100', ocrServerBaseUrl());
+    }
+
+    #[Test]
+    public function not_configured_emits_503_with_documented_shape(): void
+    {
+        ob_start();
+        try {
+            respondOcrNotConfigured();
+        } finally {
+            $output = (string) ob_get_clean();
+        }
+
+        self::assertSame(503, http_response_code());
+
+        $json = json_decode($output, true);
+        self::assertIsArray($json);
+        self::assertSame('ยังไม่ได้ติดตั้งบริการแปลงเอกสาร (OCR)', $json['error']);
+        self::assertSame('OCR_NOT_CONFIGURED', $json['code']);
+        self::assertArrayHasKey('message', $json);
+    }
+}


### PR DESCRIPTION
## สรุป

- เมื่อไม่ได้ตั้ง `OCR_SERVER_URL` (หรือตั้งเป็นค่าว่าง/ช่องว่าง) endpoint `/ocr/health` และ `/ocr/convert` จะตอบ **503** พร้อม `code: OCR_NOT_CONFIGURED` และข้อความภาษาไทยที่ผู้ใช้อ่านรู้เรื่อง
- เดิม fallback เป็น `http://127.0.0.1:8100` ทำให้ "ยังไม่ได้ติดตั้ง" กับ "ติดตั้งแล้วแต่พัง" ให้ผลหน้าจอเหมือนกัน (curl ชน localhost ของ container เอง) — "ไม่รู้" ต้องไม่กลายเป็น "สะอาด"

Refs #147

## API note

| กรณี | เดิม | ใหม่ |
|---|---|---|
| ไม่ได้ตั้ง `OCR_SERVER_URL` | curl ไป 127.0.0.1:8100 → error กำกวม | **503** `{error, message, code: "OCR_NOT_CONFIGURED"}` |
| ตั้งค่าแล้วแต่ OCR service ล่ม | 502 unreachable | 502 (ไม่เปลี่ยน) |
| 401/403 จาก requirePermission | เหมือนเดิม | เหมือนเดิม (เช็คสิทธิ์ก่อนเช็ค config) |

## Verification

- [x] Unit test ใหม่ `backend/tests/Unit/OcrRouteConfigTest.php` 4 เคส (unset / blank / trim+trailing slash / shape ของ 503)
- [x] PHPUnit (Docker local): Unit suite **270 tests · 495 assertions · 1 skipped · 0 failed** — รวม OcrRouteConfigTest ทั้ง 4 เคส
- [x] Frontend `OcrPage.vue` แสดง `body.error` อยู่แล้ว → ข้อความ 503 โชว์ได้ทันทีโดยไม่ต้องแก้ frontend

## ค้างตัดสินใจเจ้าของ (นอก scope PR นี้)

Deploy document-ocr service จริงบน production หรือซ่อนเมนู OCR ไว้ก่อน
