### PR TITLE
ci: เพิ่ม job รัน tidb-init.sql bootstrap (MySQL 8 เปล่า) — ปิด A2 drift detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,60 @@ jobs:
       - name: Script regressions (offline mock servers)
         run: node --test scripts/tests/*.test.mjs
 
+  # A2 (review finding 2026-08-20): tidb-init.sql คือ bootstrap ตัวจริงของ production
+  # (Render ตั้ง RUN_MIGRATIONS=0) แต่ไม่เคยถูก execute จริง — validator เทียบชื่อเป็น
+  # สตริงเท่านั้น จับ syntax error / FK ลำดับ / INSERT seed พัง / view compile ไม่ได้
+  # job นี้ import ไฟล์เข้า MySQL 8 เปล่า (common subset เดียวกับ TiDB) แล้ว assert ตาราง seed
+  # + view query — จบที่ A2
+  tidb-init-bootstrap:
+    name: tidb-init.sql Bootstrap Smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # mount เฉพาะ tidb-init.sql — ห้ามปน migration mounts ของ backend-tests
+      # (จุดประสงค์คือพิสูจน์ว่า "สร้างจากไฟล์เดียว" ได้จริง ไม่ใช่ทดสอบ migration chain)
+      - name: Start MySQL with tidb-init.sql as the only init script
+        run: |
+          # ไม่ publish port — wait/assert ใช้ docker exec ล้วน (host port 3306 อาจถูก
+          # e2e-menus/backend-tests ครอบได้ถ้ารัน parallel ในเครื่องเดียวกัน)
+          # ลบ container ชื่อเดียวกันจากรอบก่อน (retry/run ซ้ำ) ก่อนเสมอ
+          docker rm -f tidb-init-smoke >/dev/null 2>&1 || true
+          docker run -d --name tidb-init-smoke \
+            -e MYSQL_ROOT_PASSWORD=rootpassword \
+            -e MYSQL_DATABASE=civil_service_mgmt \
+            -v "$PWD/database/tidb-init.sql:/docker-entrypoint-initdb.d/tidb-init.sql" \
+            mysql:8.0
+
+      - name: Wait for bootstrap + assert seeded tables and views
+        run: |
+          # -h 127.0.0.1 สำคัญ: ระหว่าง init mysql:8.0 รัน temporary server แบบ
+          # socket-only (--skip-networking) — probe ผ่าน socket จะผ่านก่อน init จบ (Issue #129)
+          for i in $(seq 1 60); do
+            if docker exec tidb-init-smoke mysql -h 127.0.0.1 -uroot -prootpassword --silent \
+              -e "SELECT 1 FROM personnel LIMIT 1" civil_service_mgmt >/dev/null 2>&1; then
+              echo "bootstrap ready"; break
+            fi
+            sleep 5
+          done
+          # init SQL ล้ม = entrypoint abort -> container ไม่ถึง ready จน timeout
+          if ! docker exec tidb-init-smoke mysql -h 127.0.0.1 -uroot -prootpassword --silent \
+              -e "SELECT 1 FROM personnel LIMIT 1" civil_service_mgmt >/dev/null 2>&1; then
+            echo "tidb-init.sql bootstrap timed out"; docker logs tidb-init-smoke; exit 1
+          fi
+          # ตารางที่ seed ไว้ต้องมีแถว (พิสูจน์ว่า INSERT ในไฟล์รันจริง ไม่ใช่แค่ DDL ผ่าน)
+          docker exec tidb-init-smoke mysql -h 127.0.0.1 -uroot -prootpassword civil_service_mgmt \
+            -e "SELECT 'personnel' AS tbl, COUNT(*) AS n FROM personnel \
+                UNION ALL SELECT 'users', COUNT(*) FROM users \
+                UNION ALL SELECT 'organization', COUNT(*) FROM organization \
+                UNION ALL SELECT 'position', COUNT(*) FROM position \
+                UNION ALL SELECT 'promotion_criteria', COUNT(*) FROM promotion_criteria \
+                UNION ALL SELECT 'probation_program', COUNT(*) FROM probation_program"
+          # view ต้อง compile ได้จริง — text-parity ตรวจไม่ได้
+          docker exec tidb-init-smoke mysql -h 127.0.0.1 -uroot -prootpassword civil_service_mgmt \
+            -e "SELECT COUNT(*) FROM vw_probation_dashboard; SELECT COUNT(*) FROM vw_audit_log;" >/dev/null
+          echo "tidb-init.sql bootstrap OK"
+
   backend-tests:
     name: Backend PHPUnit (Unit + Integration)
     runs-on: ubuntu-latest

--- a/docs/adr/0002-schema-parity-gate.md
+++ b/docs/adr/0002-schema-parity-gate.md
@@ -51,8 +51,15 @@
 
 ยืนยันด้วยการ build ทั้งสองทางแล้ว: repo root → `migrations_available: 18` และ runner รันตอน container start จริง · `backend/Dockerfile` → `migrations_available: 0` พร้อมคำเตือน
 
+## ภาคต่อ (2026-08-26): ปิด A2 — tidb-init.sql ถูก execute จริงใน CI + ci-local
+
+- **A2 (review finding 2026-08-20)** คือจุดอ่อนที่เหลืออยู่ของ ADR นี้: `tidb-init.sql` ไม่เคยถูก execute จริง — validator เทียบชื่อเป็นสตริงเท่านั้น จับไม่ได้ถ้าไฟล์มี syntax error, FK อ้างตารางที่นิยามทีหลัง, INSERT seed พัง หรือ view compile ไม่ได้
+- **แก้แล้ว**: job ใหม่ `tidb-init-bootstrap` ใน `.github/workflows/ci.yml` — `docker run mysql:8.0` mount **เฉพาะ** `database/tidb-init.sql` เข้า `/docker-entrypoint-initdb.d/` (ไม่ปน migration mounts ของ backend-tests; จุดประสงค์คือพิสูจน์ "สร้างจากไฟล์เดียว" ได้จริง) → wait แบบ TCP + `SELECT 1 FROM personnel` (บทเรียน #129) → assert แถวของตาราง seed 6 ตาราง (`personnel` · `users` · `organization` · `position` · `promotion_criteria` · `probation_program`) → query ผ่านบน `vw_probation_dashboard` + `vw_audit_log` (พิสูจน์ว่า view compile — สิ่งที่ text-parity จับไม่ได้)
+- **ท้องถิ่นด้วย**: step `tidb-init.sql Bootstrap Smoke` ใน `scripts/ci-local.sh` / `ci-local.ps1` (ชุดคำสั่งเดียวกัน, ข้ามด้วย `--skip-tidb-bootstrap` / `-SkipTidbBootstrap` — sandbox เทสของ ci-local ใช้ flag นี้) — กัน job "เขียวลอย" เพราะ GitHub Actions ปิด auto-trigger (workflow_dispatch-only) gate ที่บังคับจริงคือ pre-push + ci-local
+- **ข้อจำกัดที่รับรู้**: พิสูจน์ด้วย MySQL 8 (common subset ที่ไฟล์เขียนมาให้รองรับ TiDB อยู่แล้ว) — ถ้าอนาคตเจอ drift ที่ MySQL จับไม่ได้แต่ TiDB จับได้ ค่อยเพิ่ม TiDB container จริงเป็น follow-up
+
 ## References
 
-- Gate: `scripts/validate-schema-parity.mjs`
+- Gate: `scripts/validate-schema-parity.mjs` + job `tidb-init-bootstrap` ใน `.github/workflows/ci.yml` (execute จริง)
 - Runbook: `docs/render-tidb-production.md`
 - Runner + baseline: `backend/scripts/run-migrations.php`, `backend/tests/Unit/MigrationBaselineTest.php`

--- a/scripts/ci-local.ps1
+++ b/scripts/ci-local.ps1
@@ -32,6 +32,7 @@ param(
   [switch]$SkipE2E,
   [switch]$SkipBackend,
   [switch]$SkipDocker,
+  [switch]$SkipTidbBootstrap,
   [switch]$Help
 )
 
@@ -66,10 +67,11 @@ function Write-Skip([string]$Msg) {
 
 if ($Help) {
   @"
-Usage: .\scripts\ci-local.ps1 [-SkipInstall] [-SkipFrontend] [-SkipE2E] [-SkipBackend] [-SkipDocker] [-Help]
+Usage: .\scripts\ci-local.ps1 [-SkipInstall] [-SkipFrontend] [-SkipE2E] [-SkipBackend] [-SkipDocker] [-SkipTidbBootstrap] [-Help]
 
 Mirrors .github/workflows/ci.yml locally (no GitHub Actions minutes):
   0) Fast gates schema parity + multiplier validator regression
+  0.5) tidb-init.sql bootstrap smoke (Docker MySQL 8, skippable -SkipTidbBootstrap)
   1) Frontend   npm ci + npm audit (prod, high+) + vitest (forks/2) + build
   2) E2E        Docker db/backend + Playwright Chromium (all sidebar menus)
   3) Backend    bash backend/tests/run.sh
@@ -89,7 +91,7 @@ Examples:
 }
 
 Write-Host "smart-port local CI  (root: $Root)"
-Write-Host "flags: SkipInstall=$SkipInstall SkipFrontend=$SkipFrontend SkipE2E=$SkipE2E SkipBackend=$SkipBackend SkipDocker=$SkipDocker"
+Write-Host "flags: SkipInstall=$SkipInstall SkipFrontend=$SkipFrontend SkipE2E=$SkipE2E SkipBackend=$SkipBackend SkipDocker=$SkipDocker SkipTidbBootstrap=$SkipTidbBootstrap"
 
 function Resolve-GitBash {
   $candidates = @(
@@ -129,6 +131,59 @@ if ($LASTEXITCODE -eq 0) {
 } else {
   Write-Fail 'script regressions'
   $failed += 'script-regressions'
+}
+
+# ---- 0.5) tidb-init bootstrap (A2 — กัน "เขียวลอย") ---------------------------
+# tidb-init.sql คือ bootstrap ตัวจริงของ production (Render ตั้ง RUN_MIGRATIONS=0) —
+# พิสูจน์ว่า import ลง MySQL เปล่าแล้ว seed/view ใช้งานได้จริง (ดู ci.yml job เดียวกัน)
+# ข้ามได้ด้วย -SkipTidbBootstrap (เช่น sandbox เทสของ ci-local-csp-gate.test.mjs)
+if (-not $SkipTidbBootstrap) {
+  Write-Step 'tidb-init.sql Bootstrap Smoke'
+  # $ErrorActionPreference='Stop' + mysql client เขียน warning ลง stderr = PowerShell
+  # ตีเป็น terminating error ได้ ตั้ง Continue เฉพาะบล็อกนี้ (การตัดสินใจอยู่ที่
+  # $LASTEXITCODE เราเองอยู่แล้ว) · ใช้ -prootpassword ตรง ๆ เพราะ docker exec
+  # ไม่ส่ง env ของ host process เข้า container (MYSQL_PWD จึงใช้ไม่ได้)
+  $prevEap = $ErrorActionPreference
+  $ErrorActionPreference = 'Continue'
+  try {
+    # container ชื่อเดียวกับรอบก่อนอาจค้าง (เช่น engine หลุดกลางทางจน rm ไม่ทัน) —
+    # ลบของเก่าทิ้งก่อนเสมอ ไม่งั้น docker run --name ชนและ step แดงทั้งที่ bootstrap ดี
+    docker rm -f tidb-init-smoke 2>&1 | Out-Null
+    $mysql = docker run -d --name tidb-init-smoke `
+      -e MYSQL_ROOT_PASSWORD=rootpassword `
+      -e MYSQL_DATABASE=civil_service_mgmt `
+      -v "$(Join-Path $Root 'database/tidb-init.sql'):/docker-entrypoint-initdb.d/tidb-init.sql" `
+      mysql:8.0 2>&1
+    $container = ($mysql -join "`n") -replace '^([0-9a-f]{12}).*', '$1'
+    $bootstrapOk = $false
+    for ($i = 0; $i -lt 60; $i++) {
+      Start-Sleep -Seconds 5
+      docker exec $container mysql -h 127.0.0.1 -uroot -prootpassword --silent `
+        -e 'SELECT 1 FROM personnel LIMIT 1' civil_service_mgmt *> $null
+      if ($LASTEXITCODE -eq 0) { $bootstrapOk = $true; break }
+    }
+    if ($bootstrapOk) {
+      docker exec $container mysql -h 127.0.0.1 -uroot -prootpassword civil_service_mgmt `
+        -e "SELECT 'personnel' AS tbl, COUNT(*) AS n FROM personnel UNION ALL SELECT 'users', COUNT(*) FROM users UNION ALL SELECT 'organization', COUNT(*) FROM organization UNION ALL SELECT 'position', COUNT(*) FROM position UNION ALL SELECT 'promotion_criteria', COUNT(*) FROM promotion_criteria UNION ALL SELECT 'probation_program', COUNT(*) FROM probation_program"
+      if ($LASTEXITCODE -ne 0) { $bootstrapOk = $false }
+    }
+    if ($bootstrapOk) {
+      docker exec $container mysql -h 127.0.0.1 -uroot -prootpassword civil_service_mgmt `
+        -e 'SELECT COUNT(*) FROM vw_probation_dashboard; SELECT COUNT(*) FROM vw_audit_log;' *> $null
+      if ($LASTEXITCODE -ne 0) { $bootstrapOk = $false }
+    }
+    docker rm -f $container *> $null
+  } finally {
+    $ErrorActionPreference = $prevEap
+  }
+  if ($bootstrapOk) {
+    Write-Ok 'tidb-init.sql bootstrap'
+  } else {
+    Write-Fail 'tidb-init.sql bootstrap (ดู docker logs tidb-init-smoke ก่อนลบ container)'
+    $failed += 'tidb-init-bootstrap'
+  }
+} else {
+  Write-Skip 'tidb-init.sql bootstrap (-SkipTidbBootstrap)'
 }
 
 # ---- 1) Frontend Build & Test ----------------------------------------------

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -29,6 +29,7 @@ SKIP_FRONTEND=0
 SKIP_E2E=0
 SKIP_BACKEND=0
 SKIP_DOCKER=0
+SKIP_TIDB_BOOTSTRAP=0
 FAILED=()
 STARTED=$(date +%s)
 
@@ -46,6 +47,7 @@ while [[ $# -gt 0 ]]; do
     --skip-e2e)      SKIP_E2E=1 ;;
     --skip-backend)  SKIP_BACKEND=1 ;;
     --skip-docker)   SKIP_DOCKER=1 ;;
+    --skip-tidb-bootstrap) SKIP_TIDB_BOOTSTRAP=1 ;;
     -h|--help)       usage ;;
     *) echo "Unknown flag: $1 (try --help)"; exit 2 ;;
   esac
@@ -62,7 +64,7 @@ warn() { printf 'WARN  %s\n' "$1"; }
 skip() { printf 'SKIP  %s\n' "$1"; }
 
 echo "smart-port local CI  (root: ${ROOT})"
-echo "flags: skip-install=${SKIP_INSTALL} skip-frontend=${SKIP_FRONTEND} skip-e2e=${SKIP_E2E} skip-backend=${SKIP_BACKEND} skip-docker=${SKIP_DOCKER}"
+echo "flags: skip-install=${SKIP_INSTALL} skip-frontend=${SKIP_FRONTEND} skip-e2e=${SKIP_E2E} skip-backend=${SKIP_BACKEND} skip-docker=${SKIP_DOCKER} skip-tidb-bootstrap=${SKIP_TIDB_BOOTSTRAP}"
 
 # ---- 0) Schema parity (เร็ว รันก่อนเสมอ — fail เร็วดีกว่ารอ docker build) -----
 step 'Schema Parity Gate'
@@ -82,6 +84,54 @@ if node --test "${ROOT}"/scripts/tests/*.test.mjs; then
   ok 'script regressions'
 else
   fail 'script regressions'
+fi
+
+# ---- 0.5) tidb-init bootstrap (A2 — กัน "เขียวลอย") ---------------------------
+# tidb-init.sql คือ bootstrap ตัวจริงของ production (Render ตั้ง RUN_MIGRATIONS=0) —
+# พิสูจน์ว่า import ลง MySQL เปล่าแล้ว seed/view ใช้งานได้จริง (ดู ci.yml job เดียวกัน)
+# ข้ามได้ด้วย --skip-tidb-bootstrap (เช่น sandbox เทสของ ci-local-csp-gate.test.mjs)
+if [[ "${SKIP_TIDB_BOOTSTRAP}" -eq 0 ]]; then
+  step 'tidb-init.sql Bootstrap Smoke'
+  # MSYS (Git Bash บน Windows) แปลง arg ที่มี `:` เป็น path Windows — mount spec
+  # กลายเป็นเพี้ยน (source โดนแยกที่ `;`) แล้ว entrypoint ไม่เห็นไฟล์ init เลย
+  # ต้องใช้ Windows path จาก cygpath + ปิด path conversion; บน Linux รันแบบปกติ
+  if command -v cygpath >/dev/null 2>&1; then
+    TIDB_SRC="$(cygpath -w "${ROOT}/database/tidb-init.sql")"
+    export MSYS_NO_PATHCONV=1
+  else
+    TIDB_SRC="${ROOT}/database/tidb-init.sql"
+  fi
+  # container ชื่อเดียวกับรอบก่อนอาจค้าง (เช่น engine หลุดกลางทางจน rm ไม่ทัน) —
+  # ลบของเก่าทิ้งก่อนเสมอ ไม่งั้น docker run --name ชนและ step แดงทั้งที่ bootstrap ดี
+  docker rm -f tidb-init-smoke >/dev/null 2>&1 || true
+  CONTAINER=$(docker run -d --name tidb-init-smoke \
+    -e MYSQL_ROOT_PASSWORD=rootpassword \
+    -e MYSQL_DATABASE=civil_service_mgmt \
+    -v "${TIDB_SRC}:/docker-entrypoint-initdb.d/tidb-init.sql" \
+    mysql:8.0)
+  BOOTSTRAP_OK=0
+  for _ in $(seq 1 60); do
+    sleep 5
+    if docker exec "${CONTAINER}" mysql -h 127.0.0.1 -uroot -prootpassword --silent \
+        -e 'SELECT 1 FROM personnel LIMIT 1' civil_service_mgmt >/dev/null 2>&1; then
+      BOOTSTRAP_OK=1
+      break
+    fi
+  done
+  # init SQL ล้ม = entrypoint abort -> container ไม่ถึง ready จน timeout
+  if [[ "${BOOTSTRAP_OK}" -eq 1 ]] && \
+      docker exec "${CONTAINER}" mysql -h 127.0.0.1 -uroot -prootpassword civil_service_mgmt \
+        -e "SELECT 'personnel' AS tbl, COUNT(*) AS n FROM personnel UNION ALL SELECT 'users', COUNT(*) FROM users UNION ALL SELECT 'organization', COUNT(*) FROM organization UNION ALL SELECT 'position', COUNT(*) FROM position UNION ALL SELECT 'promotion_criteria', COUNT(*) FROM promotion_criteria UNION ALL SELECT 'probation_program', COUNT(*) FROM probation_program" \
+        && docker exec "${CONTAINER}" mysql -h 127.0.0.1 -uroot -prootpassword civil_service_mgmt \
+        -e 'SELECT COUNT(*) FROM vw_probation_dashboard; SELECT COUNT(*) FROM vw_audit_log;' >/dev/null 2>&1; then
+    ok 'tidb-init.sql bootstrap'
+  else
+    docker logs "${CONTAINER}" >/dev/null 2>&1 || true
+    fail 'tidb-init.sql bootstrap (ดู docker logs tidb-init-smoke)'
+  fi
+  docker rm -f "${CONTAINER}" >/dev/null 2>&1 || true
+else
+  skip 'tidb-init.sql bootstrap (--skip-tidb-bootstrap)'
 fi
 
 # ---- 1) Frontend -----------------------------------------------------------

--- a/scripts/tests/ci-local-csp-gate.test.mjs
+++ b/scripts/tests/ci-local-csp-gate.test.mjs
@@ -84,6 +84,8 @@ const WRAPPERS = {
       '--skip-e2e',
       '--skip-backend',
       '--skip-docker',
+      // sandbox มีเฉพาะ scripts/ ไม่มี database/tidb-init.sql — ข้าม step bootstrap
+      '--skip-tidb-bootstrap',
       ...(skipFrontend ? ['--skip-frontend'] : []),
     ],
   },
@@ -103,6 +105,8 @@ const WRAPPERS = {
       '-SkipE2E',
       '-SkipBackend',
       '-SkipDocker',
+      // sandbox มีเฉพาะ scripts/ ไม่มี database/tidb-init.sql — ข้าม step bootstrap
+      '-SkipTidbBootstrap',
       ...(skipFrontend ? ['-SkipFrontend'] : []),
     ],
   },


### PR DESCRIPTION
## สรุป

ปิด **A2** (review finding 2026-08-20): `database/tidb-init.sql` — bootstrap ตัวจริงของ production (Render ตั้ง `RUN_MIGRATIONS=0`) — ไม่เคยถูก execute จริงในเทสหรือ CI เลย ความตรงกับ migration ยืนยันด้วยการเทียบสตริงเท่านั้น (จับ syntax error / FK ลำดับ / INSERT seed พัง / view compile ไม่ได้)

## สิ่งที่เพิ่ม

- **`.github/workflows/ci.yml`** — job ใหม่ `tidb-init-bootstrap`: `docker run mysql:8.0` mount **เฉพาะ** `tidb-init.sql` เข้า `/docker-entrypoint-initdb.d/` (ไม่ปน migration mounts ของ backend-tests — พิสูจน์ว่า "สร้างจากไฟล์เดียว" ได้จริง) · wait แบบ TCP + `SELECT 1 FROM personnel` (บทเรียน #129) · assert แถว seed 6 ตาราง (`personnel` · `users` · `organization` · `position` · `promotion_criteria` · `probation_program`) · query ผ่านบน `vw_probation_dashboard` + `vw_audit_log` (view compile) · timeout → `docker logs` + exit 1 · ไม่ publish port (wait/assert ใช้ `docker exec` ล้วน — host port 3306 อาจถูก job อื่นครอบ) · ลบ container ชื่อเดิมก่อน run (idempotent)
- **`scripts/ci-local.sh` / `ci-local.ps1`** — step เดียวกัน `tidb-init.sql Bootstrap Smoke` (default on) + flag `--skip-tidb-bootstrap` / `-SkipTidbBootstrap` — กัน job "เขียวลอย" เพราะ GitHub Actions ปิด auto-trigger (workflow_dispatch-only) gate ที่บังคับจริงคือ pre-push + ci-local
  - หมายเหตุ MSYS: Git Bash บน Windows แปลง mount spec เพี้ยน (`;`) → ใช้ `cygpath -w` + `MSYS_NO_PATHCONV=1`; PowerShell ตี mysql warning บน stderr เป็น terminating error ใต้ `$ErrorActionPreference='Stop'` → ตั้ง Continue เฉพาะบล็อก (ตัดสินด้วย `$LASTEXITCODE`)
- **`scripts/tests/ci-local-csp-gate.test.mjs`** — sandbox ส่ง skip flag ใหม่ (sandbox มีเฉพาะ scripts/ ไม่มี database/)
- **`docs/adr/0002-schema-parity-gate.md`** — ภาคต่อ "ปิด A2": วิธี/ข้อจำกัด (MySQL 8 common subset; TiDB container จริงเป็น follow-up ถ้าเจอ drift ที่ MySQL จับไม่ได้)

## การตรวจสอบ

- [x] Smoke test จริง: bootstrap ลง MySQL 8 เปล่า ready ~15s — personnel=7 · users=1 · organization=1 · position=1 · promotion_criteria=18 · probation_program=1 · views query ผ่าน
- [x] `scripts/tests/ci-local-csp-gate.test.mjs` — 12/12 ผ่านกับ flag ใหม่
- [x] `scripts/ci-local.ps1 -SkipInstall -SkipDocker` **ผ่านครบทุก job**: schema parity · script regressions 144/144 · **tidb-init bootstrap OK** · vitest 563/563 · build + CSP bundle audit · E2E menu 1/1 · PHPUnit 401 OK
- [x] จับบั๊กจริงระหว่าง dev: `-p 3306:3306` ชน smartport-db ที่ E2E ทิ้งค้าง → ใช้ exec ล้วน; container ชื่อซ้ำจากรอบก่อน → rm ก่อน run
