### PR TITLE
fix(ci): ปิด review findings ของ 4 PR — assert seed fail-closed + ไม่ทำลาย docker logs ตอน fail

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,6 @@ Dockerfile* text eol=lf
 # — bash ที่มากับ git ทนได้ แต่ bash ของ WSL ปฏิเสธ (`syntax error: unexpected end of file`)
 # ซึ่งเป็นสภาพแวดล้อมที่ backend/tests/run.sh ใช้จริงบนเครื่องนี้
 .githooks/* text eol=lf
+# assert SQL ถูกส่งเข้า mysql client ผ่าน `docker exec -i` stdin ทั้งจาก Linux runner และ
+# Windows — คง LF กันเส้นทาง encoding/line-ending เพี้ยนต่างกันระหว่างสองฝั่ง
+scripts/sql/*.sql text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,14 +182,16 @@ jobs:
               -e "SELECT 1 FROM personnel LIMIT 1" civil_service_mgmt >/dev/null 2>&1; then
             echo "tidb-init.sql bootstrap timed out"; docker logs tidb-init-smoke; exit 1
           fi
-          # ตารางที่ seed ไว้ต้องมีแถว (พิสูจน์ว่า INSERT ในไฟล์รันจริง ไม่ใช่แค่ DDL ผ่าน)
-          docker exec tidb-init-smoke mysql -h 127.0.0.1 -uroot -prootpassword civil_service_mgmt \
-            -e "SELECT 'personnel' AS tbl, COUNT(*) AS n FROM personnel \
-                UNION ALL SELECT 'users', COUNT(*) FROM users \
-                UNION ALL SELECT 'organization', COUNT(*) FROM organization \
-                UNION ALL SELECT 'position', COUNT(*) FROM position \
-                UNION ALL SELECT 'promotion_criteria', COUNT(*) FROM promotion_criteria \
-                UNION ALL SELECT 'probation_program', COUNT(*) FROM probation_program"
+          # ตาราง seed ต้องมีแถวจริง — assert fail-closed จากไฟล์เดียวกับ ci-local
+          # (รุ่นก่อนหน้าแค่ print COUNT ตารางว่างก็เขียว = "เขียวลอย" ตาม review 4 PR)
+          EMPTY_TABLES=$(docker exec -i tidb-init-smoke mysql -h 127.0.0.1 -uroot -prootpassword \
+            --batch --skip-column-names civil_service_mgmt \
+            < scripts/sql/tidb-init-smoke-assert.sql | tail -n 1)
+          echo "seed tables with 0 rows: ${EMPTY_TABLES}"
+          if [ "${EMPTY_TABLES}" != "0" ]; then
+            echo "tidb-init.sql bootstrap: seed rows missing (empty_tables=${EMPTY_TABLES})"
+            docker logs tidb-init-smoke; exit 1
+          fi
           # view ต้อง compile ได้จริง — text-parity ตรวจไม่ได้
           docker exec tidb-init-smoke mysql -h 127.0.0.1 -uroot -prootpassword civil_service_mgmt \
             -e "SELECT COUNT(*) FROM vw_probation_dashboard; SELECT COUNT(*) FROM vw_audit_log;" >/dev/null

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,20 +180,22 @@ jobs:
           # init SQL ล้ม = entrypoint abort -> container ไม่ถึง ready จน timeout
           if ! docker exec tidb-init-smoke mysql -h 127.0.0.1 -uroot -prootpassword --silent \
               -e "SELECT 1 FROM personnel LIMIT 1" civil_service_mgmt >/dev/null 2>&1; then
-            echo "tidb-init.sql bootstrap timed out"; docker logs tidb-init-smoke; exit 1
+            echo "tidb-init.sql bootstrap timed out"; docker logs tidb-init-smoke 2>&1 | tail -n 50; exit 1
           fi
           # ตาราง seed ต้องมีแถวจริง — assert fail-closed จากไฟล์เดียวกับ ci-local
           # (รุ่นก่อนหน้าแค่ print COUNT ตารางว่างก็เขียว = "เขียวลอย" ตาม review 4 PR)
           # print ตารางทั้งหมดก่อน — ตอน fail ต้องรู้ว่าตารางไหนว่าง ไม่ใช่แค่กี่ตาราง
+          # `|| ASSERT_OUT=''` — กัน `bash -e` ของ run block abort ก่อนพิมพ์ breakdown/docker
+          # logs เมื่อ exec ล้ม (เช่น ตารางหายตาม drift): ให้ไหลเข้าเส้นทาง stdout-ว่างด้านล่าง
           ASSERT_OUT=$(docker exec -i tidb-init-smoke mysql -h 127.0.0.1 -uroot -prootpassword \
             --batch --skip-column-names civil_service_mgmt \
-            < scripts/sql/tidb-init-smoke-assert.sql)
+            < scripts/sql/tidb-init-smoke-assert.sql) || ASSERT_OUT=''
           echo "seed row counts (แถวสุดท้าย = จำนวนตารางที่ว่าง):"
           echo "${ASSERT_OUT:-<empty — assert exec failed>}"
           EMPTY_TABLES=$(printf '%s\n' "${ASSERT_OUT}" | tail -n 1)
           if [ "${EMPTY_TABLES}" != "0" ]; then
             echo "tidb-init.sql bootstrap: seed rows missing (empty_tables=${EMPTY_TABLES})"
-            docker logs tidb-init-smoke; exit 1
+            docker logs tidb-init-smoke 2>&1 | tail -n 50; exit 1
           fi
           # view ต้อง compile ได้จริง — text-parity ตรวจไม่ได้
           docker exec tidb-init-smoke mysql -h 127.0.0.1 -uroot -prootpassword civil_service_mgmt \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,10 +184,13 @@ jobs:
           fi
           # ตาราง seed ต้องมีแถวจริง — assert fail-closed จากไฟล์เดียวกับ ci-local
           # (รุ่นก่อนหน้าแค่ print COUNT ตารางว่างก็เขียว = "เขียวลอย" ตาม review 4 PR)
-          EMPTY_TABLES=$(docker exec -i tidb-init-smoke mysql -h 127.0.0.1 -uroot -prootpassword \
+          # print ตารางทั้งหมดก่อน — ตอน fail ต้องรู้ว่าตารางไหนว่าง ไม่ใช่แค่กี่ตาราง
+          ASSERT_OUT=$(docker exec -i tidb-init-smoke mysql -h 127.0.0.1 -uroot -prootpassword \
             --batch --skip-column-names civil_service_mgmt \
-            < scripts/sql/tidb-init-smoke-assert.sql | tail -n 1)
-          echo "seed tables with 0 rows: ${EMPTY_TABLES}"
+            < scripts/sql/tidb-init-smoke-assert.sql)
+          echo "seed row counts (แถวสุดท้าย = จำนวนตารางที่ว่าง):"
+          echo "${ASSERT_OUT:-<empty — assert exec failed>}"
+          EMPTY_TABLES=$(printf '%s\n' "${ASSERT_OUT}" | tail -n 1)
           if [ "${EMPTY_TABLES}" != "0" ]; then
             echo "tidb-init.sql bootstrap: seed rows missing (empty_tables=${EMPTY_TABLES})"
             docker logs tidb-init-smoke; exit 1

--- a/database/tidb-init.sql
+++ b/database/tidb-init.sql
@@ -3,6 +3,8 @@
 --         04 career path, 05 probation, 06 seed, 07 education, 08 v11, 09 auth
 -- Import: mysql --default-character-set=utf8mb4 <db_name> < tidb-init.sql
 -- TiDB: ไม่ใช้ ENUM/TRIGGER/DEFINER (ENUM ต้นฉบับแปลงเป็น VARCHAR แล้ว validate ฝั่ง PHP)
+-- NOTE: เพิ่ม/ลบ "ตาราง seed" ที่ต้องมีแถว → ต้องเติมรายชื่อใน scripts/sql/tidb-init-smoke-assert.sql
+--       ด้วย ไม่งั้น smoke (ci.yml `tidb-init-bootstrap` + ci-local) จะไม่ cover ตารางนั้นเงียบ ๆ
 
 SET FOREIGN_KEY_CHECKS = 0;
 

--- a/docs/adr/0002-schema-parity-gate.md
+++ b/docs/adr/0002-schema-parity-gate.md
@@ -54,12 +54,13 @@
 ## ภาคต่อ (2026-08-26): ปิด A2 — tidb-init.sql ถูก execute จริงใน CI + ci-local
 
 - **A2 (review finding 2026-08-20)** คือจุดอ่อนที่เหลืออยู่ของ ADR นี้: `tidb-init.sql` ไม่เคยถูก execute จริง — validator เทียบชื่อเป็นสตริงเท่านั้น จับไม่ได้ถ้าไฟล์มี syntax error, FK อ้างตารางที่นิยามทีหลัง, INSERT seed พัง หรือ view compile ไม่ได้
-- **แก้แล้ว**: job ใหม่ `tidb-init-bootstrap` ใน `.github/workflows/ci.yml` — `docker run mysql:8.0` mount **เฉพาะ** `database/tidb-init.sql` เข้า `/docker-entrypoint-initdb.d/` (ไม่ปน migration mounts ของ backend-tests; จุดประสงค์คือพิสูจน์ "สร้างจากไฟล์เดียว" ได้จริง) → wait แบบ TCP + `SELECT 1 FROM personnel` (บทเรียน #129) → assert แถวของตาราง seed 6 ตาราง (`personnel` · `users` · `organization` · `position` · `promotion_criteria` · `probation_program`) → query ผ่านบน `vw_probation_dashboard` + `vw_audit_log` (พิสูจน์ว่า view compile — สิ่งที่ text-parity จับไม่ได้)
+- **แก้แล้ว**: job ใหม่ `tidb-init-bootstrap` ใน `.github/workflows/ci.yml` — `docker run mysql:8.0` mount **เฉพาะ** `database/tidb-init.sql` เข้า `/docker-entrypoint-initdb.d/` (ไม่ปน migration mounts ของ backend-tests; จุดประสงค์คือพิสูจน์ "สร้างจากไฟล์เดียว" ได้จริง) → wait แบบ TCP + `SELECT 1 FROM personnel` (บทเรียน #129) → assert แถวของตาราง seed 6 ตาราง (`personnel` · `users` · `organization` · `position` · `promotion_criteria` · `probation_program`) **แบบ fail-closed** — จำนวนตาราง seed ที่ว่างต้องเป็น 0 (SQL อยู่ไฟล์เดียว `scripts/sql/tidb-init-smoke-assert.sql` ใช้ร่วมกับ ci-local; รุ่นแรกแค่ print COUNT ซึ่งตารางว่างก็ผ่าน — แก้ตาม review 29 ส.ค.) → query ผ่านบน `vw_probation_dashboard` + `vw_audit_log` (พิสูจน์ว่า view compile — สิ่งที่ text-parity จับไม่ได้)
 - **ท้องถิ่นด้วย**: step `tidb-init.sql Bootstrap Smoke` ใน `scripts/ci-local.sh` / `ci-local.ps1` (ชุดคำสั่งเดียวกัน, ข้ามด้วย `--skip-tidb-bootstrap` / `-SkipTidbBootstrap` — sandbox เทสของ ci-local ใช้ flag นี้) — กัน job "เขียวลอย" เพราะ GitHub Actions ปิด auto-trigger (workflow_dispatch-only) gate ที่บังคับจริงคือ pre-push + ci-local
 - **ข้อจำกัดที่รับรู้**: พิสูจน์ด้วย MySQL 8 (common subset ที่ไฟล์เขียนมาให้รองรับ TiDB อยู่แล้ว) — ถ้าอนาคตเจอ drift ที่ MySQL จับไม่ได้แต่ TiDB จับได้ ค่อยเพิ่ม TiDB container จริงเป็น follow-up
 
 ## References
 
 - Gate: `scripts/validate-schema-parity.mjs` + job `tidb-init-bootstrap` ใน `.github/workflows/ci.yml` (execute จริง)
+- Assert SQL ของ smoke: `scripts/sql/tidb-init-smoke-assert.sql` (ไฟล์เดียวใช้ร่วม ci.yml + `ci-local.sh`/`ci-local.ps1`)
 - Runbook: `docs/render-tidb-production.md`
 - Runner + baseline: `backend/scripts/run-migrations.php`, `backend/tests/Unit/MigrationBaselineTest.php`

--- a/scripts/ci-local.ps1
+++ b/scripts/ci-local.ps1
@@ -167,13 +167,18 @@ if (-not $SkipTidbBootstrap) {
       # seed ต้องมีแถวจริง — assert จากไฟล์เดียวกับ ci.yml (แถวสุดท้ายของ output =
       # จำนวนตาราง seed ที่ว่าง ต้องเป็น 0; รุ่นก่อนหน้าแค่ print COUNT = "เขียวลอย")
       # ไม่ merge stderr — mysql เตือนเรื่อง -p ทุกครั้ง จะทำให้แถวสุดท้ายเพี้ยน
-      $assertOut = Get-Content (Join-Path $Root 'scripts/sql/tidb-init-smoke-assert.sql') -Raw |
+      # -Encoding UTF8 — Windows PowerShell 5.1 อ่านไฟล์ UTF-8 ไร้ BOM เป็น ANSI เป็นค่าเริ่มต้น
+      $assertOut = Get-Content (Join-Path $Root 'scripts/sql/tidb-init-smoke-assert.sql') -Raw -Encoding UTF8 |
         docker exec -i $container mysql -h 127.0.0.1 -uroot -prootpassword --batch --skip-column-names civil_service_mgmt
       # print ตารางทั้งหมดก่อน — ตอน fail ต้องรู้ว่าตารางไหนว่าง ไม่ใช่แค่กี่ตาราง
       Write-Host 'seed row counts (แถวสุดท้าย = จำนวนตารางที่ว่าง):'
       if ($assertOut) { Write-Host (@($assertOut) -join "`n") } else { Write-Host '<empty — assert exec failed>' }
       $emptyTables = @($assertOut | Select-Object -Last 1)[0]
-      Write-Host "seed tables with 0 rows: $emptyTables"
+      if ($null -eq $emptyTables) {
+        Write-Host 'seed tables with 0 rows: <unknown — assert exec failed>'
+      } else {
+        Write-Host "seed tables with 0 rows: $emptyTables"
+      }
       # exec ล้ม/ตารางหาย → $emptyTables ว่าง → ไม่ใช่ '0' → fail (fail-closed ทั้งกรณี)
       if ($LASTEXITCODE -ne 0 -or "$emptyTables" -ne '0') { $bootstrapOk = $false }
     }

--- a/scripts/ci-local.ps1
+++ b/scripts/ci-local.ps1
@@ -169,6 +169,9 @@ if (-not $SkipTidbBootstrap) {
       # ไม่ merge stderr — mysql เตือนเรื่อง -p ทุกครั้ง จะทำให้แถวสุดท้ายเพี้ยน
       $assertOut = Get-Content (Join-Path $Root 'scripts/sql/tidb-init-smoke-assert.sql') -Raw |
         docker exec -i $container mysql -h 127.0.0.1 -uroot -prootpassword --batch --skip-column-names civil_service_mgmt
+      # print ตารางทั้งหมดก่อน — ตอน fail ต้องรู้ว่าตารางไหนว่าง ไม่ใช่แค่กี่ตาราง
+      Write-Host 'seed row counts (แถวสุดท้าย = จำนวนตารางที่ว่าง):'
+      if ($assertOut) { Write-Host (@($assertOut) -join "`n") } else { Write-Host '<empty — assert exec failed>' }
       $emptyTables = @($assertOut | Select-Object -Last 1)[0]
       Write-Host "seed tables with 0 rows: $emptyTables"
       # exec ล้ม/ตารางหาย → $emptyTables ว่าง → ไม่ใช่ '0' → fail (fail-closed ทั้งกรณี)

--- a/scripts/ci-local.ps1
+++ b/scripts/ci-local.ps1
@@ -156,21 +156,33 @@ if (-not $SkipTidbBootstrap) {
       mysql:8.0 2>&1
     $container = ($mysql -join "`n") -replace '^([0-9a-f]{12}).*', '$1'
     $bootstrapOk = $false
+    # probe ก่อนแล้วค่อย sleep — ตรงกับ ci.yml และ ci-local.sh
     for ($i = 0; $i -lt 60; $i++) {
-      Start-Sleep -Seconds 5
       docker exec $container mysql -h 127.0.0.1 -uroot -prootpassword --silent `
         -e 'SELECT 1 FROM personnel LIMIT 1' civil_service_mgmt *> $null
       if ($LASTEXITCODE -eq 0) { $bootstrapOk = $true; break }
+      Start-Sleep -Seconds 5
     }
     if ($bootstrapOk) {
-      docker exec $container mysql -h 127.0.0.1 -uroot -prootpassword civil_service_mgmt `
-        -e "SELECT 'personnel' AS tbl, COUNT(*) AS n FROM personnel UNION ALL SELECT 'users', COUNT(*) FROM users UNION ALL SELECT 'organization', COUNT(*) FROM organization UNION ALL SELECT 'position', COUNT(*) FROM position UNION ALL SELECT 'promotion_criteria', COUNT(*) FROM promotion_criteria UNION ALL SELECT 'probation_program', COUNT(*) FROM probation_program"
-      if ($LASTEXITCODE -ne 0) { $bootstrapOk = $false }
+      # seed ต้องมีแถวจริง — assert จากไฟล์เดียวกับ ci.yml (แถวสุดท้ายของ output =
+      # จำนวนตาราง seed ที่ว่าง ต้องเป็น 0; รุ่นก่อนหน้าแค่ print COUNT = "เขียวลอย")
+      # ไม่ merge stderr — mysql เตือนเรื่อง -p ทุกครั้ง จะทำให้แถวสุดท้ายเพี้ยน
+      $assertOut = Get-Content (Join-Path $Root 'scripts/sql/tidb-init-smoke-assert.sql') -Raw |
+        docker exec -i $container mysql -h 127.0.0.1 -uroot -prootpassword --batch --skip-column-names civil_service_mgmt
+      $emptyTables = @($assertOut | Select-Object -Last 1)[0]
+      Write-Host "seed tables with 0 rows: $emptyTables"
+      # exec ล้ม/ตารางหาย → $emptyTables ว่าง → ไม่ใช่ '0' → fail (fail-closed ทั้งกรณี)
+      if ($LASTEXITCODE -ne 0 -or "$emptyTables" -ne '0') { $bootstrapOk = $false }
     }
     if ($bootstrapOk) {
       docker exec $container mysql -h 127.0.0.1 -uroot -prootpassword civil_service_mgmt `
         -e 'SELECT COUNT(*) FROM vw_probation_dashboard; SELECT COUNT(*) FROM vw_audit_log;' *> $null
       if ($LASTEXITCODE -ne 0) { $bootstrapOk = $false }
+    }
+    if (-not $bootstrapOk) {
+      # พิมพ์ log ก่อนลบ container — ของเดิม rm ก่อนแล้วค่อยบอกให้ดู log ที่หายไปพร้อมกัน
+      Write-Host '--- docker logs tidb-init-smoke (tail 50) ---'
+      docker logs $container 2>&1 | Select-Object -Last 50
     }
     docker rm -f $container *> $null
   } finally {
@@ -179,7 +191,7 @@ if (-not $SkipTidbBootstrap) {
   if ($bootstrapOk) {
     Write-Ok 'tidb-init.sql bootstrap'
   } else {
-    Write-Fail 'tidb-init.sql bootstrap (ดู docker logs tidb-init-smoke ก่อนลบ container)'
+    Write-Fail 'tidb-init.sql bootstrap (log 50 บรรทัดท้ายอยู่ด้านบน)'
     $failed += 'tidb-init-bootstrap'
   }
 } else {

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -126,8 +126,10 @@ if [[ "${SKIP_TIDB_BOOTSTRAP}" -eq 0 ]]; then
   # จำนวนตาราง seed ที่ว่าง ต้องเป็น 0; รุ่นก่อนหน้าแค่ print COUNT = "เขียวลอย")
   if [[ "${BOOTSTRAP_OK}" -eq 1 ]]; then
     # print ตารางทั้งหมดก่อน — ตอน fail ต้องรู้ว่าตารางไหนว่าง ไม่ใช่แค่กี่ตาราง
+    # `|| ASSERT_OUT=''` — กัน `set -euo pipefail` (บรรทัด 24) abort ก่อนพิมพ์ breakdown/
+    # docker logs เมื่อ exec ล้ม (เช่น ตารางหายตาม drift): ให้ไหลเข้าเส้นทาง stdout-ว่างด้านล่าง
     ASSERT_OUT=$(docker exec -i "${CONTAINER}" mysql -h 127.0.0.1 -uroot -prootpassword \
-      --batch --skip-column-names civil_service_mgmt < "${ASSERT_SQL}")
+      --batch --skip-column-names civil_service_mgmt < "${ASSERT_SQL}") || ASSERT_OUT=''
     echo "seed row counts (แถวสุดท้าย = จำนวนตารางที่ว่าง):"
     echo "${ASSERT_OUT:-<empty — assert exec failed>}"
     EMPTY_TABLES=$(printf '%s\n' "${ASSERT_OUT}" | tail -n 1)

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -109,25 +109,38 @@ if [[ "${SKIP_TIDB_BOOTSTRAP}" -eq 0 ]]; then
     -e MYSQL_DATABASE=civil_service_mgmt \
     -v "${TIDB_SRC}:/docker-entrypoint-initdb.d/tidb-init.sql" \
     mysql:8.0)
+  # assert SQL อยู่ไฟล์เดียวกับ ci.yml — ห้าม copy inline (สำเนาเพี้ยนกันเองได้)
+  ASSERT_SQL="${ROOT}/scripts/sql/tidb-init-smoke-assert.sql"
   BOOTSTRAP_OK=0
+  # probe ก่อนแล้วค่อย sleep — ตรงกับ ci.yml (ของเดิม sleep 5s ก่อน probe แรก ทำให้
+  # สอง mirror เหลื่อมกันโดยไม่จำเป็น)
   for _ in $(seq 1 60); do
-    sleep 5
     if docker exec "${CONTAINER}" mysql -h 127.0.0.1 -uroot -prootpassword --silent \
         -e 'SELECT 1 FROM personnel LIMIT 1' civil_service_mgmt >/dev/null 2>&1; then
       BOOTSTRAP_OK=1
       break
     fi
+    sleep 5
   done
-  # init SQL ล้ม = entrypoint abort -> container ไม่ถึง ready จน timeout
+  # seed ต้องมีแถวจริง — assert จากไฟล์เดียวกับ ci.yml (แถวสุดท้ายของ output =
+  # จำนวนตาราง seed ที่ว่าง ต้องเป็น 0; รุ่นก่อนหน้าแค่ print COUNT = "เขียวลอย")
+  if [[ "${BOOTSTRAP_OK}" -eq 1 ]]; then
+    EMPTY_TABLES=$(docker exec -i "${CONTAINER}" mysql -h 127.0.0.1 -uroot -prootpassword \
+      --batch --skip-column-names civil_service_mgmt < "${ASSERT_SQL}" | tail -n 1)
+    echo "seed tables with 0 rows: ${EMPTY_TABLES:-?}"
+    # exec ล้ม/ตารางหาย → stdout ว่าง → ไม่ใช่ "0" → fail (fail-closed ทั้งกรณี)
+    [[ "${EMPTY_TABLES:-x}" == "0" ]] || BOOTSTRAP_OK=0
+  fi
+  # view ต้อง compile ได้จริง — text-parity ตรวจไม่ได้
   if [[ "${BOOTSTRAP_OK}" -eq 1 ]] && \
       docker exec "${CONTAINER}" mysql -h 127.0.0.1 -uroot -prootpassword civil_service_mgmt \
-        -e "SELECT 'personnel' AS tbl, COUNT(*) AS n FROM personnel UNION ALL SELECT 'users', COUNT(*) FROM users UNION ALL SELECT 'organization', COUNT(*) FROM organization UNION ALL SELECT 'position', COUNT(*) FROM position UNION ALL SELECT 'promotion_criteria', COUNT(*) FROM promotion_criteria UNION ALL SELECT 'probation_program', COUNT(*) FROM probation_program" \
-        && docker exec "${CONTAINER}" mysql -h 127.0.0.1 -uroot -prootpassword civil_service_mgmt \
-        -e 'SELECT COUNT(*) FROM vw_probation_dashboard; SELECT COUNT(*) FROM vw_audit_log;' >/dev/null 2>&1; then
+      -e 'SELECT COUNT(*) FROM vw_probation_dashboard; SELECT COUNT(*) FROM vw_audit_log;' >/dev/null 2>&1; then
     ok 'tidb-init.sql bootstrap'
   else
-    docker logs "${CONTAINER}" >/dev/null 2>&1 || true
-    fail 'tidb-init.sql bootstrap (ดู docker logs tidb-init-smoke)'
+    # พิมพ์ log ก่อนลบ container — ของเดิมดึง log แล้วทิ้ง แล้วบอกให้ไปดู log ที่กำลังจะหาย
+    echo '--- docker logs tidb-init-smoke (tail 50) ---'
+    docker logs "${CONTAINER}" 2>&1 | tail -n 50 || true
+    fail 'tidb-init.sql bootstrap (log 50 บรรทัดท้ายอยู่ด้านบน)'
   fi
   docker rm -f "${CONTAINER}" >/dev/null 2>&1 || true
 else

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -125,9 +125,12 @@ if [[ "${SKIP_TIDB_BOOTSTRAP}" -eq 0 ]]; then
   # seed ต้องมีแถวจริง — assert จากไฟล์เดียวกับ ci.yml (แถวสุดท้ายของ output =
   # จำนวนตาราง seed ที่ว่าง ต้องเป็น 0; รุ่นก่อนหน้าแค่ print COUNT = "เขียวลอย")
   if [[ "${BOOTSTRAP_OK}" -eq 1 ]]; then
-    EMPTY_TABLES=$(docker exec -i "${CONTAINER}" mysql -h 127.0.0.1 -uroot -prootpassword \
-      --batch --skip-column-names civil_service_mgmt < "${ASSERT_SQL}" | tail -n 1)
-    echo "seed tables with 0 rows: ${EMPTY_TABLES:-?}"
+    # print ตารางทั้งหมดก่อน — ตอน fail ต้องรู้ว่าตารางไหนว่าง ไม่ใช่แค่กี่ตาราง
+    ASSERT_OUT=$(docker exec -i "${CONTAINER}" mysql -h 127.0.0.1 -uroot -prootpassword \
+      --batch --skip-column-names civil_service_mgmt < "${ASSERT_SQL}")
+    echo "seed row counts (แถวสุดท้าย = จำนวนตารางที่ว่าง):"
+    echo "${ASSERT_OUT:-<empty — assert exec failed>}"
+    EMPTY_TABLES=$(printf '%s\n' "${ASSERT_OUT}" | tail -n 1)
     # exec ล้ม/ตารางหาย → stdout ว่าง → ไม่ใช่ "0" → fail (fail-closed ทั้งกรณี)
     [[ "${EMPTY_TABLES:-x}" == "0" ]] || BOOTSTRAP_OK=0
   fi

--- a/scripts/sql/tidb-init-smoke-assert.sql
+++ b/scripts/sql/tidb-init-smoke-assert.sql
@@ -1,0 +1,22 @@
+-- A2 smoke (tidb-init-bootstrap): seed ต้องมีแถวจริง — INSERT ใน tidb-init.sql ต้องรันจริง
+-- ไม่ใช่แค่ DDL ผ่าน · ไฟล์เดียวใช้ร่วมกันทั้ง ci.yml job `tidb-init-bootstrap` และ
+-- step `tidb-init.sql Bootstrap Smoke` ใน ci-local.sh/.ps1 (กัน 3 สำเนาเพี้ยนกันเอง)
+--
+-- output (ส่งผ่าน `docker exec -i ... mysql --batch --skip-column-names < ไฟล์นี้`):
+--   6 แถวแรก = (tbl, n) ต่อตาราง เพื่อ log วินิจฉัย
+--   แถวสุดท้าย = จำนวนตาราง seed ที่ "ว่าง" — caller ต้อง assert เป็น 0 เสมอ (fail-closed)
+--   ถ้าตารางใดไม่มีอยู่เลย statement จะ error → stdout ไม่มีแถวสุดท้าย = 0 ก็ถือว่า fail เช่นกัน
+SELECT 'personnel' AS tbl, COUNT(*) AS n FROM personnel
+UNION ALL SELECT 'users', COUNT(*) FROM users
+UNION ALL SELECT 'organization', COUNT(*) FROM organization
+UNION ALL SELECT 'position', COUNT(*) FROM position
+UNION ALL SELECT 'promotion_criteria', COUNT(*) FROM promotion_criteria
+UNION ALL SELECT 'probation_program', COUNT(*) FROM probation_program;
+SELECT SUM(zero_rows) AS empty_tables FROM (
+  SELECT (COUNT(*) = 0) AS zero_rows FROM personnel
+  UNION ALL SELECT (COUNT(*) = 0) FROM users
+  UNION ALL SELECT (COUNT(*) = 0) FROM organization
+  UNION ALL SELECT (COUNT(*) = 0) FROM position
+  UNION ALL SELECT (COUNT(*) = 0) FROM promotion_criteria
+  UNION ALL SELECT (COUNT(*) = 0) FROM probation_program
+) t;

--- a/scripts/tests/tidb-smoke-assert.test.mjs
+++ b/scripts/tests/tidb-smoke-assert.test.mjs
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+// Review ของ PR #160 (2026-08-30, Important #2): บล็อก tidb ใน ci-local sandbox ถูกข้ามด้วย
+// --skip-tidb-bootstrap และ smoke จริงต้องใช้ Docker — จึงไม่มีอะไรกัน "mirror กลับไป inline
+// assert SQL", "ชี้ไฟล์ assert ผิด/ลืมอ้าง", หรือ "รายชื่อตารางใน assert SQL เพี้ยนจาก ADR"
+// เทสนี้เช็ค invariant เหล่านั้นจากไฟล์ล้วน ๆ (ไม่ยิง Docker) ราคาถูกพอจะอยู่ใน glob
+// `node --test scripts/tests/*.test.mjs` เดียวกันทุกทางเข้า (ci-local + pre-push + ci.yml)
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const ASSERT_SQL = resolve(ROOT, 'scripts', 'sql', 'tidb-init-smoke-assert.sql');
+const CALLERS = {
+  'ci.yml': resolve(ROOT, '.github', 'workflows', 'ci.yml'),
+  'ci-local.sh': resolve(ROOT, 'scripts', 'ci-local.sh'),
+  'ci-local.ps1': resolve(ROOT, 'scripts', 'ci-local.ps1'),
+};
+const TIDB_INIT = resolve(ROOT, 'database', 'tidb-init.sql');
+
+// รายชื่อตาราง seed — จาก ADR-0002 ภาคต่อ 2026-08-26 (แหล่งความจริงของขอบเขต assert)
+const SEED_TABLES = [
+  'personnel',
+  'users',
+  'organization',
+  'position',
+  'promotion_criteria',
+  'probation_program',
+];
+
+// checkout บางส่วน (เช่น workspace จำลอง) ไม่มีไฟล์เหล่านี้ — ข้ามอย่างมีเสียง
+const MISSING = Object.values(CALLERS)
+  .concat(ASSERT_SQL, TIDB_INIT)
+  .filter((p) => !existsSync(p));
+const SKIP_REASON =
+  MISSING.length > 0
+    ? `checkout ไม่ครบ (ไม่มี: ${MISSING.map((p) => resolve(p).split(/[\\/]/).pop()).join(', ')}) — เทสนี้เช็คไฟล์จริงของ repo เท่านั้น`
+    : false;
+
+test('ทั้งสาม mirror อ้าง assert SQL ไฟล์เดียว — ห้ามกลับไป inline', { skip: SKIP_REASON }, () => {
+  for (const [name, path] of Object.entries(CALLERS)) {
+    const text = readFileSync(path, 'utf8');
+    assert.ok(
+      text.includes('scripts/sql/tidb-init-smoke-assert.sql'),
+      `${name} ต้องอ้าง scripts/sql/tidb-init-smoke-assert.sql (ตาม ADR-0002: ไฟล์เดียวใช้ร่วม)`
+    );
+    assert.ok(
+      !text.includes('UNION ALL'),
+      `${name} ห้ามมี assert SQL inline (UNION ALL) — แก้ที่ scripts/sql/tidb-init-smoke-assert.sql ไฟล์เดียว`
+    );
+  }
+  // touchpoint ที่ประกาศไว้ในหัว tidb-init.sql ต้องยังชี้มาที่ assert SQL
+  assert.ok(
+    readFileSync(TIDB_INIT, 'utf8').includes('tidb-init-smoke-assert.sql'),
+    'tidb-init.sql ต้องมี NOTE ชี้ touchpoint ไปที่ scripts/sql/tidb-init-smoke-assert.sql'
+  );
+});
+
+test('assert SQL ครอบตาราง seed ครบ 6 ตารางตาม ADR-0002 — ไม่ขาดไม่เกิน', { skip: SKIP_REASON }, () => {
+  const text = readFileSync(ASSERT_SQL, 'utf8');
+  for (const table of SEED_TABLES) {
+    assert.ok(new RegExp(`FROM ${table}\\b`).test(text), `assert SQL ต้องครอบตาราง ${table}`);
+  }
+  // บล็อก SUM ต้องมีเครื่องหมาย (COUNT(*) = 0) ครบจำนวนตารางพอดี — เพิ่มตารางใหม่ต้องมาที่นี่ด้วย
+  const marks = text.match(/\(COUNT\(\*\) = 0\)/g) ?? [];
+  assert.equal(
+    marks.length,
+    SEED_TABLES.length,
+    `บล็อก SUM ต้องมี (COUNT(*) = 0) ครบ ${SEED_TABLES.length} ตาราง (ได้ ${marks.length}) — รายชื่อในไฟล์กับ SEED_TABLES เพี้ยนกัน`
+  );
+});

--- a/scripts/tests/verify-live-headers.test.mjs
+++ b/scripts/tests/verify-live-headers.test.mjs
@@ -16,6 +16,11 @@ import { parseRenderHeaders, buildExpectations } from '../verify-live-headers.mj
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
 const SCRIPT = resolve(ROOT, 'scripts', 'verify-live-headers.mjs');
+
+// render.yaml คือ expected set ของทุกเทสในไฟล์นี้ — อ่าน/parse ที่เดียว (เดิม derive ซ้ำ 5 จุด)
+function renderHeaderEntries() {
+  return parseRenderHeaders(readFileSync(resolve(ROOT, 'render.yaml'), 'utf8'));
+}
 const ASSET = '/assets/index-TEST1234.js';
 const SHELL_HTML = `<!doctype html><html><head><script type="module" src="${ASSET}"></script></head><body>ok</body></html>`;
 
@@ -71,7 +76,7 @@ function startServer({ shell, asset, onAssetRequest }) {
 test('ผ่านเมื่อ origin ส่ง header ครบตามที่ render.yaml ประกาศ', async () => {
   // mock origin ที่ "ถูกต้อง" = ส่งทุก header ตาม entries ที่ parse ได้จาก render.yaml จริง
   // (กฎเดียว /* ครอบทั้ง site — asset จึงได้ชุดเดียวกับ shell ตาม fallback ของ buildExpectations)
-  const entries = parseRenderHeaders(readFileSync(resolve(ROOT, 'render.yaml'), 'utf8'));
+  const entries = renderHeaderEntries();
   const headers = { shell: {}, asset: {} };
   for (const e of entries) {
     headers.shell[e.name] = e.value;
@@ -88,7 +93,7 @@ test('ผ่านเมื่อ origin ส่ง header ครบตามท�
 });
 
 test('parser แกะได้เฉพาะ block headers: ของ static site (ไม่ชบักไป service อื่น)', () => {
-  const entries = parseRenderHeaders(readFileSync(resolve(ROOT, 'render.yaml'), 'utf8'));
+  const entries = renderHeaderEntries();
   const shellNames = entries.filter((e) => e.path === '/*').map((e) => e.name).sort();
   // CSP มีได้ชื่อเดียวแล้วแต่เฟส: enforce = Content-Security-Policy · report-only = ...-Report-Only
   const cspName = shellNames.find((n) => n.startsWith('Content-Security-Policy'));
@@ -137,7 +142,7 @@ test('buildExpectations ต้อง fail-closed เมื่อเจอ path g
 test('CSP ถูกผ่อนหรือ HSTS อ่อนกว่าต้อง fail แม้จะมี header ครบทุกตัว', async () => {
   // reviewer round: substring-match จะมองไม่เห็น directive ที่ถูกเติม source อ่อนกว่า
   // และ HSTS warn-only ต้องยอมเฉพาะค่าที่แรงกว่า — เคสนี้ต้อง fail ทั้งคู่
-  const entries = parseRenderHeaders(readFileSync(resolve(ROOT, 'render.yaml'), 'utf8'));
+  const entries = renderHeaderEntries();
   const headers = { shell: {}, asset: {} };
   for (const e of entries) {
     headers.shell[e.name] = e.value;
@@ -208,7 +213,7 @@ test('asset ที่แกว่งค่าระหว่างนัด (บ
   // เหตุการณ์จริง: กฎ immutable เก่าค้างระดับ service บน Render ทำให้ asset ตอบสลับ
   // immutable/no-cache ต่อ request (probe จริง 8 นัด = 6 immutable / 2 no-cache) —
   // gate รุ่นยิง-1-นัดเคย PASS โดยบังเอิญเพราะสุ่มโดน no-cache พอดี รุ่น multi-probe ต้องจับได้
-  const entries = parseRenderHeaders(readFileSync(resolve(ROOT, 'render.yaml'), 'utf8'));
+  const entries = renderHeaderEntries();
   const good = {};
   for (const e of entries) good[e.name] = e.value;
   const flapping = { ...good, 'Cache-Control': 'public, max-age=31536000, immutable' };
@@ -229,7 +234,7 @@ test('asset ที่แกว่งค่าระหว่างนัด (บ
 });
 
 test('ยิง asset ครบทุกนัดด้วย cache-buster เฉพาะตัว — URL ไม่ซ้ำกัน และทุกนัดสะอาดต้อง PASS', async () => {
-  const entries = parseRenderHeaders(readFileSync(resolve(ROOT, 'render.yaml'), 'utf8'));
+  const entries = renderHeaderEntries();
   const headers = { shell: {}, asset: {} };
   for (const e of entries) {
     headers.shell[e.name] = e.value;


### PR DESCRIPTION
## Summary

ตาม two-axis review ของชุด 4 PR (#156–#159, diff `cebb2b5...HEAD`) — แก้ 3 กลุ่มที่ review ชี้:

1. **Seed-row assert เป็นแค่ print (Spec worst finding)** — job `tidb-init-bootstrap` ใน ci.yml และ step smoke ใน ci-local.sh/.ps1 เดิมแค่พิมพ์ผล `COUNT(*)` ของตาราง seed 6 ตาราง ไม่มีการ assert → DB ที่ DDL ผ่านแต่ INSERT หายทั้งชุดก็เขียว ขัดคำเคลมใน ADR-0002 ภาคต่อ 26 ส.ค. ว่า "assert แถวของตาราง seed" — ตอนนี้ assert แบบ **fail-closed**: จำนวนตาราง seed ที่ว่างต้องเป็น 0 ไม่งั้นแดง
2. **Duplicated Code (triplicated assert SQL)** — แยก SQL ออกเป็น `scripts/sql/tidb-init-smoke-assert.sql` ไฟล์เดียว ใช้ร่วมทั้ง 3 ตัวผ่าน `docker exec -i … < ไฟล์` (ไม่เพิ่ม mount — คงหลัก "mount เฉพาะ tidb-init.sql")
3. **Fail path ทำลาย diagnostics (Standards defect)** — `ci-local.sh` เดิมดึง `docker logs` แล้วทิ้ง (`>/dev/null`), `ci-local.ps1` เดิม `docker rm -f` **ก่อน**ที่ fail message จะบอกให้ไปดู log ของ container ที่เพิ่งถูกลบ → ตอนนี้ทั้งคู่พิมพ์ log (tail 50) ก่อนลบ container ตรงแบบเดียวกับ job ใน ci.yml แล้ว
4. **จัดลำดับ probe ก่อน sleep** ให้ 3 mirror เหมือนกัน (เดิม sh/.ps1 sleep 5s ก่อน probe แรก ต่างจาก ci.yml) และ extract `renderHeaderEntries()` ใน `verify-live-headers.test.mjs` ลบการ derive ซ้ำ 5 จุด (review smell)

**ไม่แก้** (ตามที่ review วัดว่าไม่ใช่ปัญหาจริง): hardcoded `rootpassword` ใน CI — container ephemeral ไม่ publish port, ไม่ใช่ secret จริง

## Files

- `.github/workflows/ci.yml` — assert fail-closed ใน job `tidb-init-bootstrap`
- `scripts/ci-local.sh` / `scripts/ci-local.ps1` — assert + log ก่อน rm + probe ก่อน sleep
- `scripts/sql/tidb-init-smoke-assert.sql` — **ไฟล์ใหม่** assert SQL กลาง
- `docs/adr/0002-schema-parity-gate.md` — ภาคต่ออัปเดตให้ตรงพฤติกรรมจริง + References
- `scripts/tests/verify-live-headers.test.mjs` — helper `renderHeaderEntries()`

## API / schema notes

ไม่มี — ไม่แตะ schema/migration (ไฟล์ใหม่อยู่นอก `database/NN-*` จึงไม่ trigger กฎ "แตะ 3 ที่") ไม่แตะ API

## Verification

- `bash -n scripts/ci-local.sh` ผ่าน
- `node --test scripts/tests/verify-live-headers.test.mjs` — 7/7 ผ่าน
- `node --test scripts/tests/ci-local-csp-gate.test.mjs` — 12/12 ผ่าน (sandbox wrapper)
- smoke จริง (Docker MySQL 8 เปล่า + mount tidb-init.sql): `BOOTSTRAP_OK=1`, **`EMPTY_TABLES=0`**, views query ผ่าน
- smoke เชิงลบ (DB เปล่า ไม่มี init): assert ให้ output ว่าง → ไม่ใช่ "0" → **fail-closed ถูกต้อง** (พฤติกรรมที่รุ่น print-only จับไม่ได้)
- pre-push hook: `[pre-push] OK` (frontend vitest)

## Task / ที่มา

Two-axis review in-session (Standards + Spec) ของชุด PR #156–#159 — ไม่มี issue แยก