### PR TITLE
fix: stat cards count from full dataset not current page (N27, N29)

### DIFF
--- a/backend/routes/supportive.php
+++ b/backend/routes/supportive.php
@@ -134,9 +134,12 @@ function getSupportiveList(PDO $pdo): void
     unset($row);
 
     // Summary จาก full dataset (ไม่ใช่ current page)
+    // recent_count = รายการที่ start_date อยู่ในเดือนปัจจุบัน — FE ใช้แสดงการ์ด «เพิ่มล่าสุด» (N27)
     $summaryStmt = $pdo->query("
         SELECT COUNT(DISTINCT personnel_id) AS distinct_personnel,
-               SUM(effective_days) AS total_effective_days
+               SUM(effective_days) AS total_effective_days,
+               SUM(CASE WHEN YEAR(start_date) = YEAR(CURDATE()) AND MONTH(start_date) = MONTH(CURDATE())
+                        THEN 1 ELSE 0 END) AS recent_count
         FROM supportive_experience
     ");
     $summaryRow = $summaryStmt->fetch(PDO::FETCH_ASSOC);
@@ -148,6 +151,7 @@ function getSupportiveList(PDO $pdo): void
             'total' => $total,
             'distinct_personnel' => (int) ($summaryRow['distinct_personnel'] ?? 0),
             'total_effective_days' => (float) ($summaryRow['total_effective_days'] ?? 0),
+            'recent_count' => (int) ($summaryRow['recent_count'] ?? 0),
         ],
         'pagination' => [
             'total' => $total,

--- a/frontend/src/__tests__/pages/RetirementReportPage.test.js
+++ b/frontend/src/__tests__/pages/RetirementReportPage.test.js
@@ -25,6 +25,15 @@ function resolvedData(rows = [sampleRow]) {
   })
 }
 
+// mockImplementation ที่ให้ total ต่างกันตาม within — ใช้ทดสอบ totalAll แยกจาก pagination.total (N29)
+function resolvedWithTotals({ all = 10, w12 = 4, w6 = 2 } = {}) {
+  mockFetchList.mockImplementation(({ within } = {}) => {
+    if (within === 6) return Promise.resolve({ data: [sampleRow], pagination: { total: w6, limit: 1, offset: 0, has_more: false } })
+    if (within === 12) return Promise.resolve({ data: [sampleRow], pagination: { total: w12, limit: 1, offset: 0, has_more: false } })
+    return Promise.resolve({ data: [sampleRow], pagination: { total: all, limit: 20, offset: 0, has_more: false } })
+  })
+}
+
 async function mountPage() {
   const wrapper = mount(RetirementReportPage)
   await vi.waitFor(() => expect(mockFetchList).toHaveBeenCalled())
@@ -65,6 +74,20 @@ describe('RetirementReportPage', () => {
     wrapper.vm.onFilterChange()
     await vi.waitFor(() => expect(mockFetchList).toHaveBeenCalled())
     expect(mockFetchList).toHaveBeenCalledWith(expect.objectContaining({ within: '6', offset: 0 }))
+  })
+
+  it('totalAll stays unfiltered when within filter is applied', async () => {
+    resolvedWithTotals({ all: 10, w12: 4, w6: 2 })
+    const wrapper = await mountPage()
+    await vi.waitFor(() => expect(wrapper.vm.totalAll).toBe(10))
+    expect(wrapper.vm.totalWithin12).toBe(4)
+    expect(wrapper.vm.totalWithin6).toBe(2)
+
+    // เปลี่ยน filter → pagination.total เปลี่ยน แต่ totalAll ต้องยังเป็น 10
+    wrapper.vm.within = '6'
+    wrapper.vm.onFilterChange()
+    await vi.waitFor(() => expect(wrapper.vm.loading).toBe(false))
+    expect(wrapper.vm.totalAll).toBe(10)
   })
 
   it('shows empty state when no rows', async () => {

--- a/frontend/src/__tests__/pages/SupportivePage.test.js
+++ b/frontend/src/__tests__/pages/SupportivePage.test.js
@@ -124,6 +124,23 @@ describe('SupportivePage', () => {
     expect(wrapper.vm.distinctPersonnelCount).toBe(7)
   })
 
+  it('uses summary recent_count when present', async () => {
+    mockFetchList.mockResolvedValue({
+      success: true,
+      data: [sampleRow],
+      summary: { recent_count: 4 },
+      pagination: { total: 1, limit: 20, offset: 0 },
+    })
+    const wrapper = await mountPage()
+    expect(wrapper.vm.recentCount).toBe(4)
+  })
+
+  it('recentCount falls back to 0 (not N/A) when no rows match current month', async () => {
+    // sampleRow.startDate = '2021-01-01' — ไม่ตรงเดือนปัจจุบันเสมอ
+    const wrapper = await mountPage()
+    expect(wrapper.vm.recentCount).toBe(0)
+  })
+
   it('blocks save when required form fields are missing', async () => {
     const wrapper = await mountPage()
     wrapper.vm.openCreate()

--- a/frontend/src/pages/RetirementReportPage.vue
+++ b/frontend/src/pages/RetirementReportPage.vue
@@ -9,7 +9,7 @@
     <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
       <StatCard
         label="ทั้งหมดที่มีกำหนดเกษียณ"
-        :value="pagination.total"
+        :value="totalAll"
         :icon="Users"
         icon-bg-class="bg-blue-50"
         icon-class="text-blue-600"
@@ -150,15 +150,18 @@ const { run: scheduleSearch } = useDebouncedCallback(() => {
   fetchData()
 }, 300)
 const within = ref('')
+const totalAll = ref(0)
 const totalWithin12 = ref(0)
 const totalWithin6 = ref(0)
 
 async function fetchStatTotals(req) {
-  const [r12, r6] = await Promise.all([
+  const [rAll, r12, r6] = await Promise.all([
+    fetchList({ search: searchQuery.value, limit: 1, offset: 0 }),
     fetchList({ search: searchQuery.value, within: 12, limit: 1, offset: 0 }),
     fetchList({ search: searchQuery.value, within: 6, limit: 1, offset: 0 }),
   ])
   if (!req.isCurrent()) return
+  totalAll.value = rAll.pagination.total
   totalWithin12.value = r12.pagination.total
   totalWithin6.value = r6.pagination.total
 }

--- a/frontend/src/pages/SupportivePage.vue
+++ b/frontend/src/pages/SupportivePage.vue
@@ -396,17 +396,18 @@ const distinctPersonnelCount = computed(() => {
 })
 
 const recentCount = computed(() => {
-  // นับรายการที่เพิ่มในเดือนปัจจุบัน (ใช้ startDate เป็นตัวอ้างอิง)
+  // N27: ใช้ summary.recent_count จาก backend (นับจาก full dataset) ก่อน
+  // fallback นับจากหน้าปัจจุบันเท่านั้น
+  if (summary.value?.recent_count != null) return summary.value.recent_count
   const now = new Date()
   const currentMonth = now.getMonth()
   const currentYear = now.getFullYear()
-  const count = rows.value.filter(r => {
+  return rows.value.filter(r => {
     if (!r.startDate) return false
     const d = ymdToDate(r.startDate)
     if (!d) return false
     return d.getMonth() === currentMonth && d.getFullYear() === currentYear
   }).length
-  return count || 'N/A'
 })
 
 // Fetch data


### PR DESCRIPTION
## สรุป

แก้ findings N27 + N29 จาก codebase review 2026-09-08 — การ์ดสถิตินับจากหน้าปัจจุบันแทนที่จะเป็น full dataset

### N27 — การ์ดเกื้อกูล «เพิ่มล่าสุด»
- **ปัญหา:** `recentCount` นับจาก `rows` (20 แถวหน้าปัจจุบัน) และ `0` แสดงเป็น `N/A`
- **แก้:** backend เพิ่ม `recent_count` ใน summary query (`start_date` ในเดือนปัจจุบัน จาก full dataset) · frontend ใช้ `summary.recent_count` ก่อน fallback และแสดง `0` แทน `N/A`

### N29 — การ์ดเกษียณ «ทั้งหมด»
- **ปัญหา:** ผูก `pagination.total` ที่ถูกกรอง `within` แล้ว — เลือก «ภายใน 6 เดือน» การ์ด «ทั้งหมด» ก็หดตาม
- **แก้:** เพิ่ม `totalAll` fetch แบบไม่กรองใน `fetchStatTotals` ร่วมกับ `totalWithin12`/`totalWithin6` ที่มีอยู่

## Test plan
- [x] vitest ผ่าน 28/28 (รวม test ใหม่ 3 ข้อ: recentCount summary path, fallback = 0, totalAll คงค่าเมื่อเปลี่ยน within)
- [x] `php -l` ผ่าน
- [x] pre-push hook ผ่าน (full vitest suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)