### PR TITLE
chore(data): เตรียม cleanup ข้อมูลทดสอบCSP — SQL + runbook (owner รันเอง, destructive)

### DIFF
--- a/docs/frontend-security-headers.md
+++ b/docs/frontend-security-headers.md
@@ -348,7 +348,10 @@ Render dashboard ก่อน
 
 **ข้อมูลทดสอบที่ยังค้างใน production (ต้องเก็บกวาด)** — ทั้งสองรายการ **ปิดใช้งานแล้ว** แต่เป็น
 soft delete จึงยังอยู่ใน DB และมีร่องรอยใน audit log:
-`personnel` ชื่อขึ้นต้น `ทดสอบCSP` · `multiplier_areas` จังหวัดขึ้นต้น `ทดสอบCSP-`
+`personnel` ชื่อขึ้นต้น `ทดสอบCSP` · `special_area_multiplier` (API `/multiplier/areas`) จังหวัด
+ขึ้นต้น `ทดสอบCSP-` · **ขั้นตอน export backup + ลบ + ยืนยัน 0 แถว อยู่ที่
+runbook `docs/runbooks/csp-test-data-cleanup.md`** (owner รันเองผ่าน TiDB Cloud console —
+DELETE ต้องมี owner ยืนยัน scope ก่อนเสมอ)
 
 ### Enforce switch 2026-08-25 — enforce ขึ้น live และเดินเมนูผ่านทั้งระบบ
 
@@ -413,8 +416,10 @@ soft delete จึงยังอยู่ใน DB และมีร่อง�
    ใต้ report-only · กลไก `report-uri` เดียวกันทำงานต่อใต้ enforce (รายงานสิ่งที่ถูกบล็อกจริง)
    แต่ยังไม่มี marker สดที่พิสูจน์ hop สุดท้ายในโหมด enforce โดยตรง
 
-**ข้อมูลทดสอบที่ยังค้างเพิ่ม** — นอกจาก 2 รายการเดิมด้านบน ยังมี selftest marker ของ
-24 ส.ค. ใน log (ไม่เก็บใน DB) · การเก็บกวาดรวมเป็น pending เดียวกัน
+**ข้อมูลทดสอบที่ยังค้างเพิ่ม** — นอกจาก 2 รายการเดิมด้านบน (ดู runbook
+`docs/runbooks/csp-test-data-cleanup.md`) ยังมี selftest marker ของ
+24 ส.ค. ใน log (ไม่เก็บใน DB — ตกไปเองตาม retention ของ Render log) · การเก็บกวาดรวมเป็น
+pending เดียวกัน
 
 ### Cache-Control แกว่งอีกครั้ง 26 ส.ค. — gate เดิมจับไม่ได้ (#155)
 

--- a/docs/runbooks/csp-test-data-cleanup.md
+++ b/docs/runbooks/csp-test-data-cleanup.md
@@ -1,0 +1,67 @@
+# Runbook — เก็บกวาดข้อมูลทดสอบ CSP ออกจาก production (TiDB Cloud)
+
+- **งาน:** ลบข้อมูลทดสอบ `ทดสอบCSP` ที่สร้างผ่าน API วันที่ 22 ส.ค. 2026 (CSP report-only walkthrough) ออกจาก production จริง
+- **ขอบเขตที่ owner ยืนยัน (owner decisions 2026-08-24 ข้อ 4):** `personnel` ชื่อขึ้นต้น `ทดสอบCSP` · `special_area_multiplier` จังหวัดขึ้นต้น `ทดสอบCSP-`
+- **ระดับ:** ⚠️ **DESTRUCTIVE** — ต้องทำตามลำดับใน runbook นี้ทุกขั้น ไม่ข้าม
+- **สิทธิ์:** production DB = TiDB Cloud (เชื่อมผ่าน Render env `MYSQL_PORT=4000` + SSL) — repo ไม่มี credential → **owner รันเองผ่าน TiDB Cloud console**
+- **สคริปต์:** `scripts/sql/cleanup-csp-test-data.sql` (SELECT → DELETE → SELECT ยืนยัน)
+
+## ข้อตกลงสำคัญ
+
+1. **ห้ามรัน DELETE ก่อน export backup และก่อน owner เห็นผล SELECT ด้วยตา**
+2. `audit_log` เก็บไว้โดยตั้งใจ — แถว history ของรายการที่ถูกลบ (CREATE/UPDATE ที่เคยทำตอนสร้างข้อมูลทดสอบ) **ไม่ถูกลบ** เพราะ audit trail ต้องอยู่รอด (21-audit-log.sql) การลบข้อมูลทดสอบจึงเหลือร่องรอยใน `/audit` ตาม design
+3. ตารางจริงคือ `special_area_multiplier` — ไม่มีตารางชื่อ `multiplier_areas` (นั่นคือชื่อ resource ของ API `/multiplier/areas`)
+
+## ขั้นตอน
+
+### 1) Export backup (บังคับ ก่อนแตะข้อมูล)
+
+ใช้ mysqldump เฉพาะแถวในขอบเขต (utf8mb4 เสมอ — กัน Thai mojibake ตาม `docs/render-tidb-production.md`):
+
+```bash
+# แทนที่ <HOST> <PORT> <USER> ด้วยค่าจาก Render env ของ service smartport-backend
+mysqldump --default-character-set=utf8mb4 --set-charset \
+  -h <HOST> -P <PORT> -u <USER> -p --ssl-mode=REQUIRED \
+  civil_service_mgmt personnel \
+  --where="first_name LIKE 'ทดสอบCSP%' OR last_name LIKE 'ทดสอบCSP%'" \
+  > backup-csp-personnel-$(date +%Y%m%d).sql
+
+mysqldump --default-character-set=utf8mb4 --set-charset \
+  -h <HOST> -P <PORT> -u <USER> -p --ssl-mode=REQUIRED \
+  civil_service_mgmt special_area_multiplier \
+  --where="province LIKE 'ทดสอบCSP-%'" \
+  > backup-csp-areas-$(date +%Y%m%d).sql
+```
+
+- เก็บไฟล์ **นอก repo** (ธรรมเนียมเดียวกับ repair dumps — `docs/render-tidb-production.md` ห้าม commit dump เป็น source)
+- ยืนยันว่าไฟล์ไม่ว่างและเปิดดูเนื้อหาได้ (มีแถวครบตามที่คาด)
+
+### 2) SELECT ก่อนลบ + ให้ owner ยืนยัน scope
+
+รัน **เฉพาะบล็อก 1** ของ `scripts/sql/cleanup-csp-test-data.sql` (SELECT personnel + special_area_multiplier) ผ่าน TiDB Cloud console แล้ว:
+
+- ✅ ตรวจว่าแถวที่โผล่คือข้อมูลทดสอบ `ทดสอบCSP` จริงทุกแถว (ไม่มีชื่อจริงปน)
+- ✅ owner ยืนยันยอมรับ scope นี้ (จำนวนแถว + คอลัมน์ที่แสดง)
+- ถ้าไม่ตรงตามที่คาด → **หยุด** แล้วตรวจสอบก่อน (อย่าเดา)
+
+### 3) DELETE (owner เท่านั้น)
+
+รัน **เฉพาะบล็อก 2** ของสคริปต์ (DELETE สองตารางตาม WHERE เดียวกับ SELECT)
+
+### 4) ยืนยันหลังลบ
+
+รัน **เฉพาะบล็อก 3** — `personnel_left` และ `areas_left` ต้องเป็น **0 ทั้งคู่**
+
+- ถ้าไม่ใช่ 0 → ตรวจสอบว่าทำไม (ข้อมูลใหม่อาจถูกสร้างขึ้นระหว่างทาง? รูปแบบชื่อต่าง?)
+- ตรวจ `/audit` ในแอปว่า history ยังอยู่ (ตาม design ข้อ 2)
+
+### 5) บันทึกผล
+
+- Comment ผล (จำนวนแถวที่ลบ, path backup ไฟล์) ลง issue ที่ติดตามงานนี้
+- อัปเดต `docs/frontend-security-headers.md` — ลบข้อความ "ข้อมูลทดสอบที่ยังค้างใน production (ต้องเก็บกวาด)" เมื่อเคลียร์จริง
+
+## ข้อมูลอ้างอิง
+
+- ที่มาของข้อมูล: สร้างผ่าน API 22 ส.ค. (`POST /api/personnel`, `POST /api/multiplier/areas`) ระหว่าง CSP report-only walkthrough — `docs/frontend-security-headers.md` (write path ที่ทดสอบจริง)
+- วิธี connect production: `docs/render-tidb-production.md` (L50–58: TiDB Cloud, port 4000, SSL)
+- สคริปต์: `scripts/sql/cleanup-csp-test-data.sql`

--- a/scripts/sql/cleanup-csp-test-data.sql
+++ b/scripts/sql/cleanup-csp-test-data.sql
@@ -1,0 +1,55 @@
+-- ============================================================================
+-- cleanup-csp-test-data.sql — ลบข้อมูลทดสอบ CSP ออกจาก production (TiDB Cloud)
+--
+-- ขอบเขต (owner ยืนยันแล้ว — owner decisions 2026-08-24 ข้อ 4):
+--   personnel             ชื่อ (first_name/last_name) ขึ้นต้น 'ทดสอบCSP'
+--   special_area_multiplier  province ขึ้นต้น 'ทดสอบCSP-'
+--   (ตารางจริงคือ special_area_multiplier — ไม่มีตารางชื่อ multiplier_areas
+--    นั่นคือชื่อ resource ของ API)
+--
+-- ⚠️ DESTRUCTIVE — ต้องทำตาม docs/runbooks/csp-test-data-cleanup.md เท่านั้น:
+--    1) export backup ก่อนเสมอ (mysqldump --default-character-set=utf8mb4)
+--    2) รันเฉพาะ SELECT บล็อกแรก เอา output โชว์ owner ยืนยัน scope ก่อน
+--    3) owner ถึงจะรัน DELETE (ผ่าน TiDB Cloud console)
+--    4) รัน SELECT บล็อกสุดท้ายยืนยัน 0 แถว
+--
+-- หมายเหตุ audit_log: แถว history ของรายการที่ถูกลบจะถูกเก็บไว้โดยตั้งใจ
+-- (audit trail ต้องอยู่รอด — 21-audit-log.sql) — การลบข้อมูลทดสอบไม่ลบ audit history
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- บล็อก 1 — SELECT ก่อนลบ: แสดงทุกแถวที่จะโดน (ต้องโชว์ owner ยืนยันก่อนเสมอ)
+-- ---------------------------------------------------------------------------
+SELECT personnel_id, first_name, last_name, is_active, created_at
+FROM personnel
+WHERE first_name LIKE 'ทดสอบCSP%'
+   OR last_name LIKE 'ทดสอบCSP%'
+ORDER BY personnel_id;
+
+SELECT area_multiplier_id, province, district, basis_type, multiplier_ratio,
+       effective_start_date, effective_end_date, is_active, created_at
+FROM special_area_multiplier
+WHERE province LIKE 'ทดสอบCSP-%'
+ORDER BY area_multiplier_id;
+
+-- ---------------------------------------------------------------------------
+-- บล็อก 2 — DELETE (owner เท่านั้น หลังยืนยันผล SELECT)
+-- ---------------------------------------------------------------------------
+DELETE FROM personnel
+WHERE first_name LIKE 'ทดสอบCSP%'
+   OR last_name LIKE 'ทดสอบCSP%';
+
+DELETE FROM special_area_multiplier
+WHERE province LIKE 'ทดสอบCSP-%';
+
+-- ---------------------------------------------------------------------------
+-- บล็อก 3 — SELECT ยืนยันหลังลบ: ต้องได้ 0 แถวทั้งคู่
+-- ---------------------------------------------------------------------------
+SELECT COUNT(*) AS personnel_left
+FROM personnel
+WHERE first_name LIKE 'ทดสอบCSP%'
+   OR last_name LIKE 'ทดสอบCSP%';
+
+SELECT COUNT(*) AS areas_left
+FROM special_area_multiplier
+WHERE province LIKE 'ทดสอบCSP-%';


### PR DESCRIPTION
## สรุป

เตรียมเครื่องมือเก็บกวาดข้อมูลทดสอบ CSP ออกจาก production (TiDB Cloud) ตามคำตัดสินของ owner (owner decisions 2026-08-24 ข้อ 4: export backup ก่อน → DELETE โดย owner ยืนยัน scope ก่อนเสมอ) — **ไม่มีโค้ด runtime แตะ** docs + SQL สำหรับ owner รันเองเท่านั้น

## สิ่งที่เพิ่ม

- **`scripts/sql/cleanup-csp-test-data.sql`** — 3 บล็อก: (1) SELECT แสดงทุกแถวที่จะโดน (ต้องโชว์ owner ยืนยันก่อน) (2) DELETE `personnel` (`first_name`/`last_name` LIKE `ทดสอบCSP%`) + `special_area_multiplier` (`province` LIKE `ทดสอบCSP-%`) (3) SELECT ยืนยัน 0 แถว · อยู่นอก `database/NN-*.sql` กัน migration runner จับ
- **`docs/runbooks/csp-test-data-cleanup.md`** — ขั้นตอนครบ: export backup (mysqldump `--default-character-set=utf8mb4` เฉพาะแถวในขอบเขต, เก็บนอก repo) → owner เห็นผล SELECT → DELETE ผ่าน TiDB Cloud console → ยืนยัน 0 แถว → บันทึกผล
- **`docs/frontend-security-headers.md`** — ข้อความ "ต้องเก็บกวาด" เดิมชี้ไป runbook (และแก้ชื่อตารางให้ถูก: `special_area_multiplier` — `multiplier_areas` คือชื่อ API resource ไม่ใช่ตาราง)

## หมายเหตุสำคัญ (บันทึกใน runbook ด้วย)

- `audit_log` **เก็บไว้โดยตั้งใจ** — history ของรายการที่ถูกลบไม่หาย (audit trail ต้องอยู่รอดตาม design 21-audit-log.sql) — การลบข้อมูลทดสอบจึงยังเห็นร่องรอยใน `/audit`
- เราไม่ execute DELETE เด็ดขาด — repo ไม่มี credential prod DB และ owner ต้องยืนยัน scope ก่อนเสมอ

## การตรวจสอบ

- [x] `scripts/ci-local.ps1 -SkipInstall -SkipDocker` ผ่านครบทุก job (~6 นาที): schema parity · script regressions 144/144 · tidb-init bootstrap OK · vitest 563/563 · build + CSP bundle audit · E2E menu 1/1 · PHPUnit 401 OK
- [x] docs-only/SQL-only — ไม่แตะโค้ด runtime
