### PR TITLE
fix: บันทึก audit เมื่อสร้าง/แก้/ยกเลิกพ้นทดลอง (N12)

### DIFF
--- a/backend/routes/probation.php
+++ b/backend/routes/probation.php
@@ -14,6 +14,7 @@
 
 include_once __DIR__ . '/../helpers.php';
 include_once __DIR__ . '/../authz.php';
+include_once __DIR__ . '/../audit.php';
 
 /**
  * จัดการ request สำหรับ probation tracking endpoints
@@ -330,10 +331,23 @@ function createProbationEnrollment(PDO $pdo): void
         throw $e;
     }
 
-    $enrollmentId = $pdo->lastInsertId();
+    $enrollmentId = (int) $pdo->lastInsertId();
+    $afterStmt = $pdo->prepare('SELECT * FROM probation_enrollment WHERE enrollment_id = ?');
+    $afterStmt->execute([$enrollmentId]);
+    $after = $afterStmt->fetch(PDO::FETCH_ASSOC);
+    $auth = getAuthenticatedUser();
+    logAudit(
+        $pdo,
+        (int) $auth['user_id'],
+        'CREATE',
+        'probation_enrollment',
+        $enrollmentId,
+        null,
+        $after ?: null
+    );
 
     http_response_code(201);
-    echo json_encode(['success' => true, 'enrollment_id' => intval($enrollmentId)]);
+    echo json_encode(['success' => true, 'enrollment_id' => $enrollmentId]);
 }
 
 /**
@@ -343,6 +357,15 @@ function createProbationEnrollment(PDO $pdo): void
 function updateProbationEnrollment(PDO $pdo, int $enrollmentId): void
 {
     $data = json_decode(file_get_contents('php://input'), true);
+
+    $beforeStmt = $pdo->prepare('SELECT * FROM probation_enrollment WHERE enrollment_id = ?');
+    $beforeStmt->execute([$enrollmentId]);
+    $existing = $beforeStmt->fetch(PDO::FETCH_ASSOC);
+    if (!$existing) {
+        http_response_code(404);
+        echo json_encode(['error' => 'Enrollment not found']);
+        return;
+    }
 
     $allowed = [
         'start_date',
@@ -376,16 +399,19 @@ function updateProbationEnrollment(PDO $pdo, int $enrollmentId): void
     $stmt = $pdo->prepare($sql);
     $stmt->execute($params);
 
-    if ($stmt->rowCount() === 0) {
-        // แถวอาจมีอยู่แต่ค่าไม่เปลี่ยน — แยก 404 จริง
-        $check = $pdo->prepare('SELECT 1 FROM probation_enrollment WHERE enrollment_id = ?');
-        $check->execute([$enrollmentId]);
-        if (!$check->fetchColumn()) {
-            http_response_code(404);
-            echo json_encode(['error' => 'Enrollment not found']);
-            return;
-        }
-    }
+    $afterStmt = $pdo->prepare('SELECT * FROM probation_enrollment WHERE enrollment_id = ?');
+    $afterStmt->execute([$enrollmentId]);
+    $after = $afterStmt->fetch(PDO::FETCH_ASSOC);
+    $auth = getAuthenticatedUser();
+    logAudit(
+        $pdo,
+        (int) $auth['user_id'],
+        'UPDATE',
+        'probation_enrollment',
+        $enrollmentId,
+        $existing,
+        $after ?: null
+    );
 
     echo json_encode(['success' => true]);
 }
@@ -396,6 +422,19 @@ function updateProbationEnrollment(PDO $pdo, int $enrollmentId): void
  */
 function deleteProbationEnrollment(PDO $pdo, int $enrollmentId): void
 {
+    $beforeStmt = $pdo->prepare('SELECT * FROM probation_enrollment WHERE enrollment_id = ?');
+    $beforeStmt->execute([$enrollmentId]);
+    $existing = $beforeStmt->fetch(PDO::FETCH_ASSOC);
+    if (!$existing) {
+        http_response_code(404);
+        echo json_encode(['error' => 'Enrollment not found']);
+        return;
+    }
+    if ($existing['overall_status'] === 'CANCELLED') {
+        echo json_encode(['success' => true]);
+        return;
+    }
+
     $stmt = $pdo->prepare(
         "UPDATE probation_enrollment
          SET overall_status = 'CANCELLED'
@@ -404,17 +443,19 @@ function deleteProbationEnrollment(PDO $pdo, int $enrollmentId): void
     );
     $stmt->execute([$enrollmentId]);
 
-    if ($stmt->rowCount() === 0) {
-        $check = $pdo->prepare('SELECT overall_status FROM probation_enrollment WHERE enrollment_id = ?');
-        $check->execute([$enrollmentId]);
-        $status = $check->fetchColumn();
-        if ($status === false) {
-            http_response_code(404);
-            echo json_encode(['error' => 'Enrollment not found']);
-            return;
-        }
-        // already cancelled — treat as success (idempotent)
-    }
+    $afterStmt = $pdo->prepare('SELECT * FROM probation_enrollment WHERE enrollment_id = ?');
+    $afterStmt->execute([$enrollmentId]);
+    $after = $afterStmt->fetch(PDO::FETCH_ASSOC);
+    $auth = getAuthenticatedUser();
+    logAudit(
+        $pdo,
+        (int) $auth['user_id'],
+        'DELETE',
+        'probation_enrollment',
+        $enrollmentId,
+        $existing,
+        $after ?: null
+    );
 
     echo json_encode(['success' => true]);
 }

--- a/backend/tests/Unit/ProbationAuditCallTest.php
+++ b/backend/tests/Unit/ProbationAuditCallTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * N12 — create/update/delete probation ต้องเรียก logAudit
+ * (anti-drift บนซอร์ส ไม่รัน HTTP)
+ */
+final class ProbationAuditCallTest extends TestCase
+{
+    private function functionSource(string $name): string
+    {
+        $src = file_get_contents(__DIR__ . '/../../routes/probation.php');
+        self::assertIsString($src);
+        $start = strpos($src, "function {$name}");
+        self::assertNotFalse($start, "missing {$name}");
+        $next = null;
+        foreach (['createProbationEnrollment', 'updateProbationEnrollment', 'deleteProbationEnrollment'] as $fn) {
+            if ($fn === $name) {
+                continue;
+            }
+            $pos = strpos($src, "function {$fn}", $start + 1);
+            if ($pos !== false && ($next === null || $pos < $next)) {
+                $next = $pos;
+            }
+        }
+        $end = $next ?? strlen($src);
+        return substr($src, $start, $end - $start);
+    }
+
+    #[Test]
+    public function create_logs_audit_after_insert(): void
+    {
+        $fn = $this->functionSource('createProbationEnrollment');
+        self::assertStringContainsString('logAudit(', $fn);
+        self::assertStringContainsString("'CREATE'", $fn);
+        self::assertStringContainsString("'probation_enrollment'", $fn);
+        self::assertGreaterThan(
+            strpos($fn, 'lastInsertId'),
+            strpos($fn, 'logAudit('),
+            'audit must run after insert id is known'
+        );
+    }
+
+    #[Test]
+    public function update_logs_audit_with_before_snapshot(): void
+    {
+        $fn = $this->functionSource('updateProbationEnrollment');
+        self::assertStringContainsString('logAudit(', $fn);
+        self::assertStringContainsString("'UPDATE'", $fn);
+        self::assertStringContainsString("'probation_enrollment'", $fn);
+    }
+
+    #[Test]
+    public function delete_logs_audit_with_before_snapshot(): void
+    {
+        $fn = $this->functionSource('deleteProbationEnrollment');
+        self::assertStringContainsString('logAudit(', $fn);
+        self::assertStringContainsString("'DELETE'", $fn);
+        self::assertStringContainsString("'probation_enrollment'", $fn);
+    }
+}


### PR DESCRIPTION
## สรุป
`routes/probation.php` ไม่เรียก `logAudit` ทั้งที่โมดูล HR อื่นมีครบ — สร้าง/แก้/ยกเลิกพ้นทดลองไม่โผล่ใน `/audit`

- CREATE/UPDATE/DELETE บน `probation_enrollment` เขียน audit ตามแพทเทิร์น supportive
- DELETE ที่เป็น CANCELLED อยู่แล้วไม่เขียนซ้ำ (idempotent)

## ทดสอบ
- [x] PHPUnit `ProbationAuditCallTest` 3/3