### PR TITLE
fix: ปิด 44 findings จาก codebase-review-fix (security/backend/frontend/tests)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,8 @@ MYSQL_PASSWORD=change-me
 
 # ---- Backend --------------------------------------------------------------
 # กุญแจเซ็น JWT (HMAC-SHA256) — production ต้องสุ่มใหม่ อย่าใช้ค่าตัวอย่าง
+# ต้องยาว ≥32 ตัวอักษร — config.php จะ 500 ทั้งระบบถ้าสั้นกว่านั้น (fail-closed)
+# (ตัวอย่างด้านล่างยาว 33 ตัว — ผ่านเกณฑ์ แต่ยังต้องสุ่มค่าจริงก่อนใช้งาน production)
 # สร้างค่าใหม่: openssl rand -hex 32
 JWT_SECRET=change-me-to-a-long-random-string
 
@@ -18,6 +20,16 @@ JWT_SECRET=change-me-to-a-long-random-string
 # APP_ENV=development                       # เปิดผ่อนปรน CORS สำหรับ dev (backend/api.php)
 # ALLOWED_ORIGINS=http://localhost:5174      # คั่นหลายค่าด้วย comma (default: โดเมน production)
 # OCR_SERVER_URL=http://127.0.0.1:8100       # OCR sidecar (backend/routes/ocr.php)
+
+# ---- Backend optional (backend อ่านผ่าน getenv — uncomment เมื่อต้องใช้จริง) ----
+# CSP_SUMMARY_TOKEN=change-me                # กันสาธารณะ GET /api/csp-report/summary (backend/api.php)
+# SYNC_STAGING_HOST=                         # staging sync — ใช้โดย run-sync.php / routes/sync.php
+# SYNC_STAGING_DATABASE=
+# SYNC_STAGING_USER=
+# SYNC_STAGING_PORT=3306
+# SYNC_STAGING_PASSWORD=
+# SYNC_CSV_DIR=/tmp/smartport-sync-csv       # โฟลเดอร์เก็บ CSV ของ staging sync
+# ALLOW_REMOTE_TEST_DB=1                     # อนุญาต integration test ชี้ DB นอกเครื่อง (backend/tests/bootstrap.php)
 
 # ---- Migrations -----------------------------------------------------------
 # docker-compose ตั้ง APPLY_TEST_SEED_MIGRATIONS=1 ให้แล้วสำหรับ local

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
-# pre-push — light local gate (frontend vitest only; no Docker / no Actions)
+# pre-push — light gate; optional Docker steps when available (no Actions)
+#
+# บังคับทุกครั้ง (fail-closed): script regressions + schema parity (node-only) + frontend vitest
+# Optional (รันเมื่อ Docker พร้อมเท่านั้น): backend PHPUnit Unit suite
+#   — backend/tests/run.sh docker-build + docker-run เสมอ จึง "ต้องมี Docker" จริง
+#     Docker ไม่พร้อม = SKIP อย่างมีเสียง **ไม่ fail push** (hook นี้เดิมออกแบบ no-Docker)
 #
 # Skip once:  SKIP_PRE_PUSH=1 git push
 # Or:         git push --no-verify
@@ -32,6 +37,11 @@ echo "[pre-push] script regressions (node --test scripts/tests) ..."
 # quote ปิดก่อน `/scripts` โดยตั้งใจ — คลุม `*` ไว้ในเครื่องหมายคำพูดเมื่อไร glob ก็ไม่ขยาย
 # แล้ว node จะได้ path ที่มีดาวจริง ๆ ต่างจากบรรทัด audit ข้างล่างที่ไม่มี glob จึงคลุมทั้ง path ได้
 node --test "${ROOT}"/scripts/tests/*.test.mjs
+
+# Schema parity gate (T13/F14) — node-only ไม่ต้อง Docker → fail-closed ทุกครั้ง
+# (Actions ปิด auto-trigger อยู่ hook นี้จึงเป็นที่เดียวที่บังคับ gate นี้ได้จริงทุก push)
+echo "[pre-push] schema parity (node scripts/validate-schema-parity.mjs) ..."
+node "${ROOT}/scripts/validate-schema-parity.mjs"
 
 # CSP bundle audit (issue #113 R2) — เดิม gate นี้อยู่ใน ci-local เท่านั้น ซึ่งไม่มีอะไรบังคับ
 # ให้ใครรัน · Actions ปิด auto-trigger อยู่ hook นี้จึงเป็นที่เดียวที่บังคับได้จริง
@@ -84,4 +94,16 @@ fi
 echo "[pre-push] frontend vitest (forks pool from vitest.config.js) ..."
 cd "${FRONTEND}"
 npx vitest run --reporter=dot
+
+# Backend PHPUnit Unit suite (T18/F2) — guarded step: run.sh docker-build + docker-run เสมอ
+# จึงต้องมี Docker จริง · ถ้า Docker ไม่พร้อม → SKIP อย่างมีเสียง ไม่ fail push
+# (set -euo pipefail ทำให้ run.sh ล้มเหลว = push ล้มเหลว เมื่อ Docker available — fail-closed)
+if docker info >/dev/null 2>&1; then
+  echo "[pre-push] backend Unit suite (bash backend/tests/run.sh --testsuite Unit) ..."
+  bash "${ROOT}/backend/tests/run.sh" --testsuite Unit
+else
+  echo "[pre-push] SKIP  backend Unit suite skipped — Docker unavailable"
+  echo "[pre-push]       รันเองเมื่อ Docker พร้อม: bash backend/tests/run.sh --testsuite Unit"
+fi
+
 echo "[pre-push] OK"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # F18/T21: production deps audit — fail บน high/critical (mirror ci-local.ps1/sh)
+      - name: Audit production dependencies
+        run: npm audit --omit=dev --audit-level=high
+
       - name: Run tests
         run: npm test
 
@@ -82,7 +86,7 @@ jobs:
           MYSQL_DATABASE=civil_service_mgmt
           MYSQL_USER=root
           MYSQL_PASSWORD=rootpassword
-          JWT_SECRET=ci-only-not-for-production
+          JWT_SECRET=ci-only-not-for-production-jwt-32chars-min-000000
           EOF
 
       - name: Start database and backend

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,9 +129,9 @@ Pure PHP REST API with no framework.
 
 - **Single entry point**: `api.php` is the API gateway — all requests route through it via `.htaccess` rewrite rules
 - **Routing**: `switch` statement on URL path segments in `api.php`, delegating to feature handlers in `backend/routes/` (e.g. `routes/import.php`, `routes/probation.php`)
-- **Auth**: JWT (HMAC-SHA256) implemented in `auth.php` using `firebase/php-jwt`. Token expiry: 1 hour. Login endpoints (`/auth/login` and `/login`) are unauthenticated; all other routes require a valid JWT in the `Authorization` header
+- **Auth**: JWT (HMAC-SHA256) — custom HS256 implementation (`auth.php`) — ตัดสินใจแล้ว ไม่ใช้ library. Token expiry: 1 hour. Login endpoints (`/auth/login` and `/login`) are unauthenticated; all other routes require a valid JWT in the `Authorization` header
 - **Database**: PDO with prepared statements. Connection setup in `config.php`
-- **Dependencies**: Managed via Composer (`composer.json`), only dependency is `firebase/php-jwt`
+- **Dependencies**: Managed via Composer (`composer.json`), only runtime dependency is `phpoffice/phpspreadsheet` — JWT เป็น custom HS256 implementation (`auth.php`) — ตัดสินใจแล้ว ไม่ใช้ library (ไม่มี `firebase/php-jwt` ใน require block)
 
 ### Service Ports
 | Service       | Port  |
@@ -193,9 +193,9 @@ Pure PHP REST API with no framework.
 - Tailwind CSS 4.1.0 - Utility CSS framework
 - @tailwindcss/vite 4.1.0 - Vite integration plugin
 - Pure PHP REST API - No framework (custom routing via switch statement in `api.php`)
-- Firebase PHP-JWT 6.0 - JWT token generation and validation
+- Custom JWT implementation (HMAC-SHA256) in `backend/auth.php` — ตัดสินใจแล้ว ไม่ใช้ library
 ## Key Dependencies
-- firebase/php-jwt 6.0 - JWT implementation (HMAC-SHA256) for authentication
+- Custom JWT implementation (backend/auth.php) - HMAC-SHA256 for authentication — ตัดสินใจแล้ว ไม่ใช้ library
 - chart.js 4.4.0 - Chart rendering library
 - vue-chartjs 5.3.0 - Vue integration for charts
 - lucide-vue-next 0.470.0 - SVG icon library
@@ -255,7 +255,7 @@ Pure PHP REST API with no framework.
 - **Vue 3 with SPA:** Single-page application with client-side routing and state management
 - **Single-page Vite build:** `index.html` is the sole entry; admin-only views are Vue Router routes guarded by `meta.requiresAdmin`, not a separate HTML page
 - **API proxy in dev:** Vite dev server proxies `/api` requests to avoid CORS issues locally
-- **JWT with custom implementation:** Backend uses both firebase/php-jwt and custom JWT functions
+- **JWT with custom implementation:** custom HS256 implementation (`backend/auth.php`) — ตัดสินใจแล้ว ไม่ใช้ library
 - **Tailwind 4:** Modern CSS framework with `@tailwindcss/vite` plugin for optimal build performance
 - **Docker multi-stage builds:** Optimized container images for frontend (Node → Nginx) and backend (Composer → PHP)
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -14,4 +14,16 @@ APP_ENV=production
 # MYSQL_PASSWORD=
 
 # JWT Secret (ใช้ใน auth.php)
+# ต้องยาว ≥32 ตัวอักษร — config.php จะ 500 ทั้งระบบถ้าสั้นกว่านั้น (fail-closed)
+# สร้างค่าใหม่: openssl rand -hex 32
 # JWT_SECRET=your-secret-key-here
+
+# ---- Optional (backend อ่านผ่าน getenv — uncomment เมื่อต้องใช้จริง) ------------
+# CSP_SUMMARY_TOKEN=change-me                # กันสาธารณะ GET /api/csp-report/summary (api.php)
+# SYNC_STAGING_HOST=                         # staging sync — run-sync.php / routes/sync.php
+# SYNC_STAGING_DATABASE=
+# SYNC_STAGING_USER=
+# SYNC_STAGING_PORT=3306
+# SYNC_STAGING_PASSWORD=
+# SYNC_CSV_DIR=/tmp/smartport-sync-csv       # โฟลเดอร์เก็บ CSV ของ staging sync
+# ALLOW_REMOTE_TEST_DB=1                     # อนุญาต integration test ชี้ DB นอกเครื่อง (tests/bootstrap.php)

--- a/backend/.htaccess
+++ b/backend/.htaccess
@@ -4,6 +4,17 @@ RewriteEngine On
 RewriteCond %{HTTP:Authorization} .
 RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 
+# F6: ห้าม serve runtime files — storage/ มีไฟล์ runtime (rate-limit counters) ที่
+# เปิดอ่านได้จากภายนอกไม่ได้ และ composer.json/lock เปิดเผยโครงสร้าง dependencies
+# ต้องอยู่ "ก่อน" rewrite-to-api มิฉะนั้นทุก request ถูกส่งเข้า api.php ก่อนแล้ว
+RewriteRule ^storage/ - [F,L]
+RewriteRule ^composer\.(json|lock)$ - [F,L]
+# F6 (ต่อ): vendor/ เปิดเผย dependency versions (installed.json), tests/scripts/
+# เป็นโค้ดฝั่ง server และ dotfiles (เช่น .env, .git) ห้ามออกอินเทอร์เน็ตเช่นกัน
+# (หมายเหตุ: ไม่บล็อก sync/ เพราะเป็นชื่อ API route จริง)
+RewriteRule ^(vendor|tests|scripts)/ - [F,L]
+RewriteRule (^|/)\. - [F,L]
+
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule ^(.*)$ api.php [QSA,L]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -75,6 +75,13 @@ RUN printf '%s\n' \
     'expose_php = Off' \
     > /usr/local/etc/php/conf.d/zz-production-errors.ini
 
+# F17/T19: upload limits 25MB — PHP default 2M ตัดรูปขนาดใหญ่
+# ต้องตรงกับ client_max_body_size 25m ใน frontend/nginx.conf (/api/ location)
+RUN printf '%s\n' \
+    'upload_max_filesize = 25M' \
+    'post_max_size = 25M' \
+    > /usr/local/etc/php/conf.d/zz-upload-limits.ini
+
 EXPOSE 80
 
 ENTRYPOINT ["/var/www/html/docker-entrypoint.sh"]

--- a/backend/MultiplierEngine.php
+++ b/backend/MultiplierEngine.php
@@ -50,12 +50,9 @@ function computeMultiplierFields(PDO $pdo, int $areaMultiplierId, string $startD
     $bonusDays = $eligibleDays * ($ratio - 100) / 100;
     $flooredEffective = (int) floor($effectiveDays);
 
-    $netYears = (int) floor($flooredEffective / 360);
-    $netMonths = (int) floor(($flooredEffective % 360) / 30);
-    $netDayRemainder = (int) (($flooredEffective % 360) % 30);
-
-    $netEndDate = clone $eligibleStart;
-    $netEndDate->modify('+' . max($flooredEffective - 1, 0) . ' days');
+    // net breakdown รวมศูนย์ที่ helpers.php (base 365, inclusive end) — สูตรเดียวกับ supportive
+    // ส่ง eligibleStart ตรง ๆ เหมือนเดิม (จุดเริ่มนับยังคือ clip start ที่ effective window)
+    $breakdown = computeNetBreakdown($eligibleStart, $flooredEffective);
 
     return [
         'area_multiplier_id' => (int) $area['area_multiplier_id'],
@@ -69,10 +66,10 @@ function computeMultiplierFields(PDO $pdo, int $areaMultiplierId, string $startD
         'multiplier_ratio' => $ratio,
         'effective_days' => $effectiveDays,
         'bonus_days' => $bonusDays,
-        'net_end_date' => $netEndDate->format('Y-m-d'),
-        'net_years' => $netYears,
-        'net_months' => $netMonths,
-        'net_day_remainder' => $netDayRemainder,
+        'net_end_date' => $breakdown['net_end_date'],
+        'net_years' => $breakdown['net_years'],
+        'net_months' => $breakdown['net_months'],
+        'net_day_remainder' => $breakdown['net_day_remainder'],
     ];
 }
 

--- a/backend/QualificationEngine.php
+++ b/backend/QualificationEngine.php
@@ -463,7 +463,8 @@ class QualificationEngine
         $summaryRow = $summaryStmt->fetch(PDO::FETCH_ASSOC);
 
         // Step 6: Data query with ORDER BY + LIMIT/OFFSET
-        $limit = max(1, intval($limit));
+        // cap เพดาน 200 เหมือน probation list — กัน ?limit=999999999 dump ทั้งระดับ
+        $limit = max(1, min(200, intval($limit)));
         $offset = max(0, intval($offset));
         $dataSql = "{$baseSelect}{$searchClause} ORDER BY remaining_days ASC LIMIT {$limit} OFFSET {$offset}";
         $dataStmt = $this->pdo->prepare($dataSql);

--- a/backend/api.php
+++ b/backend/api.php
@@ -59,11 +59,12 @@ if (getenv('APP_ENV') === 'development') {
 }
 
 $origin = $_SERVER['HTTP_ORIGIN'] ?? '';
+// F30: ส่ง ACAO เฉพาะเมื่อ Origin อยู่ใน allowlist เท่านั้น — fallback ส่ง origin แรก
+// ให้ทุก request ทำให้ origin แปลกปลอมได้ header อนุญาตโดยไม่จำเป็น
+// Vary: Origin ต้องส่งเสมอ เพราะ response ต่างกันตาม Origin (cache ต้องแยก key)
+header('Vary: Origin');
 if (in_array($origin, $allowedOrigins, true)) {
     header("Access-Control-Allow-Origin: $origin");
-} else {
-    // Fallback to first allowed origin
-    header('Access-Control-Allow-Origin: ' . $allowedOrigins[0]);
 }
 
 header('Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS');
@@ -126,8 +127,8 @@ if ($isPublicPhotoAsset) {
     checkRateLimitPublic('csp-report', 60, 60);
 } elseif ($isCspSummary) {
     // Issue #113 code review I3: เข้มกว่าตัวอื่นเพราะ endpoint นี้มี secret ให้เดา แต่ 10/นาที
-    // นี้เป็นแค่ defence-in-depth ไม่ใช่ตัวกัน brute-force ตัวจริง — publicClientIp() อ่าน XFF
-    // hop แรกที่ client ปลอมได้ (มีเทสยืนยันที่ PublicRateLimitTest) ตัวกันจริงคือ entropy ของ
+    // นี้เป็นแค่ defence-in-depth ไม่ใช่ตัวกัน brute-force ตัวจริง — publicClientIp() อ่าน
+    // last hop ของ XFF ที่ proxy append (มีเทสยืนยันที่ PublicRateLimitTest) ตัวกันจริงคือ entropy ของ
     // token เอง (ดู CSP_SUMMARY_TOKEN_MIN_LENGTH ใน routes/csp_summary.php)
     checkRateLimitPublic('csp-summary', 10, 60);
 }
@@ -409,6 +410,25 @@ switch ($path[0]) {
         } elseif ($method === 'DELETE' && $servantId > 0) {
             // Soft-delete: ปิดใช้งานบุคลากร (ออกจากรายชื่อ candidates ที่กรอง is_active=1)
             requirePermission('delete', 'personnel');
+            // F15: บันทึก audit ก่อน UPDATE — pattern เดียวกับ PUT ใน routes/personnel.php
+            // (snapshot เฉพาะฟิลด์เดียวกัน, citizen_id ไม่เข้า audit เพราะเป็น PII)
+            $beforeStmt = $pdo->prepare(
+                'SELECT first_name, last_name, prefix_id, employee_id, is_active
+                 FROM personnel WHERE personnel_id = ?'
+            );
+            $beforeStmt->execute([$servantId]);
+            $beforeRow = $beforeStmt->fetch(PDO::FETCH_ASSOC);
+            if ($beforeRow) {
+                logAudit(
+                    $pdo,
+                    (int) (getAuthenticatedUser()['user_id'] ?? 0),
+                    'DELETE',
+                    'personnel',
+                    $servantId,
+                    $beforeRow,
+                    array_merge($beforeRow, ['is_active' => 0])
+                );
+            }
             $stmt = $pdo->prepare(
                 'UPDATE personnel SET is_active = 0 WHERE personnel_id = ? AND is_active = 1'
             );
@@ -434,18 +454,28 @@ switch ($path[0]) {
             requirePermission('read', 'dashboard');
             $pdo = getDB();
 
+            // F33: COUNT แต่ละจุดต้องไม่ทำ endpoint ทั้งอันพังเมื่อตารางใดหาย
+            // (schema ต่างกัน/TiDB) — ใช้ analyticsScalar (routes/analytics.php:29)
+            // ซึ่งครอบด้วย try/catch คืน 0 เป็น pattern เดียวกับ analytics route
+            include_once __DIR__ . '/routes/analytics.php';
+
             // จำนวนบุคลากรทั้งหมด (จาก personnel table)
-            $stmt = $pdo->query("SELECT COUNT(*) as total FROM personnel WHERE is_active = 1");
-            $totalPersonnel = (int) $stmt->fetch(PDO::FETCH_ASSOC)['total'];
+            $totalPersonnel = analyticsScalar($pdo, "SELECT COUNT(*) FROM personnel WHERE is_active = 1");
 
             // สรุปพ้นทดลอง
-            $stmt = $pdo->query("SELECT COUNT(*) as total FROM probation_enrollment");
-            $probationTotal = (int) $stmt->fetch(PDO::FETCH_ASSOC)['total'];
+            $probationTotal = analyticsScalar($pdo, "SELECT COUNT(*) FROM probation_enrollment");
 
             // vw_probation_dashboard อาจพังบน TiDB (definer issue) — ใช้ try-catch
+            $probationInProgress = 0;
             $probationNear = 0;
             $probationOverdue = 0;
             try {
+                // in_progress ใช้ predicate เดียวกับ summary ของ probation route
+                // (routes/probation.php getProbationList: IN_PROGRESS + DATEDIFF > 0;
+                // view กรอง IN_PROGRESS ไว้แล้ว จึงเหลือกรอง remaining_days > 0)
+                $stmt = $pdo->query("SELECT COUNT(*) as c FROM vw_probation_dashboard WHERE remaining_days > 0");
+                $probationInProgress = (int) $stmt->fetch(PDO::FETCH_ASSOC)['c'];
+
                 $stmt = $pdo->query("SELECT COUNT(*) as c FROM vw_probation_dashboard WHERE remaining_days BETWEEN 1 AND 30");
                 $probationNear = (int) $stmt->fetch(PDO::FETCH_ASSOC)['c'];
 
@@ -454,6 +484,13 @@ switch ($path[0]) {
             } catch (PDOException $e) {
                 // View ไม่สามารถใช้งานได้ — fallback คำนวณจาก base tables
                 try {
+                    $stmt = $pdo->query("
+                        SELECT COUNT(*) as c FROM probation_enrollment
+                        WHERE overall_status = 'IN_PROGRESS'
+                        AND DATEDIFF(end_date, CURDATE()) > 0
+                    ");
+                    $probationInProgress = (int) $stmt->fetch(PDO::FETCH_ASSOC)['c'];
+
                     $stmt = $pdo->query("
                         SELECT COUNT(*) as c FROM probation_enrollment
                         WHERE overall_status = 'IN_PROGRESS'
@@ -473,14 +510,11 @@ switch ($path[0]) {
             }
 
             // จำนวนการนับเวลาเพิ่มเติม
-            $stmt = $pdo->query("SELECT COUNT(*) as c FROM supportive_experience");
-            $supportiveCount = (int) $stmt->fetch(PDO::FETCH_ASSOC)['c'];
+            $supportiveCount = analyticsScalar($pdo, "SELECT COUNT(*) FROM supportive_experience");
 
-            $stmt = $pdo->query("SELECT COUNT(*) as c FROM diverse_experience");
-            $diverseCount = (int) $stmt->fetch(PDO::FETCH_ASSOC)['c'];
+            $diverseCount = analyticsScalar($pdo, "SELECT COUNT(*) FROM diverse_experience");
 
-            $stmt = $pdo->query("SELECT COUNT(*) as c FROM position_equivalence");
-            $equivalenceCount = (int) $stmt->fetch(PDO::FETCH_ASSOC)['c'];
+            $equivalenceCount = analyticsScalar($pdo, "SELECT COUNT(*) FROM position_equivalence");
 
             // Candidate totals จาก QualificationEngine overview (seam เดียวกับ /candidates/overview)
             $candidateTotals = [];
@@ -528,6 +562,7 @@ switch ($path[0]) {
                 'total_personnel' => $totalPersonnel,
                 'probation' => [
                     'total' => $probationTotal,
+                    'in_progress' => $probationInProgress,
                     'near_deadline' => $probationNear,
                     'overdue' => $probationOverdue,
                 ],

--- a/backend/config.php
+++ b/backend/config.php
@@ -25,10 +25,23 @@ function buildSslOptions(string $useSSL, string $caPath): array {
 
 header('Content-Type: application/json; charset=UTF-8');
 
+// ============================================================================
+// Timezone Alignment (F26) — PHP + MySQL ต้องเห็นเวลาไทยเดียวกัน
+// date()/time() ฝั่ง PHP ใช้ Asia/Bangkok และทุก connection ตั้ง session
+// time_zone = +07:00 (ใน attemptDbConnection) — ไม่งั้น remaining_days,
+// lockout window ฯลฯ ที่คำนวณจาก NOW() ฝั่ง SQL เทียบ clock ฝั่ง PHP จะเพี้ยน 7 ชม.
+// ข้อมูลเก่าแบบ DATETIME (เช่น civil_servant_photos.upload_date) จะถูกตีความ
+// เป็นเวลาไทยเฉพาะตอนแสดงผล — ยอมรับได้เฉพาะ display ส่วน TIMESTAMP columns
+// (refresh_tokens/login_attempts) MySQL แปลงตาม session tz เองจึงไม่มี skew
+// ============================================================================
+date_default_timezone_set('Asia/Bangkok');
+
 // JWT Secret — ต้องมาจาก env var เท่านั้น
 // ห้ามมี default: ค่า fallback ใน source สาธารณะ = ใครก็ forge token ได้
 $jwtSecret = env('JWT_SECRET', '');
-if ($jwtSecret === '') {
+// F8: สั้นกว่า 32 ตัวอักษร = brute force ได้จริง ถือว่า config พังเทียบเท่าค่าว่าง
+// (fail-closed เช่นเดียวกับ CSP_SUMMARY_TOKEN_MIN_LENGTH ใน routes/csp_summary.php)
+if ($jwtSecret === '' || strlen($jwtSecret) < 32) {
     http_response_code(500);
     echo json_encode(['error' => 'Server configuration error']);
     exit;
@@ -48,8 +61,13 @@ function attemptDbConnection(): ?PDO {
     $host     = env('MYSQL_HOST', 'db');
     $port     = env('MYSQL_PORT', '3306');
     $dbname   = env('MYSQL_DATABASE', 'civil_service_mgmt');
-    $username = env('MYSQL_USER', 'root');
-    $password = env('MYSQL_PASSWORD', 'rootpassword');
+    $username = env('MYSQL_USER', '');
+    $password = env('MYSQL_PASSWORD', '');
+    // F31: ไม่มี default credential — เคย fallback root/rootpassword ซึ่งเดาได้จาก repo
+    // ถ้า env ไม่ถูกตั้งให้พังชัดเจนตั้งแต่ต่อ DB (fail-closed แบบเดียวกับ JWT_SECRET ด้านบน)
+    if ($username === '' || $password === '') {
+        throw new RuntimeException('MYSQL_USER/MYSQL_PASSWORD ไม่ได้ตั้งค่า — ปฏิเสธการเชื่อมต่อฐานข้อมูล');
+    }
     $useSSL   = env('MYSQL_SSL', '');
 
     // สร้าง DSN — รองรับ port ที่ต่างจาก default (TiDB ใช้ 4000)
@@ -76,6 +94,9 @@ function attemptDbConnection(): ?PDO {
     for ($attempt = 1; $attempt <= $maxRetries; $attempt++) {
         try {
             $connection = new PDO($dsn, $username, $password, $options);
+            // F26: จับคู่กับ date_default_timezone_set('Asia/Bangkok') ด้านบน —
+            // NOW() ฝั่ง SQL กับ clock ฝั่ง PHP จึงชี้เวลาไทยเดียวกัน
+            $connection->exec("SET time_zone = '+07:00'");
             $lastException = null;
             break;
         } catch (PDOException $e) {
@@ -102,7 +123,15 @@ function tryGetDB(): ?PDO {
         return $pdo;
     }
 
-    $pdo = attemptDbConnection();
+    // F31/T39: RuntimeException (env credential ขาด) ต้องไม่ทะลุออกนอก — readyz
+    // อาศัย null คืน documented not_ready shape (Issue #124) ส่วน getDB() ค่อย exit
+    // ด้วยข้อความ fail-closed เดิม
+    try {
+        $pdo = attemptDbConnection();
+    } catch (RuntimeException $e) {
+        error_log('[db] ' . $e->getMessage());
+        return null;
+    }
     return $pdo;
 }
 

--- a/backend/csp_violations.php
+++ b/backend/csp_violations.php
@@ -7,7 +7,8 @@ declare(strict_types=1);
  *
  * ทำไมถึง aggregate ไม่ใช่ append: POST /api/csp-report เป็น public endpoint
  * การเก็บ 1 แถวต่อ event เปิดช่องให้ใครก็ได้เขียนแถวเข้า DB production ไม่จำกัด และ
- * rate limit 60/นาที กันไม่ได้จริงเพราะ publicClientIp() อ่าน XFF ตัวแรกที่ client ปลอมได้
+ * rate limit 60/นาที เป็นแค่ defence-in-depth — publicClientIp() อ่าน last hop ของ XFF
+ * (hop ที่ proxy append จึงปลอมยากขึ้น) แต่ endpoint ก็ยังเปิดให้ใครก็ยิงได้จากหลายแหล่ง
  * เพดานการเติบโตจึงต้องอยู่ในตัว schema เอง (CSP_MAX_KEYS_PER_DAY)
  *
  * Invariant จริงของจำนวนแถวต่อวัน: ≤ CSP_MAX_KEYS_PER_DAY + 1 — แถวส่วนเกินหนึ่งแถวคือ

--- a/backend/helpers.php
+++ b/backend/helpers.php
@@ -191,3 +191,40 @@ function sqlPersonnelFullName(string $personnelAlias = 'p', string $prefixAlias 
     return "CONCAT(COALESCE({$prefixAlias}.prefix_name_th COLLATE utf8mb4_unicode_ci, ''),"
         . " {$personnelAlias}.first_name, ' ', {$personnelAlias}.last_name)";
 }
+
+/**
+ * คำนวณ net breakdown (ปี/เดือน/วัน + net_end_date) จากวันเริ่มต้นและจำนวนวัน effective
+ * รวมศูนย์ logic เดิมที่เคยกระจายใน MultiplierEngine และ supportive (สูตรเดียวทั้งระบบ)
+ *
+ * ⚠ การรวมศูนย์นี้เปลี่ยนความหมายของข้อมูลที่เก็บไว้ 2 มิติ (ตัดสินใจแล้ว — ไม่ทำ migration
+ * เพราะทีมยืนยันว่ายังไม่มีข้อมูลจริงที่ต่างกัน):
+ *   (1) base ของ "ปี" เปลี่ยนจาก 360 → 365 วัน — แถวเก่าที่คำนวณด้วย base 360
+ *       (multiplier) จะไม่ตรงกับสูตรใหม่ถ้าคำนวณซ้ำ
+ *   (2) MultiplierEngine เดิมวาง net_end_date จาก eligible_start (clip start ที่ effective
+ *       window) — ตอนนี้ helper รับ startDate ตรง ๆ caller เป็นคนเลือกว่าจะส่งวันอะไร
+ *       และทุก caller ใช้นิยาม inclusive: net_end_date = start + effective - 1
+ *       (supportive เดิมใช้ start + effective แบบไม่ -1 จึงเลื่อนไป 1 วันจากของเดิม)
+ *
+ * สูตร: base 365 วัน/ปี, 30 วัน/เดือน (ไม่คิด leap year)
+ *
+ * @param DateTime $startDate วันเริ่มต้นนับ (เวลา 00:00:00 ตาม pattern ของ caller)
+ * @param int $effectiveDays จำนวนวัน effective ที่ floor แล้ว
+ * @return array{net_end_date: string, net_years: int, net_months: int, net_day_remainder: int}
+ */
+function computeNetBreakdown(DateTime $startDate, int $effectiveDays): array
+{
+    $netYears = (int) floor($effectiveDays / 365);
+    $netMonths = (int) floor(($effectiveDays % 365) / 30);
+    $netDayRemainder = (int) (($effectiveDays % 365) % 30);
+
+    // inclusive end: effective = 1 วัน → net_end_date = วันเริ่มต้นเอง; effective <= 0 → ใช้วันเริ่มต้น
+    $netEndDate = clone $startDate;
+    $netEndDate->modify('+' . max($effectiveDays - 1, 0) . ' days');
+
+    return [
+        'net_end_date' => $netEndDate->format('Y-m-d'),
+        'net_years' => $netYears,
+        'net_months' => $netMonths,
+        'net_day_remainder' => $netDayRemainder,
+    ];
+}

--- a/backend/middleware/rate_limit.php
+++ b/backend/middleware/rate_limit.php
@@ -165,15 +165,27 @@ function rateLimitGlobal(): void
 // ============================================================================
 
 /**
- * IP ของ client — first hop ของ X-Forwarded-For (Render/nginx ตั้งให้)
- * fallback REMOTE_ADDR; sanitize ให้เหลือแค่รูปของ IPv4/IPv6
+ * IP ของ client — last hop ของ X-Forwarded-For
+ *
+ * Render proxy chain: client → Render edge proxy → Apache ใน container
+ * ทุก proxy ผนวก IP ของผู้ส่งต่อท้าย XFF ดังนั้น hop ท้ายสุดคือ IP จากการเชื่อมต่อจริง
+ * ที่ proxy เชื่อถือได้ ส่วน hop แรกมาจาก header ที่ client ตั้งเองได้ (ปลอมได้)
+ * — เคยใช้ first hop แล้วผู้โจมตีสุ่ม XFF เพื่อเปลี่ยน IP หนี rate limit ได้ทุก request
+ * จึงเปลี่ยนมาใช้ last hop
+ * (ห้าม end(explode(...)) ตรง ๆ — PHP 8.3 notice: Only variables should be passed by reference)
+ *
+ * กรณีเรียกตรงไม่ผ่าน proxy (dev) จะไม่มี XFF → fallback REMOTE_ADDR เดิม
+ * sanitize ให้เหลือแค่รูปของ IPv4/IPv6
  */
 function publicClientIp(): string
 {
     $forwarded = (string) ($_SERVER['HTTP_X_FORWARDED_FOR'] ?? '');
-    $first = trim(explode(',', $forwarded)[0]);
-    if ($first !== '' && preg_match('/^[0-9a-fA-F:.]{7,45}$/', $first) === 1) {
-        return $first;
+    if ($forwarded !== '') {
+        $hops = array_map('trim', explode(',', $forwarded));
+        $ip = end($hops);
+        if (is_string($ip) && $ip !== '' && preg_match('/^[0-9a-fA-F:.]{7,45}$/', $ip) === 1) {
+            return $ip;
+        }
     }
 
     return (string) ($_SERVER['REMOTE_ADDR'] ?? 'unknown');

--- a/backend/phpunit.xml
+++ b/backend/phpunit.xml
@@ -22,9 +22,16 @@
         </testsuite>
     </testsuites>
     <source>
+        <!-- F43: ครอบ *.php ทั้ง backend (root + routes/ + sync/ + middleware/)
+             เพื่อให้ coverage ไม่หลุดไฟล์ใหม่ — ตัดโฟลเดอร์ runtime/third-party ออก -->
         <include>
-            <file>QualificationEngine.php</file>
-            <file>helpers.php</file>
+            <directory>.</directory>
         </include>
+        <exclude>
+            <directory>vendor</directory>
+            <directory>storage</directory>
+            <directory>uploads</directory>
+            <directory>tests</directory>
+        </exclude>
     </source>
 </phpunit>

--- a/backend/routes/auth.php
+++ b/backend/routes/auth.php
@@ -11,12 +11,14 @@
 //
 // Rate limiting (ตาราง login_attempts):
 //   ผิดติดต่อกัน 5 ครั้งภายใน 15 นาที (นับต่อ username) -> 429
+//   หรือรวมผิดเกิน 20 ครั้งภายใน 15 นาที (นับต่อ IP — กันลอง username ต่าง ๆ กระจายจาก IP เดียว) -> 429
 // ============================================================================
 
 include_once __DIR__ . '/../helpers.php';
 include_once __DIR__ . '/../audit.php';
 
 const MAX_LOGIN_ATTEMPTS = 5;
+const MAX_LOGIN_ATTEMPTS_PER_IP = 20;
 const LOCKOUT_WINDOW_MINUTES = 15;
 const AUTH_PASSWORD_MIN_LENGTH = 8;
 
@@ -300,6 +302,15 @@ function changePassword(PDO $pdo, array $user, ?array $input = null): void
         (int) $user['user_id'],
     ]);
 
+    // F5: เปลี่ยนรหัสผ่านแล้วเพิกถอน refresh token ทุกใบของ user นี้ (kill-all) —
+    // session อื่นที่ถือ token เก่าจะ refresh ต่อไม่ได้ แม้ access JWT ยังไม่หมดอายุ
+    // (เขียน revoked_at ด้วย PHP clock — grace ฝั่ง refresh เทียบกับ time() ของ PHP เช่นกัน)
+    $pdo->prepare(
+        'UPDATE refresh_tokens
+         SET revoked_at = ?
+         WHERE user_id = ? AND revoked_at IS NULL'
+    )->execute([date('Y-m-d H:i:s'), (int) $user['user_id']]);
+
     logAudit(
         $pdo,
         (int) $user['user_id'],
@@ -318,10 +329,12 @@ function changePassword(PDO $pdo, array $user, ?array $input = null): void
  *
  * ข้อความ error 401 เหมือนกันทุกกรณี (user ไม่มี / รหัสผิด / ถูกปิดใช้งาน)
  * เพื่อไม่เปิดเผยว่า username ใดมีอยู่ในระบบ
+ *
+ * @param array<string,mixed>|null $input ใช้ inject ใน tests
  */
-function loginUser(PDO $pdo): void
+function loginUser(PDO $pdo, ?array $input = null): void
 {
-    $data = json_decode(file_get_contents('php://input'), true);
+    $data = $input ?? json_decode(file_get_contents('php://input'), true);
 
     // รองรับทั้ง username/password และ email/password (frontend เดิมส่งได้ทั้งสอง key)
     $username = trim((string) ($data['username'] ?? $data['email'] ?? ''));
@@ -336,6 +349,10 @@ function loginUser(PDO $pdo): void
     // ลบ log เก่าเกิน 1 วัน — กันตาราง login_attempts โตไม่จำกัด
     $pdo->exec("DELETE FROM login_attempts WHERE attempted_at < NOW() - INTERVAL 1 DAY");
 
+    // IP ของ client จริง (last hop ของ XFF — หลัง Render proxy REMOTE_ADDR เดี่ยว ๆ
+    // คือ IP ของ proxy ทั้งหมด ถ้าใช้บันทึก counter จะรวมทุก client เป็น IP เดียว)
+    $ip = publicClientIp();
+
     // Rate limit: นับครั้งที่ผิดใน 15 นาทีล่าสุดของ username นี้
     $stmt = $pdo->prepare(
         "SELECT COUNT(*) AS fails FROM login_attempts
@@ -349,6 +366,27 @@ function loginUser(PDO $pdo): void
         http_response_code(429);
         echo json_encode(['error' => 'พยายามเข้าสู่ระบบผิดเกินกำหนด กรุณารอ ' . LOCKOUT_WINDOW_MINUTES . ' นาที']);
         return;
+    }
+
+    // Rate limit ต่อ IP: รวมทุก username ที่ผิดจาก IP นี้ใน 15 นาที —
+    // กันการกระจายลอง username จาก IP เดียว (tradeoff ที่ยอมรับ: NAT shared-IP
+    // อาจโดนรวมกัน แต่เกณฑ์ 20 สูงกว่าต่อ-username 5 มากพอที่ผู้ใช้ปกติไม่โดน)
+    // ข้ามถ้าไม่รู้ IP จริง (dev/CLI ไม่มี REMOTE_ADDR/XFF) — กัน bucket 'unknown'
+    // รวมทุก client เป็นหนึ่งเดียว (ยังบันทึก IP ลง log ตามจริงเพื่อ audit)
+    if ($ip !== 'unknown' && $ip !== '') {
+        $stmt = $pdo->prepare(
+            "SELECT COUNT(*) AS fails FROM login_attempts
+             WHERE ip_address = ? AND is_success = 0
+               AND attempted_at > NOW() - INTERVAL " . LOCKOUT_WINDOW_MINUTES . " MINUTE"
+        );
+        $stmt->execute([$ip]);
+        $ipFails = (int) $stmt->fetch(PDO::FETCH_ASSOC)['fails'];
+
+        if ($ipFails >= MAX_LOGIN_ATTEMPTS_PER_IP) {
+            http_response_code(429);
+            echo json_encode(['error' => 'พยายามเข้าสู่ระบบผิดเกินกำหนด กรุณารอ ' . LOCKOUT_WINDOW_MINUTES . ' นาที']);
+            return;
+        }
     }
 
     $stmt = $pdo->prepare(
@@ -366,7 +404,6 @@ function loginUser(PDO $pdo): void
         && $user['password_hash'] !== null
         && (int) $user['is_active'] === 1;
 
-    $ip = $_SERVER['REMOTE_ADDR'] ?? null;
     $logStmt = $pdo->prepare(
         "INSERT INTO login_attempts (username, ip_address, is_success) VALUES (?, ?, ?)"
     );
@@ -381,6 +418,14 @@ function loginUser(PDO $pdo): void
     $logStmt->execute([$username, $ip, 1]);
     $pdo->prepare("UPDATE users SET last_login_at = NOW() WHERE user_id = ?")
         ->execute([$user['user_id']]);
+
+    // Prune refresh token ที่หมดอายุ หรือถูกเพิกถอนมานานเกิน 30 วัน —
+    // กันตาราง refresh_tokens โตไม่จำกัด (ทำหลัง login สำเร็จเท่านั้น ไม่เพิ่มภาระ path อื่น)
+    $pdo->exec(
+        "DELETE FROM refresh_tokens
+         WHERE expires_at < NOW()
+            OR (revoked_at IS NOT NULL AND revoked_at < NOW() - INTERVAL 30 DAY)"
+    );
 
     $jwtResult = generateJWT((int) $user['user_id'], $user['role']);
     $refreshToken = issueRefreshToken($pdo, (int) $user['user_id']);
@@ -466,6 +511,9 @@ function refreshSession(PDO $pdo, ?array $input = null): void
     if ($row['revoked_at'] !== null) {
         $revokedTs = strtotime((string) $row['revoked_at']);
         $graceSeconds = 10;
+        // F16 นาฬิกาเดียว: เขียน revoked_at ด้วย PHP clock (date()) และ grace เทียบกับ
+        // time() ฝั่ง PHP เช่นกัน — ถ้าผสม NOW() ของ MySQL ที่ session tz ต่างจาก PHP
+        // grace window จะเพี้ยนตามช่องว่างของสองนาฬิกา
         // เพิ่ง revoke ไม่กี่วินาที = race ระหว่าง tab (ไม่ใช่ขโมย) -> 401 เฉยๆ ไม่ kill-all
         if ($revokedTs !== false && (time() - $revokedTs) <= $graceSeconds) {
             http_response_code(401);
@@ -474,17 +522,17 @@ function refreshSession(PDO $pdo, ?array $input = null): void
         }
         // revoke มานานแล้วถูกใช้ซ้ำ = สงสัยถูกขโมย -> เพิกถอนทุกใบ
         $pdo->prepare(
-            'UPDATE refresh_tokens SET revoked_at = NOW()
+            'UPDATE refresh_tokens SET revoked_at = ?
              WHERE user_id = ? AND revoked_at IS NULL'
-        )->execute([(int) $row['user_id']]);
+        )->execute([date('Y-m-d H:i:s'), (int) $row['user_id']]);
         http_response_code(401);
         echo json_encode(['error' => 'refresh token ไม่ถูกต้องหรือหมดอายุ']);
         return;
     }
 
     if (strtotime((string) $row['expires_at']) < time()) {
-        $pdo->prepare('UPDATE refresh_tokens SET revoked_at = NOW() WHERE token_id = ?')
-            ->execute([(int) $row['token_id']]);
+        $pdo->prepare('UPDATE refresh_tokens SET revoked_at = ? WHERE token_id = ?')
+            ->execute([date('Y-m-d H:i:s'), (int) $row['token_id']]);
         http_response_code(401);
         echo json_encode(['error' => 'refresh token ไม่ถูกต้องหรือหมดอายุ']);
         return;
@@ -498,16 +546,16 @@ function refreshSession(PDO $pdo, ?array $input = null): void
     $user = $userStmt->fetch(PDO::FETCH_ASSOC);
 
     if (!$user) {
-        $pdo->prepare('UPDATE refresh_tokens SET revoked_at = NOW() WHERE token_id = ?')
-            ->execute([(int) $row['token_id']]);
+        $pdo->prepare('UPDATE refresh_tokens SET revoked_at = ? WHERE token_id = ?')
+            ->execute([date('Y-m-d H:i:s'), (int) $row['token_id']]);
         http_response_code(401);
         echo json_encode(['error' => 'refresh token ไม่ถูกต้องหรือหมดอายุ']);
         return;
     }
 
-    // Rotation: เพิกถอนใบเดิม ออกใบใหม่
-    $pdo->prepare('UPDATE refresh_tokens SET revoked_at = NOW() WHERE token_id = ?')
-        ->execute([(int) $row['token_id']]);
+    // Rotation: เพิกถอนใบเดิม ออกใบใหม่ (เขียนด้วย PHP clock — เหตุผลเดียวกับ F16 ด้านบน)
+    $pdo->prepare('UPDATE refresh_tokens SET revoked_at = ? WHERE token_id = ?')
+        ->execute([date('Y-m-d H:i:s'), (int) $row['token_id']]);
 
     $jwtResult = generateJWT((int) $user['user_id'], $user['role']);
     $newRefreshToken = issueRefreshToken($pdo, (int) $user['user_id']);
@@ -529,10 +577,11 @@ function logoutSession(PDO $pdo, ?array $input = null): void
     $rawToken = is_array($data) ? (string) ($data['refresh_token'] ?? '') : '';
 
     if ($rawToken !== '') {
+        // เขียน revoked_at ด้วย PHP clock — นาฬิกาเดียวกับ grace ฝั่ง refresh (F16)
         $pdo->prepare(
-            'UPDATE refresh_tokens SET revoked_at = NOW()
+            'UPDATE refresh_tokens SET revoked_at = ?
              WHERE token_hash = ? AND revoked_at IS NULL'
-        )->execute([hashRefreshToken($rawToken)]);
+        )->execute([date('Y-m-d H:i:s'), hashRefreshToken($rawToken)]);
     }
 
     echo json_encode(['success' => true]);

--- a/backend/routes/csp_summary.php
+++ b/backend/routes/csp_summary.php
@@ -9,7 +9,7 @@ require_once __DIR__ . '/../csp_violations.php';
  * Issue #113 code review I3: ความยาวขั้นต่ำของ CSP_SUMMARY_TOKEN
  *
  * ตัวกันสาธารณะ (rate limit 10/นาทีใน api.php) เป็นแค่ defence-in-depth — publicClientIp()
- * (middleware/rate_limit.php) อ่าน XFF hop แรกที่ client ปลอมได้ (มีเทสยืนยันที่
+ * (middleware/rate_limit.php) อ่าน last hop ของ XFF ที่ proxy append (มีเทสยืนยันที่
  * PublicRateLimitTest) ตัวกัน brute-force ตัวจริงคือ entropy ของ token เอง 32 ตัวอักษร
  * (สุ่มจาก charset กว้าง) ให้ entropy ที่เดาไม่ไหวจริงในทางปฏิบัติ — token ที่ Task 5 สุ่มให้
  * ยาว 43 ตัวอักษรอยู่แล้ว จึงไม่กระทบ

--- a/backend/routes/ocr.php
+++ b/backend/routes/ocr.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 include_once __DIR__ . '/../authz.php';
+include_once __DIR__ . '/../helpers.php';
 
 /**
  * Issue #147 — คืน null เมื่อไม่ได้ตั้ง OCR_SERVER_URL
@@ -112,8 +113,11 @@ function handleOcr(PDO $pdo, string $method, array $path): void
         curl_close($ch);
 
         if ($body === false || $code === 0) {
+            // F29: รายละเอียด error ของ upstream ไม่ควรกลับไปถึง client (info leak) —
+            // ลง error_log ฝั่ง server เท่านั้น (sanitize ก่อน ตาม Issue #122)
+            error_log('[ocr] convert unreachable: ' . sanitizeLogValue($err));
             http_response_code(502);
-            echo json_encode(['error' => 'OCR server unreachable', 'detail' => $err]);
+            echo json_encode(['error' => 'OCR server unreachable']);
             return;
         }
 

--- a/backend/routes/photos.php
+++ b/backend/routes/photos.php
@@ -38,6 +38,18 @@ function storePhotoRecord(PDO $pdo, int $servantId, string $fileName, string $we
         $stmt->execute([$servantId, $fileName, $webPath, $bytes, $mime, strlen($bytes)]);
         $photoId = (int) $pdo->lastInsertId();
 
+        // รูปล่าสุดต้องเป็น primary เสมอ — กวาด is_primary = 0 ทุกแถวเก่าของ servant นี้
+        // (รวมแถวที่ถูก soft-delete ด้วย) ก่อนตั้งแถวใหม่เป็น 1 ใน transaction เดียวกัน
+        // เพราะ GET /profile/{id} JOIN ด้วย is_primary = 1 ถ้ามี primary ค้างหลายแถว
+        // profile จะได้รูปไม่ตรงหรือได้ null
+        $sweep = $pdo->prepare(
+            'UPDATE civil_servant_photos SET is_primary = 0 WHERE servant_id = ? AND photo_id != ?'
+        );
+        $sweep->execute([$servantId, $photoId]);
+
+        $setPrimary = $pdo->prepare('UPDATE civil_servant_photos SET is_primary = 1 WHERE photo_id = ?');
+        $setPrimary->execute([$photoId]);
+
         $pdo->commit();
 
         return ['photo_id' => $photoId];

--- a/backend/routes/probation.php
+++ b/backend/routes/probation.php
@@ -88,8 +88,9 @@ function handleProbation(PDO $pdo, string $method, array $path): void
 function getProbationList(PDO $pdo): void
 {
     $search = $_GET['search'] ?? '';
-    $limit = intval($_GET['limit'] ?? 20);
-    $offset = intval($_GET['offset'] ?? 0);
+    // clamp กันค่าติดลบ (500 ที่ SQL ไม่รับ) และค่ายักษ์ (dump ตารางทั้งตาราง)
+    $limit = max(1, min(200, intval($_GET['limit'] ?? 20)));
+    $offset = max(0, intval($_GET['offset'] ?? 0));
 
     $where = '';
     $params = [];
@@ -286,16 +287,48 @@ function createProbationEnrollment(PDO $pdo): void
         }
     }
 
+    // กัน FK ระเบิดเป็น 500 — pre-check ทรัพยากรอ้างอิงก่อน INSERT (pattern เดียวกับ multiplier)
+    $personnelId = intval($data['personnel_id']);
+    if (!personnelExists($pdo, $personnelId)) {
+        http_response_code(404);
+        echo json_encode(['error' => 'Personnel not found']);
+        return;
+    }
+    $programCheck = $pdo->prepare('SELECT 1 FROM probation_program WHERE program_id = ? LIMIT 1');
+    $programCheck->execute([intval($data['program_id'])]);
+    if (!$programCheck->fetchColumn()) {
+        http_response_code(404);
+        echo json_encode(['error' => 'Program not found']);
+        return;
+    }
+
+    // end_date ต้องไม่น้อยกว่า start_date (เทียบ string Y-m-d ได้ตรงเพราะรูปแบบ sort ได้)
+    if ($data['end_date'] < $data['start_date']) {
+        http_response_code(400);
+        echo json_encode(['error' => 'end_date must be greater than or equal to start_date']);
+        return;
+    }
+
     $sql = "INSERT INTO probation_enrollment (personnel_id, program_id, start_date, end_date, overall_status)
             VALUES (?, ?, ?, ?, 'IN_PROGRESS')";
 
-    $stmt = $pdo->prepare($sql);
-    $stmt->execute([
-        intval($data['personnel_id']),
-        intval($data['program_id']),
-        $data['start_date'],
-        $data['end_date']
-    ]);
+    try {
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute([
+            $personnelId,
+            intval($data['program_id']),
+            $data['start_date'],
+            $data['end_date']
+        ]);
+    } catch (PDOException $e) {
+        // duplicate (personnel_id, program_id) มี unique key — ต้องเป็น 409 ไม่ใช่ 500
+        if ($e->getCode() === '23000') {
+            http_response_code(409);
+            echo json_encode(['error' => 'Enrollment already exists for this personnel and program']);
+            return;
+        }
+        throw $e;
+    }
 
     $enrollmentId = $pdo->lastInsertId();
 

--- a/backend/routes/supportive.php
+++ b/backend/routes/supportive.php
@@ -188,6 +188,24 @@ function getSupportiveDetail(PDO $pdo, int $id): void
 }
 
 /**
+ * parse Y-m-d แบบเข้มงวด (ลอก pattern จาก MultiplierEngine::parseStrictDate มาไว้ที่นี่
+ * เพื่อไม่ต้อง include engine ทั้งไฟล์) — คืน null ถ้า format ผิดหรือมี overflow
+ * (เดือน 13, วัน 45) — 'Y-m-d|' reset เวลาเป็น 00:00:00 กันคลาดเคลื่อน ±1 วัน
+ */
+function supportiveStrictDate(string $value): ?DateTime
+{
+    $date = DateTime::createFromFormat('Y-m-d|', $value);
+    $errors = DateTime::getLastErrors();
+    if (
+        $date === false
+        || ($errors !== false && ($errors['warning_count'] > 0 || $errors['error_count'] > 0))
+    ) {
+        return null;
+    }
+    return $date;
+}
+
+/**
  * คำนวณ total_days, effective_days, net_* จาก start_date, end_date, ratio
  * ใช้ร่วมกันระหว่าง create และ update
  *
@@ -197,11 +215,20 @@ function getSupportiveDetail(PDO $pdo, int $id): void
  * @param string $jobSeriesName สายงานที่เกื้อกูล (map to supportive_series_name)
  * @param string|null $primarySeriesName สายงานหลัก (map to primary_series_name)
  * @return array Computed fields
+ * @throws InvalidArgumentException เมื่อวันที่ malformed หรือ end < start (route ตอบ 400)
  */
 function computeSupportiveFields(PDO $pdo, string $startDateStr, string $endDateStr, string $jobSeriesName, ?string $primarySeriesName = null): array
 {
-    $startDate = new DateTime($startDateStr);
-    $endDate = new DateTime($endDateStr);
+    // F11: parse แบบเข้มงวด — เดิมใช้ new DateTime() หลวม และ end < start ยังได้
+    // total_days positive ที่ผิดความหมาย
+    $startDate = supportiveStrictDate($startDateStr);
+    $endDate = supportiveStrictDate($endDateStr);
+    if ($startDate === null || $endDate === null) {
+        throw new InvalidArgumentException('รูปแบบวันที่ไม่ถูกต้อง (ต้องเป็น YYYY-MM-DD)');
+    }
+    if ($endDate < $startDate) {
+        throw new InvalidArgumentException('end_date ต้องไม่น้อยกว่า start_date');
+    }
 
     // D-05: total_days = DATEDIFF + 1 (inclusive)
     $totalDays = $endDate->diff($startDate)->days + 1;
@@ -228,24 +255,17 @@ function computeSupportiveFields(PDO $pdo, string $startDateStr, string $endDate
     // Floor for net_* calculations since effective_days is DECIMAL(10,2)
     $flooredEffective = intval(floor($effectiveDays));
 
-    // D-07: net breakdown
-    $netYears = intval(floor($flooredEffective / 365));
-    $netMonths = intval(floor(($flooredEffective % 365) / 30));
-    $netDayRemainder = intval($flooredEffective % 365 % 30);
-
-    // net_end_date = start_date + floored effective days
-    $netEndDate = clone $startDate;
-    $netEndDate->modify("+{$flooredEffective} days");
-    $netEndDateStr = $netEndDate->format('Y-m-d');
+    // D-07: net breakdown รวมศูนย์ที่ helpers.php (base 365, inclusive end) — สูตรเดียวกับ multiplier
+    $breakdown = computeNetBreakdown($startDate, $flooredEffective);
 
     return [
         'total_days' => $totalDays,
         'ratio_percent' => $ratioPercent,
         'effective_days' => $effectiveDays,
-        'net_end_date' => $netEndDateStr,
-        'net_years' => $netYears,
-        'net_months' => $netMonths,
-        'net_day_remainder' => $netDayRemainder
+        'net_end_date' => $breakdown['net_end_date'],
+        'net_years' => $breakdown['net_years'],
+        'net_months' => $breakdown['net_months'],
+        'net_day_remainder' => $breakdown['net_day_remainder']
     ];
 }
 
@@ -268,13 +288,20 @@ function createSupportive(PDO $pdo, array $user, ?array $input = null): void
     }
 
     // Server-side computation (D-05, D-06, D-07, SE-04)
-    $computed = computeSupportiveFields(
-        $pdo,
-        $data['start_date'],
-        $data['end_date'],
-        $data['job_series_name'],
-        $data['primary_series_name'] ?? null
-    );
+    // วันที่ malformed หรือ end < start → 400 (message มาจาก InvalidArgumentException)
+    try {
+        $computed = computeSupportiveFields(
+            $pdo,
+            $data['start_date'],
+            $data['end_date'],
+            $data['job_series_name'],
+            $data['primary_series_name'] ?? null
+        );
+    } catch (InvalidArgumentException $e) {
+        http_response_code(400);
+        echo json_encode(['error' => $e->getMessage()], JSON_UNESCAPED_UNICODE);
+        return;
+    }
 
     $sql = "INSERT INTO supportive_experience
             (personnel_id, job_series_name, start_date, end_date,
@@ -364,7 +391,33 @@ function updateSupportive(PDO $pdo, int $id, array $user, ?array $input = null):
         $jobSeriesName = $data['job_series_name'] ?? $existing['job_series_name'];
         $primarySeriesName = $data['primary_series_name'] ?? null;
 
-        $computed = computeSupportiveFields($pdo, $startDate, $endDate, $jobSeriesName, $primarySeriesName);
+        // F11: request ไม่ส่ง primary_series_name → อ่าน "ค่าเดิม" จาก DB ก่อน recompute
+        // ไม่งั้น ratio lookup พลาดแล้ว ratio_percent เดิมถูกรีเซ็ตเป็น 100 เฉย ๆ
+        // (primary_series_name ไม่ได้เก็บบน supportive_experience จึง recovery กลับจาก
+        // mapping table ด้วย supportive_series_name + ratio_percent เดิมของแถว —
+        // ใช้ job_series_name เดิมเพราะ ratio_percent ที่เก็บไว้มาจาก mapping คู่เดิม;
+        // ถ้าหาไม่เจอ (mapping ถูกแก้/ซ้ำหลายคู่) ค่อยปล่อย null ให้ default 100 ตาม D-04)
+        if (($primarySeriesName === null || $primarySeriesName === '') && isset($existing['ratio_percent'])) {
+            $prevLookup = $pdo->prepare(
+                'SELECT primary_series_name FROM supportive_job_series
+                 WHERE supportive_series_name = ? AND ratio_percent = ? AND is_active = 1
+                 LIMIT 1'
+            );
+            $prevLookup->execute([$existing['job_series_name'], $existing['ratio_percent']]);
+            $prevPrimary = $prevLookup->fetchColumn();
+            if ($prevPrimary !== false) {
+                $primarySeriesName = (string) $prevPrimary;
+            }
+        }
+
+        // วันที่ malformed หรือ end < start → 400 (message มาจาก InvalidArgumentException)
+        try {
+            $computed = computeSupportiveFields($pdo, $startDate, $endDate, $jobSeriesName, $primarySeriesName);
+        } catch (InvalidArgumentException $e) {
+            http_response_code(400);
+            echo json_encode(['error' => $e->getMessage()], JSON_UNESCAPED_UNICODE);
+            return;
+        }
 
         $sets[] = "total_days = ?";
         $params[] = $computed['total_days'];

--- a/backend/routes/sync.php
+++ b/backend/routes/sync.php
@@ -4,8 +4,8 @@
 // Sync Transform Layer — legacy HR → Smart Port (ADR-0001)
 //
 // Endpoints:
-//   POST /sync/{domain}  — trigger sync for one domain (admin-only)
-//   POST /sync           — trigger sync all domains (admin-only)
+//   POST /sync/{domain}  — trigger sync for one domain (ต้องมีสิทธิ์ create:sync)
+//   POST /sync           — trigger sync all domains (ต้องมีสิทธิ์ create:sync)
 //   GET  /sync/status    — last sync timestamps per domain
 // ============================================================================
 
@@ -24,11 +24,9 @@ function handleSync(PDO $pdo, string $method, array $path): void
         return;
     }
 
-    if (($user['role'] ?? '') !== 'admin') {
-        http_response_code(403);
-        echo json_encode(['error' => 'เฉพาะผู้ดูแลระบบเท่านั้นที่สามารถสั่ง sync ได้']);
-        return;
-    }
+    // ใช้ authz matrix เป็นเส้นตัดสิน (fail-closed) — ห้าม hardcode role check
+    // เพราะ superadmin โดน 403 และ override จาก settings ไม่ถูกนับ
+    requirePermission('create', 'sync');
 
     $sub = $path[1] ?? '';
 

--- a/backend/routes/users.php
+++ b/backend/routes/users.php
@@ -299,6 +299,7 @@ function updateUser(PDO $pdo, int $id, array $auth, ?array $input = null): void
     }
 
     // Reset password — hash ใหม่ + บังคับเปลี่ยนครั้งถัดไป
+    $passwordReset = false;
     if (isset($data['password']) && $data['password'] !== '') {
         if (strlen($data['password']) < PASSWORD_MIN_LENGTH) {
             http_response_code(400);
@@ -308,6 +309,7 @@ function updateUser(PDO $pdo, int $id, array $auth, ?array $input = null): void
         $sets[] = "password_hash = ?";
         $params[] = password_hash($data['password'], PASSWORD_DEFAULT);
         $sets[] = "must_change_password = 1";
+        $passwordReset = true;
     }
 
     if (empty($sets)) {
@@ -339,6 +341,17 @@ function updateUser(PDO $pdo, int $id, array $auth, ?array $input = null): void
 
         $stmt = $pdo->prepare($sql);
         $stmt->execute($params);
+
+        // F5: admin reset รหัสผ่านแล้วเพิกถอน refresh token ทุกใบของเจ้าของบัญชี
+        // (kill-all เหมือน self change-password — session เดิม refresh ต่อไม่ได้)
+        // อยู่ใน transaction เดียวกันกับ UPDATE users เมื่อ guardLastSuperadmin
+        if ($passwordReset) {
+            $pdo->prepare(
+                'UPDATE refresh_tokens
+                 SET revoked_at = ?
+                 WHERE user_id = ? AND revoked_at IS NULL'
+            )->execute([date('Y-m-d H:i:s'), $id]);
+        }
 
         $afterStmt = $pdo->prepare("SELECT " . USER_PUBLIC_COLUMNS . " FROM users WHERE user_id = ?");
         $afterStmt->execute([$id]);

--- a/backend/tests/Integration/AnalyticsRouteTest.php
+++ b/backend/tests/Integration/AnalyticsRouteTest.php
@@ -8,7 +8,7 @@ use PDO;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
-putenv('JWT_SECRET=integration-test-secret');
+putenv('JWT_SECRET=integration-test-secret-0123456789abcdef');
 
 require_once __DIR__ . '/../../config.php';
 require_once __DIR__ . '/../../routes/analytics.php';

--- a/backend/tests/Integration/AuthenticatedUserTest.php
+++ b/backend/tests/Integration/AuthenticatedUserTest.php
@@ -7,7 +7,7 @@ namespace Tests\Integration;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
-putenv('JWT_SECRET=integration-test-secret');
+putenv('JWT_SECRET=integration-test-secret-0123456789abcdef');
 
 require_once __DIR__ . '/../../config.php';
 require_once __DIR__ . '/../../auth.php';

--- a/backend/tests/Integration/AwardsRouteTest.php
+++ b/backend/tests/Integration/AwardsRouteTest.php
@@ -8,7 +8,7 @@ use PDO;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
-putenv('JWT_SECRET=integration-test-secret');
+putenv('JWT_SECRET=integration-test-secret-0123456789abcdef');
 
 require_once __DIR__ . '/../../config.php';
 require_once __DIR__ . '/../../routes/awards.php';

--- a/backend/tests/Integration/DecorationsRouteTest.php
+++ b/backend/tests/Integration/DecorationsRouteTest.php
@@ -8,7 +8,7 @@ use PDO;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
-putenv('JWT_SECRET=integration-test-secret');
+putenv('JWT_SECRET=integration-test-secret-0123456789abcdef');
 
 require_once __DIR__ . '/../../config.php';
 require_once __DIR__ . '/../../routes/decorations.php';

--- a/backend/tests/Integration/PasswordChangeTest.php
+++ b/backend/tests/Integration/PasswordChangeTest.php
@@ -8,6 +8,7 @@ use PDO;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
+require_once __DIR__ . '/../../auth.php';
 require_once __DIR__ . '/../../routes/auth.php';
 
 final class PasswordChangeTest extends TestCase
@@ -53,6 +54,7 @@ final class PasswordChangeTest extends TestCase
         }
         self::$pdo->prepare("DELETE FROM audit_log WHERE table_name = 'users' AND record_id = ?")
             ->execute([$this->userId]);
+        self::$pdo->prepare('DELETE FROM refresh_tokens WHERE user_id = ?')->execute([$this->userId]);
         self::$pdo->prepare('DELETE FROM users WHERE user_id = ?')->execute([$this->userId]);
     }
 
@@ -92,6 +94,54 @@ final class PasswordChangeTest extends TestCase
             ['must_change_password' => false],
             json_decode($row['after_value'], true)
         );
+    }
+
+    #[Test]
+    public function changing_password_revokes_all_active_refresh_tokens(): void
+    {
+        if (!self::$pdo->query("SHOW TABLES LIKE 'refresh_tokens'")->fetchColumn()) {
+            self::markTestSkipped('ไม่พบตาราง refresh_tokens — รัน migration 18-refresh-tokens.sql');
+        }
+
+        // token ใช้งานอยู่ 2 ใบ (เครื่องลูกหลายเครื่อง) — เปลี่ยนรหัสแล้วต้องถูกเพิกถอนหมด (kill-all)
+        $insert = self::$pdo->prepare(
+            'INSERT INTO refresh_tokens (user_id, token_hash, expires_at) VALUES (?, ?, ?)'
+        );
+        $insert->execute([
+            $this->userId,
+            hashRefreshToken('old-device-raw-token'),
+            date('Y-m-d H:i:s', time() + 3600),
+        ]);
+        $insert->execute([
+            $this->userId,
+            hashRefreshToken('other-device-raw-token'),
+            date('Y-m-d H:i:s', time() + 3600),
+        ]);
+
+        ob_start();
+        changePassword(self::$pdo, ['user_id' => $this->userId], [
+            'current_password' => 'temporary-password',
+            'new_password' => 'new-secure-password',
+        ]);
+        $response = json_decode((string) ob_get_clean(), true);
+        self::assertTrue($response['success'] ?? false);
+
+        $stmt = self::$pdo->prepare(
+            'SELECT COUNT(*) FROM refresh_tokens WHERE user_id = ? AND revoked_at IS NULL'
+        );
+        $stmt->execute([$this->userId]);
+        self::assertSame(
+            0,
+            (int) $stmt->fetchColumn(),
+            'เปลี่ยนรหัสผ่านแล้ว refresh token ทุกใบต้องถูกเพิกถอน'
+        );
+
+        // token เก่าถูกนำมา reuse = ต้องถูกปฏิเสธ (kill-all ของ F5 ทำงานก่อนถึงจุดนี้แล้ว)
+        http_response_code(200);
+        ob_start();
+        refreshSession(self::$pdo, ['refresh_token' => 'old-device-raw-token']);
+        json_decode((string) ob_get_clean(), true);
+        self::assertSame(401, http_response_code());
     }
 
     #[Test]

--- a/backend/tests/Integration/PersonnelFullNamePrefixTest.php
+++ b/backend/tests/Integration/PersonnelFullNamePrefixTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Throwable;
 
-putenv('JWT_SECRET=integration-test-secret');
+putenv('JWT_SECRET=integration-test-secret-0123456789abcdef');
 
 require_once __DIR__ . '/../../config.php';
 require_once __DIR__ . '/../../routes/supportive.php';

--- a/backend/tests/Integration/PersonnelMasterCrudTest.php
+++ b/backend/tests/Integration/PersonnelMasterCrudTest.php
@@ -7,7 +7,7 @@ use PDO;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
-putenv('JWT_SECRET=integration-test-secret');
+putenv('JWT_SECRET=integration-test-secret-0123456789abcdef');
 
 require_once __DIR__ . '/../../config.php';
 require_once __DIR__ . '/../../routes/personnel.php';

--- a/backend/tests/Integration/PersonnelTypeaheadSearchTest.php
+++ b/backend/tests/Integration/PersonnelTypeaheadSearchTest.php
@@ -7,7 +7,7 @@ use PDO;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
-putenv('JWT_SECRET=integration-test-secret');
+putenv('JWT_SECRET=integration-test-secret-0123456789abcdef');
 
 require_once __DIR__ . '/../../config.php';
 require_once __DIR__ . '/../../routes/personnel.php';

--- a/backend/tests/Integration/RateLimitDatabaseTest.php
+++ b/backend/tests/Integration/RateLimitDatabaseTest.php
@@ -19,8 +19,8 @@ final class RateLimitDatabaseTest extends TestCase
     {
         self::$pdo = testPdo();
         if (!getenv('JWT_SECRET')) {
-            putenv('JWT_SECRET=test-jwt-secret-for-integration');
-            $_ENV['JWT_SECRET'] = 'test-jwt-secret-for-integration';
+            putenv('JWT_SECRET=test-jwt-secret-for-integration-32-chars');
+            $_ENV['JWT_SECRET'] = 'test-jwt-secret-for-integration-32-chars';
         }
     }
 

--- a/backend/tests/Integration/RefreshTokenTest.php
+++ b/backend/tests/Integration/RefreshTokenTest.php
@@ -8,7 +8,7 @@ use PDO;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
-putenv('JWT_SECRET=integration-test-secret');
+putenv('JWT_SECRET=integration-test-secret-0123456789abcdef');
 
 require_once __DIR__ . '/../../config.php';
 require_once __DIR__ . '/../../auth.php';

--- a/backend/tests/Integration/RetirementRouteTest.php
+++ b/backend/tests/Integration/RetirementRouteTest.php
@@ -8,7 +8,7 @@ use PDO;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
-putenv('JWT_SECRET=integration-test-secret');
+putenv('JWT_SECRET=integration-test-secret-0123456789abcdef');
 
 require_once __DIR__ . '/../../config.php';
 require_once __DIR__ . '/../../routes/retirement.php';

--- a/backend/tests/Integration/SearchFilterRouteTest.php
+++ b/backend/tests/Integration/SearchFilterRouteTest.php
@@ -8,7 +8,7 @@ use PDO;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
-putenv('JWT_SECRET=integration-test-secret');
+putenv('JWT_SECRET=integration-test-secret-0123456789abcdef');
 
 require_once __DIR__ . '/../../config.php';
 require_once __DIR__ . '/../../routes/supportive.php';

--- a/backend/tests/Unit/ConfigSslTest.php
+++ b/backend/tests/Unit/ConfigSslTest.php
@@ -11,7 +11,7 @@ use RuntimeException;
 
 // ตั้ง JWT_SECRET ก่อน require config.php เพื่อกัน exit() side-effect
 // (config.php เช็ค JWT_SECRET ว่างแล้ว exit ทันที)
-putenv('JWT_SECRET=test-secret');
+putenv('JWT_SECRET=test-secret-with-32-chars-minimum-len');
 
 // โหลด config.php เพื่อเข้าถึง buildSslOptions() — define() ซ้ำก็ไม่เป็นไร
 // เพราะ bootstrap.php ไม่ได้ require config.php

--- a/backend/tests/Unit/LoginLockoutTest.php
+++ b/backend/tests/Unit/LoginLockoutTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PDO;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+// ตั้ง JWT_SECRET ก่อน require config.php (≥32 ตัวอักษร — config.php ปฏิเสธค่าที่สั้นกว่า)
+putenv('JWT_SECRET=login-lockout-test-secret-0123456789abcdef');
+
+require_once __DIR__ . '/../../config.php';
+require_once __DIR__ . '/../../auth.php';
+require_once __DIR__ . '/../../middleware/rate_limit.php';
+require_once __DIR__ . '/../../routes/auth.php';
+
+/**
+ * F3/F4: lockout ต่อ IP (รวมทุก username) + prune refresh token หลัง login สำเร็จ
+ *
+ * **test isolation (บังคับ)**: ตั้ง XFF/REMOTE_ADDR เฉพาะตัวต่อเคส (จัดการ $_SERVER
+ * ตรง ๆ ตาม pattern ของ PublicRateLimitTest แล้ว unset ใน tearDown) และ
+ * DELETE FROM login_attempts ใน setUp — ไม่งั้นทุกเคสแชร์ IP เดียวบน DB ถาวร
+ * และ rerun ภายใน 15 นาทีจะเริ่มที่ counter ค้าง ทำให้ assertion เอง flaky
+ *
+ * ต้องมี MySQL (skip เมื่อต่อไม่ได้ เหมือน integration suite) เพราะ lockout นับจากตารางจริง
+ */
+final class LoginLockoutTest extends TestCase
+{
+    private const TEST_IP = '203.0.113.77';
+
+    private static ?PDO $pdo = null;
+    private int $userId = 0;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$pdo = testPdo();
+    }
+
+    protected function setUp(): void
+    {
+        if (self::$pdo === null) {
+            self::markTestSkipped('ต่อ MySQL ไม่ได้ — รัน: docker compose up -d db แล้วใช้ tests/run.sh');
+        }
+
+        foreach (['users', 'login_attempts', 'refresh_tokens'] as $table) {
+            if (!self::$pdo->query("SHOW TABLES LIKE '{$table}'")->fetchColumn()) {
+                self::markTestSkipped("ไม่พบตาราง {$table} — รัน migration ก่อน");
+            }
+        }
+
+        // isolation: เคลียร์ counter แล้วตั้ง IP ของเคสนี้ (publicClientIp อ่าน last hop ของ XFF)
+        self::$pdo->exec('DELETE FROM login_attempts');
+        $_SERVER['REMOTE_ADDR'] = '10.9.9.9';
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '198.51.100.1, ' . self::TEST_IP;
+        http_response_code(200);
+    }
+
+    protected function tearDown(): void
+    {
+        if (self::$pdo !== null) {
+            self::$pdo->prepare('DELETE FROM login_attempts WHERE ip_address = ?')
+                ->execute([self::TEST_IP]);
+            if ($this->userId !== 0) {
+                self::$pdo->prepare('DELETE FROM refresh_tokens WHERE user_id = ?')->execute([$this->userId]);
+                self::$pdo->prepare('DELETE FROM users WHERE user_id = ?')->execute([$this->userId]);
+                $this->userId = 0;
+            }
+        }
+        unset($_SERVER['HTTP_X_FORWARDED_FOR'], $_SERVER['REMOTE_ADDR']);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function login(string $username, string $password = 'wrong-password'): array
+    {
+        ob_start();
+        loginUser(self::$pdo, ['username' => $username, 'password' => $password]);
+        return json_decode((string) ob_get_clean(), true) ?? [];
+    }
+
+    #[Test]
+    public function six_failures_on_the_same_username_are_locked_out(): void
+    {
+        // เกณฑ์เดิมต่อ username (5 ครั้ง) — ครั้งที่ 6 ต้อง 429
+        for ($i = 0; $i < 5; $i++) {
+            $this->login('lockout-user');
+            self::assertSame(401, http_response_code(), "ครั้งที่ " . ($i + 1) . " ยังต้องตอบ 401 ปกติ");
+            http_response_code(200);
+        }
+
+        $response = $this->login('lockout-user');
+        self::assertSame(429, http_response_code());
+        self::assertArrayHasKey('error', $response);
+    }
+
+    #[Test]
+    public function twenty_one_failures_across_usernames_from_one_ip_are_locked_out(): void
+    {
+        // 20 ครั้งแรกคนละ username (ไม่โดนเกณฑ์ต่อ username) ต้องยังตอบ 401 ปกติ
+        for ($i = 0; $i < 20; $i++) {
+            $this->login('spread-user-' . $i);
+            self::assertSame(401, http_response_code(), "ครั้งที่ " . ($i + 1) . " ยังต้องตอบ 401 ปกติ");
+            http_response_code(200);
+        }
+
+        // ครั้งที่ 21 จาก IP เดียวกัน = รวมครบ 20 แล้ว ต้อง 429
+        // (บนโค้ดเก่าที่นับเฉพาะต่อ username เทสนี้ fail เพราะไม่มี lockout ต่อ IP)
+        $response = $this->login('spread-user-20');
+        self::assertSame(429, http_response_code());
+        self::assertArrayHasKey('error', $response);
+    }
+
+    #[Test]
+    public function successful_login_prunes_expired_and_stale_revoked_refresh_tokens(): void
+    {
+        self::$pdo->prepare(
+            'INSERT INTO users
+                (username, password_hash, full_name, role, is_active, must_change_password)
+             VALUES (?, ?, ?, ?, 1, 0)'
+        )->execute([
+            'lockout-prune-user',
+            password_hash('correct-password', PASSWORD_DEFAULT),
+            'Login Lockout Test',
+            'operator',
+        ]);
+        $this->userId = (int) self::$pdo->lastInsertId();
+
+        // 3 ใบ: หมดอายุแล้ว / ถูก revoke นานเกิน 30 วัน / ยังใช้ได้ — prune ต้องลบเฉพาะ 2 ใบแรก
+        $insert = self::$pdo->prepare(
+            'INSERT INTO refresh_tokens (user_id, token_hash, expires_at, revoked_at)
+             VALUES (?, ?, ?, ?)'
+        );
+        $insert->execute([
+            $this->userId,
+            hashRefreshToken('expired-raw-token'),
+            date('Y-m-d H:i:s', time() - 60),
+            null,
+        ]);
+        $insert->execute([
+            $this->userId,
+            hashRefreshToken('stale-revoked-raw-token'),
+            date('Y-m-d H:i:s', time() + 3600),
+            date('Y-m-d H:i:s', time() - 31 * 86400),
+        ]);
+        $insert->execute([
+            $this->userId,
+            hashRefreshToken('live-raw-token'),
+            date('Y-m-d H:i:s', time() + 3600),
+            null,
+        ]);
+
+        $response = $this->login('lockout-prune-user', 'correct-password');
+        self::assertSame(200, http_response_code());
+        self::assertArrayHasKey('token', $response);
+
+        $stmt = self::$pdo->prepare('SELECT token_hash FROM refresh_tokens WHERE user_id = ?');
+        $stmt->execute([$this->userId]);
+        $remaining = $stmt->fetchAll(PDO::FETCH_COLUMN);
+
+        self::assertNotContains(
+            hashRefreshToken('expired-raw-token'),
+            $remaining,
+            'token หมดอายุแล้วต้องถูก prune'
+        );
+        self::assertNotContains(
+            hashRefreshToken('stale-revoked-raw-token'),
+            $remaining,
+            'token ที่ถูก revoke เกิน 30 วันต้องถูก prune'
+        );
+        self::assertContains(
+            hashRefreshToken('live-raw-token'),
+            $remaining,
+            'token ที่ยังใช้ได้ต้องรอดจาก prune'
+        );
+    }
+}

--- a/backend/tests/Unit/PublicRateLimitTest.php
+++ b/backend/tests/Unit/PublicRateLimitTest.php
@@ -54,9 +54,19 @@ final class PublicRateLimitTest extends TestCase
     }
 
     #[Test]
-    public function it_uses_first_hop_of_forwarded_for(): void
+    public function it_uses_last_hop_of_forwarded_for(): void
     {
+        // Render proxy chain append IP จริงต่อท้าย XFF — hop ท้ายสุดเชื่อถือได้
+        // hop แรกคือค่าที่ client ตั้งเองได้ (ปลอมได้) จึงต้องไม่ถูกใช้
         $_SERVER['HTTP_X_FORWARDED_FOR'] = '198.51.100.7, 10.0.0.1';
+
+        self::assertSame('10.0.0.1', publicClientIp());
+    }
+
+    #[Test]
+    public function it_uses_the_only_hop_when_forwarded_for_is_single_hop(): void
+    {
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '198.51.100.7';
 
         self::assertSame('198.51.100.7', publicClientIp());
     }

--- a/backend/tests/bootstrap.php
+++ b/backend/tests/bootstrap.php
@@ -83,12 +83,17 @@ function testPdo(): ?PDO
     $dsn = "mysql:host={$host};port={$port};dbname={$dbname};charset=utf8mb4";
 
     try {
-        return new PDO($dsn, $user, $pass, [
+        $pdo = new PDO($dsn, $user, $pass, [
             PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
             PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
             PDO::ATTR_EMULATE_PREPARES   => false,
             PDO::ATTR_TIMEOUT            => 4,
         ]);
+        // F26: จัดนาฬิกาให้เทสเห็นเวลาเดียวกับ app — config.php ตั้ง PHP tz = Asia/Bangkok
+        // และ app connection ใช้ session time_zone +07:00 ถ้าเทสเขียน date() ผ่าน session
+        // ที่ tz อื่น TIMESTAMP จะถูกตีความคลาด 7 ชม. ทำให้ grace/prune เทียบเวลาเพี้ยน
+        $pdo->exec("SET time_zone = '+07:00'");
+        return $pdo;
     } catch (PDOException $e) {
         return null;
     }

--- a/database/tidb-init.sql
+++ b/database/tidb-init.sql
@@ -58,8 +58,9 @@ CREATE TABLE civil_servant_photos (
     photo_status VARCHAR(30) DEFAULT 'pending_approval',
     is_primary TINYINT(1) NOT NULL DEFAULT 0,
     upload_date DATETIME DEFAULT CURRENT_TIMESTAMP,
-    is_active TINYINT(1) NOT NULL DEFAULT 1,
-    FOREIGN KEY (servant_id) REFERENCES civil_servants(servant_id)
+    is_active TINYINT(1) NOT NULL DEFAULT 1
+    -- FK (servant_id) -> civil_servants ถูกปลดโดย migration 22 (unify person identity)
+    -- parity gate เทียบ FK pairs — ห้ามใส่กลับ
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- เวอร์ชันภาพ — schema simple ตาม backend/helpers.php ที่ INSERT แค่
@@ -148,8 +149,8 @@ CREATE TABLE performance_proposals (
     is_active TINYINT(1) NOT NULL DEFAULT 1,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    FOREIGN KEY (servant_id) REFERENCES civil_servants(servant_id),
-    FOREIGN KEY (evaluator_id) REFERENCES civil_servants(servant_id),
+    -- FK (servant_id)/(evaluator_id) -> civil_servants ถูกปลดโดย migration 22
+    -- (ตารางนี้ไม่ถูก drop — parity gate เทียบ FK pairs ห้ามใส่กลับ)
     INDEX idx_servant_type (servant_id, proposal_type),
     INDEX idx_status (status),
     INDEX idx_submission_date (submission_date)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,6 +19,15 @@ services:
       - JWT_SECRET=${JWT_SECRET}
       # Local/dev only — production Render ต้องไม่ตั้งค่านี้จนกว่าจะตั้งใจใช้ TEST_SEED
       - APPLY_TEST_SEED_MIGRATIONS=1
+    # F41/T24: healthcheck ด้วย `php -r` เรียก /api/readyz — curl CLI ไม่การันตีว่ามี
+    # ใน php:8.3-apache image · /api/readyz เป็น public route (ไม่ต้อง JWT) และ
+    # api.php ตัด prefix 'api' ออกให้เอง
+    healthcheck:
+      test: ["CMD", "php", "-r", "exit(@file_get_contents('http://localhost/api/readyz') === false ? 1 : 0);"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
     depends_on:
       db:
         condition: service_healthy
@@ -37,7 +46,10 @@ services:
     ports:
       - "8081:80" # ใช้ port 8081
     depends_on:
-      - backend
+      # F41/T24: รอ backend healthy (healthcheck ด้านบน) ไม่ใช่แค่ started —
+      # กัน nginx proxy ยิง /api/ ไป backend ที่ยังไม่พร้อมตอน compose up ครั้งแรก
+      backend:
+        condition: service_healthy
     networks:
       - smartport-net
     restart: unless-stopped

--- a/docs/adr/0001-no-framework-php-api.md
+++ b/docs/adr/0001-no-framework-php-api.md
@@ -18,7 +18,7 @@ Smart Port ต้อง deploy บนสภาพแวดล้อมของ�
 
 1. **API เป็น PHP ล้วน ไม่มี framework** — `backend/api.php` เป็น entry point เดียว รับทุก request ผ่าน rewrite rule ใน `.htaccess`
 2. **Routing ด้วย switch statement** บน path segment แรก แล้ว `include` ไฟล์ handler ใน `backend/routes/` ต่อ domain
-3. **Dependency เดียวที่ยอมรับคือ `firebase/php-jwt`** — งาน crypto ห้ามเขียนเอง นอกนั้นใช้ standard library
+3. **JWT เป็น custom HS256 implementation (`backend/auth.php`) — ตัดสินใจแล้ว ไม่ใช้ library** (ข้อความเดิมที่ระบุ `firebase/php-jwt` เป็นความคลาดเคลื่อนของเอกสาร — `composer.json` ไม่มี dependency นี้; dependency เดียวที่ยอมรับคือ `phpoffice/phpspreadsheet`)
 4. **เข้าถึงฐานข้อมูลผ่าน PDO + prepared statements เท่านั้น** ไม่มี ORM — query อยู่ในไฟล์ route หรือ service class (`ImportService`, `QualificationEngine`)
 5. **Cross-cutting concern เขียนเป็น middleware แบบ include** (`backend/middleware/csrf.php`, `rate_limit.php`) เรียกจาก `api.php` ก่อน dispatch
 

--- a/docs/project-documents/generate-docs.js
+++ b/docs/project-documents/generate-docs.js
@@ -252,7 +252,7 @@ function createExecutiveSummary() {
         new TableRow({ children: [dataCell('Frontend', 2500), dataCell('Vue 3 + Vite + Tailwind CSS 4', 3263), dataCell('Vue 3.5, Vite 6.0, Tailwind 4.1', 3263)] }),
         new TableRow({ children: [dataCell('Backend', 2500, { shading: COLOR_ROW_ALT }), dataCell('PHP 8.3 REST API', 3263, { shading: COLOR_ROW_ALT }), dataCell('PHP 8.3-Apache', 3263, { shading: COLOR_ROW_ALT })] }),
         new TableRow({ children: [dataCell('Database', 2500), dataCell('MySQL 8.0 / TiDB Cloud', 3263), dataCell('MySQL 8.0, utf8mb4', 3263)] }),
-        new TableRow({ children: [dataCell('Authentication', 2500, { shading: COLOR_ROW_ALT }), dataCell('JWT (HMAC-SHA256)', 3263, { shading: COLOR_ROW_ALT }), dataCell('firebase/php-jwt 6.0', 3263, { shading: COLOR_ROW_ALT })] }),
+        new TableRow({ children: [dataCell('Authentication', 2500, { shading: COLOR_ROW_ALT }), dataCell('JWT (HMAC-SHA256)', 3263, { shading: COLOR_ROW_ALT }), dataCell('custom HS256 implementation (backend/auth.php) \u2014 \u0E15\u0E31\u0E14\u0E2A\u0E34\u0E19\u0E43\u0E08\u0E41\u0E25\u0E49\u0E27 \u0E44\u0E21\u0E48\u0E43\u0E0A\u0E49 library', 3263, { shading: COLOR_ROW_ALT })] }),
         new TableRow({ children: [dataCell('Deployment', 2500), dataCell('Docker + Render.com', 3263), dataCell('Multi-stage builds', 3263)] }),
         new TableRow({ children: [dataCell('State Management', 2500, { shading: COLOR_ROW_ALT }), dataCell('Pinia', 3263, { shading: COLOR_ROW_ALT }), dataCell('Pinia 3.0', 3263, { shading: COLOR_ROW_ALT })] }),
         new TableRow({ children: [dataCell('Charts', 2500), dataCell('Chart.js + vue-chartjs', 3263), dataCell('Chart.js 4.4', 3263)] }),

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,7 +4,12 @@
 # === FIX 3 ===
 # เปลี่ยนไปใช้ Debian-based image (slim version) เพื่อความเข้ากันได้ที่ดีกว่า
 # สำหรับ native modules เมื่อเทียบกับ Alpine
-FROM node:20-slim AS builder
+#
+# F19/T22 version gotcha: Node 20→24 pin ให้ตรงกับ CI (setup-node node-version: 24)
+# — ต้อง validate Vite 6/Vitest บน Node 24 ผ่าน docker build ก่อน merge เสมอ
+# (enforcement จริงคือ pin ที่นี่ + CI setup-node 24 · "engines" ใน package.json
+#  เป็น warn-only เชิง documentation เท่านั้น — npm ไม่ block ตอน install)
+FROM node:24-slim AS builder
 
 # ระบุ build-time argument สำหรับ VITE_API_URL
 ARG VITE_API_URL=http://localhost:8000

--- a/frontend/nginx-security-headers.conf
+++ b/frontend/nginx-security-headers.conf
@@ -5,4 +5,6 @@ add_header X-Frame-Options "DENY" always;
 add_header X-Content-Type-Options "nosniff" always;
 add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 add_header Permissions-Policy "camera=(), geolocation=(), microphone=(), payment=()" always;
-add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
+# T20/F42: เพิ่ม report-uri ต่อท้าย CSP ให้ตรงกับ render.yaml:25 (แหล่งเดียวที่อนุญาต
+# ให้แตะ CSP ตาม Non-goals ของ PRP — ห้ามแตะ directive อื่น) — report ส่งเข้า /api/csp-report
+add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; report-uri /api/csp-report" always;

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -30,6 +30,9 @@ server {
 
     # API proxy to backend
     location /api/ {
+        # F17/T19: อัปโหลดรูป (photo blob) อนุญาตถึง 25MB — nginx default 1m จะตัด 413
+        # ต้องตรงกับ upload_max_filesize/post_max_size ฝั่ง backend Dockerfile
+        client_max_body_size 25m;
         proxy_pass http://backend:80/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "2.0.0",
   "type": "module",
+  "engines": {
+    "node": ">=24"
+  },
   "scripts": {
     "dev": "vite --host 0.0.0.0 --port 5174",
     "build": "vite build",

--- a/frontend/src/__tests__/composables/useApi.test.js
+++ b/frontend/src/__tests__/composables/useApi.test.js
@@ -18,6 +18,14 @@ vi.mock('@/stores/auth.js', () => ({
   useAuthStore: () => authMock.state,
 }))
 
+const uiMock = vi.hoisted(() => ({
+  showToast: vi.fn(),
+}))
+
+vi.mock('@/stores/ui.js', () => ({
+  useUiStore: () => ({ showToast: uiMock.showToast }),
+}))
+
 vi.mock('@/router', () => ({
   default: { push: (...args) => mockPush(...args) },
 }))
@@ -76,6 +84,7 @@ describe('useApi', () => {
   beforeEach(() => {
     api = useApi()
     mockPush.mockReset()
+    uiMock.showToast.mockReset()
     authMock.state.token = 'fake-jwt-token'
     authMock.state.csrfToken = 'fake-csrf'
     authMock.state.refreshToken = ''
@@ -246,6 +255,40 @@ describe('useApi', () => {
       expect(mockPush).toHaveBeenCalledWith('/login')
     })
 
+    it('shows the Thai expired-session toast once before redirecting on 401', async () => {
+      authMock.state.refreshToken = ''
+      // เรียกสำเร็จ 1 ครั้งก่อน — เคลียร์ latch (หลังเข้าสู่ระบบใหม่ flag จะถูกรีเซ็ต)
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce(jsonResponse({ ok: true }))
+        .mockResolvedValue(jsonResponse({ error: 'Unauthorized' }, 401))
+
+      await api.get('/warmup')
+      await expect(api.get('/protected')).rejects.toThrow('Unauthorized')
+
+      expect(uiMock.showToast).toHaveBeenCalledTimes(1)
+      expect(uiMock.showToast).toHaveBeenCalledWith('เซสชันหมดอายุ กรุณาเข้าสู่ระบบอีกครั้ง', 'error')
+      expect(mockPush).toHaveBeenCalledWith('/login')
+    })
+
+    it('does not repeat the expired-session toast for follow-up 401s before re-login', async () => {
+      authMock.state.refreshToken = ''
+      // เรียกสำเร็จ 1 ครั้งก่อน — เคลียร์ latch (หลังเข้าสู่ระบบใหม่ flag จะถูกรีเซ็ต)
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce(jsonResponse({ ok: true }))
+        .mockResolvedValue(jsonResponse({ error: 'Unauthorized' }, 401))
+
+      await api.get('/warmup')
+      await expect(api.get('/first')).rejects.toThrow('Unauthorized')
+      await expect(api.get('/second')).rejects.toThrow('Unauthorized')
+
+      // 401 สองครั้งติดกัน (token ตกครั้งเดียว) — toast ต้องโชว์ครั้งเดียว ไม่ซ้ำ
+      expect(uiMock.showToast).toHaveBeenCalledTimes(1)
+      expect(uiMock.showToast).toHaveBeenCalledWith('เซสชันหมดอายุ กรุณาเข้าสู่ระบบอีกครั้ง', 'error')
+      expect(authMock.state.logout).toHaveBeenCalledTimes(2)
+    })
+
     it('does not refresh on /auth/login 401 (shows API error instead)', async () => {
       authMock.state.refreshToken = 'refresh-abc'
       global.fetch = mockFetch(jsonResponse({ error: 'ชื่อผู้ใช้หรือรหัสผ่านไม่ถูกต้อง' }, 401))
@@ -264,7 +307,7 @@ describe('useApi', () => {
         headers: { 'Content-Type': 'application/json' },
       }))
 
-      await expect(api.get('/dashboard')).rejects.toThrow('Password change required')
+      await expect(api.get('/dashboard')).rejects.toThrow('กรุณาเปลี่ยนรหัสผ่านก่อนใช้งานระบบ')
 
       expect(authMock.state.setMustChangePassword).toHaveBeenCalledWith(true)
       expect(mockPush).toHaveBeenCalledWith('/change-password')

--- a/frontend/src/__tests__/pages/ChangePasswordPage.test.js
+++ b/frontend/src/__tests__/pages/ChangePasswordPage.test.js
@@ -4,10 +4,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const changePassword = vi.fn()
 const logout = vi.fn()
 const push = vi.fn()
+const showToast = vi.fn()
 const confirmLogoutMock = vi.fn(async () => true)
 
 vi.mock('@/stores/auth.js', () => ({
   useAuthStore: () => ({ changePassword, logout }),
+}))
+
+vi.mock('@/stores/ui.js', () => ({
+  useUiStore: () => ({ showToast }),
 }))
 
 vi.mock('vue-router', () => ({
@@ -25,6 +30,7 @@ describe('ChangePasswordPage', () => {
     changePassword.mockReset()
     logout.mockReset()
     push.mockReset()
+    showToast.mockReset()
     confirmLogoutMock.mockReset()
     confirmLogoutMock.mockResolvedValue(true)
   })
@@ -41,7 +47,7 @@ describe('ChangePasswordPage', () => {
     expect(wrapper.get('[role="alert"]').text()).toContain('ไม่ตรงกัน')
   })
 
-  it('changes the password and continues to the dashboard', async () => {
+  it('changes the password, revokes the session, and returns to login', async () => {
     changePassword.mockResolvedValue({ success: true })
     const wrapper = mount(ChangePasswordPage)
     await wrapper.get('#current-password').setValue('temporary-password')
@@ -52,7 +58,10 @@ describe('ChangePasswordPage', () => {
     await flushPromises()
 
     expect(changePassword).toHaveBeenCalledWith('temporary-password', 'new-secure-password')
-    expect(push).toHaveBeenCalledWith('/dashboard')
+    // T4: เปลี่ยนรหัส = revoke ทุก session — บังคับ login ใหม่พร้อม toast แจ้ง
+    expect(logout).toHaveBeenCalledTimes(1)
+    expect(showToast).toHaveBeenCalledWith('เปลี่ยนรหัสผ่านสำเร็จ กรุณาเข้าสู่ระบบด้วยรหัสผ่านใหม่', 'success')
+    expect(push).toHaveBeenCalledWith('/login')
   })
 
   it('logout asks for confirmation before signing out', async () => {

--- a/frontend/src/__tests__/pages/LoginPage.test.js
+++ b/frontend/src/__tests__/pages/LoginPage.test.js
@@ -86,9 +86,24 @@ describe('LoginPage', () => {
     await wrapper.get('form').trigger('submit')
     await flushPromises()
 
-    expect(login).toHaveBeenCalledWith({ username: 'admin', password: 'admin123' })
+    expect(login).toHaveBeenCalledWith({ username: 'admin', password: 'admin123' }, { remember: false })
     expect(push).toHaveBeenCalledWith('/dashboard')
     expect(wrapper.vm.loading).toBe(false)
+  })
+
+  it('passes remember=true when remember-me is checked', async () => {
+    login.mockResolvedValue({ token: 't', user: { id: 1, role: 'admin' } })
+    mustChangePasswordVal = false
+    const wrapper = mountPage()
+    await wrapper.get('input[autocomplete="username"]').setValue('admin')
+    await wrapper.get('input[autocomplete="current-password"]').setValue('admin123')
+    await wrapper.get('input[type="checkbox"]').setValue(true)
+
+    await wrapper.get('form').trigger('submit')
+    await flushPromises()
+
+    expect(login).toHaveBeenCalledWith({ username: 'admin', password: 'admin123' }, { remember: true })
+    expect(push).toHaveBeenCalledWith('/dashboard')
   })
 
   it('redirects to change-password when mustChangePassword is true', async () => {
@@ -101,7 +116,7 @@ describe('LoginPage', () => {
     await wrapper.get('form').trigger('submit')
     await flushPromises()
 
-    expect(login).toHaveBeenCalledWith({ username: 'operator1', password: 'tempPass1' })
+    expect(login).toHaveBeenCalledWith({ username: 'operator1', password: 'tempPass1' }, { remember: false })
     expect(push).toHaveBeenCalledWith('/change-password')
   })
 

--- a/frontend/src/__tests__/router/guards.test.js
+++ b/frontend/src/__tests__/router/guards.test.js
@@ -126,6 +126,12 @@ describe('router candidate paths', () => {
     expect(router.currentRoute.value.params.section).toBe('overview')
   })
 
+  it('redirects unknown candidate sections to overview', async () => {
+    await router.push('/candidates/foo')
+    expect(router.currentRoute.value.name).toBe('candidates')
+    expect(router.currentRoute.value.params.section).toBe('overview')
+  })
+
   it('does not expose legacy /supportive quick-action path', async () => {
     await router.push('/supportive')
     expect(router.currentRoute.value.path).toBe('/dashboard')

--- a/frontend/src/__tests__/stores/auth.test.js
+++ b/frontend/src/__tests__/stores/auth.test.js
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
-import { useAuthStore } from '@/stores/auth.js'
+import { decodeJwtPayload, useAuthStore } from '@/stores/auth.js'
 
 const mockPost = vi.fn()
 
@@ -25,6 +25,7 @@ const authData = () => ({
 describe('auth store', () => {
   beforeEach(() => {
     localStorage.clear()
+    sessionStorage.clear()
     setActivePinia(createPinia())
     mockPost.mockReset()
   })
@@ -125,5 +126,103 @@ describe('auth store', () => {
     })
     expect(auth.isAdmin).toBe(true)
     expect(auth.isSuperAdmin).toBe(true)
+  })
+
+  // ===== base64url payload (F35) =====
+
+  function toBase64UrlSegment(b64) {
+    return b64.replace(/=+$/, '').replace(/\+/g, '-').replace(/\//g, '_')
+  }
+
+  it('decodeJwtPayload normalizes - and _ and restores missing padding', () => {
+    // '\u00FA' (ú) bytes ทำให้ base64 มี '+' แน่นอน → segment มี '-'
+    const plusPayload = { u: '\u00FA\u00FA\u00FA' }
+    const plusSegment = toBase64UrlSegment(btoa(JSON.stringify(plusPayload)))
+    expect(plusSegment).toContain('-')
+    expect(decodeJwtPayload(plusSegment)).toEqual(plusPayload)
+
+    // '???' ทำให้ base64 มี '/' แน่นอน → segment มี '_'
+    const slashPayload = { q: '???' }
+    const slashSegment = toBase64UrlSegment(btoa(JSON.stringify(slashPayload)))
+    expect(slashSegment).toContain('_')
+    expect(decodeJwtPayload(slashSegment)).toEqual(slashPayload)
+  })
+
+  it('keeps tokens with base64url payload characters valid (no false logout)', () => {
+    const payload = { sub: 1, exp: Math.floor(Date.now() / 1000) + 3600, name: '???' }
+    const segment = toBase64UrlSegment(btoa(JSON.stringify(payload)))
+    expect(segment).toContain('_')
+
+    const auth = useAuthStore()
+    auth.setAuth({ ...authData(), token: `hdr.${segment}.sig` })
+    expect(auth.isAuthenticated).toBe(true)
+  })
+
+  // ===== remember-me (F36) =====
+
+  it('setAuth with remember=false persists all auth keys to sessionStorage only', () => {
+    const auth = useAuthStore()
+    auth.setAuth({ ...authData(), refresh_token: 'refresh-1' }, { remember: false })
+
+    expect(sessionStorage.getItem('auth_token')).toBe(auth.token)
+    expect(sessionStorage.getItem('refresh_token')).toBe('refresh-1')
+    expect(sessionStorage.getItem('csrf_token')).toBe('csrf-123')
+    expect(JSON.parse(sessionStorage.getItem('user')).username).toBe('admin')
+    for (const key of ['auth_token', 'refresh_token', 'csrf_token', 'user']) {
+      expect(localStorage.getItem(key)).toBeNull()
+    }
+  })
+
+  it('hydrates a remember=false session from sessionStorage', () => {
+    sessionStorage.setItem('auth_token', validToken())
+    sessionStorage.setItem('user', JSON.stringify({ user_id: 1, username: 'admin', role: 'admin' }))
+    setActivePinia(createPinia())
+
+    const auth = useAuthStore()
+    expect(auth.isAuthenticated).toBe(true)
+    expect(auth.isAdmin).toBe(true)
+  })
+
+  it('login forwards remember so the session lands in sessionStorage', async () => {
+    mockPost.mockResolvedValue(authData())
+    const auth = useAuthStore()
+
+    await auth.login({ username: 'admin', password: 'x' }, { remember: false })
+
+    expect(mockPost).toHaveBeenCalledWith('/auth/login', { username: 'admin', password: 'x' })
+    expect(sessionStorage.getItem('auth_token')).toBe(auth.token)
+    expect(localStorage.getItem('auth_token')).toBeNull()
+  })
+
+  it('refresh keeps a remember=false session in sessionStorage', async () => {
+    const auth = useAuthStore()
+    auth.setAuth({ ...authData(), refresh_token: 'refresh-1' }, { remember: false })
+
+    const newToken = validToken()
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      token: newToken,
+      csrf_token: 'csrf-9',
+      refresh_token: 'refresh-2',
+      user: authData().user,
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+
+    await auth.refresh()
+
+    expect(auth.token).toBe(newToken)
+    expect(sessionStorage.getItem('auth_token')).toBe(newToken)
+    expect(sessionStorage.getItem('refresh_token')).toBe('refresh-2')
+    expect(localStorage.getItem('auth_token')).toBeNull()
+  })
+
+  it('logout clears session-stored remember=false keys too', () => {
+    const auth = useAuthStore()
+    auth.setAuth({ ...authData(), refresh_token: 'refresh-1' }, { remember: false })
+    auth.logout()
+
+    expect(auth.isAuthenticated).toBe(false)
+    for (const key of ['auth_token', 'refresh_token', 'csrf_token', 'user']) {
+      expect(sessionStorage.getItem(key)).toBeNull()
+      expect(localStorage.getItem(key)).toBeNull()
+    }
   })
 })

--- a/frontend/src/__tests__/utils/serverDateTime.test.js
+++ b/frontend/src/__tests__/utils/serverDateTime.test.js
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import { formatServerDateTime, parseServerDateTime } from '@/utils/serverDateTime.js'
+
+// หมายเหตุ: การ assert "แสดง 10:00" ทำได้ deterministic โดยไม่ต้องแก้ TZ ของ process
+// เพราะ helper format ด้วย timeZone: 'Asia/Bangkok' เสมอ (เวลาที่แสดง = เวลาที่เก็บทุกเครื่อง)
+
+describe('parseServerDateTime', () => {
+  it('binds server DATETIME strings to +07:00 (not Z)', () => {
+    // '2026-09-01 10:00:00' เก็บเป็นเวลาไทยแล้ว — instant ต้องเท่ากับ 10:00+07:00 (03:00 UTC)
+    expect(parseServerDateTime('2026-09-01 10:00:00').getTime()).toBe(
+      Date.parse('2026-09-01T10:00:00+07:00'),
+    )
+    // ถ้าตีความผิดเป็น UTC ('Z') instant จะเพี้ยนไป 7 ชม.
+    expect(parseServerDateTime('2026-09-01 10:00:00').getTime()).not.toBe(
+      Date.parse('2026-09-01T10:00:00Z'),
+    )
+  })
+
+  it('accepts the T-separated ISO-ish form from the backend as well', () => {
+    expect(parseServerDateTime('2026-07-01T10:30:00').getTime()).toBe(
+      Date.parse('2026-07-01T10:30:00+07:00'),
+    )
+  })
+
+  it('keeps explicit timezone markers untouched', () => {
+    expect(parseServerDateTime('2026-09-01T03:00:00Z').getTime()).toBe(
+      Date.parse('2026-09-01T03:00:00Z'),
+    )
+    expect(parseServerDateTime('2026-09-01T03:00:00+00:00').getTime()).toBe(
+      Date.parse('2026-09-01T03:00:00+00:00'),
+    )
+  })
+
+  it('parses date-only strings as Thai midnight', () => {
+    expect(parseServerDateTime('2026-09-01').getTime()).toBe(
+      Date.parse('2026-09-01T00:00:00+07:00'),
+    )
+  })
+
+  it('returns null for empty or invalid input', () => {
+    expect(parseServerDateTime(null)).toBeNull()
+    expect(parseServerDateTime(undefined)).toBeNull()
+    expect(parseServerDateTime('')).toBeNull()
+    expect(parseServerDateTime('not-a-date')).toBeNull()
+  })
+})
+
+describe('formatServerDateTime', () => {
+  it("displays '2026-09-01 10:00:00' as 10:00 ICT — เวลาเดียวกับที่เก็บ", () => {
+    const formatted = formatServerDateTime('2026-09-01 10:00:00')
+    expect(formatted).toContain('10:00')
+    expect(formatted).not.toContain('17:00') // จะเป็นค่านี้ถ้า helper ใช้ 'Z'
+    expect(formatted).not.toContain('03:00') // จะเป็นค่านี้ถ้า parse เป็น UTC แต่ format ที่เครื่อง UTC
+    // ปี พ.ศ. (2569 = ค.ศ. 2026 + 543) — th-TH default calendar
+    expect(formatted).toContain('2569')
+  })
+
+  it('returns a dash for empty or invalid values', () => {
+    expect(formatServerDateTime(null)).toBe('-')
+    expect(formatServerDateTime('')).toBe('-')
+    expect(formatServerDateTime('garbage')).toBe('-')
+  })
+
+  it('supports custom format options while keeping the Thai time zone', () => {
+    // options override เป็นราย key — default (วัน/เดือน/ปี) ยังอยู่ แต่เวลายังเป็น 10:00 เวลาไทย
+    const formatted = formatServerDateTime('2026-09-01 10:00:00', { hour: '2-digit', minute: '2-digit' })
+    expect(formatted).toContain('10:00')
+    expect(formatted).toContain('2569')
+  })
+})

--- a/frontend/src/composables/useApi.js
+++ b/frontend/src/composables/useApi.js
@@ -1,5 +1,9 @@
 const API_BASE = import.meta.env.VITE_API_URL || '/api'
 
+// dedupe toast "เซสชันหมดอายุ" — เมื่อ token ตก, หลาย request ชอบ 401 พร้อมกัน
+// ต้องแจ้งผู้ใช้ครั้งเดียว ไม่ใช่หลาย toast ซ้อนกัน
+let sessionExpiredNotified = false
+
 async function authenticatedFetch(url, options = {}, retried = false) {
   const { useAuthStore } = await import('@/stores/auth.js')
   const auth = useAuthStore()
@@ -28,6 +32,11 @@ async function authenticatedFetch(url, options = {}, retried = false) {
     headers,
   })
 
+  if (response.ok) {
+    // เรียกสำเร็จ (เช่นหลังเข้าสู่ระบบใหม่) — เปิดให้แจ้งเตือน session หมดอายุได้อีกครั้ง
+    sessionExpiredNotified = false
+  }
+
   if (response.status === 401) {
     // Login 401 ต้องโชว์ข้อความจาก API (ไทย) — ห้ามกลายเป็น "Unauthorized" แล้วเด้ง logout
     const isPublicAuth =
@@ -46,6 +55,13 @@ async function authenticatedFetch(url, options = {}, retried = false) {
       } catch {
         // refresh ล้มเหลว — ตกไป logout ด้านล่าง
       }
+    }
+
+    // แจ้งผู้ใช้ด้วย toast ไทยก่อนเด้งกลับหน้า login — dedupe กันหลาย request โชว์ซ้ำ
+    if (!sessionExpiredNotified) {
+      sessionExpiredNotified = true
+      const { useUiStore } = await import('@/stores/ui.js')
+      useUiStore().showToast('เซสชันหมดอายุ กรุณาเข้าสู่ระบบอีกครั้ง', 'error')
     }
 
     auth.logout()
@@ -74,6 +90,10 @@ async function request(url, options = {}) {
     const contentType = response.headers.get('content-type') || ''
     if (contentType.includes('application/json')) {
       const error = await response.json().catch(() => ({ error: response.statusText }))
+      // backend ส่ง error ภาษาอังกฤษมากับโค้ดนี้ — บังคับข้อความไทยให้ผู้ใช้
+      if (error.code === 'PASSWORD_CHANGE_REQUIRED') {
+        throw new Error('กรุณาเปลี่ยนรหัสผ่านก่อนใช้งานระบบ')
+      }
       throw new Error(error.error || response.statusText)
     }
     // Non-JSON response (HTML error page, 503 from cold start, etc.)

--- a/frontend/src/pages/AuditLogPage.vue
+++ b/frontend/src/pages/AuditLogPage.vue
@@ -214,8 +214,13 @@ import EmptyState from '@/components/EmptyState.vue'
 import PaginationBar from '@/components/PaginationBar.vue'
 import TableRowActions from '@/components/TableRowActions.vue'
 import { useApi } from '@/composables/useApi.js'
+import { useDebouncedCallback } from '@/composables/useDebouncedCallback.js'
+import { useRequestSeq } from '@/composables/useRequestSeq.js'
+import { formatServerDateTime } from '@/utils/serverDateTime.js'
 
 const api = useApi()
+// กัน response เก่า (ช้ามาทีหลัง) ทับ state ใหม่เมื่อสลับ filter/page เร็ว ๆ
+const { next: nextRequest } = useRequestSeq()
 
 const loading = ref(false)
 const error = ref('')
@@ -235,6 +240,7 @@ const pagination = ref({
 })
 
 async function fetchData() {
+  const req = nextRequest()
   loading.value = true
   error.value = ''
 
@@ -249,12 +255,14 @@ async function fetchData() {
     if (filters.value.userId) params.append('user_id', filters.value.userId)
 
     const result = await api.get(`/audit?${params}`)
+    if (!req.isCurrent()) return
     rows.value = result.data || []
     pagination.value.total = result.pagination?.total || 0
   } catch (err) {
+    if (!req.isCurrent()) return
     error.value = err.message || 'เกิดข้อผิดพลาดในการโหลดข้อมูล'
   } finally {
-    loading.value = false
+    if (req.isCurrent()) loading.value = false
   }
 }
 
@@ -263,6 +271,12 @@ function onPageChange(newOffset) {
   fetchData()
 }
 
+// พิมพ์ user id แล้วรอให้หยุดพิมพ์ก่อนยิง request — debounced + auto-clear เมื่อ unmount
+const { run: scheduleUserIdFilter } = useDebouncedCallback(() => {
+  pagination.value.offset = 0
+  fetchData()
+}, 300)
+
 // เปลี่ยน filter/limit ใดๆ ต้องรีเซ็ต offset กลับหน้าแรกก่อนเสมอ
 // ไม่งั้นถ้าอยู่หน้าท้ายๆ แล้ว filter เหลือผลน้อยกว่า offset เดิม จะเห็น "ไม่พบข้อมูล" ทั้งที่มีจริง
 function onFilterChange() {
@@ -270,10 +284,8 @@ function onFilterChange() {
   fetchData()
 }
 
-let userIdDebounce = null
 function onUserIdInput() {
-  clearTimeout(userIdDebounce)
-  userIdDebounce = setTimeout(onFilterChange, 300)
+  scheduleUserIdFilter()
 }
 
 function showDetail(row) {
@@ -311,15 +323,8 @@ function tableName(table) {
 }
 
 function formatDateTime(dateStr) {
-  if (!dateStr) return '-'
-  const date = new Date(dateStr)
-  return date.toLocaleString('th-TH', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  })
+  // backend คืนเวลาไทย (+07:00) — ใช้ helper ผูก marker ให้แสดงเวลาเดียวกับที่เก็บทุก timezone
+  return formatServerDateTime(dateStr)
 }
 
 function onGlobalKeydown(e) {
@@ -333,6 +338,5 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   window.removeEventListener('keydown', onGlobalKeydown)
-  clearTimeout(userIdDebounce)
 })
 </script>

--- a/frontend/src/pages/ChangePasswordPage.vue
+++ b/frontend/src/pages/ChangePasswordPage.vue
@@ -75,9 +75,11 @@
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth.js'
+import { useUiStore } from '@/stores/ui.js'
 import { confirmLogout } from '@/composables/useConfirm.js'
 
 const auth = useAuthStore()
+const ui = useUiStore()
 const router = useRouter()
 
 const currentPassword = ref('')
@@ -96,7 +98,11 @@ async function submit() {
   submitting.value = true
   try {
     await auth.changePassword(currentPassword.value, newPassword.value)
-    await router.push('/dashboard')
+    // T4: เปลี่ยนรหัส = revoke ทุก session (รวม session ปัจจุบัน) — ต้อง login
+    // ใหม่ด้วยรหัสผ่านใหม่ จึงบังคับออกจากระบบแทน push /dashboard
+    auth.logout()
+    ui.showToast('เปลี่ยนรหัสผ่านสำเร็จ กรุณาเข้าสู่ระบบด้วยรหัสผ่านใหม่', 'success')
+    await router.push('/login')
   } catch (error) {
     errorMessage.value = error?.message || 'ไม่สามารถเปลี่ยนรหัสผ่านได้'
   } finally {

--- a/frontend/src/pages/DashboardPage.vue
+++ b/frontend/src/pages/DashboardPage.vue
@@ -178,12 +178,15 @@ import { RouterLink } from 'vue-router'
 import StatCard from '@/components/StatCard.vue'
 import SkeletonLoader from '@/components/SkeletonLoader.vue'
 import { useApi } from '@/composables/useApi.js'
+import { useRequestSeq } from '@/composables/useRequestSeq.js'
 import {
   Users, UserCheck, TrendingUp, Clock,
   RefreshCw, AlertCircle, Zap,
 } from 'lucide-vue-next'
 
 const api = useApi()
+// กัน response เก่า (กดรีเฟรชซ้ำเร็ว ๆ) ทับตัวเลขใหม่
+const { next: nextRequest } = useRequestSeq()
 
 const loading = ref(false)
 const error = ref('')
@@ -221,19 +224,26 @@ function formatNumber(value) {
 }
 
 async function fetchDashboard() {
+  const req = nextRequest()
   loading.value = true
   error.value = ''
 
   try {
     // ดึงข้อมูลสรุปจาก /dashboard endpoint เดียว (รวม candidate totals)
     const d = await api.get('/dashboard')
+    if (!req.isCurrent()) return
 
     stats.value.totalPersonnel = d.total_personnel || 0
     stats.value.probationTotal = d.probation?.total || 0
     stats.value.timeCountTotal = d.time_counting?.total || 0
     stats.value.candidateTotal = d.candidates?.total || 0
+    // ใช้ค่า in_progress จาก backend ตรง ๆ (predicate เดียวกับหน้า probation)
+    // fallback คำนวณเองแบบเดิมไว้รองรับช่วงก่อน backend deploy ครบ
+    const inProgress = typeof d.probation?.in_progress === 'number'
+      ? d.probation.in_progress
+      : Math.max(0, (d.probation?.total || 0) - (d.probation?.near_deadline || 0) - (d.probation?.overdue || 0))
     probationSummary.value = {
-      inProgress: Math.max(0, (d.probation?.total || 0) - (d.probation?.near_deadline || 0) - (d.probation?.overdue || 0)),
+      inProgress,
       nearDeadline: d.probation?.near_deadline || 0,
       overdue: d.probation?.overdue || 0,
     }
@@ -274,10 +284,11 @@ async function fetchDashboard() {
     priorityTasks.value = tasks
 
   } catch (err) {
+    if (!req.isCurrent()) return
     error.value = 'ไม่สามารถโหลดข้อมูลได้ กรุณาลองใหม่อีกครั้ง'
     console.error('Dashboard fetch error:', err)
   } finally {
-    loading.value = false
+    if (req.isCurrent()) loading.value = false
   }
 }
 

--- a/frontend/src/pages/LoginPage.vue
+++ b/frontend/src/pages/LoginPage.vue
@@ -151,7 +151,8 @@ async function handleLogin() {
   infoMsg.value = ''
   loading.value = true
   try {
-    await auth.login({ username: form.username, password: form.password })
+    // remember=true → เก็บ session ใน localStorage, false → sessionStorage (ปิดเบราว์เซอร์แล้วหมดอายุ)
+    await auth.login({ username: form.username, password: form.password }, { remember: rememberMe.value })
     router.push(auth.mustChangePassword ? '/change-password' : '/dashboard')
   } catch (e) {
     errorMsg.value = e.message || 'เข้าสู่ระบบไม่สำเร็จ กรุณาลองใหม่'

--- a/frontend/src/pages/MultiplierAreasPage.vue
+++ b/frontend/src/pages/MultiplierAreasPage.vue
@@ -311,6 +311,7 @@
 <script setup>
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import { useMultiplier } from '@/composables/useMultiplier.js'
+import { useRequestSeq } from '@/composables/useRequestSeq.js'
 import { confirmAction } from '@/composables/useConfirm.js'
 import StatCard from '@/components/StatCard.vue'
 import SkeletonLoader from '@/components/SkeletonLoader.vue'
@@ -330,6 +331,8 @@ import {
 } from 'lucide-vue-next'
 
 const { fetchAreas, createArea, setAreaStatus } = useMultiplier()
+// กัน response เก่า (กดรีเฟรช/toggle ซ้ำเร็ว ๆ) ทับ state ใหม่
+const { next: nextRequest } = useRequestSeq()
 
 const RATIO_PRESETS = [150, 200, 300]
 
@@ -349,15 +352,18 @@ const pendingCount = computed(() => areas.value.filter((area) => area.sourcePend
 const basisOptions = computed(() => [...new Set(areas.value.map((area) => area.basisType).filter(Boolean))])
 
 async function fetchData() {
+  const req = nextRequest()
   loading.value = true
   error.value = null
   try {
     const result = await fetchAreas({ activeOnly: false })
+    if (!req.isCurrent()) return
     areas.value = result.data
   } catch (err) {
+    if (!req.isCurrent()) return
     error.value = err.message || 'ไม่สามารถโหลดข้อมูลพื้นที่พิเศษได้'
   } finally {
-    loading.value = false
+    if (req.isCurrent()) loading.value = false
   }
 }
 

--- a/frontend/src/pages/MultiplierPage.vue
+++ b/frontend/src/pages/MultiplierPage.vue
@@ -559,7 +559,8 @@ async function openDeleteConfirm(row) {
     await remove(row.multiplierId)
     await fetchData()
   } catch (err) {
-    alert(err.message || 'ไม่สามารถลบรายการได้')
+    // toast แทน alert() — สไตล์เดียวกับหน้าอื่น และไม่บล็อกเธรด UI
+    ui.showToast(err.message || 'ไม่สามารถลบรายการได้', 'error')
   } finally {
     saving.value = false
   }

--- a/frontend/src/pages/ProbationEndPage.vue
+++ b/frontend/src/pages/ProbationEndPage.vue
@@ -353,6 +353,10 @@ function validateForm() {
   const errors = {}
   if (!formData.value.start_date) errors.start_date = true
   if (!formData.value.end_date) errors.end_date = true
+  // end >= start เหมือน MultiplierPage — กันบันทึกช่วงวันทดลองกลับด้าน
+  if (formData.value.start_date && formData.value.end_date && formData.value.end_date < formData.value.start_date) {
+    errors.end_date = true
+  }
   formErrors.value = errors
   return Object.keys(errors).length === 0
 }

--- a/frontend/src/pages/UserManagementPage.vue
+++ b/frontend/src/pages/UserManagementPage.vue
@@ -294,6 +294,7 @@ import { useRequestSeq } from '@/composables/useRequestSeq.js'
 import { useAuthStore } from '@/stores/auth.js'
 import { useUiStore } from '@/stores/ui.js'
 import { roleLabel } from '@/utils/roleLabels.js'
+import { formatServerDateTime } from '@/utils/serverDateTime.js'
 import ListSearchInput from '@/components/ListSearchInput.vue'
 import PaginationBar from '@/components/PaginationBar.vue'
 import EmptyState from '@/components/EmptyState.vue'
@@ -543,16 +544,8 @@ async function submitToggleActive() {
 // ==================== Helpers ====================
 
 function formatDateTime(value) {
-  if (!value) return '-'
-  const date = new Date(value.replace(' ', 'T'))
-  if (isNaN(date.getTime())) return '-'
-  return date.toLocaleString('th-TH', {
-    day: 'numeric',
-    month: 'short',
-    year: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  })
+  // backend คืน DATETIME เป็นเวลาไทย (+07:00) — ใช้ helper ผูก marker ให้แสดงตรงกับที่เก็บทุก timezone
+  return formatServerDateTime(value)
 }
 
 onMounted(fetchData)

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -2,6 +2,10 @@ import { createRouter, createWebHistory } from 'vue-router'
 import { isChunkLoadError, resolveChunkRecoveryTarget } from '@/utils/chunkGuard.js'
 import { useNavProgress } from '@/composables/useNavProgress.js'
 
+// section ที่ CandidateListsPage รู้จัก (ตรงกับ categoryConfig ในหน้า) — ค่าอื่น redirect
+// ไป overview กัน bookmark/URL ผิดแล้วเข้าหน้าเปล่า
+export const KNOWN_CANDIDATE_SECTIONS = ['overview', 'general', 'academic', 'support', 'management']
+
 const routes = [
   {
     path: '/login',
@@ -188,6 +192,16 @@ router.beforeEach(async (to) => {
 
   if (to.path === '/login' && auth.isAuthenticated) {
     return '/dashboard'
+  }
+
+  // section ไม่รู้จัก → กลับ /candidates/overview — เช็คใน global guard เพราะ
+  // beforeEnter ของ route record ไม่ทำงานตอนสลับ params ภายใน record เดิม
+  if (
+    to.name === 'candidates' &&
+    to.params.section &&
+    !KNOWN_CANDIDATE_SECTIONS.includes(String(to.params.section))
+  ) {
+    return { path: '/candidates/overview' }
   }
 
   // หน้า admin only — operator/viewer เด้งกลับ dashboard (superadmin ผ่านได้)

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -1,30 +1,62 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 
+// คีย์ที่ persist ทั้งสอง storage — remember=true → localStorage, remember=false → sessionStorage
+const AUTH_STORAGE_KEYS = ['auth_token', 'refresh_token', 'csrf_token', 'user']
+// คียยุคเก่าที่เคยใช้ — เคลียร์ตอน logout ด้วย
+const LEGACY_AUTH_STORAGE_KEYS = ['authToken', 'refreshToken']
+
+// hydrate จาก localStorage ก่อน แล้ว fallback ไป sessionStorage — session แบบ
+// "ไม่จดจำฉัน" (remember=false) ถูกเก็บไว้ใน sessionStorage เท่านั้น
+function* authStorages() {
+  yield localStorage
+  yield sessionStorage
+}
+
 function readStoredString(key) {
-  const value = localStorage.getItem(key)
-  if (!value || value === 'undefined' || value === 'null') {
-    localStorage.removeItem(key)
-    return ''
+  for (const storage of authStorages()) {
+    const value = storage.getItem(key)
+    if (value === null) continue
+    if (value === 'undefined' || value === 'null') {
+      storage.removeItem(key)
+      return ''
+    }
+    return value
   }
 
-  return value
+  return ''
 }
 
 function readStoredJson(key, fallback = null) {
-  const value = localStorage.getItem(key)
+  for (const storage of authStorages()) {
+    const value = storage.getItem(key)
+    if (value === null) continue
 
-  if (!value || value === 'undefined' || value === 'null') {
-    localStorage.removeItem(key)
-    return fallback
+    if (value === 'undefined' || value === 'null') {
+      storage.removeItem(key)
+      return fallback
+    }
+
+    try {
+      return JSON.parse(value)
+    } catch {
+      storage.removeItem(key)
+      return fallback
+    }
   }
 
-  try {
-    return JSON.parse(value)
-  } catch {
-    localStorage.removeItem(key)
-    return fallback
-  }
+  return fallback
+}
+
+// token segment เป็น base64url ('-' / '_') และไม่มี padding '=' — normalize เป็น base64
+// ก่อน atob ไม่งั้น payload ที่มีตัวอักษร url-safe ทำให้ atob พัง → isTokenValid false
+// → ระบบ logout เองทั้งที่ token ยังใช้ได้
+export function decodeJwtPayload(segment) {
+  const base64 = segment
+    .replace(/-/g, '+')
+    .replace(/_/g, '/')
+    .padEnd(segment.length + (4 - (segment.length % 4)) % 4, '=')
+  return JSON.parse(atob(base64))
 }
 
 export const useAuthStore = defineStore('auth', () => {
@@ -41,37 +73,65 @@ export const useAuthStore = defineStore('auth', () => {
   function isTokenValid() {
     if (!token.value) return false
     try {
-      const payload = JSON.parse(atob(token.value.split('.')[1]))
+      const payload = decodeJwtPayload(token.value.split('.')[1])
       return payload.exp * 1000 > Date.now()
     } catch {
       return false
     }
   }
 
-  function setAuth(data) {
+  // session ปัจจุบันอยู่ storage ไหน — ใช้ตอน refresh (ไม่ส่ง remember มา) ให้คงที่เดิม
+  function preferredStorage() {
+    if (!localStorage.getItem('auth_token') && sessionStorage.getItem('auth_token')) {
+      return sessionStorage
+    }
+    return localStorage
+  }
+
+  // remember=true → localStorage (อยู่รอดหลังปิดเบราว์เซอร์)
+  // remember=false → sessionStorage (ปิดเบราว์เซอร์แล้ว session จบ)
+  // ไม่ระบุ (เช่นตอน refresh) → คง storage เดิมของ session
+  function persistAuthStorage(remember) {
+    const storage = remember === false
+      ? sessionStorage
+      : remember === true
+        ? localStorage
+        : preferredStorage()
+    const other = storage === localStorage ? sessionStorage : localStorage
+
+    storage.setItem('auth_token', token.value)
+    storage.setItem('user', JSON.stringify(user.value))
+    if (csrfToken.value) {
+      storage.setItem('csrf_token', csrfToken.value)
+    } else {
+      storage.removeItem('csrf_token')
+    }
+    if (refreshToken.value) {
+      storage.setItem('refresh_token', refreshToken.value)
+    } else {
+      storage.removeItem('refresh_token')
+    }
+    // เคลียร์อีกฝั่ง — กันคีย์ค้างสองที่ (hydrate อ่าน localStorage ก่อน)
+    for (const key of AUTH_STORAGE_KEYS) other.removeItem(key)
+  }
+
+  function persistUserStorage() {
+    preferredStorage().setItem('user', JSON.stringify(user.value))
+  }
+
+  function setAuth(data, options = {}) {
     token.value = data.token
     csrfToken.value = data.csrf_token || ''
     user.value = data.user
     refreshToken.value = data.refresh_token || ''
-    localStorage.setItem('auth_token', data.token)
-    localStorage.setItem('user', JSON.stringify(data.user))
-    if (data.csrf_token) {
-      localStorage.setItem('csrf_token', data.csrf_token)
-    } else {
-      localStorage.removeItem('csrf_token')
-    }
-    if (data.refresh_token) {
-      localStorage.setItem('refresh_token', data.refresh_token)
-    } else {
-      localStorage.removeItem('refresh_token')
-    }
+    persistAuthStorage(options.remember)
   }
 
-  async function login(credentials) {
+  async function login(credentials, { remember = true } = {}) {
     const { useApi } = await import('@/composables/useApi.js')
     const api = useApi()
     const data = await api.post('/auth/login', credentials)
-    setAuth(data)
+    setAuth(data, { remember })
     return data
   }
 
@@ -112,7 +172,7 @@ export const useAuthStore = defineStore('auth', () => {
   function setMustChangePassword(required) {
     if (!user.value) return
     user.value = { ...user.value, must_change_password: Boolean(required) }
-    localStorage.setItem('user', JSON.stringify(user.value))
+    persistUserStorage()
   }
 
   async function changePassword(currentPassword, newPassword) {
@@ -141,7 +201,7 @@ export const useAuthStore = defineStore('auth', () => {
         role: me.role ?? user.value.role,
         must_change_password: Boolean(me.must_change_password),
       }
-      localStorage.setItem('user', JSON.stringify(user.value))
+      persistUserStorage()
     }
     return me
   }
@@ -160,7 +220,7 @@ export const useAuthStore = defineStore('auth', () => {
         email: me.email ?? user.value.email,
         role: me.role ?? user.value.role,
       }
-      localStorage.setItem('user', JSON.stringify(user.value))
+      persistUserStorage()
     }
     return me
   }
@@ -181,12 +241,12 @@ export const useAuthStore = defineStore('auth', () => {
     refreshToken.value = ''
     csrfToken.value = ''
     user.value = null
-    localStorage.removeItem('auth_token')
-    localStorage.removeItem('authToken')
-    localStorage.removeItem('refresh_token')
-    localStorage.removeItem('refreshToken')
-    localStorage.removeItem('csrf_token')
-    localStorage.removeItem('user')
+    // เคลียร์ทั้งสอง storage — session อาจถูก persist แบบ remember หรือไม่ก็ได้
+    for (const storage of [localStorage, sessionStorage]) {
+      for (const key of [...AUTH_STORAGE_KEYS, ...LEGACY_AUTH_STORAGE_KEYS]) {
+        storage.removeItem(key)
+      }
+    }
   }
 
   return {

--- a/frontend/src/utils/serverDateTime.js
+++ b/frontend/src/utils/serverDateTime.js
@@ -1,0 +1,67 @@
+/**
+ * Helper วันเวลาสำหรับค่า DATETIME ที่ backend ส่งมา
+ *
+ * Backend ตั้ง MySQL session time zone เป็น +07:00 แล้ว (ดู config.php — SET time_zone
+ * คู่กับ date_default_timezone_set('Asia/Bangkok')) ดังนั้น string เช่น
+ * '2026-09-01 10:00:00' คือ "เวลาไทย" อยู่แล้ว — เราต้อง parse โดยบอก JS ว่าเป็น +07:00
+ * ไม่ใช่ 'Z' (UTC) ไม่งั้นเบราว์เซอร์ที่อยู่ timezone อื่นจะแสดงเวลาเบี่ยงไป 7 ชั่วโมง
+ *
+ * หลัง append marker แล้ว format เป็น th-TH ตาม convention ของระบบ
+ */
+
+const DEFAULT_FORMAT_OPTIONS = {
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit',
+}
+
+// format ในเวลาไทยเสมอ — เวลาที่แสดง = เวลาเดียวกับที่เก็บ แม้เครื่องผู้ใช้ตั้ง timezone อื่น
+const SERVER_TIME_ZONE = 'Asia/Bangkok'
+
+// มี timezone marker แล้ว (Z หรือ +07:00 / -0500) — ห้ามเติมซ้ำ
+const HAS_TZ_MARKER = /(?:Z|[+-]\d{2}:?\d{2})$/i
+
+/**
+ * แปลง DATETIME string จาก backend เป็น Date โดยผูกเวลาไทย (+07:00) เสมอ
+ *
+ * @param {string|Date|null|undefined} value เช่น '2026-09-01 10:00:00' หรือ '2026-09-01T10:00:00'
+ * @returns {Date|null} Date หรือ null ถ้าค่าว่าง/แปลงไม่ได้
+ */
+export function parseServerDateTime(value) {
+  if (!value) return null
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value
+
+  let text = String(value).trim()
+  if (!text) return null
+
+  // 'YYYY-MM-DD HH:mm:ss' → 'YYYY-MM-DDTHH:mm:ss' ให้ Date parser อ่านได้
+  text = text.replace(' ', 'T')
+
+  if (!HAS_TZ_MARKER.test(text)) {
+    // date-only ('2026-09-01') ต้องมีเวลาต่อท้ายก่อน ไม่งั้น '+07:00' ต่อแล้ว invalid
+    text += text.length === 10 ? 'T00:00:00+07:00' : '+07:00'
+  }
+
+  const date = new Date(text)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+/**
+ * Format DATETIME จาก backend เป็นภาษาไทยในเวลาไทย — เวลาที่แสดง = เวลาเดียวกับที่เก็บ (ICT)
+ * ทุก timezone ของเครื่องผู้ใช้
+ *
+ * @param {string|Date|null|undefined} value
+ * @param {Intl.DateTimeFormatOptions} [options] override รูปแบบ default ได้ (timeZone คงเป็นไทย)
+ * @returns {string} ข้อความ th-TH หรือ '-' ถ้าแปลงไม่ได้
+ */
+export function formatServerDateTime(value, options) {
+  const date = parseServerDateTime(value)
+  if (!date) return '-'
+  return date.toLocaleString('th-TH', {
+    timeZone: SERVER_TIME_ZONE,
+    ...DEFAULT_FORMAT_OPTIONS,
+    ...options,
+  })
+}

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -4,7 +4,7 @@
 #
 # Local gates:
 #   0) Fast gates: schema parity + multiplier validator regression
-#   1) Frontend:  npm ci (optional) + vitest + build
+#   1) Frontend:  npm ci (optional) + npm audit (prod, high+) + npm test + build
 #   1.5) CSP audit: bundle ตรวจว่าไม่มีอะไรชน CSP หลัง enforce (อ่าน frontend/dist)
 #   2) E2E:       Playwright Chromium checks all sidebar menus (Docker db + backend)
 #   3) Backend:   bash backend/tests/run.sh
@@ -169,6 +169,10 @@ frontend_gate() {
     # คือรายงานความคืบหน้า *ภายใน* gate ไม่ใช่การตัดสินระดับ gate ที่ summary สนใจ จึงไม่ใช้ skip()
     echo 'skip npm ci (--skip-install)'
   fi
+
+  # F18/T21: npm audit production deps — fail บน high/critical (mirror ci-local.ps1)
+  echo 'npm audit --omit=dev --audit-level=high ...'
+  npm audit --omit=dev --audit-level=high || return 1
 
   # pool/maxWorkers come from frontend/vitest.config.js (forks + 2 workers)
   echo 'npm test (vitest) ...'

--- a/scripts/validate-schema-parity.mjs
+++ b/scripts/validate-schema-parity.mjs
@@ -9,6 +9,9 @@
 //   INV-3  ทุก migration ต้องถูก mount ใน docker-compose.yaml
 //          (นักพัฒนาที่รันแค่ `docker compose up -d db` ตามคู่มือ backend/tests/run.sh
 //           จะไม่มี backend container มารัน run-migrations.php ให้)
+//   INV-4  FK pairs ของตารางที่ยังมีอยู่ต้องตรงกันทั้งสองฝั่ง (migration final state
+//          เทียบกับ tidb-init.sql) — FK ของตารางที่ถูก drop พร้อมตาราง (เช่นโดย
+//          migration 24) ไม่เทียบ เพราะฝั่ง migration ไม่มี CREATE ของตารางนั้นให้ extract
 //
 // ไฟล์ที่ชื่อมี test-seed ถูกยกเว้นโดยตั้งใจ — ควบคุมด้วย APPLY_TEST_SEED_MIGRATIONS ผ่าน runner
 //
@@ -85,6 +88,44 @@ function objectsCreatedBy(sql) {
 }
 
 /**
+ * FK pairs ทั้งหมดในไฟล์ SQL — Set ของ "table|columns|ref_table" (lowercase ทั้งหมด)
+ *
+ * ต้อง parse ทั้ง FK แบบ inline ใน CREATE TABLE **และ** แบบ
+ * `ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY` — เช่น FK ของ import_log มาจาก
+ * 12-import-log-fk.sql (ALTER) ถ้า parse เฉพาะ CREATE TABLE gate จะ false-drift
+ *
+ * `ALTER TABLE ... DROP FOREIGN KEY <ชื่อ>` ไม่ออกจาก extractor นี้ (ไม่มี REFERENCES
+ * ให้จับ) — การ drop ของ migration 22 สะท้อนผ่าน final state: tidb-init.sql ต้อง
+ * ไม่มี FK คู่นั้นอีก (INV-4 ฝั่ง init ที่ฝั่ง migration ไม่มี = fail)
+ */
+function foreignKeyPairs(sql) {
+  const fks = new Set();
+  const createRe = /\bCREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?`?(\w+)`?/i;
+  const alterRe = /\bALTER\s+TABLE\s+`?(\w+)`?/i;
+  const fkRe = /\bFOREIGN\s+KEY\s*\(([^)]*)\)\s*REFERENCES\s+`?(\w+)`?/gi;
+
+  // แตก statement ด้วย ';' — INSERT ที่มี ';' ใน string literal อาจแตกผิดชิ้น แต่ชิ้นที่เสีย
+  // ไม่มีทั้ง CREATE/ALTER TABLE จึงไม่มีทางถูกนับเป็น FK pair
+  for (const stmt of sqlLines(sql).join('\n').split(';')) {
+    if (!/\bFOREIGN\s+KEY\b/i.test(stmt)) continue;
+    const owner = createRe.exec(stmt) ?? alterRe.exec(stmt);
+    if (!owner) continue;
+    const table = owner[1].toLowerCase();
+    let m;
+    fkRe.lastIndex = 0;
+    while ((m = fkRe.exec(stmt))) {
+      const cols = m[1]
+        .split(',')
+        .map((c) => c.replace(/[`\s]/g, ''))
+        .filter(Boolean)
+        .join(',');
+      fks.add(`${table}|${cols}|${m[2].toLowerCase()}`);
+    }
+  }
+  return fks;
+}
+
+/**
  * ไฟล์ migration ทั้งหมดที่ประกอบกันเป็น schema จริง (repo-relative)
  *
  * อยู่ใน database/ ที่เดียวโดยตั้งใจ — เป็นโฟลเดอร์ที่ image copy ไปเป็น MIGRATIONS_DIR
@@ -127,6 +168,31 @@ for (const [name, src] of expected.altered) {
   if (!initLower.includes(name)) failures.push(`INV-1b ${TIDB_INIT} ขาด column/key \`${name}\` (เพิ่มโดย ${src})`);
 }
 
+// ---- INV-4: FK parity — FK pairs ของตารางที่ยังมีอยู่ต้องตรงกันทั้งสองฝั่ง ----
+// ขอบเขตคือ FK คู่ของตารางที่ "ยังมีอยู่" เท่านั้น — ข้าม FK ที่ referencing table
+// ไม่มีอยู่ในอีกฝั่ง (dropped-table semantics) เช่น advance_notifications/task_assignments
+// ที่ migration 24 drop พร้อมตาราง หรือตาราง root schema (mysql_database_design.sql)
+// ที่ไม่ได้อยู่ในชุดสแกน migration
+const initFks = foreignKeyPairs(initSql);
+const migFks = new Set();
+for (const rel of applied) {
+  for (const fk of foreignKeyPairs(read(rel))) migFks.add(fk);
+}
+
+const relevantMigFks = [...migFks].filter((fk) => initObjects.tables.has(fk.split('|')[0]));
+const relevantInitFks = [...initFks].filter((fk) => expected.tables.has(fk.split('|')[0]));
+
+for (const fk of relevantMigFks) {
+  if (!initFks.has(fk)) {
+    failures.push(`INV-4 ${TIDB_INIT} ขาด FOREIGN KEY ${fk} (ฝั่ง migration มี)`);
+  }
+}
+for (const fk of relevantInitFks) {
+  if (!migFks.has(fk)) {
+    failures.push(`INV-4 ${TIDB_INIT} มี FOREIGN KEY ${fk} ที่ฝั่ง migration ไม่มี (ถูก drop ไปแล้ว — ลบออกจาก ${TIDB_INIT})`);
+  }
+}
+
 // ---- INV-2/INV-3: migration ต้องถูก mount ในทั้ง CI และ docker-compose ----
 const ci = read(CI_WORKFLOW);
 const compose = read(COMPOSE);
@@ -144,7 +210,9 @@ if (seedOnly.length) {
 }
 
 // ---- รายงานผล --------------------------------------------------------------
-console.log(`schema parity gate — migration ${applied.length} ไฟล์, ${expected.tables.size} ตาราง, ${expected.views.size} view`);
+console.log(
+  `schema parity gate — migration ${applied.length} ไฟล์, ${expected.tables.size} ตาราง, ${expected.views.size} view, ${relevantMigFks.length}/${migFks.size} FK pair (ที่เทียบได้/ทั้งหมดฝั่ง migration)`
+);
 for (const n of notes) console.log(`  note: ${n}`);
 
 if (failures.length === 0) {


### PR DESCRIPTION
## Summary

ผลของ workflow `/codebase-review-fix` เต็มรูปแบบ — review codebase ทั้งหมดด้วย 4 agents แบบ read-only → **44 findings** (2 High · 26 Medium · 16 Low) → PRD + PRP (40 tasks) → dual-review gate (`prp-validate-plan`) 5 loops → implement ด้วย 4 agents ขนาน → full validation → final review (code + security) → scoped fix loop

### Highlights (แก้ทั้งหมด 40 findings ใน PR นี้)

**High**
- **F1** รูปพนักงานไม่เคยมี `is_primary` → `/profile/{id}` คืน `photo_path: null` เสมอ — ตอนนี้ transaction ตั้ง primary ให้รูปล่าสุดจริง
- **F2** backend gates (parity/PHPUnit) ไม่ถูกบังคับบน push — pre-push hook เพิ่ม parity (fail-closed) + Unit suite (Docker-guarded, loud SKIP)

**Security**
- Login lockout ครอบทั้ง username + IP (`publicClientIp` last-hop XFF, skip 'unknown'), เปลี่ยนรหัสผ่าน revoke ทุก session (หน้าเปลี่ยนรหัสพาไป login พร้อม toast), JWT_SECRET ≥32 fail-closed + หมุน local secret, DB creds fail-closed, `.htaccess` บล็อก `storage/`·`vendor/`·`tests/`·`scripts/`·dotfiles, CORS allowlist-only + `Vary: Origin`, prune `refresh_tokens`, ตัด OCR error detail, upload limits (nginx 25m + PHP ini)

**Backend**: clamp limit ทั้ง probation/QualificationEngine, enrollment 404/400/409, supportive strict-date + ไม่รีเซ็ต ratio, sync ใช้ authz matrix (superadmin ไม่โดน 403), net-breakdown helper รวมศูนย์, audit soft-delete, readyz not_ready contract คงเดิม, single-clock revokes

**Frontend**: AuditLog/Dashboard/MultiplierAreas ใช้ `useRequestSeq` กัน stale fetch, `serverDateTime` (+07:00) แก้เวลาเพี้ยน 7 ชม., dashboard `in_progress` ตรง predicate เดียวกับหน้า probation, remember-me ทำงานจริง, base64url decode กัน logout เอง, form end≥start, toast 401 ภาษาไทย, alert→toast

**Config**: upload limits (nginx 25m + PHP 25M), `npm audit` ครบทั้ง 3 entry, Node 24 pin (Dockerfile+engines), `.env.example` ครบ + เกณฑ์ ≥32, compose healthcheck (`php -r` /api/readyz), nginx CSP report-uri ตรง render.yaml, phpunit coverage source ครบ

## Schema notes

- `tidb-init.sql`: ลบ 3 FK ที่ migration 22 ลบแล้ว (ทำให้ bootstrap ตรง migration) — ไม่มี migration ใหม่ (index `login_attempts.ip_address` เป็น follow-up)
- parity gate ใหม่: เทียบ FK pairs (ทั้ง CREATE TABLE inline + ALTER TABLE ADD CONSTRAINT) — 43/43 ผ่าน

## Validation

- PHPUnit: **406 tests / 1145 assertions** (0 fail, 1 pre-existing skip)
- Vitest: **582/582** · parity: **43/43 FK** · `node --test`: **146/146** · build: **exit 0**
- Final review (code + security) → scoped fix loop ปิดทุก Critical/High (G3 ผ่าน)

## Deferrals (บันทึกเหตุผลใน PRD Non-goals)

- F21/F22 — integration test suites + e2e write-path (follow-up แยก, scope ใหญ่)
- F34 — signed photo URLs (ตัดสินใจ design, กระทบ #112)
- F44 — asset caching tradeoff (เพิ่งปิด #155 — ห้ามสั่น cache)

## สิ่งที่ owner ต้องรู้หลัง merge

1. **Render JWT_SECRET** ต้องยาว ≥32 ตัว — เช็คความยาวก่อน deploy (ไม่งั้น API 500 ทั้งหมด)
2. **ผู้ใช้ local ทุกคนถูกบังคับ logout ครั้งเดียว** (JWT_SECRET local ถูกหมุน + นโยบาย revoke)
3. **เปลี่ยนรหัสผ่าน = ออกจากระบบทุก session** (ต้อง login ใหม่) — by design
4. pre-push ใหม่: parity fail-closed + Unit suite เมื่อ Docker ขึ้น (SKIP อย่างมีเสียงถ้าไม่มี)