### PR TITLE
test: e2e role-permissions + CRUD specs (16/16) + fix Dockerfile VITE_API_URL footgun

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,8 +11,11 @@
 #  เป็น warn-only เชิง documentation เท่านั้น — npm ไม่ block ตอน install)
 FROM node:24-slim AS builder
 
-# ระบุ build-time argument สำหรับ VITE_API_URL
-ARG VITE_API_URL=http://localhost:8000
+# ระบุ build-time argument สำหรับ VITE_API_URL — ต้องว่าง (ไม่ใช่ default URL)
+# เมื่อว่างโค้ด fallback ไป '/api' แล้วใช้ nginx proxy ต่อ backend (CSP 'self' บล็อก
+# cross-origin โดยตรง); ค่า http://localhost:8000 ทำ login พังเงียบๆ ตอน deploy
+# ผ่าน nginx และเคยเกิดจริงใน E2E smoke run
+ARG VITE_API_URL=
 
 # กำหนด working directory ภายใน container
 WORKDIR /app

--- a/frontend/e2e/features/api-permissions.spec.js
+++ b/frontend/e2e/features/api-permissions.spec.js
@@ -1,0 +1,186 @@
+import { test, expect } from '@playwright/test'
+import { apiBase, apiLogin, createUserViaApi, thaiCitizenId } from '../helpers/auth.js'
+
+/**
+ * Backend permission matrix (backend/authz.php) ผ่าน HTTP จริง — ต่างจาก PHPUnit
+ * ที่ทดสอบ function-level seam เท่านั้น (PermissionGateHttpTest, PersonnelAuthzHttpTest)
+ */
+const stamp = Date.now()
+
+// prefix 10 หลัก unique ต่อรอบ + suffix 2 หลักต่อ test = 12 หลักพอดีก่อนเติม check digit
+const CID_PREFIX = `555${String(stamp % 10_000_000).padStart(7, '0')}`
+
+/** user ที่ describe นี้สร้าง — เก็บไว้ deactivate ใน afterEach (กันสะสมข้ามรอบ) */
+const createdUserIds = []
+
+async function expectForbidden(res, requiredPermission) {
+  expect(res.status(), await res.text()).toBe(403)
+  const body = await res.json()
+  expect(body.error).toBe('Forbidden')
+  expect(body.required_permission).toBe(requiredPermission)
+}
+
+test.describe('api permission matrix', () => {
+  test.afterEach(async ({ request }) => {
+    if (createdUserIds.length === 0) return
+    const admin = await apiLogin(request, 'admin', 'admin123')
+    for (const userId of createdUserIds) {
+      await request.put(`${apiBase()}/users/${userId}`, {
+        headers: {
+          Authorization: `Bearer ${admin.token}`,
+          'X-CSRF-Token': admin.csrf_token,
+        },
+        data: { is_active: 0 },
+      }).catch(() => {})
+    }
+    createdUserIds.length = 0
+  })
+  test('viewer can read allowed resources but is denied write and restricted read', async ({ request }) => {
+    const creds = await createUserViaApi(request, {
+      username: `e2e_api_viewer_${stamp}`,
+      password: 'ApiViewer1!',
+      role: 'viewer',
+      fullName: 'E2E Api Viewer',
+    })
+    createdUserIds.push(creds.userId)
+    const viewer = await apiLogin(request, creds.username, creds.password)
+
+    const authHeaders = {
+      Authorization: `Bearer ${viewer.token}`,
+    }
+
+    // matrix: viewer read = multiplier, personnel, candidates, probation, dashboard, profile
+    const dashboard = await request.get(`${apiBase()}/dashboard`, { headers: authHeaders })
+    expect(dashboard.status()).toBe(200)
+
+    const personnel = await request.get(`${apiBase()}/personnel`, { headers: authHeaders })
+    expect(personnel.status()).toBe(200)
+
+    // users / audit ไม่อยู่ใน read list ของ viewer
+    await expectForbidden(
+      await request.get(`${apiBase()}/users`, { headers: authHeaders }),
+      'read:users',
+    )
+    await expectForbidden(
+      await request.get(`${apiBase()}/audit`, { headers: authHeaders }),
+      'read:audit',
+    )
+
+    await expectForbidden(
+      await request.post(`${apiBase()}/personnel`, {
+        headers: { ...authHeaders, 'X-CSRF-Token': viewer.csrf_token },
+        data: { first_name: 'ทดสอบ', last_name: 'วิวเวอร์', citizen_id: thaiCitizenId(CID_PREFIX + '01') },
+      }),
+      'create:personnel',
+    )
+    await expectForbidden(
+      await request.post(`${apiBase()}/import/executive`, {
+        headers: { ...authHeaders, 'X-CSRF-Token': viewer.csrf_token },
+        multipart: { file: { name: 'x.xlsx', mimeType: 'application/zip', buffer: Buffer.from('PK') } },
+      }),
+      'create:import',
+    )
+  })
+
+  test('operator can read everywhere but cannot write personnel, delete, or import', async ({ request }) => {
+    const creds = await createUserViaApi(request, {
+      username: `e2e_api_op_${stamp}`,
+      password: 'ApiOp12!',
+      role: 'operator',
+      fullName: 'E2E Api Operator',
+    })
+    createdUserIds.push(creds.userId)
+    const op = await apiLogin(request, creds.username, creds.password)
+
+    const authHeaders = {
+      Authorization: `Bearer ${op.token}`,
+    }
+
+    const dashboard = await request.get(`${apiBase()}/dashboard`, { headers: authHeaders })
+    expect(dashboard.status()).toBe(200)
+
+    const users = await request.get(`${apiBase()}/users`, { headers: authHeaders })
+    expect(users.status()).toBe(200)
+
+    await expectForbidden(
+      await request.post(`${apiBase()}/personnel`, {
+        headers: { ...authHeaders, 'X-CSRF-Token': op.csrf_token },
+        data: { first_name: 'ทดสอบ', last_name: 'โอเปอเรเตอร์', citizen_id: thaiCitizenId(CID_PREFIX + '02') },
+      }),
+      'create:personnel',
+    )
+
+    // operator delete = [] ทุก resource — DELETE เป็น stateful method ต้องแนบ CSRF (api.php:149-153)
+    await expectForbidden(
+      await request.delete(`${apiBase()}/civil-servants/999999`, {
+        headers: { ...authHeaders, 'X-CSRF-Token': op.csrf_token },
+      }),
+      'delete:personnel',
+    )
+
+    // 403 ต้องเกิดก่อน validation ของ import (ยังไม่แนบไฟล์ก็ต้องโดน 403)
+    await expectForbidden(
+      await request.post(`${apiBase()}/import/executive`, {
+        headers: { ...authHeaders, 'X-CSRF-Token': op.csrf_token },
+        multipart: { file: { name: 'x.xlsx', mimeType: 'application/zip', buffer: Buffer.from('PK') } },
+      }),
+      'create:import',
+    )
+  })
+
+  test('admin passes permission gates and hits validation instead — personnel create lifecycle', async ({ request }) => {
+    const creds = await createUserViaApi(request, {
+      username: `e2e_api_adm_${stamp}`,
+      password: 'ApiAdm1!',
+      role: 'admin',
+      fullName: 'E2E Api Admin',
+    })
+    createdUserIds.push(creds.userId)
+    const admin = await apiLogin(request, creds.username, creds.password)
+    const authHeaders = {
+      Authorization: `Bearer ${admin.token}`,
+      'X-CSRF-Token': admin.csrf_token,
+    }
+
+    // admin ผ่าน permission gate ของ import → ตกไปโดน validation "ไม่มีไฟล์"
+    const noFile = await request.post(`${apiBase()}/import/executive`, {
+      headers: authHeaders,
+      multipart: {},
+    })
+    expect(noFile.status(), await noFile.text()).toBe(400)
+    expect(await noFile.text()).toContain('กรุณาแนบไฟล์ Excel')
+
+    // สร้าง personnel จริงผ่าน API — success แล้ว deactivate เป็น cleanup
+    const citizenId = thaiCitizenId(CID_PREFIX + '03')
+    const create = await request.post(`${apiBase()}/personnel`, {
+      headers: authHeaders,
+      data: {
+        first_name: 'ทดสอบ',
+        last_name: 'อีทูไอ',
+        citizen_id: citizenId,
+      },
+    })
+    expect(create.status(), await create.text()).toBe(201)
+    const created = await create.json()
+    expect(created.success).toBe(true)
+    expect(created.personnel_id).toBeTruthy()
+
+    // deactivate (soft) — ทำความสะอาดข้อมูลที่ test สร้างเอง
+    const deactivate = await request.put(`${apiBase()}/personnel/${created.personnel_id}`, {
+      headers: authHeaders,
+      data: { is_active: false },
+    })
+    expect(deactivate.status(), await deactivate.text()).toBe(200)
+
+    // duplicate citizen_id กับแถวที่เพิ่งสร้าง (ยังอยู่ในระบบแม้ปิดใช้งาน) → 409
+    const dup = await request.post(`${apiBase()}/personnel`, {
+      headers: authHeaders,
+      data: {
+        first_name: 'ทดสอบ',
+        last_name: 'ซ้ำซ้อก',
+        citizen_id: citizenId,
+      },
+    })
+    expect(dup.status(), await dup.text()).toBe(409)
+  })
+})

--- a/frontend/e2e/features/import.spec.js
+++ b/frontend/e2e/features/import.spec.js
@@ -13,4 +13,22 @@ test.describe('import (admin)', () => {
     await expect(page.getByRole('link', { name: /ดาวน์โหลดเทมเพลต/ })).toBeVisible()
     await expect(page.getByText('2. อัปโหลดไฟล์')).toBeVisible()
   })
+
+  test('uploading a fake xlsx shows failure panel without importing', async ({ page }) => {
+    await page.goto('/import')
+
+    // ตั้งชื่อ .xlsx ผ่าน client validation (ImportPage pick()) แต่ magic bytes ไม่ใช่ zip
+    // → backend ปฏิเสธที่ routes/import.php:81-93 (415 ไฟล์ไม่ใช่ .xlsx ที่ถูกต้อง) ก่อนแตะ import logic
+    await page.locator('#import-file-input').setInputFiles({
+      name: 'e2e-fake-excel.xlsx',
+      mimeType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      buffer: Buffer.from('definitely not a zip file'),
+    })
+
+    await page.getByRole('button', { name: 'นำเข้าข้อมูล' }).click()
+
+    // แผงผลลัพธ์ (aria-live) แสดง error จาก backend ไม่ใช่แค่ client-side validation
+    await expect(page.getByText('นำเข้าไม่สำเร็จ', { exact: false })).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByText('ไฟล์ไม่ใช่ .xlsx ที่ถูกต้อง')).toBeVisible()
+  })
 })

--- a/frontend/e2e/features/personnel-crud.spec.js
+++ b/frontend/e2e/features/personnel-crud.spec.js
@@ -1,0 +1,158 @@
+import { test, expect } from '@playwright/test'
+import { adminPass, adminUser, apiBase, apiLogin, loginAsAdmin, thaiCitizenId } from '../helpers/auth.js'
+
+/**
+ * UI CRUD flow บน /personnel (PersonnelPage) — PHPUnit ครอบ validation ที่ function level
+ * (PersonnelMasterCrudTest) แต่ E2E ครอบ flow ผ่าน UI จริง + สถานะปิดใช้งาน/เปิดกลับ
+ *
+ * selector notes: modal ของหน้านี้เป็น div ธรรมดา (ไม่มี role="dialog") — scope ปุ่ม
+ * ใน modal ด้วย .fixed เพราะปุ่ม 'ปิดใช้งาน'/'เปิดใช้งาน' ใน row กับใน modal confirm
+ * ชื่อเหมือนกัน, และใช้ #id แทน getByLabel (label มีดาว * ต่อท้าย)
+ */
+const stamp = Date.now()
+
+// prefix 9 หลัก unique ต่อรอบ + เลขลำดับ test 3 หลัก = 12 หลักพอดีก่อนเติม check digit
+const CITIZEN_PREFIX_BASE = `996${String(stamp % 1_000_000).padStart(6, '0')}`
+
+function citizenFor(n) {
+  return thaiCitizenId(`${CITIZEN_PREFIX_BASE}${String(n).padStart(3, '0')}`)
+}
+
+async function searchPersonnel(page, name) {
+  await page.getByPlaceholder('ค้นหาชื่อ เลขบัตร หรือรหัสพนักงาน...').fill(name)
+  await page.waitForTimeout(600)
+}
+
+function rowOf(page, name) {
+  return page.getByRole('row', { name: new RegExp(name) })
+}
+
+/** สร้าง personnel ผ่าน API พร้อม cleanup handle */
+async function createPersonnelViaApi(request, firstName, lastName, citizenId) {
+  const admin = await apiLogin(request, adminUser, adminPass)
+  const create = await request.post(`${apiBase()}/personnel`, {
+    headers: {
+      Authorization: `Bearer ${admin.token}`,
+      'X-CSRF-Token': admin.csrf_token,
+    },
+    data: {
+      first_name: firstName,
+      last_name: lastName,
+      citizen_id: citizenId,
+    },
+  })
+  expect(create.status(), await create.text()).toBe(201)
+  return (await create.json()).personnel_id
+}
+
+/** deactivate ผ่าน API (best-effort) — cleanup ข้อมูลที่ test สร้างเอง */
+async function deactivatePersonnel(request, personnelId) {
+  try {
+    const admin = await apiLogin(request, adminUser, adminPass)
+    await request.put(`${apiBase()}/personnel/${personnelId}`, {
+      headers: {
+        Authorization: `Bearer ${admin.token}`,
+        'X-CSRF-Token': admin.csrf_token,
+      },
+      data: { is_active: false },
+    })
+  } catch {
+    // best-effort — ไม่ให้ cleanup พัง test ผลลัพธ์
+  }
+}
+
+test.describe('personnel CRUD (admin UI)', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page)
+    await page.goto('/personnel')
+    await expect(page.getByRole('heading', { name: 'ข้อมูลบุคลากร' })).toBeVisible()
+  })
+
+  test('admin creates personnel with valid citizen id and it appears in list', async ({ page }) => {
+    const lastName = `ครู้เด็ต${stamp % 100}`
+    const citizenId = citizenFor(1)
+
+    await page.getByRole('button', { name: 'เพิ่มบุคลากร' }).click()
+    await expect(page.getByText('เพิ่มบุคลากรใหม่')).toBeVisible()
+
+    await page.locator('#personnel-first-name').fill('อีทูอาย')
+    await page.locator('#personnel-last-name').fill(lastName)
+    await page.locator('#personnel-citizen-id').fill(citizenId)
+
+    await page.getByRole('button', { name: 'สร้างบุคลากร' }).click()
+
+    await expect(page.getByText('สร้างบุคลากรสำเร็จ')).toBeVisible()
+
+    // แถวใหม่โผล่ในตาราง (ตอน modal ปิดแล้ว list refresh)
+    await searchPersonnel(page, lastName)
+    await expect(rowOf(page, lastName)).toBeVisible()
+  })
+
+  test('client-side rejects bad citizen id checksum without calling API', async ({ page }) => {
+    const badId = citizenFor(2)
+    const tampered = badId.slice(0, 12) + (badId[12] === '0' ? '1' : '0')
+
+    await page.getByRole('button', { name: 'เพิ่มบุคลากร' }).click()
+    await page.locator('#personnel-first-name').fill('อีทูอาย')
+    await page.locator('#personnel-last-name').fill(`เช็คซัม${stamp % 100}`)
+    await page.locator('#personnel-citizen-id').fill(tampered)
+
+    await page.getByRole('button', { name: 'สร้างบุคลากร' }).click()
+
+    await expect(page.getByText('เลขบัตรประชาชนไม่ถูกต้อง')).toBeVisible()
+    // modal ยังเปิดอยู่ — ไม่ได้ปิดไปเพราะสร้างสำเร็จ
+    await expect(page.getByText('เพิ่มบุคลากรใหม่')).toBeVisible()
+  })
+
+  test('admin edits personnel — citizen id immutable', async ({ page, request }) => {
+    const lastName = `แก้ไขด้${stamp % 100}`
+    const personnelId = await createPersonnelViaApi(request, 'อีทูอาย', lastName, citizenFor(3))
+
+    await searchPersonnel(page, lastName)
+    await rowOf(page, lastName).getByRole('button', { name: 'แก้ไข' }).click()
+
+    await expect(page.getByText('แก้ไขบุคลากร')).toBeVisible()
+    await expect(page.getByText('เลขบัตรแก้ไขไม่ได้ — หากผิดให้ปิดใช้งานแล้วสร้างใหม่')).toBeVisible()
+
+    await page.locator('#personnel-last-name').fill(`${lastName}จบ`)
+    await page.getByRole('button', { name: 'บันทึก' }).click()
+
+    await expect(page.getByText('บันทึกข้อมูลบุคลากรสำเร็จ')).toBeVisible()
+
+    await deactivatePersonnel(request, personnelId)
+  })
+
+  test('admin deactivates personnel then reactivates via hidden filter', async ({ page, request }) => {
+    const lastName = `ทอกเกิล${stamp % 100}`
+    const personnelId = await createPersonnelViaApi(request, 'อีทูอาย', lastName, citizenFor(4))
+
+    await searchPersonnel(page, lastName)
+    const row = rowOf(page, lastName)
+    await expect(row).toBeVisible()
+
+    // ปิดใช้งาน — ปุ่มใน row กับปุ่ม confirm ใน modal ชื่้ 'ปิดใช้งาน' เหมือนกัน
+    await row.getByRole('button', { name: 'ปิดใช้งาน' }).click()
+    await expect(page.getByText('ยืนยันการปิดใช้งาน')).toBeVisible()
+    await page.locator('.fixed').getByRole('button', { name: 'ปิดใช้งาน' }).click()
+
+    await expect(page.getByText('ปิดใช้งานสำเร็จ')).toBeVisible()
+    // แถวหายจาก default list (ค่าเริ่มต้นไม่แสดงที่ปิดใช้งาน)
+    await expect(row).toHaveCount(0)
+
+    // เปิดตัวกรองแสดงที่ปิดใช้งาน — แถวกลับมาพร้อม badge
+    await page.locator('#personnel-include-inactive').check()
+    await expect(row).toBeVisible()
+    await expect(row.getByText('ปิดใช้งาน', { exact: true })).toBeVisible()
+
+    // เปิดกลับ — ปุ่ม row กลายเป็น 'เปิดใช้งาน' ปุ่ม confirm ใน modal ก็ 'เปิดใช้งาน' เหมือนกัน
+    await row.getByRole('button', { name: 'เปิดใช้งาน' }).click()
+    await expect(page.getByText('ยืนยันการเปิดใช้งาน')).toBeVisible()
+    await page.locator('.fixed').getByRole('button', { name: 'เปิดใช้งาน' }).click()
+
+    await expect(page.getByText('เปิดใช้งานสำเร็จ')).toBeVisible()
+    await expect(row.getByText('ใช้งาน', { exact: true })).toBeVisible()
+
+    // cleanup — ปิดกลับเพื่อไม่สะสม
+    await deactivatePersonnel(request, personnelId)
+  })
+})

--- a/frontend/e2e/features/role-guards.spec.js
+++ b/frontend/e2e/features/role-guards.spec.js
@@ -1,0 +1,112 @@
+import { test, expect } from '@playwright/test'
+import { adminPass, adminUser, apiBase, apiLogin, createUserViaApi, loginAs } from '../helpers/auth.js'
+
+// ทุก route ที่ router/index.js:208-214 เด้งกลับ /dashboard เมื่อสิทธิ์ไม่พอ
+const ADMIN_ONLY_ROUTES = [
+  '/admin',
+  '/users',
+  '/audit',
+  '/import',
+  '/ocr',
+  '/settings/special-areas',
+  '/settings/permissions',
+]
+
+const stamp = Date.now()
+
+/** user ที่ describe นี้สร้าง — เก็บไว้ deactivate ใน afterEach (กันสะสมข้ามรอบ) */
+const createdUserIds = []
+
+test.describe('role guards (router)', () => {
+  test.afterEach(async ({ request }) => {
+    const admin = await apiLogin(request, adminUser, adminPass)
+    for (const userId of createdUserIds) {
+      await request.put(`${apiBase()}/users/${userId}`, {
+        headers: {
+          Authorization: `Bearer ${admin.token}`,
+          'X-CSRF-Token': admin.csrf_token,
+        },
+        data: { is_active: 0 },
+      }).catch(() => {})
+    }
+    createdUserIds.length = 0
+  })
+  test('operator is bounced from every admin-only route', async ({ page, request }) => {
+    const creds = await createUserViaApi(request, {
+      username: `e2e_guard_op_${stamp}`,
+      password: 'GuardOp1!',
+      role: 'operator',
+      fullName: 'E2E Guard Operator',
+    })
+    createdUserIds.push(creds.userId)
+
+    await loginAs(page, creds.username, creds.password)
+    await page.waitForURL('**/dashboard')
+
+    for (const route of ADMIN_ONLY_ROUTES) {
+      await page.goto(route)
+      await expect(page).toHaveURL(/\/dashboard/, { timeout: 10_000 })
+    }
+  })
+
+  test('viewer is bounced from admin routes but can still read dashboard', async ({ page, request }) => {
+    const creds = await createUserViaApi(request, {
+      username: `e2e_guard_viewer_${stamp}`,
+      password: 'GuardViewer1!',
+      role: 'viewer',
+      fullName: 'E2E Guard Viewer',
+    })
+    createdUserIds.push(creds.userId)
+
+    await loginAs(page, creds.username, creds.password)
+    await page.waitForURL('**/dashboard')
+
+    // login ใช้ได้จริง — viewer เปิดหน้า read ที่ matrix อนุญาตได้
+    await expect(
+      page.getByRole('heading', { name: 'ภาพรวมระบบสมุดพก' }),
+    ).toBeVisible()
+
+    for (const route of ADMIN_ONLY_ROUTES) {
+      await page.goto(route)
+      await expect(page).toHaveURL(/\/dashboard/, { timeout: 10_000 })
+    }
+  })
+
+  test('admin opens admin routes but is bounced from superadmin-only settings', async ({ page, request }) => {
+    const creds = await createUserViaApi(request, {
+      username: `e2e_guard_adm_${stamp}`,
+      password: 'GuardAdm1!',
+      role: 'admin',
+      fullName: 'E2E Guard Admin',
+    })
+    createdUserIds.push(creds.userId)
+
+    await loginAs(page, creds.username, creds.password)
+    await page.waitForURL('**/dashboard')
+
+    await page.goto('/users')
+    await expect(page).toHaveURL(/\/users/)
+    await expect(page.getByRole('heading', { name: 'จัดการผู้ใช้' })).toBeVisible()
+
+    await page.goto('/admin')
+    await expect(page).toHaveURL(/\/admin/)
+    await expect(page.getByRole('heading', { name: 'การจัดการระบบ' })).toBeVisible()
+
+    await page.goto('/settings/permissions')
+    await expect(page).toHaveURL(/\/dashboard/, { timeout: 10_000 })
+  })
+
+  test('superadmin can stay on superadmin-only settings', async ({ page, request }) => {
+    // seed admin ใน local DB ถูก migration 27 เลื่อนเป็น superadmin แล้ว — ตรวจก่อน
+    const me = await apiLogin(request, adminUser, adminPass)
+    const isSuperadmin = me.user?.role === 'superadmin'
+    test.skip(!isSuperadmin, 'seed admin is not superadmin in this environment')
+
+    await loginAs(page, adminUser, adminPass)
+    await page.waitForURL('**/dashboard')
+
+    await page.goto('/settings/permissions')
+    // assert URL เท่านั้น — ไม่ผูกกับ markup ของ SettingsPage
+    await expect(page).toHaveURL(/\/settings\/permissions/)
+  })
+})

--- a/frontend/e2e/features/users-crud.spec.js
+++ b/frontend/e2e/features/users-crud.spec.js
@@ -1,0 +1,188 @@
+import { test, expect } from '@playwright/test'
+import {
+  adminPass,
+  adminUser,
+  apiBase,
+  apiLogin,
+  loginAsAdmin,
+  sendWith429Retry,
+} from '../helpers/auth.js'
+
+/**
+ * UI CRUD flow บน /users (UserManagementPage) — PHPUnit ครอบ guard logic บางส่วน
+ * (UserManagementGuardTest) แต่ไม่มี E2E ทดสอบ flow ผ่าน UI จริงเลย
+ *
+ * selector notes:
+ * - modal ทั้งหมดเป็น div ธรรมดา (ไม่มี role="dialog") — scope ด้วย .fixed
+ *   กันชนปุ่มใน row ที่ชื่อเดียวกัน (ปุ่ม 'ปิดบัญชี'/'รีเซ็ตรหัสผ่าน' ใน modal
+ *   กับใน row ชื่อเหมือนกันเป๊ะ)
+ * - ใช้ #id ตรง ๆ แทน getByLabel เพราะ label มีดาว * ต่อท้าย ('รหัสผ่าน *')
+ *   และ 'รหัสผ่าน' เป็น substring ของ 'ยืนยันรหัสผ่าน'
+ */
+const stamp = Date.now()
+
+/** สร้าง user เป้าหมายผ่าน API แล้วคืน { username, userId } พร้อมใช้ */
+async function createTargetUser(request, username) {
+  const admin = await apiLogin(request, adminUser, adminPass)
+  const create = await sendWith429Retry(request, 'post', `${apiBase()}/users`, {
+    headers: {
+      Authorization: `Bearer ${admin.token}`,
+      'X-CSRF-Token': admin.csrf_token,
+    },
+    data: {
+      username,
+      password: 'CrudTarget1!',
+      full_name: 'เป้าหมาย เดิม',
+      role: 'operator',
+    },
+  })
+  if (create.status() !== 201) {
+    throw new Error(`createTargetUser failed (${create.status()}): ${await create.text()}`)
+  }
+  const body = await create.json()
+
+  // ปลดล็อก must_change_password — เปลี่ยนเป็นรหัสเดิม
+  const first = await apiLogin(request, username, 'CrudTarget1!')
+  await sendWith429Retry(request, 'post', `${apiBase()}/auth/change-password`, {
+    headers: {
+      Authorization: `Bearer ${first.token}`,
+      'X-CSRF-Token': first.csrf_token,
+    },
+    data: {
+      current_password: 'CrudTarget1!',
+      new_password: 'CrudTarget1!',
+    },
+  })
+
+  return { username, userId: body.user_id }
+}
+
+/** รอ debounce 300ms ของ ListSearchInput ให้กรองเสร็จ */
+async function searchUser(page, username) {
+  await page.getByPlaceholder('ค้นหาชื่อผู้ใช้หรือชื่อ-สกุล...').fill(username)
+  await page.waitForTimeout(600)
+}
+
+/** หาแถวของ username — row accessible name รวมข้อความทั้งแถว */
+function rowOf(page, username) {
+  return page.getByRole('row', { name: new RegExp(username) })
+}
+
+test.describe('users CRUD (admin UI)', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page)
+    await page.goto('/users')
+    await expect(page.getByRole('heading', { name: 'จัดการผู้ใช้' })).toBeVisible()
+  })
+
+  test.afterEach(async ({ request }) => {
+    // best-effort: ปิดบัญชีที่ test สร้างทั้งหมด (กันสะสมข้ามรอบ)
+    try {
+      const admin = await apiLogin(request, adminUser, adminPass)
+      const list = await request.get(`${apiBase()}/users?limit=200`, {
+        headers: { Authorization: `Bearer ${admin.token}` },
+      })
+      if (!list.ok()) return
+      const body = await list.json()
+      const mine = (body.data || []).filter((u) => String(u.username).startsWith('e2e_crud_'))
+      for (const u of mine) {
+        await sendWith429Retry(request, 'put', `${apiBase()}/users/${u.user_id}`, {
+          headers: {
+            Authorization: `Bearer ${admin.token}`,
+            'X-CSRF-Token': admin.csrf_token,
+          },
+          data: { is_active: 0 },
+        })
+      }
+    } catch {
+      // cleanup ต้องไม่พัง test ผลลัพธ์
+    }
+  })
+
+  test('admin creates a user via modal and it appears in the list', async ({ page }) => {
+    const username = `e2e_crud_new_${stamp}`
+
+    await page.getByRole('button', { name: 'เพิ่มผู้ใช้' }).click()
+    await expect(page.getByText('เพิ่มผู้ใช้ใหม่')).toBeVisible()
+
+    await page.locator('#user-username').fill(username)
+    await page.locator('#user-password').fill('NewUser1!')
+    await page.locator('#user-password-confirm').fill('NewUser1!')
+    await page.locator('#user-full-name').fill('ทดสอบ สร้างใหม่')
+    await page.locator('#user-role').selectOption({ label: 'Operator — บันทึกข้อมูล' })
+
+    await page.getByRole('button', { name: 'สร้างผู้ใช้' }).click()
+
+    await expect(page.getByText('สร้างผู้ใช้สำเร็จ')).toBeVisible()
+    await searchUser(page, username)
+    await expect(rowOf(page, username)).toBeVisible()
+  })
+
+  test('admin edits full name — username locked while editing', async ({ page, request }) => {
+    const username = `e2e_crud_edit_${stamp}`
+    await createTargetUser(request, username)
+
+    await searchUser(page, username)
+    await rowOf(page, username).getByRole('button', { name: 'แก้ไข' }).click()
+
+    await expect(page.getByText('แก้ไขผู้ใช้')).toBeVisible()
+    await expect(page.locator('#user-username')).toBeDisabled()
+
+    await page.locator('#user-full-name').fill('เป้าหมาย แก้ไขแล้ว')
+    await page.getByRole('button', { name: 'บันทึก' }).click()
+
+    await expect(page.getByText('บันทึกข้อมูลผู้ใช้สำเร็จ')).toBeVisible()
+  })
+
+  test('admin resets a user password', async ({ page, request }) => {
+    const username = `e2e_crud_reset_${stamp}`
+    await createTargetUser(request, username)
+
+    await searchUser(page, username)
+    await rowOf(page, username).getByRole('button', { name: 'รีเซ็ตรหัสผ่าน' }).click()
+
+    // heading ของ modal ('รีเซ็ตรหัสผ่าน' h2) กับปุ่มชื่อเดียวกัน — ใช้ heading role เฉพาะ
+    await expect(page.getByRole('heading', { name: 'รีเซ็ตรหัสผ่าน' })).toBeVisible()
+    await page.locator('#user-reset-password').fill('ResetNew1!')
+    await page.locator('#user-reset-password-confirm').fill('ResetNew1!')
+
+    // ปุ่ม confirm ใน modal ชื่้เดียวกับปุ่มใน row — scope ด้วย .fixed
+    await page.locator('.fixed').getByRole('button', { name: 'รีเซ็ตรหัสผ่าน' }).click()
+
+    await expect(page.getByText(/รีเซ็ตรหัสผ่านสำเร็จ/)).toBeVisible()
+  })
+
+  test('admin deactivates then reactivates a user', async ({ page, request }) => {
+    const username = `e2e_crud_toggle_${stamp}`
+    await createTargetUser(request, username)
+
+    await searchUser(page, username)
+    const row = rowOf(page, username)
+    await expect(row).toBeVisible()
+
+    await row.getByRole('button', { name: 'ปิดบัญชี' }).click()
+    await expect(page.getByText('ยืนยันการปิดบัญชี')).toBeVisible()
+    await page.locator('.fixed').getByRole('button', { name: 'ปิดบัญชี' }).click()
+
+    await expect(page.getByText('ปิดบัญชีสำเร็จ')).toBeVisible()
+    await expect(row.getByText('ปิดใช้งาน', { exact: true })).toBeVisible()
+
+    // เปิดกลับ — ปุ่ม row เปลี่ยนชื่อเป็น 'เปิดใช้งานบัญชี' ปุ่ม modal คือ 'เปิดใช้งาน'
+    await row.getByRole('button', { name: 'เปิดใช้งานบัญชี' }).click()
+    await expect(page.getByText('ยืนยันการเปิดใช้งานบัญชี')).toBeVisible()
+    await page.locator('.fixed').getByRole('button', { name: 'เปิดใช้งาน' }).click()
+
+    await expect(page.getByText('เปิดใช้งานบัญชีสำเร็จ')).toBeVisible()
+    await expect(row.getByText('ใช้งาน', { exact: true })).toBeVisible()
+  })
+
+  test('own row exposes no deactivate action (self-guard)', async ({ page }) => {
+    // seed admin อยู่แถวเดียวหลัง search — แถวของตัวเองต้องไม่มีปุ่มปิดบัญชี
+    await searchUser(page, 'admin')
+    const ownRow = rowOf(page, 'admin')
+    await expect(ownRow).toBeVisible()
+    await expect(ownRow.getByRole('button', { name: 'ปิดบัญชี' })).toHaveCount(0)
+    // แต่แก้ไขตัวเองได้
+    await expect(ownRow.getByRole('button', { name: 'แก้ไข' })).toBeVisible()
+  })
+})

--- a/frontend/e2e/helpers/auth.js
+++ b/frontend/e2e/helpers/auth.js
@@ -37,3 +37,82 @@ export async function apiLogin(request, username, password) {
   }
   return res.json()
 }
+
+/**
+ * ส่ง request แบบ retry-once เมื่อโดน 429 — rate limit global เขียน 50/min ต่อ user
+ * (backend/middleware/rate_limit.php rateLimitGlobal) และ E2E ทุก test ใช้ seed admin
+ * คนเดียว รันต่อเนื่องจึงแตะเพดานได้ รอตาม retry_after แล้วยิงซ้ำครั้งเดียว
+ */
+export async function sendWith429Retry(request, method, url, options) {
+  let res = await request[method](url, options)
+  if (res.status() === 429) {
+    const body = await res.json().catch(() => ({}))
+    const wait = Math.min(Number(body.retry_after) || 60, 65) * 1000
+    await new Promise((r) => setTimeout(r, wait))
+    res = await request[method](url, options)
+  }
+  return res
+}
+
+/**
+ * สร้าง user ผ่าน API ด้วย seed admin แล้วปลดล็อก must_change_password ทันที
+ * คืน { username, password, userId } — password เป็น "รหัสที่สอง" หลังเปลี่ยน
+ * (backend ห้ามตั้งรหัสใหม่ให้ซ้ำกับเดิม จึงเปลี่ยนเป็น password + "1e" แทน)
+ * userId ใช้ deactivate เป็น cleanup ใน afterEach
+ */
+export async function createUserViaApi(request, { username, password, role, fullName }) {
+  const admin = await apiLogin(request, adminUser, adminPass)
+
+  const create = await sendWith429Retry(request, 'post', `${apiBase()}/users`, {
+    headers: {
+      Authorization: `Bearer ${admin.token}`,
+      'X-CSRF-Token': admin.csrf_token,
+    },
+    data: {
+      username,
+      password,
+      full_name: fullName,
+      role,
+    },
+  })
+  if (create.status() !== 201) {
+    throw new Error(`Create user failed (${create.status()}): ${await create.text()}`)
+  }
+  const body = await create.json()
+
+  // First login forces password change — เปลี่ยนให้เสร็จใน helper เพื่อไม่ให้ทุก spec ต้องทำซ้ำ
+  const finalPassword = `${password}1e`
+  const first = await apiLogin(request, username, password)
+  const changed = await sendWith429Retry(request, 'post', `${apiBase()}/auth/change-password`, {
+    headers: {
+      Authorization: `Bearer ${first.token}`,
+      'X-CSRF-Token': first.csrf_token,
+    },
+    data: {
+      current_password: password,
+      new_password: finalPassword,
+    },
+  })
+  if (!changed.ok()) {
+    throw new Error(`Clear must_change_password failed (${changed.status()}): ${await changed.text()}`)
+  }
+
+  return { username, password: finalPassword, userId: body.user_id }
+}
+
+/**
+ * Thai citizen ID 13 หลักที่ผ่าน checksum — อัลกอริทึมเดียวกับ backend isValidCitizenId
+ * (backend/helpers.php:24-35): weight 13..2, check = (11 - sum%11) % 10
+ */
+export function thaiCitizenId(first12Digits) {
+  const digits = String(first12Digits).replace(/\D/g, '')
+  if (digits.length !== 12) {
+    throw new Error(`thaiCitizenId expects 12 digits, got ${digits.length}`)
+  }
+  let sum = 0
+  for (let i = 0; i < 12; i++) {
+    sum += Number(digits[i]) * (13 - i)
+  }
+  const check = (11 - (sum % 11)) % 10
+  return digits + String(check)
+}

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -13,8 +13,12 @@ export default defineConfig({
   retries: process.env.CI ? 1 : 0,
   workers: 1,
   reporter: [['list'], ['html', { open: 'never' }]],
-  timeout: 60_000,
-  expect: { timeout: 10_000 },
+  // 120s: เครื่อง dev นี้เครื่องเดียวกับ workload อื่น (VS Code/ZCode/Docker) —
+  // ตอนรันชุดต่อเนื่อง navigation บางอันค้างชั่วคราวเกิน 60s (เจอจริงใน goto /users)
+  timeout: 120_000,
+  // 20s: backend ใน Docker ตอบช้าเป็นช่วงๆ ตอน E2E รันต่อเนื่อง (toast มาช้ากว่า 10s
+  // ทำให้ assert พลาดทั้งที่ action สำเร็จจริง — พิสูจน์ด้วย curl/probe แล้ว)
+  expect: { timeout: 20_000 },
   use: {
     baseURL: process.env.E2E_BASE_URL || 'http://127.0.0.1:5174',
     trace: 'on-first-retry',
@@ -22,10 +26,13 @@ export default defineConfig({
     video: 'off',
   },
   projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
-  webServer: {
-    command: 'npm run dev -- --host 127.0.0.1 --port 5174',
-    url: 'http://127.0.0.1:5174',
-    reuseExistingServer: !process.env.CI,
-    timeout: 120_000,
-  },
+  // E2E_BASE_URL ชี้ไป frontend ภายนอก (เช่น Docker image) — ไม่ต้องเริ่ม Vite เอง
+  webServer: process.env.E2E_BASE_URL
+    ? undefined
+    : {
+        command: 'npm run dev -- --host 127.0.0.1 --port 5174',
+        url: 'http://127.0.0.1:5174',
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+      },
 })

--- a/frontend/src/__tests__/router/guards.test.js
+++ b/frontend/src/__tests__/router/guards.test.js
@@ -132,6 +132,15 @@ describe('router candidate paths', () => {
     expect(router.currentRoute.value.params.section).toBe('overview')
   })
 
+  it('redirects bare /candidates to overview (redirect record is shadowed by optional param)', async () => {
+    // Vue Router 4 score-based matching: 'candidates/:section?' match '/candidates' ก่อน
+    // redirect record 'candidates → /candidates/overview' — section จะเป็น '' ไม่ใช่ redirect
+    await router.push('/candidates')
+    expect(router.currentRoute.value.name).toBe('candidates')
+    expect(router.currentRoute.value.path).toBe('/candidates/overview')
+    expect(router.currentRoute.value.params.section).toBe('overview')
+  })
+
   it('does not expose legacy /supportive quick-action path', async () => {
     await router.push('/supportive')
     expect(router.currentRoute.value.path).toBe('/dashboard')

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -194,12 +194,14 @@ router.beforeEach(async (to) => {
     return '/dashboard'
   }
 
-  // section ไม่รู้จัก → กลับ /candidates/overview — เช็คใน global guard เพราะ
+  // section ไม่รู้จักหรือว่าง → กลับ /candidates/overview — เช็คใน global guard เพราะ
   // beforeEnter ของ route record ไม่ทำงานตอนสลับ params ภายใน record เดิม
+  // กรณีว่าง: redirect record 'candidates → /candidates/overview' โดน optional
+  // param 'candidates/:section?' บัง (Vue Router 4 จัดแบบ score) — resolve('/candidates')
+  // ตกที่ :section? พร้อม section='' หน้า overview จะไม่ยิง fetch และโล่ง
   if (
     to.name === 'candidates' &&
-    to.params.section &&
-    !KNOWN_CANDIDATE_SECTIONS.includes(String(to.params.section))
+    !KNOWN_CANDIDATE_SECTIONS.includes(String(to.params.section ?? ''))
   ) {
     return { path: '/candidates/overview' }
   }


### PR DESCRIPTION
## สรุป

งาน E2E ส่วน role-permissions และ CRUD ที่ค้างจาก session ก่อน — GREEN 16/16 บน Docker smoke แล้ว พร้อมแก้ footgun ใน Dockerfile ที่ทำให้ login พังเงียบๆ เมื่อ build ลืมใส่ build-arg

## สิ่งที่เปลี่ยน

### spec ใหม่ 4 ไฟล์ (E2E)
- `api-permissions.spec.js` (3 เทส) — ตรวจ API บังสิทธิ์ตาม role
- `personnel-crud.spec.js` (4 เทส) — CRUD หน้า personnel
- `role-guards.spec.js` (4 เทส) — guard เส้นทางตาม role (admin/superadmin/viewer)
- `users-crud.spec.js` (5 เทส) — CRUD จัดการ users

### ผู้ช่วยเทส
- `e2e/helpers/auth.js`: `sendWith429Retry` — จับ 429 จาก `rateLimitGlobal()` (write 50/นาที/user) แล้วรอตาม `retry_after` แล้ว retry ครั้งเดียว; ครอบ create / change-password / createTargetUser / cleanup PUT — **spec ใหม่ที่ยิง write ผ่าน `request.*` ตรงๆ ต้องครอบด้วย helper นี้เสมอ**
- `playwright.config.js`: timeout 120s / expect.timeout 20s (เครื่อง dev โหลดหนัก จุดตายเดิม 60s)

### แก้ guard จริง
- `src/router/index.js`: candidates section ว่าง/ไม่รู้จัก → redirect `/candidates/overview` (beforeEnter ไม่ทำงานตอนสลับ params ใน record เดิม) + เทสใน `guards.test.js`

### แก้ Dockerfile footgun
- `ARG VITE_API_URL` default เปลี่ยนจาก `http://localhost:8000` เป็นค่าว่าง — ค่าว่างทำให้โค้ด fallback ไป `/api` ผ่าน nginx proxy; ค่าเดิมทำ login พังเงียบๆ จาก CSP `connect-src 'self'` (เคสเกิดจริงใน smoke run)

## ผลทดสอบ

| ชุด | ผล |
|---|---|
| unit (frontend vitest) | 583/583 GREEN |
| E2E (Docker smoke) | 16/16 GREEN, 4.2 นาที |
| pre-push gates | script regressions 146/146 · schema parity OK · CSP audit PASS · backend Unit 274 OK (skip 1 บน Windows) |

## หมายเหตุ

- รัน E2E ต้อง build ด้วย `--build-arg VITE_API_URL=` (ตอนนี้ default ว่างแล้ว) + DB/backend containers Up
- Rate limit จะถูกทุกครั้งที่รันชุดต่อเนื่อง — ใช้ `sendWith429Retry` กับ write ทุกตัวใหม่