### PR TITLE
feat(csp): สลับ render.yaml เป็น enforce — ตัด -Report-Only ออกจากชื่อ header (#113)

### DIFF
--- a/docs/runbooks/csp-enforce-switch.md
+++ b/docs/runbooks/csp-enforce-switch.md
@@ -50,12 +50,21 @@ node scripts/csp-report-selftest.mjs   # exit 1 = ยังไม่มี marke
 
 ## ข้อ 2 — แก้เทสที่ผูกกับชื่อ header
 
-`frontend/src/__tests__/securityHeaders.test.js:34` assert ว่า `render.yaml` มีคำว่า
-`Content-Security-Policy-Report-Only` — ต้องเปลี่ยนเป็นชื่อใหม่ ไม่งั้น vitest แดงตั้งแต่ pre-push
-(บรรทัด 68–69 และ 140 เป็นของ `nginx.conf` ซึ่ง**ไม่ต้องแตะ** เพราะ nginx ใช้ enforce อยู่แล้ว)
+สามไฟล์ผูกกับชื่อ header — ต้องแก้ทั้งหมด ไม่งั้น pre-push แดง:
+
+1. `frontend/src/__tests__/securityHeaders.test.js:34` assert ว่า `render.yaml` มีคำว่า
+   `Content-Security-Policy-Report-Only` — เปลี่ยนเป็นชื่อใหม่ (assert ของ `nginx.conf`
+   **ไม่ต้องแตะ** เพราะ nginx ใช้ enforce อยู่แล้ว)
+2. `scripts/tests/audit-bundle-csp.test.mjs` เทส anti-drift "POLICY ที่เทสใช้ต้องตรงกับ
+   render.yaml จริง" ค้น header ด้วยชื่อ — ต้องค้นทั้งสองชื่อ (enforce ก่อน แล้ว fallback
+   report-only) เพื่อให้ gate ยังครอบทั้งสองเฟส
+3. `scripts/tests/verify-live-headers.test.mjs` สามจุด: เทส parser (expected list),
+   เทส CSP ถูกผ่อน (lookup ด้วยชื่อเดิม), เทส Render defaults (substring ใน output)
 
 ```bash
 cd frontend && npx vitest run src/__tests__/securityHeaders.test.js
+node --test scripts/tests/audit-bundle-csp.test.mjs        # รันผ่าน Git Bash
+node --test scripts/tests/verify-live-headers.test.mjs
 ```
 
 ## ข้อ 3 — Deploy **แล้วยืนยันว่า header เปลี่ยนจริง** (ข้อสำคัญที่สุด)

--- a/frontend/src/__tests__/securityHeaders.test.js
+++ b/frontend/src/__tests__/securityHeaders.test.js
@@ -30,8 +30,9 @@ const CSP_CORE = [
 ]
 
 describe('render.yaml security headers (Render static-site path)', () => {
-  it('declares CSP report-only with the agreed directives and report collector', () => {
-    expect(renderYaml).toContain('Content-Security-Policy-Report-Only')
+  it('enforces CSP with the agreed directives and keeps the report collector', () => {
+    expect(renderYaml).toContain('name: Content-Security-Policy')
+    expect(renderYaml).not.toContain('-Report-Only')
     for (const directive of CSP_CORE) {
       expect(renderYaml).toContain(directive)
     }

--- a/render.yaml
+++ b/render.yaml
@@ -17,10 +17,11 @@ services:
         sync: false
     # Issue #113: Render static site ไม่ได้ใช้ frontend/nginx.conf — ต้องประกาศ headers ที่นี่
     # นโยบายเต็ม + cache decision อยู่ใน docs/frontend-security-headers.md
-    # CSP เริ่มแบบ report-only เพื่อ inventory ก่อน enforce (report ไปที่ backend /api/csp-report)
+    # Issue #113: CSP enforce ตาม runbook docs/runbooks/csp-enforce-switch.md
+    # (คง report-uri ไว้เพื่อเก็บ violation ต่อ — report ยังส่งเข้า backend /api/csp-report)
     headers:
       - path: /*
-        name: Content-Security-Policy-Report-Only
+        name: Content-Security-Policy
         value: "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; report-uri /api/csp-report"
       - path: /*
         name: X-Frame-Options

--- a/scripts/tests/audit-bundle-csp.test.mjs
+++ b/scripts/tests/audit-bundle-csp.test.mjs
@@ -395,7 +395,9 @@ test('parseCspPolicy แตก directive ได้ถูกต้อง', () => 
 test('POLICY ที่เทสใช้ต้องตรงกับ render.yaml จริง (anti-drift)', () => {
   // ถ้า production policy เปลี่ยนแล้วเทสยังใช้ค่าเก่า เทสจะเขียวบนกฎที่ไม่มีอยู่จริง
   const entries = parseRenderHeaders(readFileSync(resolve(ROOT, 'render.yaml'), 'utf8'));
-  const live = entries.find((e) => e.name === 'Content-Security-Policy-Report-Only');
+  // ค้นทั้งสองเฟส — enforce มาก่อน (หลังสวิตช์ csp-enforce-switch) แล้ว fallback report-only
+  const live = entries.find((e) => e.name === 'Content-Security-Policy')
+    ?? entries.find((e) => e.name === 'Content-Security-Policy-Report-Only');
   assert.ok(live, 'ไม่พบ CSP ใน render.yaml');
   assert.equal(
     live.value,

--- a/scripts/tests/verify-live-headers.test.mjs
+++ b/scripts/tests/verify-live-headers.test.mjs
@@ -80,9 +80,12 @@ test('ผ่านเมื่อ origin ส่ง header ครบตามท�
 test('parser แกะได้เฉพาะ block headers: ของ static site (ไม่ชบักไป service อื่น)', () => {
   const entries = parseRenderHeaders(readFileSync(resolve(ROOT, 'render.yaml'), 'utf8'));
   const shellNames = entries.filter((e) => e.path === '/*').map((e) => e.name).sort();
+  // CSP มีได้ชื่อเดียวแล้วแต่เฟส: enforce = Content-Security-Policy · report-only = ...-Report-Only
+  const cspName = shellNames.find((n) => n.startsWith('Content-Security-Policy'));
+  assert.ok(cspName, 'render.yaml ต้องประกาศ CSP header หนึ่งตัว');
   assert.deepEqual(shellNames, [
     'Cache-Control',
-    'Content-Security-Policy-Report-Only',
+    cspName,
     'Permissions-Policy',
     'Referrer-Policy',
     'Strict-Transport-Security',
@@ -130,7 +133,9 @@ test('CSP ถูกผ่อนหรือ HSTS อ่อนกว่าต้�
     headers.shell[e.name] = e.value;
   }
   headers.asset = { ...headers.shell };
-  headers.shell['Content-Security-Policy-Report-Only'] = headers.shell['Content-Security-Policy-Report-Only'].replace(
+  // ค้นชื่อจริงจาก render.yaml — เฟส enforce/report-only ต่างกันที่ชื่อ ไม่ใช่ค่า
+  const cspKey = Object.keys(headers.shell).find((k) => k.startsWith('Content-Security-Policy'));
+  headers.shell[cspKey] = headers.shell[cspKey].replace(
     "script-src 'self'",
     "script-src 'self' 'unsafe-eval'"
   );
@@ -173,7 +178,8 @@ test('ต้อง fail เมื่อเจอ Render/Cloudflare defaults (dri
     // header ที่ drift จริงใน production ต้องถูกจับและระบุชื่อครบ
     for (const name of [
       'Cache-Control',
-      'Content-Security-Policy-Report-Only',
+      // substring ครอบทั้งสองเฟส: enforce "Content-Security-Policy" · report-only "...-Report-Only"
+      'Content-Security-Policy',
       'X-Frame-Options',
       'Referrer-Policy',
       'Permissions-Policy',


### PR DESCRIPTION
## สรุป

- สลับ CSP บน Render static site จาก **report-only → enforce** ตาม runbook `docs/runbooks/csp-enforce-switch.md` ขั้นที่ 1-2
- `render.yaml`: ชื่อ header `Content-Security-Policy-Report-Only` → `Content-Security-Policy` — value คง `report-uri /api/csp-report` ไว้เก็บ violation ต่อ
- `securityHeaders.test.js`: guard test กลับฝั่ง — `toContain('name: Content-Security-Policy')` + `not.toContain('-Report-Only')` (nginx asserts ไม่แตะ — docker path enforce อยู่แล้ว)
- `scripts/tests/audit-bundle-csp.test.mjs`: เทส anti-drift ค้น header ด้วยชื่อเดิมตรง ๆ → แก้ให้ค้นทั้งสองชื่อ (enforce ก่อน fallback report-only)
- `scripts/tests/verify-live-headers.test.mjs`: **3 เคส**ผูกชื่อเดิม (parser expected list · เทส CSP ถูกผ่อน lookup · เทส Render defaults) → แก้ให้รองรับทั้งสองเฟส
- runbook ข้อ 2: รวมไฟล์เทสที่ผูกชื่อ header ทั้ง **3 ไฟล์** (runbook เดิมพูดถึงแค่ securityHeaders.test.js)
- ทั้งหมดพบจากการรันจริง: push รอบแรกแดงที่ anti-drift, รอบสองแดงอีก 3 เคส — hook จับได้ตามดีไซน์ gate

Refs #113 · Runbook: `docs/runbooks/csp-enforce-switch.md`

## ⚠️ Merge = deploy เข้า production ทันที

Render service `smart-port` ตั้ง `autoDeployTrigger: commit` + buildFilter ครอบ `render.yaml` — **การ merge PR นี้คือการกด enforce CSP จริง** จึงเป็นการตัดสินใจระดับ owner:

- [ ] Pre-flight ตาม runbook ขั้นที่ 1: `node scripts/csp-report-selftest.mjs` + ดู log Render ยืนยัน marker ถูกนับ
- [ ] ยืนยันจากเจ้าของให้ merge
- [ ] หลัง deploy: รอ propagate (blueprint lag) → Dashboard→Blueprint→Sync ถ้า header ยังไม่สลับ
- [ ] `node scripts/verify-live-headers.mjs` → ต้อง PASS โหมด exact (script fallback เองเมื่อชื่อไม่ใช่ -Report-Only)
- [ ] เดินเมนูทั้ง sidebar เปิด DevTools console — ห้ามมี violation บล็อกฟีเจอร์
- [ ] บันทึก evidence ใน `docs/frontend-security-headers.md`

Rollback: สลับชื่อกลับเป็น `-Report-Only` แล้ว commit/push (runbook ขั้นที่ 7)

## Verification

- [x] `npx vitest run src/__tests__/securityHeaders.test.js` — **9/9 passed**
- [x] `node --test scripts/tests/audit-bundle-csp.test.mjs` — **79/79 passed** (รวม anti-drift)
- [x] `node --test scripts/tests/verify-live-headers.test.mjs` — **5/5 passed** (3 เคสที่แก้ + 2 เดิม)
- [x] พิสูจน์ด้วยการรันจริง: push รอบแรกโดน pre-push hook แดงที่ anti-drift, รอบสองแดง verify-live-headers 3 เคส → แก้ครบและอัปเดต runbook ข้อ 2 เป็น 3 ไฟล์
- [x] grep ยืนยันที่เหลือ reference `-Report-Only` ทั้งหมดตั้งใจไว้แล้ว: `audit-bundle-csp.mjs` รองรับทั้งสองชื่อ (enforce มี precedence), `verify-live-headers.mjs` บรรทัด 181 ตกไปโหมด exact เอง, assert nginx ใน securityHeaders (enforce อยู่แล้ว), และ docs/fixture ของ test script
