### PR TITLE
feat(ui): ซ่อนเมนู OCR จนกว่า document-ocr service deploy จริง (#147)

### DIFF
--- a/docs/frontend-security-headers.md
+++ b/docs/frontend-security-headers.md
@@ -387,6 +387,10 @@ soft delete จึงยังอยู่ใน DB และมีร่อง�
 `/royal-decorations` · `/retirement-report` · `/admin` · `/work-results` · `/awards` ·
 `/import` · `/ocr` · `/users` · `/audit` · `/settings/special-areas`
 
+> หมายเหตุ (26 ส.ค.): ตัวเลข 22/22 เป็น historical — หลังจากนี้ `/ocr` ถูกซ่อนจากเมนู
+> จนกว่า document-ocr service จะ deploy จริง (#147) menu walk ปกติจึงครอบ 21 route
+> (route `/ocr` ยังอยู่และตรวจได้ด้วย direct URL)
+
 **การทำนายของรอบ 22 ส.ค. เป็นจริงทุกตัวอักษร** — "ถ้าครึ่งการลบ rule ไม่ propagate จะได้
 ทั้งสอง header พร้อมกัน" เกิดขึ้นจริงหลัง deploy และบทเรียนยกระดับขึ้นอีกขั้น: **สิ่งที่ค้างไม่ใช่
 แค่ blueprint ที่ตามหลัง repo แต่รวมถึง custom headers ที่ตั้งบน dashboard ซึ่ง `render.yaml`

--- a/frontend/e2e/features/all-menu-content.spec.js
+++ b/frontend/e2e/features/all-menu-content.spec.js
@@ -20,7 +20,7 @@ const expectedMenuPaths = [
   '/work-results',
   '/awards',
   '/import',
-  '/ocr',
+  // '/ocr' ถูกซ่อนจากเมนูจนกว่า document-ocr service จะ deploy จริง (#147) — route ยังอยู่สำหรับ direct URL
   '/users',
   '/audit',
   '/settings/special-areas',

--- a/frontend/src/__tests__/components/AppSidebar.test.js
+++ b/frontend/src/__tests__/components/AppSidebar.test.js
@@ -77,6 +77,19 @@ describe('AppSidebar', () => {
     expect(wrapper.text()).not.toContain('จัดการพื้นที่พิเศษ')
   })
 
+  it('hides OCR menu entry until document-ocr service deploys (#147)', () => {
+    // ซ่อนทั้ง admin และ superadmin — เหตุผลคือ service ยังไม่ deploy ไม่ใช่เรื่องสิทธิ์
+    // กลับมาเปิด: คืน entry ใน AppSidebar + '/ocr' ใน e2e all-menu-content.spec.js
+    userVal = { name: 'admin', role: 'admin' }
+    let wrapper = mountSidebar()
+    expect(wrapper.text()).not.toContain('แปลงเอกสาร PDF')
+    wrapper.unmount()
+
+    userVal = { name: 'sa', role: 'superadmin' }
+    wrapper = mountSidebar()
+    expect(wrapper.text()).not.toContain('แปลงเอกสาร PDF')
+  })
+
   it('renders Dashboard under ภาพรวม section', () => {
     const wrapper = mountSidebar()
     expect(wrapper.text()).toContain('Dashboard')

--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -111,7 +111,7 @@ import { useAuthStore } from '@/stores/auth.js'
 import { roleLabel } from '@/utils/roleLabels.js'
 import {
   X, BookOpen, LayoutDashboard, UserCheck, Users, Clock, Award, UserMinus,
-  Briefcase, FileText, Trophy, ChevronRight, UserCog, FileUp, FileSearch, Shield, ScanText,
+  Briefcase, FileText, Trophy, ChevronRight, UserCog, FileUp, FileSearch, Shield,
   Contact,
 } from 'lucide-vue-next'
 
@@ -168,7 +168,8 @@ const menuSections = computed(() => [
         label: 'ADMIN',
         items: [
           { id: 'data-import', label: 'นำเข้าข้อมูล', icon: FileUp, to: '/import' },
-          { id: 'ocr', label: 'แปลงเอกสาร PDF', icon: ScanText, to: '/ocr' },
+          // OCR ซ่อนจากเมนูชั่วคราวจนกว่า document-ocr service จะ deploy จริง (#147)
+          // route /ocr กับ OcrPage เก็บไว้ — admin พิมพ์ URL ตรงยังเข้าได้ (backend ตอบ 503 OCR_NOT_CONFIGURED)
           { id: 'user-management', label: 'จัดการผู้ใช้', icon: UserCog, to: '/users' },
           { id: 'audit-log', label: 'ประวัติการเปลี่ยนแปลง', icon: FileSearch, to: '/audit' },
           { id: 'special-areas', label: 'จัดการพื้นที่พิเศษ', icon: Shield, to: '/settings/special-areas' },


### PR DESCRIPTION
## สรุป

ซ่อนเมนู **แปลงเอกสาร PDF (/ocr)** จาก sidebar ชั่วคราวจนกว่า document-ocr service จะถูก deploy จริง — ตามคำตัดสินของเจ้าของระบบ (owner decisions 2026-08-24 ข้อ 2) หลัง issue #147 วินิจฉัยว่า `/ocr` ใช้ไม่ได้บน production เพราะไม่มี OCR service เลย (backend ตอบ 503 `OCR_NOT_CONFIGURED` อยู่แล้วจาก PR #149)

## สิ่งที่เปลี่ยน

- **`frontend/src/components/AppSidebar.vue`**: ลบ entry `ocr` ออกจาก ADMIN section + เอา `ScanText` ออกจาก import — พร้อม comment ระบุเงื่อนไขการกลับมาเปิด (route `/ocr` กับ `OcrPage.vue` เก็บไว้ครบ — admin พิมพ์ URL ตรงยังเข้าได้ หน้า render ปกติ แค่ submit จะได้ 503 ตาม backend)
- **`frontend/e2e/features/all-menu-content.spec.js`**: ลบ `'/ocr'` จาก `expectedMenuPaths` (22 → 21) — count assertion ปรับตาม `.length` อัตโนมัติ
- **`frontend/src/__tests__/components/AppSidebar.test.js`**: เพิ่ม guard test — admin และ superadmin **ไม่เห็น** "แปลงเอกสาร PDF" (กันมีคนคืน entry กลับมาเงียบ ๆ)
- **`docs/frontend-security-headers.md`**: หมายเหตุตัวเลข 22/22 ใน evidence enforce switch เป็น historical (หลังนี้ menu walk ครอบ 21 route)

## เหตุผลที่ไม่ใช้ feature flag / role gate

- **Flag (VITE_OCR_ENABLED)**: repo ยังไม่มี infra feature flag — ต้องแตะ .env.example + docker-compose + render.yaml 3 จุด เพื่อของครั้งเดียว
- **Role gate (superadmin)**: เหตุผลที่ซ่อนคือ "service ยังไม่พร้อม" ไม่ใช่เรื่องสิทธิ์ — gate ด้วย role จะทำให้เข้าใจผิดว่ามันเป็นฟีเจอร์ superadmin
- เมื่อ document-ocr deploy จริง: คืน entry บรรทัดเดียวใน AppSidebar + คืน `'/ocr'` ใน E2E (ตาม comment ในโค้ด)

## การตรวจสอบ

- [x] `npx vitest run src/__tests__/components/AppSidebar.test.js` — 20/20 ผ่าน
- [x] `scripts/ci-local.ps1 -SkipInstall -SkipDocker` ผ่านครบทุก job (~13 นาที): script regressions 144/144 · vitest **563/563** · build + CSP bundle audit · **E2E menu walk ผ่าน (21 route)** · PHPUnit 401 OK

Refs #147 — ยังไม่ปิด issue (root cause = ยังไม่มี OCR service deploy; ซ่อนเมนูคือ mitigation — deploy document-ocr แล้วค่อยปิด)
