### PR TITLE
fix: restrict special-area writes to admin (N10)

### DIFF
--- a/backend/routes/multiplier.php
+++ b/backend/routes/multiplier.php
@@ -25,6 +25,23 @@ const MULTIPLIER_OVERLAP_EXCLUDE_SQL = 'SELECT COUNT(*) FROM multiplier_experien
           AND eligible_start_date <= ?
           AND eligible_end_date >= ?';
 
+/** N10 — เขียน master พื้นที่พิเศษ = admin/superadmin (UI requiresAdmin) */
+function multiplierAreaWriteAllowed(?array $user): bool
+{
+    $role = (string) ($user['role'] ?? '');
+    return $role === 'admin' || $role === 'superadmin';
+}
+
+function denyMultiplierAreaWrite(): void
+{
+    http_response_code(403);
+    echo json_encode([
+        'error' => 'Forbidden',
+        'message' => 'คุณไม่มีสิทธิ์ในการดำเนินการนี้',
+        'required_permission' => 'admin',
+    ]);
+}
+
 function handleMultiplier(PDO $pdo, string $method, array $path): void
 {
     // GET = read, POST = create, PUT = update, DELETE = delete
@@ -58,6 +75,10 @@ function handleMultiplier(PDO $pdo, string $method, array $path): void
 
             case 'POST':
                 if (($path[1] ?? '') === 'areas') {
+                    if (!multiplierAreaWriteAllowed($user)) {
+                        denyMultiplierAreaWrite();
+                        return;
+                    }
                     createMultiplierArea($pdo, $user);
                     return;
                 }
@@ -71,6 +92,10 @@ function handleMultiplier(PDO $pdo, string $method, array $path): void
                     && ctype_digit($path[2] ?? '')
                     && ($path[3] ?? '') === 'status'
                 ) {
+                    if (!multiplierAreaWriteAllowed($user)) {
+                        denyMultiplierAreaWrite();
+                        return;
+                    }
                     setMultiplierAreaStatus($pdo, (int) $path[2]);
                     return;
                 }

--- a/backend/tests/Unit/MultiplierAreaWriteAuthzTest.php
+++ b/backend/tests/Unit/MultiplierAreaWriteAuthzTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../routes/multiplier.php';
+
+/**
+ * N10 — เขียนพื้นที่พิเศษต้องเป็น admin/superadmin (UI requiresAdmin)
+ * operator มี create:multiplier สำหรับรายการทวีคูณ แต่ไม่ใช่ master พื้นที่
+ */
+final class MultiplierAreaWriteAuthzTest extends TestCase
+{
+    /** @return array<string, array{string, bool}> */
+    public static function roleProvider(): array
+    {
+        return [
+            'admin' => ['admin', true],
+            'superadmin' => ['superadmin', true],
+            'operator' => ['operator', false],
+            'viewer' => ['viewer', false],
+            'empty' => ['', false],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('roleProvider')]
+    public function write_allowed_only_for_admin_roles(string $role, bool $allowed): void
+    {
+        self::assertSame($allowed, multiplierAreaWriteAllowed(['role' => $role]));
+    }
+
+    #[Test]
+    public function null_user_is_denied(): void
+    {
+        self::assertFalse(multiplierAreaWriteAllowed(null));
+    }
+
+    #[Test]
+    public function handle_multiplier_gates_area_writes(): void
+    {
+        $src = file_get_contents(__DIR__ . '/../../routes/multiplier.php');
+        self::assertIsString($src);
+        $start = strpos($src, 'function handleMultiplier');
+        self::assertNotFalse($start);
+        $end = strpos($src, 'function getMultiplierAreas', $start);
+        self::assertNotFalse($end);
+        $fn = substr($src, $start, $end - $start);
+        self::assertStringContainsString('multiplierAreaWriteAllowed(', $fn);
+        self::assertLessThan(
+            strpos($fn, 'createMultiplierArea('),
+            strpos($fn, 'multiplierAreaWriteAllowed(')
+        );
+        self::assertLessThan(
+            strpos($fn, 'setMultiplierAreaStatus('),
+            strpos($fn, 'multiplierAreaWriteAllowed(')
+        );
+    }
+}


### PR DESCRIPTION
## Summary
N10 จาก findings 2026-09-08: `POST /multiplier/areas` และ `PUT /multiplier/areas/{id}/status` ใช้สิทธิ์ `create/update:multiplier` จึงให้ operator เขียน master พื้นที่พิเศษได้ ทั้งที่ UI เป็น `requiresAdmin`.

แก้ด้วย `multiplierAreaWriteAllowed()` — อนุญาตเฉพาะ `admin` / `superadmin`. GET `/multiplier/areas` ยังเปิดให้ operator เลือกพื้นที่ตอนสร้างรายการทวีคูณ.

## Test plan
- [x] PHPUnit `MultiplierAreaWriteAuthzTest` (role matrix + source gate)
- [x] `MultiplierOverlapLockTest` ยังผ่าน
- [x] pre-push ผ่าน

🤖 Generated with [Claude Code](https://claude.com/claude-code)