### PR TITLE
fix: GET /sync/status requires read:sync not create:sync (N32)

### DIFF
--- a/backend/routes/sync.php
+++ b/backend/routes/sync.php
@@ -24,16 +24,14 @@ function handleSync(PDO $pdo, string $method, array $path): void
         return;
     }
 
-    // ใช้ authz matrix เป็นเส้นตัดสิน (fail-closed) — ห้าม hardcode role check
-    // เพราะ superadmin โดน 403 และ override จาก settings ไม่ถูกนับ
-    requirePermission('create', 'sync');
-
     $sub = $path[1] ?? '';
 
     try {
         switch ($method) {
             case 'GET':
                 if ($sub === 'status') {
+                    // N32: GET ใช้ read:sync ไม่ใช่ create:sync
+                    requirePermission('read', 'sync');
                     handleSyncStatus($pdo);
                 } else {
                     http_response_code(404);
@@ -42,6 +40,9 @@ function handleSync(PDO $pdo, string $method, array $path): void
                 break;
 
             case 'POST':
+                // ใช้ authz matrix เป็นเส้นตัดสิน (fail-closed) — ห้าม hardcode role check
+                // เพราะ superadmin โดน 403 และ override จาก settings ไม่ถูกนับ
+                requirePermission('create', 'sync');
                 handleSyncTrigger($pdo, $sub);
                 break;
 

--- a/backend/tests/Unit/SyncPermissionTest.php
+++ b/backend/tests/Unit/SyncPermissionTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../authz.php';
+
+/**
+ * N32 — GET /sync/status ต้องใช้ read:sync ไม่ใช่ create:sync
+ * ล็อก default matrix ที่ route fix อ้างอิง: admin/operator อ่าน sync ได้
+ * (read = ['*']) ส่วน viewer ไม่มี sync ใน read list → 403 เหมือนเดิม
+ */
+final class SyncPermissionTest extends TestCase
+{
+    #[Test]
+    public function admin_and_operator_can_read_sync_by_default(): void
+    {
+        self::assertTrue(checkPermissionDefault('admin', 'read', 'sync'));
+        self::assertTrue(checkPermissionDefault('operator', 'read', 'sync'));
+        self::assertTrue(checkPermissionDefault('superadmin', 'read', 'sync'));
+    }
+
+    #[Test]
+    public function viewer_cannot_read_or_create_sync_by_default(): void
+    {
+        self::assertFalse(checkPermissionDefault('viewer', 'read', 'sync'));
+        self::assertFalse(checkPermissionDefault('viewer', 'create', 'sync'));
+    }
+
+    #[Test]
+    public function operator_cannot_trigger_sync_by_default(): void
+    {
+        // POST /sync ยังเป็น create:sync — operator ไม่มีสิทธิ์ trigger
+        self::assertFalse(checkPermissionDefault('operator', 'create', 'sync'));
+    }
+}


### PR DESCRIPTION
## สรุป

แก้ finding N32 (Low) จาก codebase review 2026-09-08 — `GET /sync/status` เรียก `requirePermission('create', 'sync')` รวมกับ POST ทำให้ role ที่มีแค่ read อ่าน status ไม่ได้

## การแก้
- `backend/routes/sync.php` — ย้าย `requirePermission` เข้าไปในแต่ละ method: GET `/sync/status` → `read:sync` · POST trigger → `create:sync` เหมือนเดิม
- `backend/tests/Unit/SyncPermissionTest.php` (ใหม่) — ล็อก default matrix ที่ fix อ้างอิง: admin/operator อ่าน sync ได้ (`read=['*']`) · viewer อ่านไม่ได้ · operator trigger ไม่ได้

## Test plan
- [x] PHPUnit `SyncPermissionTest` ผ่าน 3/3
- [x] `php -l` ผ่าน
- [x] pre-push hook ผ่าน (full vitest suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)