### PR TITLE
fix(graft): restrict local build wrapper

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,6 +16,9 @@ smart-port-graphify-safe-*/
 .worktrees/
 project-log-md/
 graft/
+.graft-backup-*/
+.graft-safe.lock
+smart-port-graft-safe-*/
 document-ocr/input/
 document-ocr/output/
 

--- a/.gitignore
+++ b/.gitignore
@@ -93,7 +93,7 @@ backend/vendor/
 backend/.phpunit.cache/
 backend/.phpunit.result.cache
 
-secrets/
+/secrets/
 /.qwen/
 /.zcode/
 /graphify-out/
@@ -101,6 +101,10 @@ secrets/
 /.graphify-safe.lock
 /smart-port-graphify-safe-*/
 __pycache__/
+/graft/
+/.graft-backup-*/
+/.graft-safe.lock
+/smart-port-graft-safe-*/
 
 # Session/debug artifacts — ห้าม track (diff dumps, crash dumps, debug screenshots)
 *diff.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ Add frontend tests under `frontend/src/__tests__/` and name them `*.test.js`. Up
 Follow the existing Conventional Commit style: `feat:`, `fix:`, `fix(test):`, and similar short imperative subjects. Keep commits scoped to one logical change. PRs should include a concise summary, linked issue or task, API or schema notes, verification steps, and screenshots for UI changes. Avoid mixing unrelated frontend, backend, and SQL work in one PR.
 
 ## Security & Configuration Tips
-Keep secrets in local `.env` files only. Review authentication and CORS changes carefully in `backend/api.php`. Do not commit database data, upload artifacts, credentials, or generated bundles.
+Keep secrets in local `.env` files only. The entire root `/secrets/` directory is local-only: never search, index, summarize, upload, or send any file beneath it to an external service. Build Graft only through `./scripts/graft-safe.ps1 build .`; never invoke `graft` directly in this repository, including automatic refresh hooks and MCP integrations. The wrapper accepts only structural builds, uses selected tracked source files in a temporary snapshot, rejects symlinks/junctions, and runs Graft with a minimal child-environment allowlist. External summarization is disabled. This wrapper is not a network sandbox or a comprehensive sensitive-content detector; direct CLI invocation bypasses it. Do not upload its snapshot, generated graph, or `.graft-backup-*/` directories. Review authentication and CORS changes carefully in `backend/api.php`. Do not commit database data, upload artifacts, credentials, or generated bundles.
 
 ## Agent-Specific Instructions
 

--- a/scripts/graft-safe.ps1
+++ b/scripts/graft-safe.ps1
@@ -149,20 +149,29 @@ try {
     }
 
     $generatedGraph = Join-Path $tempRoot 'graft'
-    if (Test-Path -LiteralPath $generatedGraph -PathType Container) {
-        $repoGraph = Join-Path $repoRoot 'graft'
-        Assert-NoReparsePoint $repoGraph $repoRoot
-        Assert-NoReparsePoint $generatedGraph $tempRoot
-        if ([IO.Path]::GetFullPath((Split-Path -Parent $repoGraph)) -ne $repoRoot -or (Split-Path -Leaf $repoGraph) -ne 'graft') {
-            throw 'Refusing to replace an unexpected graph path.'
-        }
-        if (Test-Path -LiteralPath $repoGraph) {
-            $backupGraph = Join-Path $repoRoot ('.graft-backup-' + [guid]::NewGuid().ToString('N'))
-            Move-Item -LiteralPath $repoGraph -Destination $backupGraph
-            Write-Host 'Previous graph preserved in a local .graft-backup-* directory.'
-        }
-        Copy-Item -LiteralPath $generatedGraph -Destination $repoGraph -Recurse
+    if (-not (Test-Path -LiteralPath $generatedGraph -PathType Container)) {
+        throw 'Graft reported success without producing a graph directory.'
     }
+    Assert-NoReparsePoint $generatedGraph $tempRoot
+    foreach ($requiredFileName in @('INDEX.md', '.graph/wiring.json')) {
+        $requiredFile = Join-Path $generatedGraph $requiredFileName
+        Assert-NoReparsePoint $requiredFile $tempRoot
+        if (-not (Test-Path -LiteralPath $requiredFile -PathType Leaf)) {
+            throw "Graft output is incomplete: missing $requiredFileName."
+        }
+    }
+    $repoGraph = Join-Path $repoRoot 'graft'
+    Assert-NoReparsePoint $repoGraph $repoRoot
+    if ([IO.Path]::GetFullPath((Split-Path -Parent $repoGraph)) -ne $repoRoot -or (Split-Path -Leaf $repoGraph) -ne 'graft') {
+        throw 'Refusing to replace an unexpected graph path.'
+    }
+    if (Test-Path -LiteralPath $repoGraph) {
+        $backupGraph = Join-Path $repoRoot ('.graft-backup-' + [guid]::NewGuid().ToString('N'))
+        Assert-NoReparsePoint $backupGraph $repoRoot
+        Move-Item -LiteralPath $repoGraph -Destination $backupGraph
+        Write-Host 'Previous graph preserved in a local .graft-backup-* directory.'
+    }
+    Copy-Item -LiteralPath $generatedGraph -Destination $repoGraph -Recurse
 
     Write-Host "Safe local Graft command completed. Included tracked files: $copiedCount; excluded sensitive/local files: $excludedCount."
 }

--- a/scripts/graft-safe.ps1
+++ b/scripts/graft-safe.ps1
@@ -1,0 +1,186 @@
+[CmdletBinding()]
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$GraftArguments = @('build', '.')
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+if (($GraftArguments.Count -ne 1 -and $GraftArguments.Count -ne 2) -or
+    $GraftArguments[0] -cne 'build' -or
+    ($GraftArguments.Count -eq 2 -and $GraftArguments[1] -cne '.')) {
+    throw 'Only build or build . is permitted. Flags, other commands and external paths are blocked.'
+}
+
+$scriptRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..'))
+$repoRoot = (& git -C $scriptRoot rev-parse --show-toplevel).Trim()
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($repoRoot)) {
+    throw 'Run this script from inside the Smart Port Git worktree.'
+}
+$repoRoot = [IO.Path]::GetFullPath($repoRoot)
+if ($repoRoot -ne $scriptRoot) { throw 'Unexpected repository root.' }
+
+function Assert-NoReparsePoint([string]$Path, [string]$Root) {
+    $full = [IO.Path]::GetFullPath($Path)
+    if (-not $full.StartsWith($Root + [IO.Path]::DirectorySeparatorChar, [StringComparison]::OrdinalIgnoreCase)) {
+        throw 'Path escapes the permitted root.'
+    }
+    $cursor = $full
+    while ($cursor) {
+        if (Test-Path -LiteralPath $cursor) {
+            if ((Get-Item -Force -LiteralPath $cursor).Attributes -band [IO.FileAttributes]::ReparsePoint) {
+                throw 'Symlinks and junctions are not permitted.'
+            }
+        }
+        $cursor = Split-Path -Parent $cursor
+    }
+}
+
+$excludedPrefixes = @(
+    '.agents/',
+    '.claude/',
+    '.qwen/',
+    '.zcode/',
+    'database/',
+    'docs/',
+    'document-ocr/',
+    'graft/',
+    'project-log-md/',
+    'secrets/',
+    'smartport/db-data/',
+    'uploads/'
+)
+$excludedExtensions = @(
+    '.bak', '.csv', '.doc', '.docx', '.dump', '.env', '.jks', '.kdbx',
+    '.key', '.log', '.pdf', '.pem', '.pfx', '.p12', '.sql', '.xls', '.xlsx'
+)
+
+$tempRoot = Join-Path $repoRoot ("smart-port-graft-safe-" + [guid]::NewGuid().ToString('N'))
+$lockPath = Join-Path $repoRoot '.graft-safe.lock'
+$graftCommand = Get-Command graft -ErrorAction Stop
+$allowedEnvironment = @('SYSTEMROOT', 'WINDIR', 'COMSPEC', 'TEMP', 'TMP', 'LANG', 'LC_ALL', 'PATH', 'PATHEXT')
+$savedEnvironment = $null
+$environmentChanged = $false
+$lockCreated = $false
+
+try {
+    Assert-NoReparsePoint $lockPath $repoRoot
+    $lock = [IO.File]::Open($lockPath, [IO.FileMode]::CreateNew, [IO.FileAccess]::Write, [IO.FileShare]::None)
+    $lock.Dispose()
+    $lockCreated = $true
+    New-Item -ItemType Directory -Path $tempRoot | Out-Null
+
+    $trackedFiles = @(& git -C $repoRoot -c core.quotePath=false ls-files)
+    if ($LASTEXITCODE -ne 0) {
+        throw 'Unable to enumerate tracked files. Refusing to build an unbounded snapshot.'
+    }
+
+    $copiedCount = 0
+    $excludedCount = 0
+    foreach ($relativePath in $trackedFiles) {
+        $normalizedPath = $relativePath.Replace('\', '/')
+        $extension = [IO.Path]::GetExtension($normalizedPath).ToLowerInvariant()
+        $isExcluded = $false
+        # Only source code in explicit roots; never copy tool configuration or data.
+        if ($normalizedPath -notmatch '^(backend|frontend/src|scripts)/' -or
+            $normalizedPath -match '(^|/)[.]|(^|/)(secrets|credentials|backups|db-backups|uploads|node_modules|vendor|fixtures|data)(/|$)' -or
+            $extension -notin @('.php', '.js', '.mjs', '.vue', '.ts', '.css')) {
+            $isExcluded = $true
+        }
+
+        foreach ($prefix in $excludedPrefixes) {
+            if ($normalizedPath.StartsWith($prefix, [StringComparison]::OrdinalIgnoreCase)) {
+                $isExcluded = $true
+                break
+            }
+        }
+        if (-not $isExcluded -and $excludedExtensions -contains $extension) {
+            $isExcluded = $true
+        }
+        if (-not $isExcluded -and [IO.Path]::GetFileName($normalizedPath) -match '(?i)(credential|private[-_]?key|secret)') {
+            $isExcluded = $true
+        }
+
+        if ($isExcluded) {
+            $excludedCount++
+            continue
+        }
+
+        $sourcePath = Join-Path $repoRoot $relativePath
+        Assert-NoReparsePoint $sourcePath $repoRoot
+        if (-not (Test-Path -LiteralPath $sourcePath -PathType Leaf)) {
+            continue
+        }
+
+        $destinationPath = Join-Path $tempRoot $relativePath
+        Assert-NoReparsePoint $destinationPath $tempRoot
+        $destinationDirectory = Split-Path -Parent $destinationPath
+        if (-not (Test-Path -LiteralPath $destinationDirectory)) {
+            New-Item -ItemType Directory -Path $destinationDirectory -Force | Out-Null
+        }
+        Copy-Item -LiteralPath $sourcePath -Destination $destinationPath
+        $copiedCount++
+    }
+
+    # The PowerShell Env: provider can fail when a host injects case-variant names.
+    $savedEnvironment = [Environment]::GetEnvironmentVariables([EnvironmentVariableTarget]::Process)
+    $environmentChanged = $true
+    foreach ($variableName in @($savedEnvironment.Keys)) {
+        [Environment]::SetEnvironmentVariable([string]$variableName, $null, 'Process')
+    }
+    foreach ($variableName in @($savedEnvironment.Keys)) {
+        if ($allowedEnvironment -contains [string]$variableName) {
+            [Environment]::SetEnvironmentVariable([string]$variableName, [string]$savedEnvironment[$variableName], 'Process')
+        }
+    }
+    [Environment]::SetEnvironmentVariable('NO_COLOR', '1', 'Process')
+
+    Push-Location $tempRoot
+    try {
+        # Fixed invocation: never forward user arguments to the CLI.
+        & $graftCommand build .
+        if ($LASTEXITCODE -ne 0) {
+            throw "Graft exited with code $LASTEXITCODE."
+        }
+    }
+    finally {
+        Pop-Location
+    }
+
+    $generatedGraph = Join-Path $tempRoot 'graft'
+    if (Test-Path -LiteralPath $generatedGraph -PathType Container) {
+        $repoGraph = Join-Path $repoRoot 'graft'
+        Assert-NoReparsePoint $repoGraph $repoRoot
+        Assert-NoReparsePoint $generatedGraph $tempRoot
+        if ([IO.Path]::GetFullPath((Split-Path -Parent $repoGraph)) -ne $repoRoot -or (Split-Path -Leaf $repoGraph) -ne 'graft') {
+            throw 'Refusing to replace an unexpected graph path.'
+        }
+        if (Test-Path -LiteralPath $repoGraph) {
+            $backupGraph = Join-Path $repoRoot ('.graft-backup-' + [guid]::NewGuid().ToString('N'))
+            Move-Item -LiteralPath $repoGraph -Destination $backupGraph
+            Write-Host 'Previous graph preserved in a local .graft-backup-* directory.'
+        }
+        Copy-Item -LiteralPath $generatedGraph -Destination $repoGraph -Recurse
+    }
+
+    Write-Host "Safe local Graft command completed. Included tracked files: $copiedCount; excluded sensitive/local files: $excludedCount."
+}
+finally {
+    if ($environmentChanged) {
+        foreach ($variableName in @($allowedEnvironment + 'NO_COLOR')) {
+            [Environment]::SetEnvironmentVariable($variableName, $null, 'Process')
+        }
+        foreach ($variableName in @($savedEnvironment.Keys)) {
+            [Environment]::SetEnvironmentVariable([string]$variableName, [string]$savedEnvironment[$variableName], 'Process')
+        }
+    }
+    if (Test-Path -LiteralPath $tempRoot) {
+        Assert-NoReparsePoint (Join-Path $tempRoot 'cleanup-check') $tempRoot
+        Remove-Item -LiteralPath $tempRoot -Recurse -Force
+    }
+    if ($lockCreated -and (Test-Path -LiteralPath $lockPath -PathType Leaf)) {
+        Assert-NoReparsePoint $lockPath $repoRoot
+        Remove-Item -LiteralPath $lockPath -Force
+    }
+}

--- a/scripts/tests/graft-safe.test.ps1
+++ b/scripts/tests/graft-safe.test.ps1
@@ -2,6 +2,7 @@ $ErrorActionPreference = 'Stop'
 $wrapper = Join-Path $PSScriptRoot '../graft-safe.ps1'
 $root = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '../..'))
 $global:graftGuardTestCalls = 0
+$global:graftGuardMode = 'stop'
 function git {
     if ($args -contains 'rev-parse') { $global:LASTEXITCODE = 0; return $root }
     $global:LASTEXITCODE = 0
@@ -16,6 +17,7 @@ function graft {
     if ([Environment]::GetEnvironmentVariable('UNKNOWN_PROVIDER_TOKEN')) { throw 'Unknown credential inherited' }
     if ([Environment]::GetEnvironmentVariable('NODE_OPTIONS')) { throw 'Node preload inherited' }
     if (@(Get-ChildItem -Force).Count -ne 0) { throw 'Excluded file copied' }
+    if ($global:graftGuardMode -eq 'missing-output') { $global:LASTEXITCODE = 0; return }
     throw 'EXPECTED_MOCK_STOP'
 }
 $savedKey = [Environment]::GetEnvironmentVariable('OPENROUTER_API_KEY')
@@ -55,11 +57,15 @@ try {
         $env:NODE_OPTIONS -ne '--require=synthetic-test-only') {
         throw 'Parent environment not restored'
     }
+    $global:graftGuardMode = 'missing-output'
+    try { & $wrapper build .; throw 'Missing graph output was accepted' }
+    catch { if ($_.Exception.Message -ne 'Graft reported success without producing a graph directory.') { throw } }
+    if ($global:graftGuardTestCalls -ne 2) { throw 'Expected missing-output invocation' }
     if (Test-Path -LiteralPath (Join-Path $root '.graft-safe.lock')) { throw 'Build lock was not removed' }
     if (@(Get-ChildItem -LiteralPath $root -Directory -Filter 'smart-port-graft-safe-*').Count -ne 0) {
         throw 'Snapshot was not removed'
     }
-    Write-Output 'PASS: argument rejection, excluded paths, environment allowlist, fixed invocation, restoration and cleanup.'
+    Write-Output 'PASS: argument rejection, excluded paths, environment allowlist, output validation, fixed invocation, restoration and cleanup.'
 }
 finally {
     [Environment]::SetEnvironmentVariable('OPENROUTER_API_KEY', $savedKey)

--- a/scripts/tests/graft-safe.test.ps1
+++ b/scripts/tests/graft-safe.test.ps1
@@ -1,0 +1,69 @@
+$ErrorActionPreference = 'Stop'
+$wrapper = Join-Path $PSScriptRoot '../graft-safe.ps1'
+$root = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '../..'))
+$global:graftGuardTestCalls = 0
+function git {
+    if ($args -contains 'rev-parse') { $global:LASTEXITCODE = 0; return $root }
+    $global:LASTEXITCODE = 0
+    # Excluded paths must not be opened, even if Git returns them.
+    return @('secrets/never-read.php', 'database/never-read.sql', '.env', 'scripts/../secrets/never-read.php')
+}
+function graft {
+    $global:graftGuardTestCalls++
+    if (($args -join ' ') -cne 'build .') { throw 'Unexpected CLI arguments' }
+    if ([Environment]::GetEnvironmentVariable('OPENROUTER_API_KEY')) { throw 'Legacy credential inherited' }
+    if ([Environment]::GetEnvironmentVariable('GRAFT_DIR')) { throw 'Graph override inherited' }
+    if ([Environment]::GetEnvironmentVariable('UNKNOWN_PROVIDER_TOKEN')) { throw 'Unknown credential inherited' }
+    if ([Environment]::GetEnvironmentVariable('NODE_OPTIONS')) { throw 'Node preload inherited' }
+    if (@(Get-ChildItem -Force).Count -ne 0) { throw 'Excluded file copied' }
+    throw 'EXPECTED_MOCK_STOP'
+}
+$savedKey = [Environment]::GetEnvironmentVariable('OPENROUTER_API_KEY')
+$savedDir = [Environment]::GetEnvironmentVariable('GRAFT_DIR')
+$savedUnknown = [Environment]::GetEnvironmentVariable('UNKNOWN_PROVIDER_TOKEN')
+$savedNodeOptions = [Environment]::GetEnvironmentVariable('NODE_OPTIONS')
+try {
+    $env:OPENROUTER_API_KEY = 'synthetic-test-only'
+    $env:GRAFT_DIR = 'synthetic-outside-path'
+    $env:UNKNOWN_PROVIDER_TOKEN = 'synthetic-test-only'
+    $env:NODE_OPTIONS = '--require=synthetic-test-only'
+    foreach ($case in @(
+        @('build', '.', '--deep'), @('build', '--deep=true'),
+        @('build', '..'), @('build', 'C:\'), @('ask', 'question'),
+        @('build', '.', '--dir=..'), @('build', '.', '--lsp')
+    )) {
+        try { & $wrapper @case; throw 'Unexpected acceptance' }
+        catch { if ($_.Exception.Message -notlike 'Only build*') { throw } }
+    }
+    if ($global:graftGuardTestCalls -ne 0) { throw 'Rejected arguments reached Graft' }
+    $lockPath = Join-Path $root '.graft-safe.lock'
+    try {
+        [IO.File]::WriteAllText($lockPath, 'synthetic-test-only')
+        try { & $wrapper build .; throw 'Concurrent build lock was ignored' }
+        catch { if ($_.Exception.Message -notlike '*already exists*') { throw } }
+    }
+    finally {
+        if (Test-Path -LiteralPath $lockPath) { Remove-Item -LiteralPath $lockPath -Force }
+    }
+    if ($global:graftGuardTestCalls -ne 0) { throw 'Locked build reached Graft' }
+    try { & $wrapper build .; throw 'Expected mock failure' }
+    catch { if ($_.Exception.Message -ne 'EXPECTED_MOCK_STOP') { throw } }
+    if ($global:graftGuardTestCalls -ne 1) { throw 'Expected one structural invocation' }
+    if ($env:OPENROUTER_API_KEY -ne 'synthetic-test-only' -or
+        $env:GRAFT_DIR -ne 'synthetic-outside-path' -or
+        $env:UNKNOWN_PROVIDER_TOKEN -ne 'synthetic-test-only' -or
+        $env:NODE_OPTIONS -ne '--require=synthetic-test-only') {
+        throw 'Parent environment not restored'
+    }
+    if (Test-Path -LiteralPath (Join-Path $root '.graft-safe.lock')) { throw 'Build lock was not removed' }
+    if (@(Get-ChildItem -LiteralPath $root -Directory -Filter 'smart-port-graft-safe-*').Count -ne 0) {
+        throw 'Snapshot was not removed'
+    }
+    Write-Output 'PASS: argument rejection, excluded paths, environment allowlist, fixed invocation, restoration and cleanup.'
+}
+finally {
+    [Environment]::SetEnvironmentVariable('OPENROUTER_API_KEY', $savedKey)
+    [Environment]::SetEnvironmentVariable('GRAFT_DIR', $savedDir)
+    [Environment]::SetEnvironmentVariable('UNKNOWN_PROVIDER_TOKEN', $savedUnknown)
+    [Environment]::SetEnvironmentVariable('NODE_OPTIONS', $savedNodeOptions)
+}


### PR DESCRIPTION
Graft could scan the live worktree and inherit provider credentials or local graph overrides when invoked directly. This change adds a repository-scoped wrapper so `./scripts/graft-safe.ps1 build .` accepts structural builds only, copies selected tracked source files into a guarded snapshot, rejects links, isolates the child environment, and preserves prior graph output locally.

The wrapper now fails closed if Graft exits successfully without producing both `graft/INDEX.md` and `graft/.graph/wiring.json`. The Graphify changes already on `main` are retained. Git and Docker exclusions cover Graft output, snapshots, locks, and backups, and `AGENTS.md` records the required invocation and limits.

Validation:

- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/tests/graft-safe.test.ps1`
- Real safe build with Graft 0.10.1: 280 selected tracked files; 241 parsed files; 1,512 nodes; 1,515 edges
- Normal pre-push hook after each pushed change: 146 Node regression tests, schema parity, CSP bundle audit, and 582 Vitest tests passed
- Backend Unit suite was skipped by the hook because Docker is unavailable

The wrapper is not an OS sandbox or a comprehensive source-content secret scanner. Generated `graft/` data and `.graft-backup-*/` remain local-only.
