### PR TITLE
fix: skip CSP audit เมื่อ dist เก่ากว่า src (#151)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -57,8 +57,7 @@ if [[ ! -f "${DIST_STAMP}" ]]; then
   echo "[pre-push] SKIP  csp bundle audit: ไม่มี frontend/dist/index.html — build ก่อน (cd frontend && npm run build) แล้ว push ใหม่ถ้าต้องการให้ gate นี้ตรวจ"
 else
   # hook ไม่ build ให้เอง (npm run build ทุกครั้งที่ push แพงเกินไป) dist จึงอาจเก่ากว่าโค้ด
-  # — แต่เตือนเฉพาะเมื่อ **วัดได้ว่าเก่าจริง** ไม่ใช่เตือนทุกครั้ง · คำเตือนที่ดังตลอดเวลาไม่ใช่
-  # สัญญาณ มันสอนให้คนเลิกอ่าน WARN ซึ่งย้อนแย้งกับ gate ที่สร้างมาให้คนเชื่อ
+  # — วัด stale จริงแล้ว skip อย่างมีเสียง ไม่ audit ของเก่าแล้วขึ้นผ่าน (#151)
   # เทียบ mtime ของ source กับ index.html ของ build (ยืนยันแล้วว่าให้ผลสองทางทั้ง Git Bash และ WSL)
   # ไม่นับไฟล์เทส — vite ไม่เอาเข้า bundle การแก้เทสจึงไม่ทำให้ dist เพี้ยน (วัดแล้ว: ก่อนกรอง
   # repo นี้เตือนเพราะไฟล์ `__tests__/securityHeaders.test.js` ไฟล์เดียว ซึ่งไม่เกี่ยวกับ bundle เลย)
@@ -85,10 +84,14 @@ else
       -newer "${DIST_STAMP}" -print -quit 2>/dev/null || true)"
   fi
   if [[ -n "${STALE_SRC}" ]]; then
-    echo "[pre-push] WARN  csp bundle audit: ${STALE_SRC} ใหม่กว่า dist — ผลนี้เป็นของ build เก่า (cd frontend && npm run build)"
+    # Issue #151 — dist เก่า = ยังไม่ได้ตรวจ bundle ของโค้ดปัจจุบัน
+    # WARN แล้ว audit ต่อแล้วขึ้นผ่านคือ false assurance ("ไม่รู้" กลายเป็น "สะอาด")
+    # skip อย่างมีเสียงให้สมมาตรกับเคสไม่มี dist เลย — hook ไม่ build ให้เอง
+    echo "[pre-push] SKIP  csp bundle audit: ${STALE_SRC} ใหม่กว่า dist — ยังไม่ได้ตรวจ bundle ของโค้ดปัจจุบัน (cd frontend && npm run build แล้ว push ใหม่ถ้าต้องการให้ gate นี้ตรวจ)"
+  else
+    echo "[pre-push] csp bundle audit (frontend/dist) ..."
+    node "${ROOT}/scripts/audit-bundle-csp.mjs"
   fi
-  echo "[pre-push] csp bundle audit (frontend/dist) ..."
-  node "${ROOT}/scripts/audit-bundle-csp.mjs"
 fi
 
 echo "[pre-push] frontend vitest (forks pool from vitest.config.js) ..."

--- a/scripts/tests/pre-push-csp-stale.test.mjs
+++ b/scripts/tests/pre-push-csp-stale.test.mjs
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+// Issue #151 — เมื่อ src ใหม่กว่า frontend/dist pre-push ต้องไม่ audit dist เก่าแล้วขึ้นผ่าน
+// ("ไม่รู้" ต้องไม่กลายเป็น "สะอาด") · เลือกทาง skip พร้อมข้อความ "ยังไม่ได้ตรวจ"
+// ให้สมมาตรกับเคสไม่มี dist เลย ไม่ใช่ WARN แล้วรัน audit ต่อ
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const HOOK = resolve(ROOT, '.githooks', 'pre-push');
+
+test('pre-push ข้าม CSP audit เมื่อ src ใหม่กว่า dist — ไม่ audit ของเก่าแล้วขึ้นผ่าน (#151)', () => {
+  const hook = readFileSync(HOOK, 'utf8');
+
+  assert.match(
+    hook,
+    /SKIP\s+csp bundle audit:.*ใหม่กว่า dist/,
+    'เมื่อ dist เก่าต้องพิมพ์ SKIP ไม่ใช่ WARN',
+  );
+  assert.match(
+    hook,
+    /ยังไม่ได้ตรวจ/,
+    'ข้อความ skip ต้องบอกว่ายังไม่ได้ตรวจ bundle ของโค้ดปัจจุบัน',
+  );
+  assert.doesNotMatch(
+    hook,
+    /WARN\s+csp bundle audit:.*ใหม่กว่า dist/,
+    'ห้าม WARN แล้ว audit dist เก่าต่อ — นั่นคือ false assurance ที่ #151 ถาม',
+  );
+
+  const staleIdx = hook.indexOf('STALE_SRC');
+  assert.notEqual(staleIdx, -1, 'hook ต้องยังวัดว่า src ใหม่กว่า dist');
+  const afterStale = hook.slice(staleIdx);
+  const auditCall = afterStale.indexOf('audit-bundle-csp.mjs');
+  assert.notEqual(auditCall, -1, 'ยังต้องเรียก audit เมื่อ dist ไม่เก่า');
+  const skipIdx = afterStale.indexOf('SKIP  csp bundle audit');
+  assert.notEqual(skipIdx, -1);
+  assert.ok(
+    skipIdx < auditCall,
+    'กิ่ง stale ต้อง SKIP ก่อน — ห้ามไหลไปเรียก audit-bundle-csp.mjs',
+  );
+  assert.match(
+    afterStale.slice(skipIdx, auditCall),
+    /\belse\b/,
+    'audit ต้องอยู่ใน else ของกิ่ง stale ไม่ใช่รันต่อหลัง WARN',
+  );
+});


### PR DESCRIPTION
## สรุป
เลือกทางเลือก 3 ของ #151: เมื่อ `frontend/src` ใหม่กว่า `frontend/dist` pre-push **skip** การ audit พร้อมข้อความว่ายังไม่ได้ตรวจ — ไม่ WARN แล้ว audit dist เก่าต่อ

WARN แล้วผ่านบน bundle ที่ไม่ใช่ของจริง = false assurance ("ไม่รู้" กลายเป็น "สะอาด")
fail ถ้า stale จะบังคับ `npm run build` ทุกครั้ง ซึ่ง hook ตั้งใจไม่ทำเพราะแพงเกินไป

## ทดสอบ
- [x] `node --test scripts/tests/pre-push-csp-stale.test.mjs` 1/1