### PR TITLE
fix: ปิด findings รีวิว codebase (PII candidates, วันที่, auth rate limit)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -30,6 +30,9 @@ if [[ ! -d "${FRONTEND}/node_modules" ]]; then
   exit 1
 fi
 
+echo "[pre-push] npm audit --omit=dev --audit-level=high ..."
+(cd "${FRONTEND}" && npm audit --omit=dev --audit-level=high)
+
 # Script regressions (mock server ในเครื่อง ไม่ออกเน็ต) — ~15s เร็วกว่า vitest มาก
 # รันก่อนเพื่อ fail เร็ว และเพราะ Actions ปิด auto-trigger อยู่ hook นี้คือที่เดียวที่
 # gate พวกนี้ถูกบังคับจริงทุกครั้ง (schema parity validator / live header / CSP self-test)

--- a/backend/QualificationEngine.php
+++ b/backend/QualificationEngine.php
@@ -243,9 +243,9 @@ class QualificationEngine
                     WHERE approval_status = 'APPROVED'
                     GROUP BY personnel_id
                 ) eqs ON eqs.personnel_id = e.personnel_id AND eqs.eqv_days > 0";
-        // วันดำรง M1/M2 สะสม (ช่วงปิด end_date NOT NULL) — S2 path บต/ทว + อต-อส + เทียบ
+        // วันดำรง M1/M2 สะสม (ช่วงปิด end_date NOT NULL) — inclusive end (+1) ตาม computeNetBreakdown
         $msTenure = "LEFT JOIN (
-                    SELECT personnel_id, SUM(DATEDIFF(end_date, effective_date)) AS ms_days
+                    SELECT personnel_id, SUM(DATEDIFF(end_date, effective_date) + 1) AS ms_days
                     FROM personnel_position_history
                     WHERE position_level IN ('M1','M2') AND end_date IS NOT NULL
                     GROUP BY personnel_id
@@ -466,7 +466,7 @@ class QualificationEngine
         // cap เพดาน 200 เหมือน probation list — กัน ?limit=999999999 dump ทั้งระดับ
         $limit = max(1, min(200, intval($limit)));
         $offset = max(0, intval($offset));
-        $dataSql = "{$baseSelect}{$searchClause} ORDER BY remaining_days ASC LIMIT {$limit} OFFSET {$offset}";
+        $dataSql = "{$baseSelect}{$searchClause} ORDER BY (remaining_days IS NULL), remaining_days ASC LIMIT {$limit} OFFSET {$offset}";
         $dataStmt = $this->pdo->prepare($dataSql);
         $dataStmt->execute($params);
         $rows = $dataStmt->fetchAll(PDO::FETCH_ASSOC);

--- a/backend/api.php
+++ b/backend/api.php
@@ -131,6 +131,8 @@ if ($isPublicPhotoAsset) {
     // last hop ของ XFF ที่ proxy append (มีเทสยืนยันที่ PublicRateLimitTest) ตัวกันจริงคือ entropy ของ
     // token เอง (ดู CSP_SUMMARY_TOKEN_MIN_LENGTH ใน routes/csp_summary.php)
     checkRateLimitPublic('csp-summary', 10, 60);
+} elseif ($isPublicAuth) {
+    checkRateLimitPublic('auth', 60, 60);
 }
 
 // login/refresh/logout เป็น public; auth endpoint อื่นต้องมี JWT เช่นเดียวกับ API ปกติ

--- a/backend/routes/candidates.php
+++ b/backend/routes/candidates.php
@@ -13,6 +13,7 @@
 include_once __DIR__ . '/../helpers.php';
 include_once __DIR__ . '/../authz.php';
 include_once __DIR__ . '/../QualificationEngine.php';
+include_once __DIR__ . '/personnel.php';
 
 /**
  * จัดการ request สำหรับ candidate list endpoints
@@ -71,6 +72,8 @@ function handleCandidates(PDO $pdo, string $method, array $path): void
             echo json_encode(['error' => 'Personnel not found']);
             return;
         }
+        $role = (string) (getAuthenticatedUser()['role'] ?? '');
+        $result['data'] = redactPersonnelCitizenIdForRole($result['data'], $role);
         echo json_encode($result);
     } else {
         // รายชื่อทั้งหมด: GET /candidates/K2?search=&limit=20&offset=0

--- a/backend/routes/diverse.php
+++ b/backend/routes/diverse.php
@@ -17,6 +17,23 @@ include_once __DIR__ . '/../helpers.php';
 include_once __DIR__ . '/../audit.php';
 
 /**
+ * parse Y-m-d แบบเข้มงวด (ลอก pattern จาก MultiplierEngine.php:224 / supportiveStrictDate)
+ * เพื่อไม่ต้อง include engine ทั้งไฟล์ — คืน null ถ้า format ผิดหรือมี overflow
+ */
+function diverseStrictDate(string $value): ?DateTime
+{
+    $date = DateTime::createFromFormat('Y-m-d|', $value);
+    $errors = DateTime::getLastErrors();
+    if (
+        $date === false
+        || ($errors !== false && ($errors['warning_count'] > 0 || $errors['error_count'] > 0))
+    ) {
+        return null;
+    }
+    return $date;
+}
+
+/**
  * จัดการ request สำหรับ diverse experience endpoints
  *
  * @param PDO $pdo Database connection
@@ -212,16 +229,38 @@ function createDiverse(PDO $pdo, array $user, ?array $input = null): void
         }
     }
 
-    // คำนวณ from_total_days (จำนวนวันรวม ฝั่งต้นทาง)
     $fromTotalDays = null;
     if (!empty($data['from_start_date']) && !empty($data['from_end_date'])) {
-        $fromTotalDays = (new DateTime($data['from_end_date']))->diff(new DateTime($data['from_start_date']))->days + 1;
+        $fromStart = diverseStrictDate((string) $data['from_start_date']);
+        $fromEnd = diverseStrictDate((string) $data['from_end_date']);
+        if ($fromStart === null || $fromEnd === null) {
+            http_response_code(400);
+            echo json_encode(['error' => 'รูปแบบวันที่ไม่ถูกต้อง']);
+            return;
+        }
+        if ($fromEnd < $fromStart) {
+            http_response_code(400);
+            echo json_encode(['error' => 'วันสิ้นสุดต้องไม่น้อยกว่าวันเริ่มต้น']);
+            return;
+        }
+        $fromTotalDays = $fromEnd->diff($fromStart)->days + 1;
     }
 
-    // คำนวณ to_total_days (จำนวนวันรวม ฝั่งปลายทาง)
     $toTotalDays = null;
     if (!empty($data['to_start_date']) && !empty($data['to_end_date'])) {
-        $toTotalDays = (new DateTime($data['to_end_date']))->diff(new DateTime($data['to_start_date']))->days + 1;
+        $toStart = diverseStrictDate((string) $data['to_start_date']);
+        $toEnd = diverseStrictDate((string) $data['to_end_date']);
+        if ($toStart === null || $toEnd === null) {
+            http_response_code(400);
+            echo json_encode(['error' => 'รูปแบบวันที่ไม่ถูกต้อง']);
+            return;
+        }
+        if ($toEnd < $toStart) {
+            http_response_code(400);
+            echo json_encode(['error' => 'วันสิ้นสุดต้องไม่น้อยกว่าวันเริ่มต้น']);
+            return;
+        }
+        $toTotalDays = $toEnd->diff($toStart)->days + 1;
     }
 
     // คำนวณ diff_count ใน PHP เพื่อกำหนด qualified_date
@@ -340,7 +379,19 @@ function updateDiverse(PDO $pdo, int $id, array $user, ?array $input = null): vo
     $fromStartDate = $data['from_start_date'] ?? $existing['from_start_date'];
     $fromEndDate = $data['from_end_date'] ?? $existing['from_end_date'];
     if (!empty($fromStartDate) && !empty($fromEndDate)) {
-        $fromTotalDays = (new DateTime($fromEndDate))->diff(new DateTime($fromStartDate))->days + 1;
+        $fromStart = diverseStrictDate((string) $fromStartDate);
+        $fromEnd = diverseStrictDate((string) $fromEndDate);
+        if ($fromStart === null || $fromEnd === null) {
+            http_response_code(400);
+            echo json_encode(['error' => 'รูปแบบวันที่ไม่ถูกต้อง']);
+            return;
+        }
+        if ($fromEnd < $fromStart) {
+            http_response_code(400);
+            echo json_encode(['error' => 'วันสิ้นสุดต้องไม่น้อยกว่าวันเริ่มต้น']);
+            return;
+        }
+        $fromTotalDays = $fromEnd->diff($fromStart)->days + 1;
     } else {
         $fromTotalDays = null;
     }
@@ -351,7 +402,19 @@ function updateDiverse(PDO $pdo, int $id, array $user, ?array $input = null): vo
     $toStartDate = $data['to_start_date'] ?? $existing['to_start_date'];
     $toEndDate = $data['to_end_date'] ?? $existing['to_end_date'];
     if (!empty($toStartDate) && !empty($toEndDate)) {
-        $toTotalDays = (new DateTime($toEndDate))->diff(new DateTime($toStartDate))->days + 1;
+        $toStart = diverseStrictDate((string) $toStartDate);
+        $toEnd = diverseStrictDate((string) $toEndDate);
+        if ($toStart === null || $toEnd === null) {
+            http_response_code(400);
+            echo json_encode(['error' => 'รูปแบบวันที่ไม่ถูกต้อง']);
+            return;
+        }
+        if ($toEnd < $toStart) {
+            http_response_code(400);
+            echo json_encode(['error' => 'วันสิ้นสุดต้องไม่น้อยกว่าวันเริ่มต้น']);
+            return;
+        }
+        $toTotalDays = $toEnd->diff($toStart)->days + 1;
     } else {
         $toTotalDays = null;
     }

--- a/backend/routes/equivalence.php
+++ b/backend/routes/equivalence.php
@@ -276,6 +276,20 @@ function createEquivalence(PDO $pdo, array $user, ?array $input = null): void
  *   - อัปเดตเฉพาะ field ที่อนุญาต
  *   - คำนวณ request_total_days ใหม่หากเปลี่ยนวันที่
  */
+/**
+ * Inclusive day count for an approved date range.
+ * Throws InvalidArgumentException when end < start (message matches MultiplierEngine.php:20).
+ */
+function approvedRangeTotalDays(string $start, string $end): int
+{
+    $approvedStart = new DateTime($start);
+    $approvedEnd = new DateTime($end);
+    if ($approvedEnd < $approvedStart) {
+        throw new InvalidArgumentException('วันสิ้นสุดต้องไม่น้อยกว่าวันเริ่มต้น');
+    }
+    return $approvedEnd->diff($approvedStart)->days + 1;
+}
+
 function updateEquivalence(PDO $pdo, int $id, array $user, ?array $input = null): void
 {
     $data = $input ?? json_decode(file_get_contents('php://input'), true);
@@ -317,16 +331,18 @@ function updateEquivalence(PDO $pdo, int $id, array $user, ?array $input = null)
                 return;
             }
 
-            // คำนวณ approved_total_days (DATEDIFF+1)
+            // คำนวณ approved_total_days (DATEDIFF+1) — จับ subclass ก่อน Exception
             try {
-                $approvedStart = new DateTime($data['approved_start_date']);
-                $approvedEnd = new DateTime($data['approved_end_date']);
+                $approvedTotalDays = approvedRangeTotalDays($data['approved_start_date'], $data['approved_end_date']);
+            } catch (InvalidArgumentException $e) {
+                http_response_code(400);
+                echo json_encode(['error' => $e->getMessage()]);
+                return;
             } catch (Exception $e) {
                 http_response_code(400);
                 echo json_encode(['error' => 'รูปแบบวันที่ไม่ถูกต้อง']);
                 return;
             }
-            $approvedTotalDays = $approvedEnd->diff($approvedStart)->days + 1;
 
             // ผู้อนุมัติจาก JWT (ผ่าน requirePermission('update', 'equivalence_approval') แล้ว) สำหรับ approved_by
             $userId = $approver['user_id'] ?? null;

--- a/backend/tests/Unit/CandidateCitizenIdRedactionTest.php
+++ b/backend/tests/Unit/CandidateCitizenIdRedactionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../routes/personnel.php';
+require_once __DIR__ . '/../../routes/candidates.php';
+
+/**
+ * T1 / N1 — candidate detail ต้อง redact citizen_id ใน data สำหรับ non-admin
+ * อย่าใส่เลขบัตรจริงใน fixture
+ */
+final class CandidateCitizenIdRedactionTest extends TestCase
+{
+    #[Test]
+    public function helper_omits_citizen_id_for_operator_keeps_for_admin(): void
+    {
+        $row = ['citizen_id' => 'x', 'personnel_id' => 1];
+
+        $operator = redactPersonnelCitizenIdForRole($row, 'operator');
+        self::assertArrayNotHasKey('citizen_id', $operator);
+
+        $admin = redactPersonnelCitizenIdForRole($row, 'admin');
+        self::assertSame('x', $admin['citizen_id']);
+    }
+
+    #[Test]
+    public function redact_applies_to_envelope_data_not_top_level(): void
+    {
+        $env = ['success' => true, 'data' => ['citizen_id' => 'x']];
+        $env['data'] = redactPersonnelCitizenIdForRole($env['data'], 'viewer');
+        self::assertArrayNotHasKey('citizen_id', $env['data']);
+        self::assertArrayNotHasKey('citizen_id', $env);
+    }
+
+    #[Test]
+    public function candidates_route_redacts_result_data_and_includes_personnel(): void
+    {
+        $src = file_get_contents(__DIR__ . '/../../routes/candidates.php');
+        self::assertIsString($src);
+        self::assertStringContainsString("redactPersonnelCitizenIdForRole(\$result['data']", $src);
+        self::assertMatchesRegularExpression('/include_once\s+[^;]*personnel\\.php/', $src);
+    }
+}

--- a/backend/tests/Unit/DiverseStrictDateTest.php
+++ b/backend/tests/Unit/DiverseStrictDateTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use DateTime;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../routes/diverse.php';
+
+final class DiverseStrictDateTest extends TestCase
+{
+    #[Test]
+    public function malformed_and_overflow_are_null(): void
+    {
+        self::assertNull(diverseStrictDate('abc'));
+        self::assertNull(diverseStrictDate('2026-02-30'));
+    }
+
+    #[Test]
+    public function valid_date_is_datetime(): void
+    {
+        $d = diverseStrictDate('2026-01-15');
+        self::assertInstanceOf(DateTime::class, $d);
+        self::assertSame('2026-01-15', $d->format('Y-m-d'));
+    }
+
+    #[Test]
+    public function create_and_update_do_not_use_loose_datetime(): void
+    {
+        $src = file_get_contents(__DIR__ . '/../../routes/diverse.php');
+        self::assertIsString($src);
+        self::assertDoesNotMatchRegularExpression('/new DateTime\s*\(/', $src);
+        self::assertStringContainsString('$fromEnd < $fromStart', $src);
+        self::assertStringContainsString('$toEnd < $toStart', $src);
+    }
+}

--- a/backend/tests/Unit/EquivalenceApprovedRangeTest.php
+++ b/backend/tests/Unit/EquivalenceApprovedRangeTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../routes/equivalence.php';
+
+final class EquivalenceApprovedRangeTest extends TestCase
+{
+    #[Test]
+    public function inverted_range_throws(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('วันสิ้นสุดต้องไม่น้อยกว่าวันเริ่มต้น');
+        approvedRangeTotalDays('2026-12-31', '2026-01-01');
+    }
+
+    #[Test]
+    public function inclusive_january_is_thirty_one_days(): void
+    {
+        self::assertSame(31, approvedRangeTotalDays('2026-01-01', '2026-01-31'));
+    }
+}

--- a/backend/tests/Unit/QualificationOrderClauseTest.php
+++ b/backend/tests/Unit/QualificationOrderClauseTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * T5/T6 — anti-drift บนซอร์ส QualificationEngine (ไม่รัน SQL)
+ */
+final class QualificationOrderClauseTest extends TestCase
+{
+    private function computeForLevelSource(): string
+    {
+        $src = file_get_contents(__DIR__ . '/../../QualificationEngine.php');
+        self::assertIsString($src);
+        $start = strpos($src, 'function computeForLevel');
+        self::assertNotFalse($start);
+        $end = strpos($src, 'function computeDetail', $start);
+        self::assertNotFalse($end);
+        return substr($src, $start, $end - $start);
+    }
+
+    #[Test]
+    public function compute_for_level_orders_null_remaining_days_last(): void
+    {
+        $fn = $this->computeForLevelSource();
+        $nullPos = strpos($fn, '(remaining_days IS NULL)');
+        $ascPos = strpos($fn, 'remaining_days ASC');
+        self::assertNotFalse($nullPos);
+        self::assertNotFalse($ascPos);
+        self::assertLessThan($ascPos, $nullPos);
+    }
+
+    #[Test]
+    public function ms_tenure_counts_inclusive_end_day(): void
+    {
+        $src = file_get_contents(__DIR__ . '/../../QualificationEngine.php');
+        self::assertIsString($src);
+        self::assertStringContainsString('DATEDIFF(end_date, effective_date) + 1', $src);
+    }
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -99,7 +99,7 @@ services:
       - ./database/30-photo-blob-storage.sql:/docker-entrypoint-initdb.d/30-photo-blob-storage.sql
       - ./database/31-csp-violation-daily.sql:/docker-entrypoint-initdb.d/31-csp-violation-daily.sql
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "--silent"]
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "--silent"]
       interval: 10s
       timeout: 5s
       retries: 10

--- a/frontend/src/__tests__/pages/ProfilePage.test.js
+++ b/frontend/src/__tests__/pages/ProfilePage.test.js
@@ -70,6 +70,20 @@ describe('ProfilePage', () => {
     expect(wrapper.text()).toContain('ผู้ดูแลระบบ')
   })
 
+  it('formats last login with Thai Buddhist year via formatServerDateTime (#N24)', async () => {
+    mockFetchMe.mockResolvedValue({
+      data: {
+        userId: 1, username: 'admin', fullName: 'ผู้ดูแลระบบ', email: 'a@b.c',
+        role: 'admin', isActive: true, mustChangePassword: false,
+        lastLoginAt: '2026-09-01 10:00:00', createdAt: '2023-01-01',
+      },
+    })
+    const wrapper = await mountPage()
+    await vi.waitFor(() => expect(mockFetchMe).toHaveBeenCalled())
+    await wrapper.vm.$nextTick()
+    expect(wrapper.text()).toContain('2569')
+  })
+
   it('renders servant detail when id param present', async () => {
     routeParams.value = { id: '5' }
     const wrapper = await mountPage()

--- a/frontend/src/pages/ProfilePage.vue
+++ b/frontend/src/pages/ProfilePage.vue
@@ -49,7 +49,7 @@
         </div>
         <div>
           <dt class="text-xs text-gray-500">เข้าใช้ล่าสุด</dt>
-          <dd class="text-sm text-gray-900">{{ formatDateTime(account.lastLoginAt) }}</dd>
+          <dd class="text-sm text-gray-900">{{ formatServerDateTime(account.lastLoginAt) }}</dd>
         </div>
       </dl>
     </div>
@@ -127,6 +127,7 @@ import { useAuthStore } from '@/stores/auth.js'
 import SkeletonLoader from '@/components/SkeletonLoader.vue'
 import EmptyState from '@/components/EmptyState.vue'
 import { roleLabel } from '@/utils/roleLabels.js'
+import { formatServerDateTime } from '@/utils/serverDateTime.js'
 import { User, AlertCircle } from 'lucide-vue-next'
 
 const TIME_SHORTCUTS = [
@@ -197,15 +198,6 @@ async function fetchData() {
   } finally {
     if (req.isCurrent()) loading.value = false
   }
-}
-
-function formatDateTime(value) {
-  if (!value) return '-'
-  const date = new Date(value.replace(' ', 'T'))
-  if (isNaN(date.getTime())) return '-'
-  return date.toLocaleString('th-TH', {
-    day: 'numeric', month: 'short', year: 'numeric', hour: '2-digit', minute: '2-digit',
-  })
 }
 
 watch(() => route.params.id, fetchData)


### PR DESCRIPTION
## สรุป
ปิด High/Medium จาก `/codebase-review-fix` (2026-09-08) ตาม PRP ที่ผ่าน G2 READY 10/10

- **N1** `GET /candidates/{level}/{id}` redact `citizen_id` สำหรับ non-admin (คง SELECT ให้ admin เห็น)
- **N2** ช่วงอนุมัติกลับด้าน → 400
- **N11** diverse ใช้วันที่แบบเข้ม ไม่ throw 500
- **N18** rate limit `/auth/login|refresh|logout`
- **N16** NULLS LAST บน `remaining_days`
- **N7** M1/M2 tenure นับ inclusive (+1)
- **N24** ProfilePage ใช้ `formatServerDateTime`
- **N21** db healthcheck `127.0.0.1`
- **N31** pre-push `npm audit --omit=dev --audit-level=high`

แผน: `.claude/PRPs/codebase-review-fix-20260908-prp.md`

## ทดสอบ
- [x] PHPUnit ใหม่ 10/10
- [x] ProfilePage vitest 9/9
- [x] schema parity
- [x] `npm run build`