### PR TITLE
fix: count probation overdue as remaining_days < 0 (N25)

### DIFF
--- a/backend/routes/probation.php
+++ b/backend/routes/probation.php
@@ -279,7 +279,7 @@ function getProbationList(PDO $pdo): void
             SELECT
                 SUM(CASE WHEN DATEDIFF(end_date, CURDATE()) > 0 THEN 1 ELSE 0 END) AS in_progress,
                 SUM(CASE WHEN DATEDIFF(end_date, CURDATE()) BETWEEN 1 AND 30 THEN 1 ELSE 0 END) AS near_deadline,
-                SUM(CASE WHEN DATEDIFF(end_date, CURDATE()) <= 0 THEN 1 ELSE 0 END) AS overdue
+                SUM(CASE WHEN DATEDIFF(end_date, CURDATE()) < 0 THEN 1 ELSE 0 END) AS overdue
             FROM probation_enrollment
             WHERE overall_status = 'IN_PROGRESS'
         ");
@@ -293,7 +293,7 @@ function getProbationList(PDO $pdo): void
             $rem = intval($r['remaining_days'] ?? 0);
             if ($rem > 0) $inProgress++;
             if ($rem >= 1 && $rem <= 30) $nearDeadline++;
-            if ($rem <= 0) $overdue++;
+            if ($rem < 0) $overdue++;
         }
     }
 

--- a/backend/tests/Unit/ProbationDayZeroSummaryTest.php
+++ b/backend/tests/Unit/ProbationDayZeroSummaryTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * N25 — remaining_days === 0 คือ READY ไม่ใช่ overdue
+ * summary ของ GET /probation และ /dashboard ต้องนับ overdue เป็น < 0 เท่านั้น
+ */
+final class ProbationDayZeroSummaryTest extends TestCase
+{
+    #[Test]
+    public function list_summary_counts_overdue_as_strictly_negative(): void
+    {
+        $src = file_get_contents(__DIR__ . '/../../routes/probation.php');
+        self::assertIsString($src);
+        $start = strpos($src, 'function getProbationList');
+        self::assertNotFalse($start);
+        $end = strpos($src, 'function getProbationDetail', $start);
+        self::assertNotFalse($end);
+        $fn = substr($src, $start, $end - $start);
+        self::assertStringContainsString('DATEDIFF(end_date, CURDATE()) < 0', $fn);
+        self::assertStringNotContainsString('DATEDIFF(end_date, CURDATE()) <= 0', $fn);
+        self::assertStringContainsString('if ($rem < 0) $overdue++', $fn);
+        self::assertStringNotContainsString('if ($rem <= 0) $overdue++', $fn);
+    }
+
+    #[Test]
+    public function dashboard_overdue_matches_list_summary(): void
+    {
+        $src = file_get_contents(__DIR__ . '/../../api.php');
+        self::assertIsString($src);
+        self::assertStringContainsString('remaining_days < 0', $src);
+        self::assertDoesNotMatchRegularExpression(
+            '/remaining_days\s*<=\s*0/',
+            $src
+        );
+    }
+}

--- a/frontend/src/__tests__/utils/displayEligibility.test.js
+++ b/frontend/src/__tests__/utils/displayEligibility.test.js
@@ -40,4 +40,9 @@ describe('probationStatusFor', () => {
     expect(probationStatusFor('IN_PROGRESS', 31)).toBe('NOT_DUE')
     expect(probationStatusFor('IN_PROGRESS', 45)).toBe('NOT_DUE')
   })
+
+  it('treats remaining_days === 0 as READY and negative as OVERDUE', () => {
+    expect(probationStatusFor('IN_PROGRESS', 0)).toBe('READY')
+    expect(probationStatusFor('IN_PROGRESS', -1)).toBe('OVERDUE')
+  })
 })


### PR DESCRIPTION
## Summary
N25 จาก findings 2026-09-08: วันครบกำหนด (`remaining_days === 0`) เป็น READY เขียวบน badge แต่การ์ดหน้าพ้นทดลองนับ `<= 0` เป็น overdue ขณะที่ dashboard นับ `< 0`.

จัด summary ของ `GET /probation` ให้ overdue เป็น `< 0` เท่านั้น ให้ตรง dashboard และ `probationStatusFor`.

## Test plan
- [x] PHPUnit `ProbationDayZeroSummaryTest`
- [x] Vitest `displayEligibility` + `remainingDays`
- [x] pre-push ผ่าน

🤖 Generated with [Claude Code](https://claude.com/claude-code)