### PR TITLE
fix(a11y): ฟิลด์ฟอร์ม 72 จุดครบ id+accessible name พร้อม guard test

### DIFF
--- a/frontend/src/__tests__/a11yFormFields.test.js
+++ b/frontend/src/__tests__/a11yFormFields.test.js
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve, relative, sep } from 'node:path'
+
+// Issue #148 — ฟิลด์ฟอร์มทุกตัวใน frontend/src ต้องมี id และมี accessible name
+// (label[for] ผูกกับ id · aria-label/aria-labelledby · หรือถูกครอบด้วย <label>)
+// Chrome DevTools Issues เคยรายงาน "No label associated with a form field" +
+// "A form field element should have an id or name attribute" ทุกหน้าที่มีฟอร์ม
+// เทสนี้อ่านซอร์สโดยตรงเพื่อกัน regression — เพิ่มฟิลด์ใหม่ไม่มี label ต้องตกตั้งแต่ในเครื่อง
+
+const here = dirname(fileURLToPath(import.meta.url))
+const srcDir = resolve(here, '..')
+
+function listVueFiles(dir) {
+  const out = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = resolve(dir, entry.name)
+    if (entry.isDirectory()) {
+      if (entry.name === '__tests__') continue
+      out.push(...listVueFiles(full))
+    } else if (entry.name.endsWith('.vue')) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+function templateRegion(source) {
+  // ยึดช่วง markup ทั้งหมด: <template> แรก ถึง </template> สุดท้าย
+  // (template ภายในอย่าง <template v-if> ไม่กระทบ เพราะเราขอ superset)
+  const start = source.indexOf('<template>')
+  const end = source.lastIndexOf('</template>')
+  if (start === -1 || end === -1 || end <= start) return null
+  return source.slice(start, end + '</template>'.length)
+}
+
+function stripComments(markup) {
+  return markup.replace(/<!--[\s\S]*?-->/g, (m) => m.replace(/[^\n]/g, ' '))
+}
+
+// หาจุดปิด tag ที่รองรับ attribute คร่อม quote หลายบรรทัด
+function findTagEnd(text, from) {
+  let quote = null
+  for (let i = from; i < text.length; i++) {
+    const ch = text[i]
+    if (quote) {
+      if (ch === quote) quote = null
+    } else if (ch === '"' || ch === "'") {
+      quote = ch
+    } else if (ch === '>') {
+      return i
+    }
+  }
+  return -1
+}
+
+const CONTROL_RE = /<(input|select|textarea)(?=[\s/>])/g
+const LABEL_OPEN_RE = /<label(?=[\s/>])/g
+
+function attrValue(tagText, name) {
+  // คืน { bound, value } ของ attribute name หรือ :name (value = string literal หรือ expression ดิบ)
+  const re = new RegExp(`(?:^|\\s)(:${name}|${name})\\s*=\\s*("([^"]*)"|'([^']*)')`, 'm')
+  const m = tagText.match(re)
+  if (!m) return null
+  return { bound: m[1].startsWith(':'), value: m[3] ?? m[4] ?? '' }
+}
+
+function analyzeFile(absPath) {
+  const source = readFileSync(absPath, 'utf8')
+  const relPath = relative(srcDir, absPath).split(sep).join('/')
+  const region = templateRegion(source)
+  if (!region) return { relPath, violations: [] }
+
+  const markup = stripComments(region)
+  const baseOffset = source.indexOf('<template>') + '<template>'.length
+
+  // เก็บตำแหน่ง label เปิด/ปิด และฟิลด์ แล้วไล่ stack นับความลึกการครอบ
+  const tokens = []
+  LABEL_OPEN_RE.lastIndex = 0
+  let lm
+  while ((lm = LABEL_OPEN_RE.exec(markup)) !== null) {
+    tokens.push({ pos: lm.index, kind: 'labelOpen', end: findTagEnd(markup, lm.index) })
+  }
+  const closeRe = /<\/label\s*>/g
+  let cm
+  while ((cm = closeRe.exec(markup)) !== null) {
+    tokens.push({ pos: cm.index, kind: 'labelClose' })
+  }
+  CONTROL_RE.lastIndex = 0
+  let tm
+  while ((tm = CONTROL_RE.exec(markup)) !== null) {
+    tokens.push({ pos: tm.index, kind: 'control', tag: tm[1], end: findTagEnd(markup, tm.index) })
+  }
+  tokens.sort((a, b) => a.pos - b.pos)
+
+  // label[for] ทั้งไฟล์ — จับคู่ static↔static และ expression ของ :for ↔ :id
+  const labelFors = []
+  for (const t of tokens) {
+    if (t.kind !== 'labelOpen' || t.end === -1) continue
+    const tagText = markup.slice(t.pos, t.end + 1)
+    const f = attrValue(tagText, 'for')
+    if (f) labelFors.push(f)
+  }
+
+  const tplLine = source.slice(0, baseOffset - '<template>'.length).split('\n').length
+  function lineAt(idx) {
+    return tplLine + markup.slice(0, idx).split('\n').length
+  }
+
+  const violations = []
+  let depth = 0
+  for (const t of tokens) {
+    if (t.kind === 'labelOpen') { depth++; continue }
+    if (t.kind === 'labelClose') { depth = Math.max(0, depth - 1); continue }
+
+    if (t.end === -1) continue
+    const tagText = markup.slice(t.pos, t.end + 1)
+    const problems = []
+
+    const id = attrValue(tagText, 'id')
+    if (!id) {
+      problems.push('ไม่มี id')
+    }
+
+    const ariaLabel = attrValue(tagText, 'aria-label')
+    const ariaLabelledby = attrValue(tagText, 'aria-labelledby')
+    const wrapped = depth > 0
+    let labeled = !!ariaLabel || !!ariaLabelledby || wrapped
+    if (!labeled && id) {
+      labeled = labelFors.some(
+        (f) => f.bound === id.bound && f.value.trim() === id.value.trim(),
+      )
+    }
+    if (!labeled) {
+      problems.push('ไม่มี label/aria-label')
+    }
+
+    if (problems.length) {
+      violations.push({ where: `${relPath}:~${lineAt(t.pos)}`, tag: t.tag, why: problems.join(' + ') })
+    }
+  }
+  return { relPath, violations }
+}
+
+describe('a11y: ฟิลด์ฟอร์มต้องมี id + accessible name (issue #148)', () => {
+  const files = listVueFiles(srcDir)
+
+  it('สแกนเจอไฟล์ .vue จำนวนมากพอ (sanity check)', () => {
+    expect(files.length).toBeGreaterThan(30)
+  })
+
+  it('input/select/textarea ทุกตัวมี id และมี label ผูกกัน', () => {
+    const all = files.map(analyzeFile)
+    const violations = all.flatMap((r) => r.violations)
+    const report = violations
+      .map((v) => `  ${v.where}  <${v.tag}> — ${v.why}`)
+      .join('\n')
+    expect(
+      violations,
+      `พบฟิลด์ไม่ผ่านเกณฑ์ ${violations.length} จุด:\n${report}`,
+    ).toEqual([])
+  })
+})

--- a/frontend/src/components/ListSearchInput.vue
+++ b/frontend/src/components/ListSearchInput.vue
@@ -7,9 +7,11 @@
       <Search class="w-4 h-4 text-gray-400" aria-hidden="true" />
     </div>
     <input
+      :id="inputId"
       :value="modelValue"
       type="text"
       :placeholder="placeholder"
+      :aria-label="ariaLabel"
       class="w-full border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
       :class="showIcon ? 'pl-10 pr-4 py-2' : 'px-4 py-2'"
       @input="onInput"
@@ -20,7 +22,7 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, computed, useId } from 'vue'
 import { Search } from 'lucide-vue-next'
 
 const props = defineProps({
@@ -29,7 +31,14 @@ const props = defineProps({
   showIcon: { type: Boolean, default: true },
   /** When true, suppress input emit during IME composition */
   imeGuard: { type: Boolean, default: false },
+  /** id ของ input — ปล่อยว่าไว้จะสร้างค่าไม่ซ้ำอัตโนมัติ (issue #148) */
+  id: { type: String, default: '' },
+  /** accessible name เมื่อไม่มี label ภายนอกผูกกับ input */
+  ariaLabel: { type: String, default: 'ค้นหา' },
 })
+
+const autoId = useId()
+const inputId = computed(() => props.id || `list-search-${autoId}`)
 
 const emit = defineEmits(['update:modelValue', 'search'])
 

--- a/frontend/src/components/ThaiDatePicker.vue
+++ b/frontend/src/components/ThaiDatePicker.vue
@@ -2,7 +2,7 @@
 // ThaiDatePicker — drop-in แทน <input type="date">
 // แสดง/รับวันที่เป็น พ.ศ. (พิมพ์เอง วว/ดด/ปปปป + ปฏิทินไทย + decade grid)
 // v-model in/out = 'Y-m-d' (ค.ศ.) เหมือน native date input ทุกประการ
-import { ref, computed, watch, onMounted, onBeforeUnmount, nextTick } from 'vue'
+import { ref, computed, watch, onMounted, onBeforeUnmount, nextTick, useId } from 'vue'
 import { Calendar, ChevronLeft, ChevronRight, X, Check } from 'lucide-vue-next'
 import {
   toBE, toCE, daysInMonth, thaiDow, toYMD, ymdToDate,
@@ -14,8 +14,19 @@ const props = defineProps({
   modelValue: { type: String, default: '' },
   error: { type: String, default: '' },
   disabled: { type: Boolean, default: false },
+  /** id ฐานของช่องวว/ดด/ปปปป — ปล่อยว่าไว้จะสร้างค่าไม่ซ้ำอัตโนมัติ (issue #148) */
+  id: { type: String, default: '' },
+  /** ชื่อฟิลด์สำหรับ screen reader เมื่อ label ภายนอกไม่ได้ผูกกับ id นี้ */
+  label: { type: String, default: '' },
 })
 const emit = defineEmits(['update:modelValue'])
+
+const autoId = useId()
+const baseId = computed(() => props.id || `tdp-${autoId}`)
+// ช่องย่อยแต่ละช่องประกาศ accessible name เอง — ต่อท้ายด้วย "วัน/เดือน/ปี" ให้อ่านรู้เรื่อง
+const dayAriaLabel = computed(() => (props.label ? `${props.label} (วัน)` : 'วัน'))
+const monthAriaLabel = computed(() => (props.label ? `${props.label} (เดือน)` : 'เดือน'))
+const yearAriaLabel = computed(() => (props.label ? `${props.label} (ปี พ.ศ.)` : 'ปี พ.ศ.'))
 
 // --- ช่องพิมพ์ วว/ดด/ปปปป(พ.ศ.) ---
 const day = ref('')
@@ -229,22 +240,22 @@ onBeforeUnmount(() => {
       :class="displayError ? 'border-red-300' : 'border-gray-300'"
     >
       <input
-        ref="dayRef" :value="day" type="text" inputmode="numeric" maxlength="2"
-        placeholder="วว" aria-label="วัน" :disabled="disabled"
+        :id="`${baseId}-day`" ref="dayRef" :value="day" type="text" inputmode="numeric" maxlength="2"
+        placeholder="วว" :aria-label="dayAriaLabel" :disabled="disabled"
         class="w-9 text-center bg-transparent outline-none placeholder:text-gray-300 disabled:opacity-50"
         @input="onInput('day', $event)" @blur="onBlur" @focus="isEditing = true"
       />
       <span class="text-gray-300 select-none" aria-hidden="true">/</span>
       <input
-        ref="monthRef" :value="month" type="text" inputmode="numeric" maxlength="2"
-        placeholder="ดด" aria-label="เดือน" :disabled="disabled"
+        :id="`${baseId}-month`" ref="monthRef" :value="month" type="text" inputmode="numeric" maxlength="2"
+        placeholder="ดด" :aria-label="monthAriaLabel" :disabled="disabled"
         class="w-9 text-center bg-transparent outline-none placeholder:text-gray-300 disabled:opacity-50"
         @input="onInput('month', $event)" @blur="onBlur" @focus="isEditing = true"
       />
       <span class="text-gray-300 select-none" aria-hidden="true">/</span>
       <input
-        ref="yearRef" :value="year" type="text" inputmode="numeric" maxlength="4"
-        placeholder="ปปปป" aria-label="ปี พ.ศ." :disabled="disabled"
+        :id="`${baseId}-year`" ref="yearRef" :value="year" type="text" inputmode="numeric" maxlength="4"
+        placeholder="ปปปป" :aria-label="yearAriaLabel" :disabled="disabled"
         class="flex-1 min-w-[3rem] text-center bg-transparent outline-none placeholder:text-gray-300 disabled:opacity-50"
         @input="onInput('year', $event)" @blur="onBlur" @focus="isEditing = true"
       />

--- a/frontend/src/pages/AwardsPage.vue
+++ b/frontend/src/pages/AwardsPage.vue
@@ -103,16 +103,16 @@
 
         <div class="space-y-3">
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">รหัสข้าราชการ (servant_id) <span class="text-red-500">*</span></label>
-            <input v-model.number="form.servantId" type="number" min="1" class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+            <label for="awards-servant-id" class="block text-sm font-medium text-gray-700 mb-1">รหัสข้าราชการ (servant_id) <span class="text-red-500">*</span></label>
+            <input id="awards-servant-id" v-model.number="form.servantId" type="number" min="1" class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
           </div>
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">ชื่อรางวัล <span class="text-red-500">*</span></label>
-            <input v-model="form.awardName" type="text" class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+            <label for="awards-award-name" class="block text-sm font-medium text-gray-700 mb-1">ชื่อรางวัล <span class="text-red-500">*</span></label>
+            <input id="awards-award-name" v-model="form.awardName" type="text" class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
           </div>
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">ประเภท</label>
-            <select v-model="form.awardType" class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+            <label for="awards-type" class="block text-sm font-medium text-gray-700 mb-1">ประเภท</label>
+            <select id="awards-type" v-model="form.awardType" class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
               <option value="general">ทั่วไป</option>
               <option value="performance">ผลการปฏิบัติงาน</option>
               <option value="service">การบริการ</option>
@@ -121,8 +121,8 @@
             </select>
           </div>
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">ระดับ</label>
-            <select v-model="form.awardLevel" class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+            <label for="awards-level" class="block text-sm font-medium text-gray-700 mb-1">ระดับ</label>
+            <select id="awards-level" v-model="form.awardLevel" class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
               <option value="">-</option>
               <option value="department">ระดับกรม</option>
               <option value="ministry">ระดับกระทรวง</option>
@@ -131,12 +131,12 @@
             </select>
           </div>
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">วันที่ได้รับ</label>
-            <ThaiDatePicker v-model="form.awardedDate" />
+            <label for="awards-awarded-date" class="block text-sm font-medium text-gray-700 mb-1">วันที่ได้รับ</label>
+            <ThaiDatePicker v-model="form.awardedDate" id="awards-awarded-date" label="วันที่ได้รับรางวัล" />
           </div>
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">รายละเอียด</label>
-            <textarea v-model="form.description" rows="3" class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"></textarea>
+            <label for="awards-description" class="block text-sm font-medium text-gray-700 mb-1">รายละเอียด</label>
+            <textarea id="awards-description" v-model="form.description" rows="3" class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"></textarea>
           </div>
         </div>
 

--- a/frontend/src/pages/DiversePage.vue
+++ b/frontend/src/pages/DiversePage.vue
@@ -139,7 +139,7 @@
         <form @submit.prevent="handleSubmit" class="p-6 space-y-4">
           <!-- Personnel Autocomplete -->
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">บุคลากร <span class="text-red-500">*</span></label>
+            <label for="diverse-personnel-search" class="block text-sm font-medium text-gray-700 mb-1">บุคลากร <span class="text-red-500">*</span></label>
             <div class="relative">
               <input
                 v-model="personnelSearch"
@@ -147,6 +147,7 @@
                 @compositionstart="isComposingPersonnel = true"
                 @compositionend="onPersonnelCompositionEnd"
                 type="text"
+                id="diverse-personnel-search"
                 placeholder="พิมพ์ชื่อเพื่อค้นหา..."
                 class="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                 :class="{ 'border-red-500': validationErrors.personnel_id }"
@@ -194,31 +195,34 @@
             <div class="space-y-3">
               <h4 class="font-medium text-gray-700 border-b pb-1">จาก (เดิม)</h4>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">สายงาน <span class="text-red-500">*</span></label>
+                <label for="diverse-from-job-series" class="block text-sm font-medium text-gray-700 mb-1">สายงาน <span class="text-red-500">*</span></label>
                 <input
                   v-model="formData.from_job_series"
                   type="text"
+                  id="diverse-from-job-series"
                   class="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                   :class="{ 'border-red-500': validationErrors.from_job_series }"
                 />
                 <p v-if="validationErrors.from_job_series" class="text-red-500 text-xs mt-1">{{ validationErrors.from_job_series }}</p>
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">กลุ่มงาน</label>
-                <input v-model="formData.from_work_group" type="text" class="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500" />
+                <label for="diverse-from-work-group" class="block text-sm font-medium text-gray-700 mb-1">กลุ่มงาน</label>
+                <input v-model="formData.from_work_group" id="diverse-from-work-group" type="text" class="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500" />
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">ส่วน/ฝ่าย</label>
-                <input v-model="formData.from_division" type="text" class="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500" />
+                <label for="diverse-from-division" class="block text-sm font-medium text-gray-700 mb-1">ส่วน/ฝ่าย</label>
+                <input v-model="formData.from_division" id="diverse-from-division" type="text" class="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500" />
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">จังหวัด</label>
-                <input v-model="formData.from_province" type="text" class="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500" />
+                <label for="diverse-from-province" class="block text-sm font-medium text-gray-700 mb-1">จังหวัด</label>
+                <input v-model="formData.from_province" id="diverse-from-province" type="text" class="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500" />
               </div>
               <div>
                 <label class="block text-sm font-medium text-gray-700 mb-1">วันเริ่มต้น <span class="text-red-500">*</span></label>
                 <ThaiDatePicker
                   v-model="formData.from_start_date"
+                  id="diverse-from-start-date"
+                  label="วันเริ่มต้น (จาก)"
                   :error="validationErrors.from_start_date || ''"
                 />
               </div>
@@ -226,6 +230,8 @@
                 <label class="block text-sm font-medium text-gray-700 mb-1">วันสิ้นสุด <span class="text-red-500">*</span></label>
                 <ThaiDatePicker
                   v-model="formData.from_end_date"
+                  id="diverse-from-end-date"
+                  label="วันสิ้นสุด (จาก)"
                   :error="validationErrors.from_end_date || ''"
                 />
               </div>
@@ -235,31 +241,34 @@
             <div class="space-y-3">
               <h4 class="font-medium text-gray-700 border-b pb-1">ไป (ใหม่)</h4>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">สายงาน <span class="text-red-500">*</span></label>
+                <label for="diverse-to-job-series" class="block text-sm font-medium text-gray-700 mb-1">สายงาน <span class="text-red-500">*</span></label>
                 <input
                   v-model="formData.to_job_series"
                   type="text"
+                  id="diverse-to-job-series"
                   class="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                   :class="{ 'border-red-500': validationErrors.to_job_series }"
                 />
                 <p v-if="validationErrors.to_job_series" class="text-red-500 text-xs mt-1">{{ validationErrors.to_job_series }}</p>
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">กลุ่มงาน</label>
-                <input v-model="formData.to_work_group" type="text" class="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500" />
+                <label for="diverse-to-work-group" class="block text-sm font-medium text-gray-700 mb-1">กลุ่มงาน</label>
+                <input v-model="formData.to_work_group" id="diverse-to-work-group" type="text" class="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500" />
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">ส่วน/ฝ่าย</label>
-                <input v-model="formData.to_division" type="text" class="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500" />
+                <label for="diverse-to-division" class="block text-sm font-medium text-gray-700 mb-1">ส่วน/ฝ่าย</label>
+                <input v-model="formData.to_division" id="diverse-to-division" type="text" class="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500" />
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">จังหวัด</label>
-                <input v-model="formData.to_province" type="text" class="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500" />
+                <label for="diverse-to-province" class="block text-sm font-medium text-gray-700 mb-1">จังหวัด</label>
+                <input v-model="formData.to_province" id="diverse-to-province" type="text" class="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500" />
               </div>
               <div>
                 <label class="block text-sm font-medium text-gray-700 mb-1">วันเริ่มต้น <span class="text-red-500">*</span></label>
                 <ThaiDatePicker
                   v-model="formData.to_start_date"
+                  id="diverse-to-start-date"
+                  label="วันเริ่มต้น (ไป)"
                   :error="validationErrors.to_start_date || ''"
                 />
               </div>
@@ -267,6 +276,8 @@
                 <label class="block text-sm font-medium text-gray-700 mb-1">วันสิ้นสุด <span class="text-red-500">*</span></label>
                 <ThaiDatePicker
                   v-model="formData.to_end_date"
+                  id="diverse-to-end-date"
+                  label="วันสิ้นสุด (ไป)"
                   :error="validationErrors.to_end_date || ''"
                 />
               </div>
@@ -278,19 +289,19 @@
             <h4 class="font-medium text-gray-700 mb-3">ความแตกต่าง 4 มิติ</h4>
             <div class="grid grid-cols-2 gap-3">
               <label class="flex items-center gap-2">
-                <input type="checkbox" v-model="formData.is_diff_job_series" class="rounded text-blue-500">
+                <input id="diverse-diff-job-series" type="checkbox" v-model="formData.is_diff_job_series" class="rounded text-blue-500">
                 <span>สายงานต่างกัน</span>
               </label>
               <label class="flex items-center gap-2">
-                <input type="checkbox" v-model="formData.is_diff_org" class="rounded text-blue-500">
+                <input id="diverse-diff-org" type="checkbox" v-model="formData.is_diff_org" class="rounded text-blue-500">
                 <span>หน่วยงานต่างกัน</span>
               </label>
               <label class="flex items-center gap-2">
-                <input type="checkbox" v-model="formData.is_diff_location" class="rounded text-blue-500">
+                <input id="diverse-diff-location" type="checkbox" v-model="formData.is_diff_location" class="rounded text-blue-500">
                 <span>พื้นที่ต่างกัน</span>
               </label>
               <label class="flex items-center gap-2">
-                <input type="checkbox" v-model="formData.is_diff_work_nature" class="rounded text-blue-500">
+                <input id="diverse-diff-work-nature" type="checkbox" v-model="formData.is_diff_work_nature" class="rounded text-blue-500">
                 <span>ลักษณะงานต่างกัน</span>
               </label>
             </div>

--- a/frontend/src/pages/EquivalencePage.vue
+++ b/frontend/src/pages/EquivalencePage.vue
@@ -155,13 +155,14 @@
           <div class="px-6 py-4 space-y-4">
             <!-- Personnel autocomplete -->
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">บุคลากร <span class="text-red-500">*</span></label>
+              <label for="equivalence-personnel-search" class="block text-sm font-medium text-gray-700 mb-1">บุคลากร <span class="text-red-500">*</span></label>
               <div class="relative">
                 <input
                   v-model="personnelSearch"
                   @input="onPersonnelSearch"
                   :disabled="!!editingRecord"
                   type="text"
+                  id="equivalence-personnel-search"
                   placeholder="พิมพ์ชื่อเพื่อค้นหา..."
                   class="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                   :class="[
@@ -204,10 +205,11 @@
 
             <!-- actual_position -->
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">ตำแหน่งจริง <span class="text-red-500">*</span></label>
+              <label for="equivalence-actual-position" class="block text-sm font-medium text-gray-700 mb-1">ตำแหน่งจริง <span class="text-red-500">*</span></label>
               <input
                 v-model="formData.actual_position"
                 type="text"
+                id="equivalence-actual-position"
                 class="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                 :class="formErrors.actual_position ? 'border-red-300' : 'border-gray-300'"
               />
@@ -216,10 +218,11 @@
 
             <!-- equivalent_type -->
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">เทียบเป็นตำแหน่ง <span class="text-red-500">*</span></label>
+              <label for="equivalence-equivalent-type" class="block text-sm font-medium text-gray-700 mb-1">เทียบเป็นตำแหน่ง <span class="text-red-500">*</span></label>
               <input
                 v-model="formData.equivalent_type"
                 type="text"
+                id="equivalence-equivalent-type"
                 class="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                 :class="formErrors.equivalent_type ? 'border-red-300' : 'border-gray-300'"
               />
@@ -231,6 +234,8 @@
               <label class="block text-sm font-medium text-gray-700 mb-1">วันเริ่มต้น (คำขอ) <span class="text-red-500">*</span></label>
               <ThaiDatePicker
                 v-model="formData.request_start_date"
+                id="equivalence-request-start-date"
+                label="วันเริ่มต้น (คำขอ)"
                 :error="formErrors.request_start_date || ''"
               />
             </div>
@@ -240,16 +245,19 @@
               <label class="block text-sm font-medium text-gray-700 mb-1">วันสิ้นสุด (คำขอ) <span class="text-red-500">*</span></label>
               <ThaiDatePicker
                 v-model="formData.request_end_date"
+                id="equivalence-request-end-date"
+                label="วันสิ้นสุด (คำขอ)"
                 :error="formErrors.request_end_date || ''"
               />
             </div>
 
             <!-- approval_order_ref -->
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">อ้างอิงคำสั่ง</label>
+              <label for="equivalence-approval-order-ref" class="block text-sm font-medium text-gray-700 mb-1">อ้างอิงคำสั่ง</label>
               <input
                 v-model="formData.approval_order_ref"
                 type="text"
+                id="equivalence-approval-order-ref"
                 class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               />
             </div>
@@ -292,13 +300,13 @@
             <!-- approved_start_date -->
             <div>
               <label class="block text-sm font-medium text-gray-700 mb-1">วันเริ่มต้นที่อนุมัติ <span class="text-red-500">*</span></label>
-              <ThaiDatePicker v-model="approveForm.approved_start_date" />
+              <ThaiDatePicker v-model="approveForm.approved_start_date" id="equivalence-approved-start-date" label="วันเริ่มต้นที่อนุมัติ" />
             </div>
 
             <!-- approved_end_date -->
             <div>
               <label class="block text-sm font-medium text-gray-700 mb-1">วันสิ้นสุดที่อนุมัติ <span class="text-red-500">*</span></label>
-              <ThaiDatePicker v-model="approveForm.approved_end_date" />
+              <ThaiDatePicker v-model="approveForm.approved_end_date" id="equivalence-approved-end-date" label="วันสิ้นสุดที่อนุมัติ" />
             </div>
           </div>
           <div class="px-6 py-4 border-t border-gray-200 flex justify-end gap-3">

--- a/frontend/src/pages/ImportPage.vue
+++ b/frontend/src/pages/ImportPage.vue
@@ -52,10 +52,12 @@
         @drop.prevent="onDrop"
       >
         <input
+          id="import-file-input"
           ref="inputEl"
           type="file"
           accept=".xlsx"
           class="hidden"
+          aria-label="เลือกไฟล์ Excel (.xlsx) สำหรับนำเข้าข้อมูลบุคลากร"
           @change="onPick"
         />
         <FileSpreadsheet class="w-10 h-10 mx-auto text-gray-400" />

--- a/frontend/src/pages/LoginPage.vue
+++ b/frontend/src/pages/LoginPage.vue
@@ -29,12 +29,13 @@
         <!-- Login Form -->
         <form @submit.prevent="handleLogin" class="space-y-5">
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-2">ชื่อผู้ใช้</label>
+            <label class="block text-sm font-medium text-gray-700 mb-2" for="login-username">ชื่อผู้ใช้</label>
             <div class="relative">
               <div class="pointer-events-none absolute inset-y-0 left-0 z-10 flex items-center pl-3">
                 <User class="h-5 w-5 text-gray-400" aria-hidden="true" />
               </div>
               <input
+                id="login-username"
                 v-model="form.username"
                 type="text"
                 class="block w-full rounded-xl border border-gray-300 bg-white py-3 pl-10 pr-3 text-gray-900 transition-shadow duration-200 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/30"
@@ -45,12 +46,13 @@
           </div>
 
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-2">รหัสผ่าน</label>
+            <label class="block text-sm font-medium text-gray-700 mb-2" for="login-password">รหัสผ่าน</label>
             <div class="relative">
               <div class="pointer-events-none absolute inset-y-0 left-0 z-10 flex items-center pl-3">
                 <Lock class="h-5 w-5 text-gray-400" aria-hidden="true" />
               </div>
               <input
+                id="login-password"
                 v-model="form.password"
                 :type="showPassword ? 'text' : 'password'"
                 class="block w-full rounded-xl border border-gray-300 bg-white py-3 pl-10 pr-10 text-gray-900 transition-shadow duration-200 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/30"
@@ -71,7 +73,7 @@
           <!-- spacing like jsk-app: space-y-5 (20px) + submit mt-4 (16px) => 36px to button -->
           <div class="flex items-center justify-between gap-3 px-1">
             <label class="flex cursor-pointer items-center gap-2.5">
-              <input type="checkbox" v-model="rememberMe" class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500" />
+              <input id="login-remember-me" type="checkbox" v-model="rememberMe" class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500" />
               <span class="text-sm text-gray-600">จดจำฉัน</span>
             </label>
             <button

--- a/frontend/src/pages/MultiplierAreasPage.vue
+++ b/frontend/src/pages/MultiplierAreasPage.vue
@@ -168,8 +168,9 @@
         <form class="p-6 space-y-4" @submit.prevent="handleSubmit">
           <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">จังหวัด <span class="text-red-500">*</span></label>
+              <label for="multiplier-areas-province" class="block text-sm font-medium text-gray-700 mb-1">จังหวัด <span class="text-red-500">*</span></label>
               <input
+                id="multiplier-areas-province"
                 v-model="formData.province"
                 type="text"
                 class="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
@@ -178,8 +179,9 @@
               <p v-if="formErrors.province" class="text-xs text-red-500 mt-1">กรุณาระบุจังหวัด</p>
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">อำเภอ</label>
+              <label for="multiplier-areas-district" class="block text-sm font-medium text-gray-700 mb-1">อำเภอ</label>
               <input
+                id="multiplier-areas-district"
                 v-model="formData.district"
                 type="text"
                 class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
@@ -190,8 +192,9 @@
 
           <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">ฐานประกาศ <span class="text-red-500">*</span></label>
+              <label for="multiplier-areas-basis-type" class="block text-sm font-medium text-gray-700 mb-1">ฐานประกาศ <span class="text-red-500">*</span></label>
               <input
+                id="multiplier-areas-basis-type"
                 v-model="formData.basis_type"
                 type="text"
                 list="basis-type-options"
@@ -205,8 +208,9 @@
               <p v-if="formErrors.basis_type" class="text-xs text-red-500 mt-1">กรุณาระบุฐานประกาศ</p>
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">อัตราทวีคูณ (%) <span class="text-red-500">*</span></label>
+              <label for="multiplier-areas-ratio" class="block text-sm font-medium text-gray-700 mb-1">อัตราทวีคูณ (%) <span class="text-red-500">*</span></label>
               <input
+                id="multiplier-areas-ratio"
                 v-model="formData.multiplier_ratio"
                 type="number"
                 min="100"
@@ -235,15 +239,19 @@
 
           <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">วันเริ่มมีผล <span class="text-red-500">*</span></label>
+              <label for="multiplier-areas-start" class="block text-sm font-medium text-gray-700 mb-1">วันเริ่มมีผล <span class="text-red-500">*</span></label>
               <ThaiDatePicker
+                id="multiplier-areas-start"
+                label="วันเริ่มมีผล"
                 v-model="formData.effective_start_date"
                 :error="formErrors.effective_start_date ? 'กรุณาระบุวันเริ่มมีผล' : ''"
               />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">วันสิ้นสุด (เว้นว่าง = ไม่กำหนด)</label>
+              <label for="multiplier-areas-end" class="block text-sm font-medium text-gray-700 mb-1">วันสิ้นสุด (เว้นว่าง = ไม่กำหนด)</label>
               <ThaiDatePicker
+                id="multiplier-areas-end"
+                label="วันสิ้นสุด"
                 v-model="formData.effective_end_date"
                 :error="formErrors.effective_end_date ? 'วันสิ้นสุดต้องไม่น้อยกว่าวันเริ่ม' : ''"
               />
@@ -251,8 +259,9 @@
           </div>
 
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">อ้างอิงกฎหมาย</label>
+            <label for="multiplier-areas-legal-reference" class="block text-sm font-medium text-gray-700 mb-1">อ้างอิงกฎหมาย</label>
             <input
+              id="multiplier-areas-legal-reference"
               v-model="formData.legal_reference"
               type="text"
               maxlength="300"
@@ -262,8 +271,9 @@
           </div>
 
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">แหล่งที่มา</label>
+            <label for="multiplier-areas-source-reference" class="block text-sm font-medium text-gray-700 mb-1">แหล่งที่มา</label>
             <input
+              id="multiplier-areas-source-reference"
               v-model="formData.source_reference"
               type="text"
               maxlength="500"

--- a/frontend/src/pages/MultiplierPage.vue
+++ b/frontend/src/pages/MultiplierPage.vue
@@ -66,6 +66,8 @@
         <input
           v-model="areaSearchQuery"
           type="text"
+          id="multiplier-area-search"
+          aria-label="ค้นหาพื้นที่พิเศษ จังหวัด อำเภอ หรือฐานประกาศ"
           placeholder="ค้นหา master data จากจังหวัด อำเภอ หรือฐานประกาศ..."
           class="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
         />
@@ -238,9 +240,10 @@
 
         <form class="p-6 space-y-4" @submit.prevent="handleSubmit">
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">บุคลากร <span class="text-red-500">*</span></label>
+            <label for="multiplier-personnel-search" class="block text-sm font-medium text-gray-700 mb-1">บุคลากร <span class="text-red-500">*</span></label>
             <div class="relative">
               <input
+                id="multiplier-personnel-search"
                 v-model="personnelSearch"
                 type="text"
                 placeholder="พิมพ์ชื่อเพื่อค้นหา..."
@@ -287,8 +290,9 @@
           </div>
 
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">พื้นที่พิเศษ <span class="text-red-500">*</span></label>
+            <label for="multiplier-area-select" class="block text-sm font-medium text-gray-700 mb-1">พื้นที่พิเศษ <span class="text-red-500">*</span></label>
             <select
+              id="multiplier-area-select"
               v-model="formData.area_multiplier_id"
               class="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               :class="formErrors.area_multiplier_id ? 'border-red-500' : 'border-gray-300'"
@@ -307,18 +311,19 @@
 
           <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">วันเริ่มปฏิบัติงาน <span class="text-red-500">*</span></label>
-              <ThaiDatePicker v-model="formData.start_date" :error="formErrors.start_date ? 'กรุณาระบุวันเริ่ม' : ''" />
+              <label for="multiplier-form-start" class="block text-sm font-medium text-gray-700 mb-1">วันเริ่มปฏิบัติงาน <span class="text-red-500">*</span></label>
+              <ThaiDatePicker v-model="formData.start_date" id="multiplier-form-start" label="วันเริ่มปฏิบัติงาน" :error="formErrors.start_date ? 'กรุณาระบุวันเริ่ม' : ''" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">วันสิ้นสุดปฏิบัติงาน <span class="text-red-500">*</span></label>
-              <ThaiDatePicker v-model="formData.end_date" :error="formErrors.end_date ? 'กรุณาระบุวันสิ้นสุด' : ''" />
+              <label for="multiplier-form-end" class="block text-sm font-medium text-gray-700 mb-1">วันสิ้นสุดปฏิบัติงาน <span class="text-red-500">*</span></label>
+              <ThaiDatePicker v-model="formData.end_date" id="multiplier-form-end" label="วันสิ้นสุดปฏิบัติงาน" :error="formErrors.end_date ? 'กรุณาระบุวันสิ้นสุด' : ''" />
             </div>
           </div>
 
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">เอกสารอ้างอิง</label>
+            <label for="multiplier-proof-reference" class="block text-sm font-medium text-gray-700 mb-1">เอกสารอ้างอิง</label>
             <input
+              id="multiplier-proof-reference"
               v-model="formData.proof_reference"
               type="text"
               class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
@@ -327,8 +332,9 @@
           </div>
 
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">หมายเหตุ</label>
+            <label for="multiplier-description" class="block text-sm font-medium text-gray-700 mb-1">หมายเหตุ</label>
             <textarea
+              id="multiplier-description"
               v-model="formData.description"
               rows="3"
               class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"

--- a/frontend/src/pages/OcrPage.vue
+++ b/frontend/src/pages/OcrPage.vue
@@ -27,10 +27,12 @@
         @drop.prevent="onDrop"
       >
         <input
+          id="ocr-file-input"
           ref="inputEl"
           type="file"
           accept=".pdf"
           class="hidden"
+          aria-label="เลือกไฟล์ PDF สำหรับแปลงเป็น Markdown"
           @change="onPick"
         />
         <FileText class="w-10 h-10 mx-auto text-gray-400" />

--- a/frontend/src/pages/PersonnelPage.vue
+++ b/frontend/src/pages/PersonnelPage.vue
@@ -28,6 +28,7 @@
         </div>
         <label v-if="isAdmin" class="flex items-center gap-2 text-sm text-gray-600 cursor-pointer select-none">
           <input
+            id="personnel-include-inactive"
             v-model="includeInactive"
             type="checkbox"
             class="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
@@ -122,8 +123,9 @@
 
         <div class="space-y-3">
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">คำนำหน้า</label>
+            <label for="personnel-prefix" class="block text-sm font-medium text-gray-700 mb-1">คำนำหน้า</label>
             <select
+              id="personnel-prefix"
               v-model="formData.prefixId"
               class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
             >
@@ -135,8 +137,9 @@
           </div>
 
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">ชื่อ <span class="text-red-500">*</span></label>
+            <label for="personnel-first-name" class="block text-sm font-medium text-gray-700 mb-1">ชื่อ <span class="text-red-500">*</span></label>
             <input
+              id="personnel-first-name"
               v-model="formData.firstName"
               type="text"
               class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
@@ -144,8 +147,9 @@
           </div>
 
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">นามสกุล <span class="text-red-500">*</span></label>
+            <label for="personnel-last-name" class="block text-sm font-medium text-gray-700 mb-1">นามสกุล <span class="text-red-500">*</span></label>
             <input
+              id="personnel-last-name"
               v-model="formData.lastName"
               type="text"
               class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
@@ -153,10 +157,11 @@
           </div>
 
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">
+            <label for="personnel-citizen-id" class="block text-sm font-medium text-gray-700 mb-1">
               เลขบัตรประชาชน <span v-if="!editingRow" class="text-red-500">*</span>
             </label>
             <input
+              id="personnel-citizen-id"
               v-model="formData.citizenId"
               type="text"
               maxlength="13"
@@ -169,8 +174,9 @@
           </div>
 
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">รหัสพนักงาน</label>
+            <label for="personnel-employee-id" class="block text-sm font-medium text-gray-700 mb-1">รหัสพนักงาน</label>
             <input
+              id="personnel-employee-id"
               v-model="formData.employeeId"
               type="text"
               class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"

--- a/frontend/src/pages/ProbationEndPage.vue
+++ b/frontend/src/pages/ProbationEndPage.vue
@@ -198,6 +198,8 @@
                 <label class="block text-sm font-medium text-gray-700 mb-1">วันเริ่มทดลอง <span class="text-red-500">*</span></label>
                 <ThaiDatePicker
                   v-model="formData.start_date"
+                  id="probation-start-date"
+                  label="วันเริ่มทดลอง"
                   :class="{ 'ring-2 ring-red-500 rounded-lg': formErrors.start_date }"
                 />
               </div>
@@ -205,13 +207,16 @@
                 <label class="block text-sm font-medium text-gray-700 mb-1">วันครบกำหนด <span class="text-red-500">*</span></label>
                 <ThaiDatePicker
                   v-model="formData.end_date"
+                  id="probation-end-date"
+                  label="วันครบกำหนด"
                   :class="{ 'ring-2 ring-red-500 rounded-lg': formErrors.end_date }"
                 />
               </div>
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">สถานะ</label>
+              <label for="probation-overall-status" class="block text-sm font-medium text-gray-700 mb-1">สถานะ</label>
               <select
+                id="probation-overall-status"
                 v-model="formData.overall_status"
                 class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               >
@@ -222,8 +227,9 @@
               </select>
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">หมายเหตุ</label>
+              <label for="probation-remarks" class="block text-sm font-medium text-gray-700 mb-1">หมายเหตุ</label>
               <textarea
+                id="probation-remarks"
                 v-model="formData.remarks"
                 rows="3"
                 class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"

--- a/frontend/src/pages/RetirementReportPage.vue
+++ b/frontend/src/pages/RetirementReportPage.vue
@@ -39,7 +39,9 @@
         @search="onSearchInput"
       />
       <select
+        id="retirement-report-within-filter"
         v-model="within"
+        aria-label="กรองข้าราชการตามช่วงเวลาก่อนเกษียณ"
         @change="onFilterChange"
         class="px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
       >

--- a/frontend/src/pages/RoyalDecorationsPage.vue
+++ b/frontend/src/pages/RoyalDecorationsPage.vue
@@ -101,28 +101,28 @@
 
         <div class="space-y-3">
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">รหัสข้าราชการ (servant_id) <span class="text-red-500">*</span></label>
-            <input v-model.number="form.servantId" type="number" min="1" class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+            <label for="royal-decorations-servant-id" class="block text-sm font-medium text-gray-700 mb-1">รหัสข้าราชการ (servant_id) <span class="text-red-500">*</span></label>
+            <input id="royal-decorations-servant-id" v-model.number="form.servantId" type="number" min="1" class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
           </div>
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">ชื่อเครื่องราชอิสริยาภรณ์ <span class="text-red-500">*</span></label>
-            <input v-model="form.decorationName" type="text" class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+            <label for="royal-decorations-name" class="block text-sm font-medium text-gray-700 mb-1">ชื่อเครื่องราชอิสริยาภรณ์ <span class="text-red-500">*</span></label>
+            <input id="royal-decorations-name" v-model="form.decorationName" type="text" class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
           </div>
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">ชั้น</label>
-            <input v-model="form.decorationClass" type="text" placeholder="เช่น ชั้นที่ 1, ทวีติยาภรณ์ช้างเผือก" class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+            <label for="royal-decorations-class" class="block text-sm font-medium text-gray-700 mb-1">ชั้น</label>
+            <input id="royal-decorations-class" v-model="form.decorationClass" type="text" placeholder="เช่น ชั้นที่ 1, ทวีติยาภรณ์ช้างเผือก" class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
           </div>
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">ปีที่ได้รับ (พ.ศ.)</label>
-            <input v-model.number="form.receivedYear" type="number" min="2400" max="2700" placeholder="เช่น 2566" class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+            <label for="royal-decorations-received-year" class="block text-sm font-medium text-gray-700 mb-1">ปีที่ได้รับ (พ.ศ.)</label>
+            <input id="royal-decorations-received-year" v-model.number="form.receivedYear" type="number" min="2400" max="2700" placeholder="เช่น 2566" class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
           </div>
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">อ้างอิงราชกิจจานุเบกษา</label>
-            <input v-model="form.gazetteRef" type="text" class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+            <label for="royal-decorations-gazette-ref" class="block text-sm font-medium text-gray-700 mb-1">อ้างอิงราชกิจจานุเบกษา</label>
+            <input id="royal-decorations-gazette-ref" v-model="form.gazetteRef" type="text" class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
           </div>
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">รายละเอียด</label>
-            <textarea v-model="form.description" rows="3" class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"></textarea>
+            <label for="royal-decorations-description" class="block text-sm font-medium text-gray-700 mb-1">รายละเอียด</label>
+            <textarea id="royal-decorations-description" v-model="form.description" rows="3" class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"></textarea>
           </div>
         </div>
 

--- a/frontend/src/pages/SettingsPage.vue
+++ b/frontend/src/pages/SettingsPage.vue
@@ -143,7 +143,9 @@
           </div>
           <div class="flex gap-2">
             <select
+              id="settings-role-select"
               v-model="selectedRole"
+              aria-label="เลือกบทบาทเพื่อดูเมทริกซ์สิทธิ์"
               class="rounded-lg border border-gray-300 px-3 py-2 text-sm"
             >
               <option v-for="role in matrixRoles" :key="role" :value="role">{{ role }}</option>
@@ -174,19 +176,21 @@
             </thead>
             <tbody>
               <tr
-                v-for="resource in matrixResources"
+                v-for="(resource, resourceIdx) in matrixResources"
                 :key="resource"
                 class="border-b border-gray-100"
               >
                 <td class="py-2 pr-4 font-medium text-gray-800">{{ resource }}</td>
                 <td
-                  v-for="action in matrixActions"
+                  v-for="(action, actionIdx) in matrixActions"
                   :key="`${resource}-${action}`"
                   class="py-2 px-2 text-center"
                 >
                   <input
+                    :id="`settings-perm-${resourceIdx}-${actionIdx}`"
                     type="checkbox"
                     class="h-4 w-4 rounded border-gray-300 text-blue-600 cursor-pointer"
+                    :aria-label="`สิทธิ์ ${action} ของบทบาท ${selectedRole} ในส่วน ${resource}`"
                     :checked="cellAllowed(selectedRole, action, resource)"
                     @change="toggleCell(selectedRole, action, resource, $event.target.checked)"
                   />

--- a/frontend/src/pages/SupportivePage.vue
+++ b/frontend/src/pages/SupportivePage.vue
@@ -137,12 +137,13 @@
         <form @submit.prevent="handleSave" class="space-y-4">
           <!-- บุคลากร -->
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">บุคลากร</label>
+            <label for="supportive-personnel-search" class="block text-sm font-medium text-gray-700 mb-1">บุคลากร</label>
             <div v-if="editingRecord" class="px-3 py-2 bg-gray-100 rounded-lg text-sm text-gray-700">
               {{ editingRecord.fullName }}
             </div>
             <div v-else class="relative">
               <input
+                id="supportive-personnel-search"
                 v-model="personnelSearch"
                 @input="onPersonnelInput"
                 type="text"
@@ -187,8 +188,9 @@
 
           <!-- สายงานหลัก -->
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">สายงานหลัก</label>
+            <label for="supportive-primary-series" class="block text-sm font-medium text-gray-700 mb-1">สายงานหลัก</label>
             <input
+              id="supportive-primary-series"
               v-model="formData.primary_series_name"
               type="text"
               placeholder="ระบุสายงานหลัก"
@@ -200,8 +202,9 @@
 
           <!-- สายงานที่เกื้อกูล -->
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">สายงานที่เกื้อกูล</label>
+            <label for="supportive-job-series" class="block text-sm font-medium text-gray-700 mb-1">สายงานที่เกื้อกูล</label>
             <input
+              id="supportive-job-series"
               v-model="formData.job_series_name"
               type="text"
               placeholder="ระบุสายงานที่เกื้อกูล"
@@ -213,8 +216,10 @@
 
           <!-- วันเริ่มต้น -->
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">วันเริ่มต้น</label>
+            <label for="supportive-start-date" class="block text-sm font-medium text-gray-700 mb-1">วันเริ่มต้น</label>
             <ThaiDatePicker
+              id="supportive-start-date"
+              label="วันเริ่มต้น"
               v-model="formData.start_date"
               :error="formErrors.start_date ? 'กรุณาระบุวันเริ่มต้น' : ''"
             />
@@ -222,8 +227,10 @@
 
           <!-- วันสิ้นสุด -->
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">วันสิ้นสุด</label>
+            <label for="supportive-end-date" class="block text-sm font-medium text-gray-700 mb-1">วันสิ้นสุด</label>
             <ThaiDatePicker
+              id="supportive-end-date"
+              label="วันสิ้นสุด"
               v-model="formData.end_date"
               :error="formErrors.end_date ? 'กรุณาระบุวันสิ้นสุด' : ''"
             />
@@ -231,8 +238,9 @@
 
           <!-- หมายเหตุ -->
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">หมายเหตุ (ไม่บังคับ)</label>
+            <label for="supportive-description" class="block text-sm font-medium text-gray-700 mb-1">หมายเหตุ (ไม่บังคับ)</label>
             <textarea
+              id="supportive-description"
               v-model="formData.description"
               rows="3"
               placeholder="ระบุหมายเหตุ (ถ้ามี)"

--- a/frontend/src/pages/UserManagementPage.vue
+++ b/frontend/src/pages/UserManagementPage.vue
@@ -117,8 +117,9 @@
 
         <div class="space-y-3">
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">ชื่อผู้ใช้ <span v-if="!editingUser" class="text-red-500">*</span></label>
+            <label for="user-username" class="block text-sm font-medium text-gray-700 mb-1">ชื่อผู้ใช้ <span v-if="!editingUser" class="text-red-500">*</span></label>
             <input
+              id="user-username"
               v-model="formData.username"
               type="text"
               :disabled="!!editingUser"
@@ -130,8 +131,9 @@
 
           <template v-if="!editingUser">
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">รหัสผ่าน <span class="text-red-500">*</span></label>
+              <label for="user-password" class="block text-sm font-medium text-gray-700 mb-1">รหัสผ่าน <span class="text-red-500">*</span></label>
               <input
+                id="user-password"
                 v-model="formData.password"
                 type="password"
                 autocomplete="new-password"
@@ -140,8 +142,9 @@
               />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">ยืนยันรหัสผ่าน <span class="text-red-500">*</span></label>
+              <label for="user-password-confirm" class="block text-sm font-medium text-gray-700 mb-1">ยืนยันรหัสผ่าน <span class="text-red-500">*</span></label>
               <input
+                id="user-password-confirm"
                 v-model="formData.passwordConfirm"
                 type="password"
                 autocomplete="new-password"
@@ -151,8 +154,9 @@
           </template>
 
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">ชื่อ-สกุล <span class="text-red-500">*</span></label>
+            <label for="user-full-name" class="block text-sm font-medium text-gray-700 mb-1">ชื่อ-สกุล <span class="text-red-500">*</span></label>
             <input
+              id="user-full-name"
               v-model="formData.fullName"
               type="text"
               class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
@@ -161,8 +165,9 @@
           </div>
 
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">อีเมล</label>
+            <label for="user-email" class="block text-sm font-medium text-gray-700 mb-1">อีเมล</label>
             <input
+              id="user-email"
               v-model="formData.email"
               type="email"
               class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
@@ -171,8 +176,9 @@
           </div>
 
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">สิทธิ์ <span class="text-red-500">*</span></label>
+            <label for="user-role" class="block text-sm font-medium text-gray-700 mb-1">สิทธิ์ <span class="text-red-500">*</span></label>
             <select
+              id="user-role"
               v-model="formData.role"
               :disabled="isSelfEditing"
               class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-gray-100 disabled:text-gray-500"
@@ -213,8 +219,9 @@
 
         <div class="space-y-3">
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">รหัสผ่านใหม่ <span class="text-red-500">*</span></label>
+            <label for="user-reset-password" class="block text-sm font-medium text-gray-700 mb-1">รหัสผ่านใหม่ <span class="text-red-500">*</span></label>
             <input
+              id="user-reset-password"
               v-model="resetForm.password"
               type="password"
               autocomplete="new-password"
@@ -223,8 +230,9 @@
             />
           </div>
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">ยืนยันรหัสผ่านใหม่ <span class="text-red-500">*</span></label>
+            <label for="user-reset-password-confirm" class="block text-sm font-medium text-gray-700 mb-1">ยืนยันรหัสผ่านใหม่ <span class="text-red-500">*</span></label>
             <input
+              id="user-reset-password-confirm"
               v-model="resetForm.passwordConfirm"
               type="password"
               autocomplete="new-password"

--- a/frontend/src/pages/WorkResultsPage.vue
+++ b/frontend/src/pages/WorkResultsPage.vue
@@ -14,7 +14,9 @@
         @search="onSearchInput"
       />
       <select
+        id="work-results-status-filter"
         v-model="statusFilter"
+        aria-label="กรองผลงานตามสถานะ"
         @change="onFilterChange"
         class="px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
       >


### PR DESCRIPTION
## สรุป

- ฟิลด์ฟอร์ม **72 จุดใน 18 ไฟล์ .vue** ที่ label ไม่ผูกกับ input (Chrome DevTools Issues: "No label associated with a form field") → เติม `<label for>`↔`id`, implicit wrap, หรือ `aria-label` ให้ครบทุกฟิลด์
- Component ที่ถูกใช้ซ้ำหลาย instance ต่อหน้า: `ThaiDatePicker.vue` และ `ListSearchInput.vue` รับ prop `id` ใหม่ (fallback เป็น `useId()` กัน id ซ้ำข้าม instance) + prop `label` สำหรับ accessible name ของช่องย่อย วว/ดด/ปปปป
- เพิ่ม **guard test** `frontend/src/__tests__/a11yFormFields.test.js` สแกนทุก `.vue` ใน src — ถ้าเพิ่มฟิลด์ใหม่โดยไม่มี accessible name จะ fail ทันทีพร้อมระบุไฟล์+บรรทัดทั้งหมด

Refs #148

## หมายเหตุ

- เปลี่ยนเฉพาะ attribute (id / for / aria-label) — ไม่แตะ logic, layout หรือ visual ใด ๆ
- Permission matrix ใน SettingsPage สร้าง id จาก index ของ v-for เพื่อเลี่ยงค่าที่มีช่องว่างจาก API

## Verification

- [x] Guard test ผ่าน — 0 violations จาก 38 ไฟล์
- [x] Vitest เฉพาะ 18 ไฟล์ที่กระทบ — 164 เทสผ่าน · pre-push hook ชุดเต็ม 75 ไฟล์/562 เทสผ่าน
- [x] `npm run build` ผ่าน
- ไม่มี screenshot — ไม่มีการเปลี่ยนแปลงทางสายตา (attribute-only)
