### PR TITLE
fix: หน้า /ocr แสดงว่ายังไม่พร้อมเมื่อไม่มี OCR service (#147)

### DIFF
--- a/backend/routes/ocr.php
+++ b/backend/routes/ocr.php
@@ -55,6 +55,7 @@ function handleOcr(PDO $pdo, string $method, array $path): void
         curl_close($ch);
 
         http_response_code($code ?: 502);
+        header('Content-Type: application/json');
         echo $body ?: json_encode(['error' => 'OCR server unreachable']);
         return;
     }

--- a/frontend/src/__tests__/pages/OcrPage.test.js
+++ b/frontend/src/__tests__/pages/OcrPage.test.js
@@ -1,16 +1,25 @@
-import { describe, it, expect, vi } from 'vitest'
+import { beforeEach, describe, it, expect, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { nextTick } from 'vue'
 
+const apiMock = vi.hoisted(() => ({
+  uploadResponse: vi.fn(),
+  get: vi.fn(),
+}))
+
 vi.mock('@/composables/useApi.js', () => ({
-  useApi: () => ({
-    uploadResponse: vi.fn(),
-  }),
+  useApi: () => apiMock,
 }))
 
 const OcrPage = (await import('@/pages/OcrPage.vue')).default
 
 describe('OcrPage', () => {
+  beforeEach(() => {
+    apiMock.get.mockReset()
+    apiMock.get.mockResolvedValue({ status: 'ok' })
+    apiMock.uploadResponse.mockReset()
+  })
+
   it('renders OCR preview as plain text (no HTML injection)', async () => {
     const wrapper = mount(OcrPage)
     wrapper.vm.result = {
@@ -53,5 +62,28 @@ describe('OcrPage', () => {
 
     vi.unstubAllGlobals()
     vi.useRealTimers()
+  })
+
+  it('hides the upload form when OCR is not configured (#147)', async () => {
+    apiMock.get.mockRejectedValue(new Error('ยังไม่ได้ติดตั้งบริการแปลงเอกสาร (OCR)'))
+
+    const wrapper = mount(OcrPage)
+    await flushPromises()
+
+    expect(apiMock.get).toHaveBeenCalledWith('/ocr/health')
+    expect(wrapper.text()).toContain('ฟีเจอร์นี้ยังไม่พร้อมใช้งาน')
+    expect(wrapper.text()).toContain('ยังไม่ได้ติดตั้งบริการแปลงเอกสาร (OCR)')
+    expect(wrapper.text()).not.toContain('คลิกเพื่อเลือก')
+    expect(wrapper.find('#ocr-file-input').exists()).toBe(false)
+  })
+
+  it('shows the upload form after OCR health succeeds', async () => {
+    const wrapper = mount(OcrPage)
+    await flushPromises()
+
+    expect(apiMock.get).toHaveBeenCalledWith('/ocr/health')
+    expect(wrapper.find('#ocr-file-input').exists()).toBe(true)
+    expect(wrapper.text()).toContain('คลิกเพื่อเลือก')
+    expect(wrapper.text()).not.toContain('ฟีเจอร์นี้ยังไม่พร้อมใช้งาน')
   })
 })

--- a/frontend/src/pages/OcrPage.vue
+++ b/frontend/src/pages/OcrPage.vue
@@ -3,12 +3,31 @@
     <header class="flex flex-col gap-1">
       <h1 class="text-2xl font-bold text-gray-800">แปลงเอกสาร PDF</h1>
       <p class="text-sm text-gray-500">
-        อัปโหลดไฟล์ PDF เพื่อแปลงเป็น Markdown — รองรับเอกสารภาษาไทย
+        <template v-if="availability === 'ready'">อัปโหลดไฟล์ PDF เพื่อแปลงเป็น Markdown — รองรับเอกสารภาษาไทย</template>
+        <template v-else-if="availability === 'unavailable'">บริการแปลงเอกสารยังไม่ได้ติดตั้ง</template>
+        <template v-else>กำลังตรวจสอบบริการแปลงเอกสาร…</template>
       </p>
     </header>
 
+    <section
+      v-if="availability !== 'ready'"
+      class="bg-white rounded-xl border p-5"
+      :class="availability === 'unavailable' ? 'border-amber-200' : 'border-gray-200'"
+      aria-live="polite"
+    >
+      <p v-if="availability === 'checking'" class="text-sm text-gray-500">กำลังตรวจสอบบริการแปลงเอกสาร…</p>
+      <div v-else class="flex items-start gap-2 text-amber-800">
+        <AlertCircle class="w-5 h-5 shrink-0 mt-0.5" />
+        <div>
+          <h2 class="text-sm font-semibold">ฟีเจอร์นี้ยังไม่พร้อมใช้งาน</h2>
+          <p class="mt-1 text-sm">{{ unavailableMsg }}</p>
+          <p class="mt-2 text-xs text-amber-700">กรุณาติดต่อผู้ดูแลระบบ</p>
+        </div>
+      </div>
+    </section>
+
     <!-- Upload -->
-    <section class="bg-white rounded-xl border border-gray-200 p-5 space-y-4">
+    <section v-if="availability === 'ready'" class="bg-white rounded-xl border border-gray-200 p-5 space-y-4">
       <div
         role="button"
         tabindex="0"
@@ -142,7 +161,7 @@
 </template>
 
 <script setup>
-import { ref, computed, nextTick, onBeforeUnmount } from 'vue'
+import { ref, computed, nextTick, onMounted, onBeforeUnmount } from 'vue'
 import { useApi } from '@/composables/useApi.js'
 import {
   Upload, FileText, Loader2, CheckCircle2, AlertCircle, Copy, Download,
@@ -162,8 +181,25 @@ const result = ref(null)
 const tab = ref('preview')
 const copied = ref(false)
 const copyError = ref(false)
+const availability = ref('checking')
+const unavailableMsg = ref('ยังไม่ได้ติดตั้งบริการแปลงเอกสาร (OCR)')
 let copiedTimer = null
 let copyErrorTimer = null
+let healthCheckCancelled = false
+
+onMounted(async () => {
+  try {
+    await api.get('/ocr/health')
+    if (healthCheckCancelled) return
+    availability.value = 'ready'
+  } catch (err) {
+    if (healthCheckCancelled) return
+    availability.value = 'unavailable'
+    unavailableMsg.value = err instanceof Error && err.message
+      ? err.message
+      : 'ยังไม่ได้ติดตั้งบริการแปลงเอกสาร (OCR)'
+  }
+})
 
 function clearFeedbackTimers() {
   if (copiedTimer != null) {
@@ -176,7 +212,10 @@ function clearFeedbackTimers() {
   }
 }
 
-onBeforeUnmount(clearFeedbackTimers)
+onBeforeUnmount(() => {
+  healthCheckCancelled = true
+  clearFeedbackTimers()
+})
 
 const busy = computed(() => status.value === 'uploading')
 


### PR DESCRIPTION
## สรุป
เมนู OCR ซ่อนแล้วจาก PR #157 แต่พิมพ์ `/ocr` ตรงยังเห็นฟอร์มอัปโหลดเหมือนใช้ได้ ทั้งที่ production ไม่มี OCR service

- `OcrPage` ยิง `GET /ocr/health` ตอนโหลด — ไม่พร้อม = แบนเนอร์ ซ่อนฟอร์ม
- `/ocr/health` ใส่ `Content-Type: application/json` กัน `api.get` ถือว่าพังทั้งที่ service พร้อม

Fail-closed บนหน้า direct URL — ไม่ปิด #147 จนกว่าจะมี OCR service จริง

## ทดสอบ
- [x] frontend OcrPage.test.js 4/4
- [x] AppSidebar.test.js รวม 24/24
- [x] PHPUnit OcrRouteConfigTest 4/4