### PR TITLE
fix(gate): verify-live-headers ยิง asset 5 นัด cache-buster — นัดเดียวผิด = fail (#155)

### DIFF
--- a/docs/frontend-security-headers.md
+++ b/docs/frontend-security-headers.md
@@ -361,8 +361,10 @@ soft delete จึงยังอยู่ใน DB และมีร่อง�
    (06:48:20Z) — สาเหตุตามที่วิเคราะห์ภายหลัง: blueprint ยังไม่ sync
 3. **25 ส.ค.** — เจ้าของระบบกด **Blueprint → Sync** บน Render dashboard → deploy live
    **10:00:41Z** (asset hash ไม่เปลี่ยน: `index-CByuy7Fh.js` เพราะเนื้อโค้ดเดิม)
-4. `verify-live-headers.mjs` **PASS ทุกข้อ** — รวม `Cache-Control` ของ hashed asset ที่เคย
-   FAIL ตั้งแต่รอบ 22 ส.ค. (กฎ `immutable` เก่าที่ค้างใน blueprint ถูกล้างด้วยการ sync ครั้งนี้)
+4. `verify-live-headers.mjs` **PASS** — แต่ตีความใหม่หลัง #155: gate รุ่นนั้นยิง asset URL ละ
+   **1 นัด** จับการแกว่งค่าไม่ได้ · `Cache-Control` ของ hashed asset ที่เคย FAIL ตั้งแต่รอบ 22 ส.ค.
+   กลับมาแกว่ง `immutable`/`no-cache` อีกในวันที่ 26 ส.ค. — แปลว่ากฎ `immutable` เก่า**ไม่เคยถูกล้าง
+   จริง** รอบนั้น PASS เพราะสุ่มโดน `no-cache` พอดี (ดู `### Cache-Control แกว่งอีกครั้ง 26 ส.ค.` ด้านล่าง)
 5. **แต่ curl ยังเห็นสอง header พร้อมกัน** — การวินิจฉัยแยกสาเหตุ:
    - cache-buster (`cf-cache-status: MISS`) ยังได้ทั้งคู่ → **มาจาก origin ไม่ใช่ cache ของ Cloudflare**
    - `smartport-backend.onrender.com` โดยตรงไม่ส่ง CSP เลย → ไม่ใช่ backend
@@ -374,7 +376,7 @@ soft delete จึงยังอยู่ใน DB และมีร่อง�
 | หลักฐาน | ผล | วิธีได้มา |
 |---|---|---|
 | header สดจาก origin | `content-security-policy:` (enforce) **อันเดียว ไม่มี `-report-only`** | `curl -I` โดยยืนยัน `cf-cache-status: MISS` ทั้ง root และ cache-buster |
-| smoke gate | `verify-live-headers.mjs` **PASS ทุกข้อ** (ทั้ง app shell และ hashed asset) | รันหลังลบ header ค้าง |
+| smoke gate | `verify-live-headers.mjs` **PASS** — จุดอ่อนที่ทราบทีหลัง (#155): gate รุ่นนั้นยิง asset ละ 1 นัด จับค่าที่แกว่งไม่ได้ (แก้เป็น multi-probe แล้วในรอบ #155) | รันหลังลบ header ค้าง |
 | เดินเมนูใต้ enforce | **22/22 route render เต็ม** — มากกว่ารอบ 22 ส.ค. (19 หน้า) เพราะครอบ candidate sub-routes ครบ 5 เส้นทาง | Playwright chromium headless ล็อกอินจริงบน production แล้วไล่ตาม `nav a[href]` ทั้งหมด |
 | console ระหว่างเดินเมนู | **เงียบสนิท — 0 CSP violation · 0 console error · 0 page error** | listener `console` + `pageerror` เก็บทุกหน้า |
 | write path ใต้ enforce | `POST /api/auth/login` ตอบ 200 (อย่างน้อยหนึ่ง write path ผ่าน) | response listener ระหว่าง login |
@@ -410,13 +412,30 @@ soft delete จึงยังอยู่ใน DB และมีร่อง�
 **ข้อมูลทดสอบที่ยังค้างเพิ่ม** — นอกจาก 2 รายการเดิมด้านบน ยังมี selftest marker ของ
 24 ส.ค. ใน log (ไม่เก็บใน DB) · การเก็บกวาดรวมเป็น pending เดียวกัน
 
+### Cache-Control แกว่งอีกครั้ง 26 ส.ค. — gate เดิมจับไม่ได้ (#155)
+
+หลัง merge PR #154 (docs-only) แล้ว auto-deploy วิ่ง ปุ่บ `verify-live-headers.mjs` FAIL:
+hashed asset ได้ `public, max-age=31536000, immutable` ทั้งที่ render.yaml ประกาศ `no-cache`
+กฎเดียวทั้ง site วินิจฉัยด้วย cache-buster (`cf-cache-status: MISS` ยังเห็น `immutable`
+→ ค่ามาจาก origin ไม่ใช่ cache ของ Cloudflare) แล้ว probe 8 นัดได้ **6 immutable /
+2 no-cache** — คือการแกว่ง non-deterministic ของกฎซ้อนทับที่เคยวัดไว้รอบ 17 ส.ค. ·
+app shell `/` นิ่ง `no-cache` 4/4 นัด · CSP enforce อันเดียวสม่ำเสมอทุกนัด — **ไม่ใช่ช่องโหว่
+เรื่อง security** กระทบแค่ความน่าเชื่อถือของ gate และพฤติกรรม cache ของ asset
+
+สรุป: กฎ `immutable` เก่ายังค้างระดับ service บน Render dashboard (อยู่นอก `render.yaml`)
+การแก้คือ **owner ลบ rule + Blueprint Sync + ยืนยัน probe ≥8 นัดได้ `no-cache` 100%**
+· ฝั่ง repo แก้ gate แล้ว: asset ถูกยิง **5 นัด** ด้วย cache-buster เฉพาะตัวต่อนัด
+**นัดเดียวผิด = fail** — รายละเอียดเต็มและขั้นตอนของ owner อยู่ที่ issue #155
+
 ## การทดสอบ
 
 - `frontend/src/__tests__/securityHeaders.test.js` — assert header set ข้างต้นในทั้ง
   render.yaml และ nginx.conf กัน drift/regression
 - `scripts/verify-live-headers.mjs` — external smoke gate (issue #131): curl
   production จริงแล้ว assert กับ header set ที่ parse จาก render.yaml ตรง ๆ (single
-  source of truth — แก้ render.yaml แล้ว gate ตามอัตโนมัติ) exit 1 เมื่อพบ drift;
+  source of truth — แก้ render.yaml แล้ว gate ตามอัตโนมัติ) · hashed asset ถูกยิง **5 นัด**
+  ด้วย cache-buster เฉพาะตัวต่อนัด และ **นัดเดียวผิด = fail** (#155 — กฎ header ที่ path
+  ทับกันของ Render ตอบค่าสลับกันต่อ request response เดียวพิสูจน์อะไรไม่ได้) exit 1 เมื่อพบ drift;
   regression อยู่ที่ `scripts/tests/verify-live-headers.test.mjs` (mock origin บน
   127.0.0.1 ไม่พึ่งเครือข่าย) เสียบใน `scripts/ci-local.sh` / `.ps1` แล้ว
   **ตัวสคริปต์เองไม่ได้อยู่ใน gate อัตโนมัติใด ๆ** เพราะยิง production จริง — เรียกมือเท่านั้น

--- a/docs/runbooks/csp-enforce-switch.md
+++ b/docs/runbooks/csp-enforce-switch.md
@@ -80,7 +80,7 @@ node --test scripts/tests/verify-live-headers.test.mjs
 > แต่สับสน) หรือแย่กว่านั้นคือ enforce ไม่ติดเลยทั้งที่ทุกคนเชื่อว่าติดแล้ว
 
 ```bash
-node scripts/verify-live-headers.mjs        # ต้อง exit 0
+node scripts/verify-live-headers.mjs        # ต้อง exit 0 (asset ถูกยิง 5 นัด — นัดเดียวผิดคือ fail)
 curl -sI https://smart-port.onrender.com/ | grep -i content-security-policy
 ```
 

--- a/scripts/tests/verify-live-headers.test.mjs
+++ b/scripts/tests/verify-live-headers.test.mjs
@@ -40,9 +40,19 @@ function run(baseUrl) {
   });
 }
 
-function startServer({ shell, asset }) {
+function startServer({ shell, asset, onAssetRequest }) {
+  let assetHits = 0;
   const server = createServer((req, res) => {
-    const headers = req.url === '/' ? shell : req.url === ASSET ? asset : null;
+    // จับด้วย pathname ไม่ใช่ URL เต็ม — gate เติม cache-buster (?probe=...) ต่อนัด
+    // ทำให้ URL เต็มไม่ซ้ำกัน (issue #155) ถ้าจับแบบตรง ๆ ทุกนัดจะกลายเป็น 404
+    const pathname = new URL(req.url, 'http://127.0.0.1').pathname;
+    if (pathname === ASSET) {
+      assetHits += 1;
+      if (onAssetRequest) onAssetRequest(req.url, assetHits);
+    }
+    // asset ให้เป็น object (ค่าเดียวทุกนัด) หรือ function ของเลขนัด (เลียนแบบค่าที่แกว่ง)
+    const assetHeaders = typeof asset === 'function' ? asset(assetHits) : asset;
+    const headers = pathname === '/' ? shell : pathname === ASSET ? assetHeaders : null;
     if (!headers) {
       res.statusCode = 404;
       res.end('not found');
@@ -189,6 +199,62 @@ test('ต้อง fail เมื่อเจอ Render/Cloudflare defaults (dri
     // X-Content-Type-Options มีค่าถูกอยู่แล้วจึงผ่าน — และ HSTS ค่าที่แรงกว่า (preload)
     // ต้องเป็นแค่ warning [~] ไม่ใช่สาเหตุของการ fail
     assert.match(output, /~\] Strict-Transport-Security/);
+  } finally {
+    server.close();
+  }
+});
+
+test('asset ที่แกว่งค่าระหว่างนัด (บางนัด immutable) ต้อง fail — โหมด production จริง 26 ส.ค. (#155)', async () => {
+  // เหตุการณ์จริง: กฎ immutable เก่าค้างระดับ service บน Render ทำให้ asset ตอบสลับ
+  // immutable/no-cache ต่อ request (probe จริง 8 นัด = 6 immutable / 2 no-cache) —
+  // gate รุ่นยิง-1-นัดเคย PASS โดยบังเอิญเพราะสุ่มโดน no-cache พอดี รุ่น multi-probe ต้องจับได้
+  const entries = parseRenderHeaders(readFileSync(resolve(ROOT, 'render.yaml'), 'utf8'));
+  const good = {};
+  for (const e of entries) good[e.name] = e.value;
+  const flapping = { ...good, 'Cache-Control': 'public, max-age=31536000, immutable' };
+  // นัดที่ 3 ของ 5 ตอบผิด — เสียงข้างมากยังถูกอยู่ แต่ gate ต้อง fail (นัดเดียวผิด = fail)
+  const asset = (hit) => (hit === 3 ? flapping : good);
+  const { server, baseUrl } = await startServer({ shell: good, asset });
+  try {
+    const { status, output } = await run(baseUrl);
+    assert.equal(status, 1, output);
+    assert.match(output, /probe 3\/5/);
+    assert.match(output, /✗\] Cache-Control/);
+    // ต้องชี้ชื่อโรค: คำว่า immutable + การอ้าง issue #155 อยู่ในข้อความ fail
+    assert.ok(output.includes('immutable'), `output ต้องระบุ immutable:\n${output}`);
+    assert.ok(output.includes('#155'), `output ต้องอ้าง issue #155:\n${output}`);
+  } finally {
+    server.close();
+  }
+});
+
+test('ยิง asset ครบทุกนัดด้วย cache-buster เฉพาะตัว — URL ไม่ซ้ำกัน และทุกนัดสะอาดต้อง PASS', async () => {
+  const entries = parseRenderHeaders(readFileSync(resolve(ROOT, 'render.yaml'), 'utf8'));
+  const headers = { shell: {}, asset: {} };
+  for (const e of entries) {
+    headers.shell[e.name] = e.value;
+  }
+  headers.asset = { ...headers.shell };
+  const seenUrls = [];
+  const { server, baseUrl } = await startServer({
+    ...headers,
+    onAssetRequest: (url) => seenUrls.push(url),
+  });
+  try {
+    const { status, output } = await run(baseUrl);
+    assert.equal(status, 0, output);
+    assert.match(output, /PASS/);
+    assert.match(output, /probe 5\/5/);
+    // ครบ 5 นัด และ buster ต้องไม่ซ้ำกันแม้แต่คู่เดียว (ซ้ำ = CDN/origin อาจตอบของเก่าได้)
+    assert.equal(seenUrls.length, 5, `ต้องยิง asset 5 นัด ได้ยิง ${seenUrls.length} นัด`);
+    assert.equal(new Set(seenUrls).size, 5, `cache-buster ต้องไม่ซ้ำกัน: ${seenUrls.join(', ')}`);
+    for (const url of seenUrls) {
+      assert.match(
+        url,
+        /^\/assets\/index-TEST1234\.js\?probe=\d+-[0-9a-f-]{36}$/,
+        `รูปแบบ buster ผิด: ${url}`
+      );
+    }
   } finally {
     server.close();
   }

--- a/scripts/verify-live-headers.mjs
+++ b/scripts/verify-live-headers.mjs
@@ -10,12 +10,18 @@
 //   --base-url  ใช้ตอนเทสกับ mock server (default = production)
 // Exit 0 = header set ครบตาม render.yaml, Exit 1 = ขาด/ค่าผิด/network fail
 //
+// hashed asset ถูกยิง ASSET_PROBES นัด (default 5) ด้วย cache-buster เฉพาะตัวต่อนัด
+// — response เดียวพิสูจน์อะไรไม่ได้เพราะกฎ header ที่ path ทับกันของ Render ตอบค่าสลับ
+// กัน non-deterministic ต่อ request (วัดจริง 26 ส.ค.: 8 นัดได้ 6 immutable / 2 no-cache
+// จน gate รุ่นยิง-1-นัดเคย PASS โดยบังเอิญ — issue #155) นัดเดียวผิด = fail ทั้งชุด
+//
 // หมายเหตุ edge layer: production อยู่หลัง Cloudflare ซึ่งอาจเติม header ของตัวเอง
 // (cf-*, และ HSTS ค่าที่แรงกว่า เช่น preload) — เรา assert เฉพาะชุดที่ประกาศใน render.yaml
 // ส่วน HSTS ถ้าค่าจริง "แรงกว่าหรือเท่ากัน" ที่ประกาศ (max-age ≥ และครอบทุก directive)
 // จะเป็นแค่ warning — อ่อนกว่าถือว่า drift และ fail ตัวอย่างจริง: platform default ส่ง
 // max-age=315360000; preload ซึ่งแรงกว่าจึงผ่านเป็น warning
 
+import { randomUUID } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -25,6 +31,7 @@ const RENDER_YAML = resolve(ROOT, 'render.yaml');
 const DEFAULT_BASE = 'https://smart-port.onrender.com';
 const FETCH_TIMEOUT_MS = 30_000;
 const FETCH_ATTEMPTS = 2; // gateway DNS เคยหน่วง/ตายเป็นพัก ๆ (handoff 2026-08-16) — retry หนึ่งครั้ง
+const ASSET_PROBES = 5; // จำนวนนัดที่ยิง hashed asset — ทำไมหลายนัด ดูหัวไฟล์ (issue #155)
 
 function parseArgs(argv) {
   const args = { baseUrl: DEFAULT_BASE };
@@ -110,7 +117,7 @@ async function fetchWithRetry(url, method) {
   let lastError;
   for (let attempt = 1; attempt <= FETCH_ATTEMPTS; attempt++) {
     try {
-      return await fetch(url, { method, redirect: 'follow', signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+      return await fetch(url, { method, redirect: 'follow', cache: 'no-store', signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
     } catch (err) {
       lastError = err;
       if (attempt < FETCH_ATTEMPTS) console.error(`  (retry ${attempt}/${FETCH_ATTEMPTS - 1} หลังจาก: ${err.message})`);
@@ -244,20 +251,32 @@ async function main() {
   let shellFailures = printResults(`— App shell (/) —`, checkHeaders(expectations.shell, shellRes.headers, { url: baseUrl + '/' }));
 
   // 2) hashed asset: ดึงชื่อจาก <script src> ของ shell แล้วตรวจ cache header
+  //    ยิงหลายนัด แต่ละนัดใส่ cache-buster เฉพาะตัว (กัน CDN ตอบของเก่า + บังคับวัด origin)
+  //    และนัดเดียวผิด = fail ทั้งชุด — ไม่โหวตเสียงข้างมาก เพราะค่าที่ถูกต้องต้อง deterministic
   const assetMatch = /assets\/[\w.-]+\.js/.exec(body);
   if (!assetMatch) {
     console.error(`\n✗ หาชื่อ hashed asset (assets/*.js) ใน HTML ไม่ได้ — ตรวจว่า build ยัง emit Vite chunk ปกติ`);
     process.exitCode = 1;
     return;
   }
-  const assetUrl = `${baseUrl}/${assetMatch[0]}`;
-  const assetRes = await fetchWithRetry(assetUrl, 'HEAD');
-  if (!assetRes.ok) {
-    console.error(`✗ HEAD ${assetMatch[0]} ได้ status ${assetRes.status}`);
-    process.exitCode = 1;
-    return;
+  let assetFailures = 0;
+  for (let probe = 1; probe <= ASSET_PROBES; probe++) {
+    const probeUrl = `${baseUrl}/${assetMatch[0]}?probe=${probe}-${randomUUID()}`;
+    const assetRes = await fetchWithRetry(probeUrl, 'HEAD');
+    if (!assetRes.ok) {
+      console.error(`✗ HEAD ${assetMatch[0]} (probe ${probe}/${ASSET_PROBES}) ได้ status ${assetRes.status}`);
+      process.exitCode = 1;
+      return;
+    }
+    const probeResults = checkHeaders(expectations.asset, assetRes.headers, { url: probeUrl });
+    for (const r of probeResults) {
+      // ชี้ชื่อโรคให้ทันที: immutable บน asset คือลายเซ็นของกฎเก่าที่ค้างระดับ service บน Render
+      if (!r.ok && r.name === 'Cache-Control' && /immutable/i.test(r.detail)) {
+        r.detail += ' — ลายเซ็นกฎ immutable เก่าที่ค้างระดับ service บน Render (issue #155)';
+      }
+    }
+    assetFailures += printResults(`— Hashed asset probe ${probe}/${ASSET_PROBES} (${assetMatch[0]}) —`, probeResults);
   }
-  const assetFailures = printResults(`— Hashed asset (${assetMatch[0]}) —`, checkHeaders(expectations.asset, assetRes.headers, { url: assetUrl }));
 
   const failures = shellFailures + assetFailures;
   if (failures > 0) {


### PR DESCRIPTION
## สรุป

แก้ `verify-live-headers.mjs` ให้จับ drift ที่ "แกว่งค่าต่อ request" ได้จริง — สาเหตุจาก #155: กฎ `Cache-Control` เก่า (immutable) ค้างระดับ service บน Render ทำให้ hashed asset ตอบสลับ `immutable`/`no-cache` แบบ non-deterministic และ gate รุ่นยิง-URL-ละ-1-นัดเคย PASS โดยบังเอิญ (รอบ 25 ส.ค.)

## สิ่งที่เปลี่ยน

- **`scripts/verify-live-headers.mjs`**: hashed asset ถูกยิง **5 นัด** แต่ละนัดใส่ cache-buster เฉพาะตัว (`?probe=i-<uuid>` กัน CDN ตอบของเก่า) + `cache: 'no-store'` · **นัดเดียวผิด = fail ทั้งชุด** (ไม่โหวตเสียงข้างมาก) · เจอ `immutable` ใน `Cache-Control` จะชี้ชื่อโรคชี้ issue #155 ทันที · output แยก section ต่อ probe · CLI (`--base-url`) เหมือนเดิม
- **`scripts/tests/verify-live-headers.test.mjs`**: mock server จับด้วย pathname (กัน buster ทำ URL match พัง) + รองรับ `asset` เป็น function ต่อเลขนัด · เทสใหม่ 2 เทส: (1) นัดที่ 3 ของ 5 ตอบ immutable → exit 1 พร้อมชี้ #155 (2) ยิงครบ 5 นัด URL ไม่ซ้ำกัน + ทุกนัดสะอาด → exit 0
- **`docs/frontend-security-headers.md`**: แก้เคลมผิดใน Enforce switch 2026-08-25 ("กฎ immutable ถูกล้างด้วย sync" → จริงคือ gate ยิง 1 นัดจับการแกว่งไม่ได้ รอบนั้น PASS โดยบังเอิญ) · เพิ่มหัวข้อ `### Cache-Control แกว่งอีกครั้ง 26 ส.ค.` พร้อมผล probe จริง 8 นัด (6 immutable / 2 no-cache) · อัปเดตคำอธิบายเครื่องมือในหัวข้อการทดสอบ
- **`docs/runbooks/csp-enforce-switch.md`**: หมายเหตุจุดตรวจข้อ 3 ให้สอดคล้องพฤติกรรม multi-probe

## การตรวจสอบ

- [x] `node --test scripts/tests/*.test.mjs` — 144/144 ผ่าน (รวมเทสใหม่ 2 เทส)
- [x] ยิง production จริง: gate FAIL ถูกต้องตามสถานะ drift ปัจจุบัน — probe 4/5, 5/5 จับ `immutable` พร้อมข้อความชี้ #155 (ยืนยันว่าจับการแกว่งได้จริง รอบนี้ 5 นัดเจอ 2 นัดผิด)
- [x] `scripts/ci-local.ps1 -SkipInstall -SkipDocker` ผ่านครบทุก job (~16 นาที): schema parity · script regressions 144/144 · npm audit 0 vuln · vitest 562/562 · build + CSP bundle audit · E2E menu 1/1 · PHPUnit 401 OK

## หมายเหตุ

Refs #155 — issue ยังไม่ปิดจนกว่า owner จะลบ rule immutable ที่ค้างบน Render dashboard + Blueprint Sync แล้วยืนยัน probe ≥8 นัดได้ `no-cache` 100% (หลังแก้ gate ตัวนี้ต้อง PASS ก่อนปิด) · ไม่แตะ render.yaml ไม่แตะ policy — กระทบแค่ความสามารถจับ drift ของ gate
