### PR TITLE
fix: close remaining Medium findings N13–N17, N26, N28

### DIFF
--- a/backend/routes/awards.php
+++ b/backend/routes/awards.php
@@ -144,6 +144,20 @@ function validateAwardPayload(array $data, bool $requireCore): array
         return [null, 'ระดับรางวัลไม่ถูกต้อง'];
     }
 
+    if (array_key_exists('awarded_date', $data) && $data['awarded_date'] !== '' && $data['awarded_date'] !== null) {
+        if (!is_string($data['awarded_date']) || !preg_match('/^\d{4}-\d{2}-\d{2}$/', $data['awarded_date'])) {
+            return [null, 'รูปแบบวันที่ไม่ถูกต้อง'];
+        }
+        $parsed = DateTime::createFromFormat('Y-m-d|', $data['awarded_date']);
+        $errors = DateTime::getLastErrors();
+        if (
+            $parsed === false
+            || ($errors !== false && ($errors['warning_count'] > 0 || $errors['error_count'] > 0))
+        ) {
+            return [null, 'รูปแบบวันที่ไม่ถูกต้อง'];
+        }
+    }
+
     return [$data, null];
 }
 

--- a/backend/routes/multiplier.php
+++ b/backend/routes/multiplier.php
@@ -13,6 +13,18 @@ include_once __DIR__ . '/../helpers.php';
 include_once __DIR__ . '/../audit.php';
 include_once __DIR__ . '/../MultiplierEngine.php';
 
+/** N13 — ล็อกแถวบุคคลก่อนเช็ค overlap เพื่อกัน concurrent INSERT นับโบนัสซ้ำ */
+const MULTIPLIER_PERSONNEL_LOCK_SQL = 'SELECT personnel_id FROM personnel WHERE personnel_id = ? FOR UPDATE';
+const MULTIPLIER_OVERLAP_SQL = 'SELECT COUNT(*) FROM multiplier_experience
+        WHERE personnel_id = ?
+          AND eligible_start_date <= ?
+          AND eligible_end_date >= ?';
+const MULTIPLIER_OVERLAP_EXCLUDE_SQL = 'SELECT COUNT(*) FROM multiplier_experience
+        WHERE personnel_id = ?
+          AND multiplier_id != ?
+          AND eligible_start_date <= ?
+          AND eligible_end_date >= ?';
+
 function handleMultiplier(PDO $pdo, string $method, array $path): void
 {
     // GET = read, POST = create, PUT = update, DELETE = delete
@@ -310,24 +322,29 @@ function createMultiplier(PDO $pdo, array $user): void
         return;
     }
 
-    // กันการนับซ้ำ: ปฏิเสธถ้า "ช่วงที่นับได้จริง" (eligible period) ทับกับรายการเดิมของบุคคลนี้
-    // เพราะ bonus_days aggregate จากช่วงเหล่านี้ การทับ = double-count วันเลื่อนระดับ
-    $overlapStmt = $pdo->prepare("
-        SELECT COUNT(*) FROM multiplier_experience
-        WHERE personnel_id = ?
-          AND eligible_start_date <= ?
-          AND eligible_end_date >= ?
-    ");
-    $overlapStmt->execute([
-        $personnelId,
-        $computed['eligible_end_date'],
-        $computed['eligible_start_date'],
-    ]);
-    if ((int) $overlapStmt->fetchColumn() > 0) {
-        http_response_code(409);
-        echo json_encode(['error' => 'ช่วงวันที่นับทวีคูณทับซ้อนกับรายการเดิมของบุคลากรนี้']);
-        return;
-    }
+    // กันการนับซ้ำ: ล็อกแถวบุคคลแล้วค่อย COUNT overlap ของช่วงที่นับได้จริง
+    $pdo->beginTransaction();
+    try {
+        $lockStmt = $pdo->prepare(MULTIPLIER_PERSONNEL_LOCK_SQL);
+        $lockStmt->execute([$personnelId]);
+        if (!$lockStmt->fetchColumn()) {
+            $pdo->rollBack();
+            http_response_code(404);
+            echo json_encode(['error' => 'ไม่พบบุคลากรตามรหัสที่ระบุ']);
+            return;
+        }
+        $overlapStmt = $pdo->prepare(MULTIPLIER_OVERLAP_SQL);
+        $overlapStmt->execute([
+            $personnelId,
+            $computed['eligible_end_date'],
+            $computed['eligible_start_date'],
+        ]);
+        if ((int) $overlapStmt->fetchColumn() > 0) {
+            $pdo->rollBack();
+            http_response_code(409);
+            echo json_encode(['error' => 'ช่วงวันที่นับทวีคูณทับซ้อนกับรายการเดิมของบุคลากรนี้']);
+            return;
+        }
 
     $sql = "INSERT INTO multiplier_experience
             (personnel_id, area_multiplier_id, province, district, basis_type,
@@ -380,6 +397,14 @@ function createMultiplier(PDO $pdo, array $user): void
             'bonus_days' => $computed['bonus_days'],
         ]
     );
+
+        $pdo->commit();
+    } catch (Throwable $e) {
+        if ($pdo->inTransaction()) {
+            $pdo->rollBack();
+        }
+        throw $e;
+    }
 
     http_response_code(201);
     echo json_encode([
@@ -560,25 +585,29 @@ function updateMultiplier(PDO $pdo, int $multiplierId, array $user, ?array $inpu
         return;
     }
 
-    // ตรวจ overlap (ยกเว้นตัวเอง)
-    $overlapStmt = $pdo->prepare("
-        SELECT COUNT(*) FROM multiplier_experience
-        WHERE personnel_id = ?
-          AND multiplier_id != ?
-          AND eligible_start_date <= ?
-          AND eligible_end_date >= ?
-    ");
-    $overlapStmt->execute([
-        $personnelId,
-        $multiplierId,
-        $computed['eligible_end_date'],
-        $computed['eligible_start_date'],
-    ]);
-    if ((int) $overlapStmt->fetchColumn() > 0) {
-        http_response_code(409);
-        echo json_encode(['error' => 'ช่วงวันที่นับทวีคูณทับซ้อนกับรายการเดิมของบุคลากรนี้']);
-        return;
-    }
+    $pdo->beginTransaction();
+    try {
+        $lockStmt = $pdo->prepare(MULTIPLIER_PERSONNEL_LOCK_SQL);
+        $lockStmt->execute([$personnelId]);
+        if (!$lockStmt->fetchColumn()) {
+            $pdo->rollBack();
+            http_response_code(404);
+            echo json_encode(['error' => 'ไม่พบบุคลากรตามรหัสที่ระบุ']);
+            return;
+        }
+        $overlapStmt = $pdo->prepare(MULTIPLIER_OVERLAP_EXCLUDE_SQL);
+        $overlapStmt->execute([
+            $personnelId,
+            $multiplierId,
+            $computed['eligible_end_date'],
+            $computed['eligible_start_date'],
+        ]);
+        if ((int) $overlapStmt->fetchColumn() > 0) {
+            $pdo->rollBack();
+            http_response_code(409);
+            echo json_encode(['error' => 'ช่วงวันที่นับทวีคูณทับซ้อนกับรายการเดิมของบุคลากรนี้']);
+            return;
+        }
 
     // Update
     $sql = "UPDATE multiplier_experience SET
@@ -642,6 +671,14 @@ function updateMultiplier(PDO $pdo, int $multiplierId, array $user, ?array $inpu
         $existing,
         $after ?: null
     );
+
+        $pdo->commit();
+    } catch (Throwable $e) {
+        if ($pdo->inTransaction()) {
+            $pdo->rollBack();
+        }
+        throw $e;
+    }
 
     // ดึงข้อมูลที่อัปเดตแล้วพร้อม decoration
     $updatedStmt = $pdo->prepare("

--- a/backend/routes/probation.php
+++ b/backend/routes/probation.php
@@ -95,6 +95,23 @@ function probationUpdateResolvedDate(array $data, array $existing, string $field
     return probationStrictDate($raw) ?? 'Invalid date format';
 }
 
+/** N17 — POST create ใช้ parse เข้มชุดเดียวกับ PUT */
+function probationCreateDateError(mixed $start, mixed $end): ?string
+{
+    if (!is_string($start) || !is_string($end)) {
+        return 'Invalid date format';
+    }
+    $startDate = probationStrictDate($start);
+    $endDate = probationStrictDate($end);
+    if ($startDate === null || $endDate === null) {
+        return 'Invalid date format';
+    }
+    if ($endDate < $startDate) {
+        return 'end_date must be greater than or equal to start_date';
+    }
+    return null;
+}
+
 /**
  * จัดการ request สำหรับ probation tracking endpoints
  *
@@ -382,10 +399,10 @@ function createProbationEnrollment(PDO $pdo): void
         return;
     }
 
-    // end_date ต้องไม่น้อยกว่า start_date (เทียบ string Y-m-d ได้ตรงเพราะรูปแบบ sort ได้)
-    if ($data['end_date'] < $data['start_date']) {
+    $dateError = probationCreateDateError($data['start_date'] ?? null, $data['end_date'] ?? null);
+    if ($dateError !== null) {
         http_response_code(400);
-        echo json_encode(['error' => 'end_date must be greater than or equal to start_date']);
+        echo json_encode(['error' => $dateError]);
         return;
     }
 

--- a/backend/routes/probation.php
+++ b/backend/routes/probation.php
@@ -16,6 +16,85 @@ include_once __DIR__ . '/../helpers.php';
 include_once __DIR__ . '/../authz.php';
 include_once __DIR__ . '/../audit.php';
 
+/** @var list<string> overall_status ที่ PUT รับได้ — CANCELLED ตั้งได้เฉพาะ DELETE */
+const PROBATION_OVERALL_STATUSES = ['IN_PROGRESS', 'COMPLETED', 'FAILED', 'EXTENDED'];
+
+/**
+ * parse Y-m-d แบบเข้ม (pattern เดียวกับ diverseStrictDate) — คืน null ถ้า format ผิดหรือ overflow
+ */
+function probationStrictDate(string $value): ?DateTime
+{
+    if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $value)) {
+        return null;
+    }
+    $date = DateTime::createFromFormat('Y-m-d|', $value);
+    $errors = DateTime::getLastErrors();
+    if (
+        $date === false
+        || ($errors !== false && ($errors['warning_count'] > 0 || $errors['error_count'] > 0))
+    ) {
+        return null;
+    }
+    return $date;
+}
+
+/**
+ * N14 — ตรวจ payload PUT พ้นทดลอง: whitelist status, ห้ามเปิด CANCELLED, end≥start (merge กับแถวเดิม)
+ *
+ * @param array<string, mixed> $data
+ * @param array<string, mixed> $existing
+ */
+function probationUpdateValidationError(array $data, array $existing): ?string
+{
+    $currentStatus = (string) ($existing['overall_status'] ?? '');
+    if ($currentStatus === 'CANCELLED') {
+        return 'Cancelled enrollment cannot be reopened';
+    }
+    if (array_key_exists('overall_status', $data)) {
+        $next = $data['overall_status'];
+        if (!is_string($next) || !in_array($next, PROBATION_OVERALL_STATUSES, true)) {
+            return 'Invalid overall_status';
+        }
+    }
+
+    $start = probationUpdateResolvedDate($data, $existing, 'start_date');
+    if (is_string($start)) {
+        return $start;
+    }
+    $end = probationUpdateResolvedDate($data, $existing, 'end_date');
+    if (is_string($end)) {
+        return $end;
+    }
+    if ($start !== null && $end !== null && $end < $start) {
+        return 'end_date must be greater than or equal to start_date';
+    }
+
+    return null;
+}
+
+/**
+ * @param array<string, mixed> $data
+ * @param array<string, mixed> $existing
+ * @return DateTime|string|null DateTime, ข้อความ error, หรือ null ถ้าไม่มีค่า
+ */
+function probationUpdateResolvedDate(array $data, array $existing, string $field): DateTime|string|null
+{
+    if (array_key_exists($field, $data)) {
+        if (!is_string($data[$field])) {
+            return 'Invalid date format';
+        }
+        return probationStrictDate($data[$field]) ?? 'Invalid date format';
+    }
+    $raw = $existing[$field] ?? null;
+    if ($raw === null || $raw === '') {
+        return null;
+    }
+    if (!is_string($raw)) {
+        return 'Invalid date format';
+    }
+    return probationStrictDate($raw) ?? 'Invalid date format';
+}
+
 /**
  * จัดการ request สำหรับ probation tracking endpoints
  *
@@ -364,6 +443,16 @@ function updateProbationEnrollment(PDO $pdo, int $enrollmentId): void
     if (!$existing) {
         http_response_code(404);
         echo json_encode(['error' => 'Enrollment not found']);
+        return;
+    }
+
+    if (!is_array($data)) {
+        $data = [];
+    }
+    $validationError = probationUpdateValidationError($data, $existing);
+    if ($validationError !== null) {
+        http_response_code(400);
+        echo json_encode(['error' => $validationError]);
         return;
     }
 

--- a/backend/routes/supportive.php
+++ b/backend/routes/supportive.php
@@ -192,6 +192,12 @@ function getSupportiveDetail(PDO $pdo, int $id): void
  * เพื่อไม่ต้อง include engine ทั้งไฟล์) — คืน null ถ้า format ผิดหรือมี overflow
  * (เดือน 13, วัน 45) — 'Y-m-d|' reset เวลาเป็น 00:00:00 กันคลาดเคลื่อน ±1 วัน
  */
+/** N15 — DECIMAL(5,2) ต้องเป็น float ไม่ใช่ intval ที่ตัดทศนิยม */
+function supportiveRatioPercent(int|float|string $raw): float
+{
+    return (float) $raw;
+}
+
 function supportiveStrictDate(string $value): ?DateTime
 {
     $date = DateTime::createFromFormat('Y-m-d|', $value);
@@ -245,7 +251,7 @@ function computeSupportiveFields(PDO $pdo, string $startDateStr, string $endDate
         $ratioStmt->execute([$primarySeriesName, $jobSeriesName]);
         $ratioRow = $ratioStmt->fetch(PDO::FETCH_ASSOC);
         if ($ratioRow) {
-            $ratioPercent = intval($ratioRow['ratio_percent']);
+            $ratioPercent = supportiveRatioPercent($ratioRow['ratio_percent']);
         }
     }
 

--- a/backend/tests/Unit/AwardDateValidationTest.php
+++ b/backend/tests/Unit/AwardDateValidationTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../routes/awards.php';
+
+/** N17 — awarded_date ที่ส่งมาต้องเป็น Y-m-d เข้ม หรือว่าง (null) */
+final class AwardDateValidationTest extends TestCase
+{
+    #[Test]
+    public function malformed_awarded_date_is_rejected(): void
+    {
+        [, $err] = validateAwardPayload([
+            'servant_id' => 1,
+            'award_name' => 'x',
+            'awarded_date' => 'not-a-date',
+        ], true);
+        self::assertSame('รูปแบบวันที่ไม่ถูกต้อง', $err);
+    }
+
+    #[Test]
+    public function overflow_awarded_date_is_rejected(): void
+    {
+        [, $err] = validateAwardPayload([
+            'servant_id' => 1,
+            'award_name' => 'x',
+            'awarded_date' => '2026-02-30',
+        ], true);
+        self::assertSame('รูปแบบวันที่ไม่ถูกต้อง', $err);
+    }
+
+    #[Test]
+    public function blank_awarded_date_is_allowed(): void
+    {
+        [, $err] = validateAwardPayload([
+            'servant_id' => 1,
+            'award_name' => 'x',
+            'awarded_date' => '',
+        ], true);
+        self::assertNull($err);
+    }
+
+    #[Test]
+    public function canonical_awarded_date_is_allowed(): void
+    {
+        [, $err] = validateAwardPayload([
+            'servant_id' => 1,
+            'award_name' => 'x',
+            'awarded_date' => '2024-06-01',
+        ], true);
+        self::assertNull($err);
+    }
+}

--- a/backend/tests/Unit/MultiplierOverlapLockTest.php
+++ b/backend/tests/Unit/MultiplierOverlapLockTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../routes/multiplier.php';
+
+/**
+ * N13 — overlap ของ multiplier_experience ต้องล็อกแถวบุคคลก่อน COUNT
+ * (anti-drift บนซอร์ส ไม่รัน concurrent HTTP)
+ */
+final class MultiplierOverlapLockTest extends TestCase
+{
+    #[Test]
+    public function personnel_lock_sql_uses_for_update(): void
+    {
+        self::assertStringContainsString('FOR UPDATE', MULTIPLIER_PERSONNEL_LOCK_SQL);
+        self::assertStringContainsString('FROM personnel', MULTIPLIER_PERSONNEL_LOCK_SQL);
+    }
+
+    #[Test]
+    public function overlap_sql_has_no_for_update_on_experience(): void
+    {
+        self::assertStringNotContainsString('FOR UPDATE', MULTIPLIER_OVERLAP_SQL);
+        self::assertStringContainsString('FROM multiplier_experience', MULTIPLIER_OVERLAP_SQL);
+    }
+
+    #[Test]
+    public function create_locks_then_checks_overlap_inside_transaction(): void
+    {
+        $src = file_get_contents(__DIR__ . '/../../routes/multiplier.php');
+        self::assertIsString($src);
+        $start = strpos($src, 'function createMultiplier(');
+        self::assertNotFalse($start);
+        $end = strpos($src, 'function fetchAreaRow', $start);
+        self::assertNotFalse($end);
+        $fn = substr($src, $start, $end - $start);
+        self::assertStringContainsString('beginTransaction', $fn);
+        self::assertStringContainsString('MULTIPLIER_PERSONNEL_LOCK_SQL', $fn);
+        self::assertLessThan(
+            strpos($fn, 'MULTIPLIER_OVERLAP_SQL'),
+            strpos($fn, 'MULTIPLIER_PERSONNEL_LOCK_SQL'),
+            'personnel lock must run before overlap count'
+        );
+        self::assertGreaterThan(
+            strpos($fn, 'beginTransaction'),
+            strpos($fn, 'commit'),
+            'commit must follow beginTransaction'
+        );
+    }
+
+    #[Test]
+    public function update_locks_then_checks_overlap_inside_transaction(): void
+    {
+        $src = file_get_contents(__DIR__ . '/../../routes/multiplier.php');
+        self::assertIsString($src);
+        $start = strpos($src, 'function updateMultiplier(');
+        self::assertNotFalse($start);
+        $fn = substr($src, $start);
+        self::assertStringContainsString('beginTransaction', $fn);
+        self::assertStringContainsString('MULTIPLIER_PERSONNEL_LOCK_SQL', $fn);
+        self::assertLessThan(
+            strpos($fn, 'MULTIPLIER_OVERLAP_EXCLUDE_SQL'),
+            strpos($fn, 'MULTIPLIER_PERSONNEL_LOCK_SQL')
+        );
+    }
+}

--- a/backend/tests/Unit/ProbationCreateDateTest.php
+++ b/backend/tests/Unit/ProbationCreateDateTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../routes/probation.php';
+
+/** N17 — POST /probation ต้อง parse Y-m-d เข้ม ไม่เทียบ string หลวม */
+final class ProbationCreateDateTest extends TestCase
+{
+    #[Test]
+    public function inverted_range_is_rejected(): void
+    {
+        self::assertSame(
+            'end_date must be greater than or equal to start_date',
+            probationCreateDateError('2026-12-31', '2026-01-01')
+        );
+    }
+
+    #[Test]
+    public function unpadded_start_is_rejected(): void
+    {
+        self::assertSame('Invalid date format', probationCreateDateError('2026-1-5', '2026-07-01'));
+    }
+
+    #[Test]
+    public function overflow_end_is_rejected(): void
+    {
+        self::assertSame('Invalid date format', probationCreateDateError('2026-01-01', '2026-02-30'));
+    }
+
+    #[Test]
+    public function valid_range_has_no_error(): void
+    {
+        self::assertNull(probationCreateDateError('2026-01-01', '2026-07-01'));
+    }
+
+    #[Test]
+    public function create_source_uses_helper(): void
+    {
+        $src = file_get_contents(__DIR__ . '/../../routes/probation.php');
+        self::assertIsString($src);
+        $start = strpos($src, 'function createProbationEnrollment');
+        self::assertNotFalse($start);
+        $end = strpos($src, 'function updateProbationEnrollment', $start);
+        self::assertNotFalse($end);
+        $fn = substr($src, $start, $end - $start);
+        self::assertStringContainsString('probationCreateDateError(', $fn);
+        self::assertStringNotContainsString('$data[\'end_date\'] < $data[\'start_date\']', $fn);
+    }
+}

--- a/backend/tests/Unit/ProbationUpdateValidationTest.php
+++ b/backend/tests/Unit/ProbationUpdateValidationTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../routes/probation.php';
+
+/**
+ * N14 — PUT /probation/{id} ต้อง whitelist overall_status และเช็ค end≥start
+ * (รวมค่าเดิมเมื่อส่งมาแค่ฝั่งเดียว) และห้ามเปิด CANCELLED กลับ
+ */
+final class ProbationUpdateValidationTest extends TestCase
+{
+    /** @return array{overall_status: string, start_date: string, end_date: string} */
+    private static function existing(): array
+    {
+        return [
+            'overall_status' => 'IN_PROGRESS',
+            'start_date' => '2026-01-01',
+            'end_date' => '2026-07-01',
+        ];
+    }
+
+    /** @return array<string, array{string}> */
+    public static function allowedStatusProvider(): array
+    {
+        return [
+            'IN_PROGRESS' => ['IN_PROGRESS'],
+            'COMPLETED' => ['COMPLETED'],
+            'FAILED' => ['FAILED'],
+            'EXTENDED' => ['EXTENDED'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('allowedStatusProvider')]
+    public function allowed_overall_status_has_no_error(string $status): void
+    {
+        self::assertNull(probationUpdateValidationError(
+            ['overall_status' => $status],
+            self::existing()
+        ));
+    }
+
+    #[Test]
+    public function unknown_overall_status_is_invalid(): void
+    {
+        self::assertSame(
+            'Invalid overall_status',
+            probationUpdateValidationError(['overall_status' => 'HACKED'], self::existing())
+        );
+    }
+
+    #[Test]
+    public function empty_overall_status_is_invalid(): void
+    {
+        self::assertSame(
+            'Invalid overall_status',
+            probationUpdateValidationError(['overall_status' => ''], self::existing())
+        );
+    }
+
+    #[Test]
+    public function cancelled_enrollment_cannot_reopen(): void
+    {
+        $existing = self::existing();
+        $existing['overall_status'] = 'CANCELLED';
+        self::assertSame(
+            'Cancelled enrollment cannot be reopened',
+            probationUpdateValidationError(['overall_status' => 'IN_PROGRESS'], $existing)
+        );
+    }
+
+    #[Test]
+    public function cancelled_enrollment_cannot_update_other_fields(): void
+    {
+        $existing = self::existing();
+        $existing['overall_status'] = 'CANCELLED';
+        self::assertSame(
+            'Cancelled enrollment cannot be reopened',
+            probationUpdateValidationError(['remarks' => 'note'], $existing)
+        );
+    }
+
+    #[Test]
+    public function put_cannot_set_cancelled(): void
+    {
+        self::assertSame(
+            'Invalid overall_status',
+            probationUpdateValidationError(['overall_status' => 'CANCELLED'], self::existing())
+        );
+    }
+
+    #[Test]
+    public function inverted_dates_in_payload_are_rejected(): void
+    {
+        self::assertSame(
+            'end_date must be greater than or equal to start_date',
+            probationUpdateValidationError(
+                ['start_date' => '2026-12-31', 'end_date' => '2026-01-01'],
+                self::existing()
+            )
+        );
+    }
+
+    #[Test]
+    public function end_date_alone_must_not_precede_existing_start(): void
+    {
+        self::assertSame(
+            'end_date must be greater than or equal to start_date',
+            probationUpdateValidationError(['end_date' => '2025-12-01'], self::existing())
+        );
+    }
+
+    #[Test]
+    public function start_date_alone_must_not_follow_existing_end(): void
+    {
+        self::assertSame(
+            'end_date must be greater than or equal to start_date',
+            probationUpdateValidationError(['start_date' => '2026-12-01'], self::existing())
+        );
+    }
+
+    #[Test]
+    public function empty_start_date_in_payload_is_rejected(): void
+    {
+        self::assertSame(
+            'Invalid date format',
+            probationUpdateValidationError(['start_date' => ''], self::existing())
+        );
+    }
+
+    #[Test]
+    public function unpadded_end_date_is_rejected(): void
+    {
+        self::assertSame(
+            'Invalid date format',
+            probationUpdateValidationError(['end_date' => '2026-1-5'], self::existing())
+        );
+    }
+
+    #[Test]
+    public function overflow_end_date_is_rejected(): void
+    {
+        self::assertSame(
+            'Invalid date format',
+            probationUpdateValidationError(['end_date' => '2026-02-30'], self::existing())
+        );
+    }
+
+    #[Test]
+    public function datetime_suffix_end_date_is_rejected(): void
+    {
+        self::assertSame(
+            'Invalid date format',
+            probationUpdateValidationError(['end_date' => '2026-01-01 00:00'], self::existing())
+        );
+    }
+
+    #[Test]
+    public function equal_dates_are_allowed(): void
+    {
+        self::assertNull(probationUpdateValidationError(
+            ['start_date' => '2026-01-15', 'end_date' => '2026-01-15'],
+            self::existing()
+        ));
+    }
+
+    #[Test]
+    public function remarks_only_skips_status_and_keeps_existing_range(): void
+    {
+        self::assertNull(probationUpdateValidationError(
+            ['remarks' => 'note'],
+            self::existing()
+        ));
+    }
+
+    #[Test]
+    public function update_source_calls_validator(): void
+    {
+        $src = file_get_contents(__DIR__ . '/../../routes/probation.php');
+        self::assertIsString($src);
+        $start = strpos($src, 'function updateProbationEnrollment');
+        self::assertNotFalse($start);
+        $end = strpos($src, 'function deleteProbationEnrollment', $start);
+        self::assertNotFalse($end);
+        $fn = substr($src, $start, $end - $start);
+        self::assertStringContainsString('probationUpdateValidationError(', $fn);
+        self::assertStringContainsString('http_response_code(400)', $fn);
+    }
+}

--- a/backend/tests/Unit/SupportiveRatioPercentTest.php
+++ b/backend/tests/Unit/SupportiveRatioPercentTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../routes/supportive.php';
+
+/** N15 — ratio_percent เป็น DECIMAL(5,2) ห้ามตัดทศนิยมด้วย intval */
+final class SupportiveRatioPercentTest extends TestCase
+{
+    #[Test]
+    public function decimal_ratio_keeps_fraction(): void
+    {
+        self::assertSame(150.5, supportiveRatioPercent('150.50'));
+        self::assertSame(100.0, supportiveRatioPercent('100'));
+        self::assertSame(87.25, supportiveRatioPercent(87.25));
+    }
+
+    #[Test]
+    public function compute_source_does_not_intval_ratio(): void
+    {
+        $src = file_get_contents(__DIR__ . '/../../routes/supportive.php');
+        self::assertIsString($src);
+        $start = strpos($src, 'function computeSupportiveFields');
+        self::assertNotFalse($start);
+        $end = strpos($src, 'function createSupportive', $start);
+        self::assertNotFalse($end);
+        $fn = substr($src, $start, $end - $start);
+        self::assertStringNotContainsString('intval($ratioRow', $fn);
+        self::assertStringContainsString('supportiveRatioPercent(', $fn);
+    }
+}

--- a/frontend/src/__tests__/pages/DashboardPage.test.js
+++ b/frontend/src/__tests__/pages/DashboardPage.test.js
@@ -1,4 +1,4 @@
-import { mount, RouterLinkStub } from '@vue/test-utils'
+import { flushPromises, mount, RouterLinkStub } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockGet = vi.fn()
@@ -30,5 +30,22 @@ describe('DashboardPage quick actions', () => {
 
     expect(supportiveLink).toBeDefined()
     expect(supportiveLink.props('to')).toBe('/time-counting')
+  })
+
+  it('shows in_progress count on the probation tracking card, not all statuses', async () => {
+    mockGet.mockResolvedValue({
+      total_personnel: 10,
+      probation: { total: 9, in_progress: 4, near_deadline: 2, overdue: 1 },
+      time_counting: { total: 0 },
+      candidates: { total: 0 },
+    })
+    const wrapper = mount(DashboardPage, {
+      global: { stubs: { RouterLink: RouterLinkStub } },
+    })
+    await flushPromises()
+    const card = wrapper.findAllComponents({ name: 'StatCard' })
+      .find((c) => c.props('label') === 'ติดตามพ้นทดลอง')
+    expect(card).toBeDefined()
+    expect(card.props('value')).toBe('4')
   })
 })

--- a/frontend/src/__tests__/pages/SupportivePage.test.js
+++ b/frontend/src/__tests__/pages/SupportivePage.test.js
@@ -190,6 +190,26 @@ describe('SupportivePage', () => {
     expect(mockRemove).not.toHaveBeenCalled()
   })
 
+  it('skips personnel typeahead while IME is composing then runs on composition end', async () => {
+    vi.useFakeTimers()
+    const wrapper = await mountPage()
+    wrapper.vm.openCreate()
+    await wrapper.vm.$nextTick()
+    mockSearchPersonnel.mockClear()
+
+    const input = wrapper.get('#supportive-personnel-search')
+    await input.trigger('compositionstart')
+    await input.setValue('สม')
+    await input.trigger('input')
+    await vi.advanceTimersByTimeAsync(300)
+    expect(mockSearchPersonnel).not.toHaveBeenCalled()
+
+    await input.trigger('compositionend')
+    await vi.advanceTimersByTimeAsync(300)
+    expect(mockSearchPersonnel).toHaveBeenCalled()
+    vi.useRealTimers()
+  })
+
   it('closeModal clears form errors', async () => {
     const wrapper = await mountPage()
     wrapper.vm.openCreate()

--- a/frontend/src/pages/DashboardPage.vue
+++ b/frontend/src/pages/DashboardPage.vue
@@ -234,7 +234,6 @@ async function fetchDashboard() {
     if (!req.isCurrent()) return
 
     stats.value.totalPersonnel = d.total_personnel || 0
-    stats.value.probationTotal = d.probation?.total || 0
     stats.value.timeCountTotal = d.time_counting?.total || 0
     stats.value.candidateTotal = d.candidates?.total || 0
     // ใช้ค่า in_progress จาก backend ตรง ๆ (predicate เดียวกับหน้า probation)
@@ -242,6 +241,7 @@ async function fetchDashboard() {
     const inProgress = typeof d.probation?.in_progress === 'number'
       ? d.probation.in_progress
       : Math.max(0, (d.probation?.total || 0) - (d.probation?.near_deadline || 0) - (d.probation?.overdue || 0))
+    stats.value.probationTotal = inProgress
     probationSummary.value = {
       inProgress,
       nearDeadline: d.probation?.near_deadline || 0,

--- a/frontend/src/pages/SupportivePage.vue
+++ b/frontend/src/pages/SupportivePage.vue
@@ -146,6 +146,8 @@
                 id="supportive-personnel-search"
                 v-model="personnelSearch"
                 @input="onPersonnelInput"
+                @compositionstart="isComposingPersonnel = true"
+                @compositionend="onPersonnelCompositionEnd"
                 type="text"
                 placeholder="พิมพ์ชื่อเพื่อค้นหาบุคลากร..."
                 class="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
@@ -359,6 +361,7 @@ const personnelSearch = ref('')
 const personnelResults = ref([])
 const showPersonnelDropdown = ref(false)
 const personnelSearchFailed = ref(false)
+const isComposingPersonnel = ref(false)
 const { run: schedulePersonnelSearch, cancel: cancelPersonnelSearch } = useDebouncedCallback(async () => {
   const req = nextPersonnelRequest()
   const val = personnelSearch.value.trim()
@@ -522,6 +525,7 @@ async function confirmDelete(id) {
 
 // Personnel autocomplete
 function onPersonnelInput() {
+  if (isComposingPersonnel.value) return
   formData.value.personnel_id = null
   const val = personnelSearch.value.trim()
   if (val.length < 2) {
@@ -533,6 +537,11 @@ function onPersonnelInput() {
     return
   }
   schedulePersonnelSearch()
+}
+
+function onPersonnelCompositionEnd() {
+  isComposingPersonnel.value = false
+  onPersonnelInput()
 }
 
 function selectPersonnel(person) {


### PR DESCRIPTION
## Summary
ปิด Medium จาก findings 2026-09-08 ที่แก้ได้ทันที (ไม่รีวิวทั้ง codebase):
- **N14** whitelist `overall_status` + ห้ามเปิด CANCELLED + วันที่ Y-m-d เข้มบน PUT พ้นทดลอง
- **N15** `ratio_percent` เป็น float ไม่ตัดทศนิยมด้วย `intval`
- **N17** POST พ้นทดลองและ `awarded_date` parse เข้ม → 400 ไม่ใช่ 500
- **N13** `SELECT personnel … FOR UPDATE` ก่อน overlap ของทวีคูณ
- **N26** การ์ด dashboard «ติดตามพ้นทดลอง» นับ `in_progress`
- **N28** typeahead เกื้อกูลมี IME composition guard

## Test plan
- [x] PHPUnit Unit: ProbationUpdateValidation / ProbationCreateDate / AwardDateValidation / SupportiveRatioPercent / MultiplierOverlapLock
- [x] Vitest: DashboardPage + SupportivePage (N26/N28)
- [x] pre-push ผ่านบนเครื่องนี้ (รอบแรก flake `verify-live-headers` exit 3221226505; รันเดี่ยวผ่าน 7/7 แล้ว push ซ้ำ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)