### PR TITLE
docs(data): เคลียร์ข้อมูลทดสอบCSP จาก production แล้ว — ปิดข้อความ "ต้องเก็บกวาด"

### DIFF
--- a/docs/frontend-security-headers.md
+++ b/docs/frontend-security-headers.md
@@ -346,12 +346,10 @@ enforce ไม่ติดเลยทั้งที่ทุกคนเชื
 แล้วดู header จริงทุกครั้ง ห้ามถือว่า merge แล้วจบ** และถ้า blueprint ไม่ตาม ต้อง Sync จาก
 Render dashboard ก่อน
 
-**ข้อมูลทดสอบที่ยังค้างใน production (ต้องเก็บกวาด)** — ทั้งสองรายการ **ปิดใช้งานแล้ว** แต่เป็น
-soft delete จึงยังอยู่ใน DB และมีร่องรอยใน audit log:
-`personnel` ชื่อขึ้นต้น `ทดสอบCSP` · `special_area_multiplier` (API `/multiplier/areas`) จังหวัด
-ขึ้นต้น `ทดสอบCSP-` · **ขั้นตอน export backup + ลบ + ยืนยัน 0 แถว อยู่ที่
-runbook `docs/runbooks/csp-test-data-cleanup.md`** (owner รันเองผ่าน TiDB Cloud console —
-DELETE ต้องมี owner ยืนยัน scope ก่อนเสมอ)
+**ข้อมูลทดสอบ CSP เคลียร์จาก production แล้ว (2026-08-30)** — ลบตามขอบเขตที่ owner ยืนยัน
+(`personnel` 1 แถว · `special_area_multiplier` 1 แถว — ทั้งหมดเป็น soft-deleted rows) หลัง export
+backup และยืนยัน 0 แถวหลังลบ · audit log เก็บ history ของรายการไว้ตาม design (4 แถว) ·
+backup และบันทึกผลเต็มที่ runbook `docs/runbooks/csp-test-data-cleanup.md`
 
 ### Enforce switch 2026-08-25 — enforce ขึ้น live และเดินเมนูผ่านทั้งระบบ
 

--- a/docs/frontend-security-headers.md
+++ b/docs/frontend-security-headers.md
@@ -349,7 +349,7 @@ Render dashboard ก่อน
 **ข้อมูลทดสอบ CSP เคลียร์จาก production แล้ว (2026-08-30)** — ลบตามขอบเขตที่ owner ยืนยัน
 (`personnel` 1 แถว · `special_area_multiplier` 1 แถว — ทั้งหมดเป็น soft-deleted rows) หลัง export
 backup และยืนยัน 0 แถวหลังลบ · audit log เก็บ history ของรายการไว้ตาม design (4 แถว) ·
-backup และบันทึกผลเต็มที่ runbook `docs/runbooks/csp-test-data-cleanup.md`
+backup และบันทึกผลเต็ม ที่ runbook `docs/runbooks/csp-test-data-cleanup.md`
 
 ### Enforce switch 2026-08-25 — enforce ขึ้น live และเดินเมนูผ่านทั้งระบบ
 
@@ -414,10 +414,10 @@ backup และบันทึกผลเต็มที่ runbook `docs/runb
    ใต้ report-only · กลไก `report-uri` เดียวกันทำงานต่อใต้ enforce (รายงานสิ่งที่ถูกบล็อกจริง)
    แต่ยังไม่มี marker สดที่พิสูจน์ hop สุดท้ายในโหมด enforce โดยตรง
 
-**ข้อมูลทดสอบที่ยังค้างเพิ่ม** — นอกจาก 2 รายการเดิมด้านบน (ดู runbook
-`docs/runbooks/csp-test-data-cleanup.md`) ยังมี selftest marker ของ
-24 ส.ค. ใน log (ไม่เก็บใน DB — ตกไปเองตาม retention ของ Render log) · การเก็บกวาดรวมเป็น
-pending เดียวกัน
+**สถานะการเก็บกวาดข้อมูลทดสอบ** — 2 รายการใน DB (ดูบันทึก "เคลียร์จาก production แล้ว
+(2026-08-30)" ด้านบน + runbook `docs/runbooks/csp-test-data-cleanup.md`) เก็บกวาดเสร็จแล้ว
+2026-08-30 · สิ่งที่เหลืออยู่ตามธรรมชาติและไม่ต้องดำเนินการ: selftest marker ของ 24 ส.ค. ยังอยู่
+ใน Render log (ไม่เก็บใน DB — ตกไปเองตาม retention ของ log)
 
 ### Cache-Control แกว่งอีกครั้ง 26 ส.ค. — gate เดิมจับไม่ได้ (#155)
 

--- a/docs/runbooks/csp-test-data-cleanup.md
+++ b/docs/runbooks/csp-test-data-cleanup.md
@@ -4,6 +4,7 @@
 - **ขอบเขตที่ owner ยืนยัน (owner decisions 2026-08-24 ข้อ 4):** `personnel` ชื่อขึ้นต้น `ทดสอบCSP` · `special_area_multiplier` จังหวัดขึ้นต้น `ทดสอบCSP-`
 - **ระดับ:** ⚠️ **DESTRUCTIVE** — ต้องทำตามลำดับใน runbook นี้ทุกขั้น ไม่ข้าม
 - **สิทธิ์:** production DB = TiDB Cloud (เชื่อมผ่าน Render env `MYSQL_PORT=4000` + SSL) — repo ไม่มี credential → **owner รันเองผ่าน TiDB Cloud console**
+  · *(อัปเดต 30 ส.ค. 2026: agent รันแทนตามอนุมัติของ owner — ดูหัวข้อ "ผลการดำเนินการ" ท้ายไฟล์)*
 - **สคริปต์:** `scripts/sql/cleanup-csp-test-data.sql` (SELECT → DELETE → SELECT ยืนยัน)
 
 ## ข้อตกลงสำคัญ
@@ -44,7 +45,7 @@ mysqldump --default-character-set=utf8mb4 --set-charset \
 - ✅ owner ยืนยันยอมรับ scope นี้ (จำนวนแถว + คอลัมน์ที่แสดง)
 - ถ้าไม่ตรงตามที่คาด → **หยุด** แล้วตรวจสอบก่อน (อย่าเดา)
 
-### 3) DELETE (owner เท่านั้น)
+### 3) DELETE (ต้องมี owner ยืนยัน scope ก่อนเสมอ — ครั้งจริง 30 ส.ค. 2026 agent รันแทนตามอนุมัติ ดู "ผลการดำเนินการ")
 
 รัน **เฉพาะบล็อก 2** ของสคริปต์ (DELETE สองตารางตาม WHERE เดียวกับ SELECT)
 
@@ -57,7 +58,8 @@ mysqldump --default-character-set=utf8mb4 --set-charset \
 
 ### 5) บันทึกผล
 
-- Comment ผล (จำนวนแถวที่ลบ, path backup ไฟล์) ลง issue ที่ติดตามงานนี้
+- Comment ผล (จำนวนแถวที่ลบ, path backup ไฟล์) ลง issue ที่ติดตามงานนี้ — *(ครั้งจริง 30 ส.ค. 2026 ไม่มี
+  issue แยก จึงบันทึกในหัวข้อ "ผลการดำเนินการ" ท้ายไฟล์แทน)*
 - อัปเดต `docs/frontend-security-headers.md` — ลบข้อความ "ข้อมูลทดสอบที่ยังค้างใน production (ต้องเก็บกวาด)" เมื่อเคลียร์จริง
 
 ## ข้อมูลอ้างอิง

--- a/docs/runbooks/csp-test-data-cleanup.md
+++ b/docs/runbooks/csp-test-data-cleanup.md
@@ -65,3 +65,25 @@ mysqldump --default-character-set=utf8mb4 --set-charset \
 - ที่มาของข้อมูล: สร้างผ่าน API 22 ส.ค. (`POST /api/personnel`, `POST /api/multiplier/areas`) ระหว่าง CSP report-only walkthrough — `docs/frontend-security-headers.md` (write path ที่ทดสอบจริง)
 - วิธี connect production: `docs/render-tidb-production.md` (L50–58: TiDB Cloud, port 4000, SSL)
 - สคริปต์: `scripts/sql/cleanup-csp-test-data.sql`
+
+## ผลการดำเนินการ (2026-08-30) — เคลียร์เรียบร้อย
+
+- **ผู้ดำเนินการ:** agent (zcode) รันแทน owner ตามอนุมัติของ owner วันที่ 30 ส.ค. 2026 — owner
+  จัดเตรียม credential ไว้ที่ `secrets/secret-keys.txt` (ค่าถูกดึงเข้า env ของ container ตรง ๆ
+  ไม่ถูกแสดง/ส่งออกภายนอก) · วิธีเดิมที่ระบุ "owner รันเองผ่าน TiDB Cloud console" ปรับเป็น
+  "agent รันผ่าน mysql client (Docker, `--ssl-mode=REQUIRED`)" ตามอนุมัตินั้น — ลำดับขั้นตอน
+  (backup → SELECT ยืนยัน → DELETE → ยืนยัน 0 แถว) คงเดิมทุกขั้น
+- **ขั้น 1 — backup:** `mysqldump --default-character-set=utf8mb4 --set-charset
+  --column-statistics=0 --ssl-mode=REQUIRED` — **ห้ามใช้ `--single-transaction` กับ TiDB**
+  (TiDB ไม่รองรับ SAVEPOINT ที่ mysqldump ใช้ → exit 2 พร้อม error ท้าย dump แม้ข้อมูลจะครบ)
+  · เก็บที่ `D:\00 hrProject\backups\csp-cleanup-20260830\` — `backup-csp-personnel-20260830.sql`
+  (3,939 bytes) · `backup-csp-areas-20260830.sql` (3,685 bytes) — ตรวจแล้วมี footer
+  "Dump completed" และข้อมูล Thai ครบทุกแถว
+- **ขั้น 2 — SELECT ยืนยัน scope:** ตรงขอบเขตที่ยืนยันไว้เป๊ะ — `personnel` 1 แถว
+  (personnel_id 60002) · `special_area_multiplier` 1 แถว (area_multiplier_id 1) — เป็นข้อมูล
+  ทดสอบ soft-deleted ล้วน ไม่มีชื่อจริงปน
+- **ขั้น 3 — DELETE:** ลบได้ 1 + 1 แถว (ROW_COUNT ต่อ statement)
+- **ขั้น 4 — ยืนยันหลังลบ:** `personnel_left = 0` · `areas_left = 0` · `audit_rows_csp = 4`
+  (history ของรายการถูกเก็บไว้ครบตาม design ข้อ 2 — ตรวจผ่าน `before_value`/`after_value`
+  เพราะ `audit_log` ไม่มีคอลัมน์ `action_detail`)
+- **บันทึกผล:** ไม่มี issue แยกติดตามงานนี้ — บันทึก ณ ที่นี้แทนการ comment ลง issue (ขั้น 5 เดิม)

--- a/scripts/sql/cleanup-csp-test-data.sql
+++ b/scripts/sql/cleanup-csp-test-data.sql
@@ -53,3 +53,10 @@ WHERE first_name LIKE 'ทดสอบCSP%'
 SELECT COUNT(*) AS areas_left
 FROM special_area_multiplier
 WHERE province LIKE 'ทดสอบCSP-%';
+
+-- audit history ต้องอยู่รอดตาม design (ลบข้อมูล แต่ไม่ลบ trail) — ค่าจริงครั้ง 30 ส.ค. 2026 = 4
+-- (audit_log ไม่มีคอลัมน์ action_detail — ค้นจาก before_value/after_value)
+SELECT COUNT(*) AS audit_rows_csp
+FROM audit_log
+WHERE before_value LIKE '%ทดสอบCSP%'
+   OR after_value LIKE '%ทดสอบCSP%';


### PR DESCRIPTION
## Summary

ดำเนินการ cleanup ข้อมูลทดสอบ CSP ตาม runbook `docs/runbooks/csp-test-data-cleanup.md` ครบทุกขั้น (owner อนุมัติให้ agent รันแทนเมื่อ 30 ส.ค. 2026 พร้อม credential — ค่าถูกดึงเข้า env ของ container ตรง ๆ ไม่ถูกแสดงใน chat/log หรือส่งออกภายนอก):

| ขั้น | ผล |
|---|---|
| 1) backup | mysqldump (utf8mb4, SSL) → `D:\00 hrProject\backups\csp-cleanup-20260830\` (2 ไฟล์ 3,939 + 3,685 bytes, มี footer "Dump completed", Thai ครบ) · **เรียนรู้: ห้ามใช้ `--single-transaction` กับ TiDB (SAVEPOINT → exit 2)** |
| 2) SELECT ยืนยัน scope | ตรงที่ owner ยืนยันไว้ 24 ส.ค. เป๊ะ — `personnel` 1 แถว (id 60002) · `special_area_multiplier` 1 แถว (id 1) — soft-deleted ทดสอบล้วน |
| 3) DELETE | ลบได้ 1 + 1 แถว (ROW_COUNT ต่อ statement) |
| 4) ยืนยันหลังลบ | `personnel_left=0` · `areas_left=0` · `audit_rows_csp=4` (history อยู่ครบตาม design) |

## Doc changes

- `docs/frontend-security-headers.md` — หัวข้อ "ต้องเก็บกวาด" → บันทึก "เคลียร์แล้ว (2026-08-30)" ตามเงื่อนไขของ runbook ขั้น 5
- `docs/runbooks/csp-test-data-cleanup.md` — เพิ่มหัวข้อ "ผลการดำเนินการ" (backup path, ข้อควรระวัง TiDB SAVEPOINT, ผลแต่ละขั้น) — ไม่มี issue แยกจึงบันทึกใน runbook แทน

## API / schema notes

ไม่มี — docs-only

## Verification

SELECT ก่อน/หลังจริงบน production TiDB (อยู่ในตารางด้านบน) · backup ตรวจ footer + ข้อมูล Thai ครบ · ไม่แตะตาราง/แถวอื่น (WHERE scope เดิมทุก statement)