### PR TITLE
fix: backend hardening batch — input validation and audit integrity (N34, N36, N38–N40)

### DIFF
--- a/backend/api.php
+++ b/backend/api.php
@@ -420,31 +420,31 @@ switch ($path[0]) {
             );
             $beforeStmt->execute([$servantId]);
             $beforeRow = $beforeStmt->fetch(PDO::FETCH_ASSOC);
-            if ($beforeRow) {
-                logAudit(
-                    $pdo,
-                    (int) (getAuthenticatedUser()['user_id'] ?? 0),
-                    'DELETE',
-                    'personnel',
-                    $servantId,
-                    $beforeRow,
-                    array_merge($beforeRow, ['is_active' => 0])
-                );
+            // N40: ไม่พบ row → 404 ก่อน audit; ปิดใช้งานอยู่แล้ว → 409 ไม่เขียน audit ซ้ำ
+            // (เดิม audit ถูกเขียนแม้ UPDATE จะ rowCount=0 ทำให้ log โกหกว่ามีการลบ)
+            if (!$beforeRow) {
+                http_response_code(404);
+                echo json_encode(['error' => 'Not found']);
+                break;
             }
+            if ((int) $beforeRow['is_active'] !== 1) {
+                http_response_code(409);
+                echo json_encode(['error' => 'บุคลากรถูกปิดใช้งานอยู่แล้ว']);
+                break;
+            }
+            logAudit(
+                $pdo,
+                (int) (getAuthenticatedUser()['user_id'] ?? 0),
+                'DELETE',
+                'personnel',
+                $servantId,
+                $beforeRow,
+                array_merge($beforeRow, ['is_active' => 0])
+            );
             $stmt = $pdo->prepare(
                 'UPDATE personnel SET is_active = 0 WHERE personnel_id = ? AND is_active = 1'
             );
             $stmt->execute([$servantId]);
-            if ($stmt->rowCount() === 0) {
-                $check = $pdo->prepare('SELECT is_active FROM personnel WHERE personnel_id = ?');
-                $check->execute([$servantId]);
-                $active = $check->fetchColumn();
-                if ($active === false) {
-                    http_response_code(404);
-                    echo json_encode(['error' => 'Not found']);
-                    break;
-                }
-            }
             echo json_encode(['success' => true]);
         } else {
             respondMethodNotAllowed();

--- a/backend/audit.php
+++ b/backend/audit.php
@@ -50,12 +50,13 @@ function logAudit(
             $action,
             $tableName,
             $recordId,
-            $beforeValue ? json_encode($beforeValue, JSON_UNESCAPED_UNICODE) : null,
-            $afterValue ? json_encode($afterValue, JSON_UNESCAPED_UNICODE) : null,
+            // N36: JSON_THROW_ON_ERROR — UTF-8 พังต้องเข้า catch + error_log ไม่ใช่ bind false เป็น payload ว่างเงียบ
+            $beforeValue ? json_encode($beforeValue, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR) : null,
+            $afterValue ? json_encode($afterValue, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR) : null,
             $ipAddress,
             $userAgent,
         ]);
-    } catch (PDOException $e) {
+    } catch (PDOException | JsonException $e) {
         error_log("[Audit] Failed to log: " . $e->getMessage());
         return false;
     }

--- a/backend/routes/diverse.php
+++ b/backend/routes/diverse.php
@@ -229,6 +229,13 @@ function createDiverse(PDO $pdo, array $user, ?array $input = null): void
         }
     }
 
+    // N39: pre-check personnel ก่อน INSERT (pattern เดียวกับ probation/multiplier)
+    if (!personnelExists($pdo, intval($data['personnel_id']))) {
+        http_response_code(404);
+        echo json_encode(['error' => 'ไม่พบบุคลากร']);
+        return;
+    }
+
     $fromTotalDays = null;
     if (!empty($data['from_start_date']) && !empty($data['from_end_date'])) {
         $fromStart = diverseStrictDate((string) $data['from_start_date']);

--- a/backend/routes/equivalence.php
+++ b/backend/routes/equivalence.php
@@ -216,6 +216,13 @@ function createEquivalence(PDO $pdo, array $user, ?array $input = null): void
         }
     }
 
+    // N39: pre-check personnel ก่อน INSERT (pattern เดียวกับ probation/multiplier)
+    if (!personnelExists($pdo, intval($data['personnel_id']))) {
+        http_response_code(404);
+        echo json_encode(['error' => 'ไม่พบบุคลากร']);
+        return;
+    }
+
     // คำนวณ request_total_days จากวันที่เริ่มต้นและสิ้นสุด (DATEDIFF+1)
     $requestTotalDays = null;
     if (!empty($data['request_start_date']) && !empty($data['request_end_date'])) {
@@ -380,11 +387,13 @@ function updateEquivalence(PDO $pdo, int $id, array $user, ?array $input = null)
         } elseif ($newStatus === 'REJECTED') {
             $userId = $approver['user_id'] ?? null;
 
+            // N38: เคลียร์ approved_by ด้วย — ไม่งั้นชื่อผู้อนุมัติค้างบนรายการที่ถูกปฏิเสธ
             $sql = "UPDATE position_equivalence
                     SET approval_status = 'REJECTED',
                         approved_start_date = NULL,
                         approved_end_date = NULL,
-                        approved_total_days = NULL
+                        approved_total_days = NULL,
+                        approved_by = NULL
                     WHERE equivalence_id = ?";
             $stmt = $pdo->prepare($sql);
             $stmt->execute([$id]);

--- a/backend/routes/supportive.php
+++ b/backend/routes/supportive.php
@@ -293,6 +293,13 @@ function createSupportive(PDO $pdo, array $user, ?array $input = null): void
         }
     }
 
+    // N39: pre-check personnel ก่อน INSERT (pattern เดียวกับ probation/multiplier)
+    if (!personnelExists($pdo, intval($data['personnel_id']))) {
+        http_response_code(404);
+        echo json_encode(['error' => 'ไม่พบบุคลากร']);
+        return;
+    }
+
     // Server-side computation (D-05, D-06, D-07, SE-04)
     // วันที่ malformed หรือ end < start → 400 (message มาจาก InvalidArgumentException)
     try {

--- a/backend/routes/users.php
+++ b/backend/routes/users.php
@@ -148,7 +148,8 @@ function createUser(PDO $pdo, ?array $auth): void
         }
     }
 
-    if (strlen($data['password']) < PASSWORD_MIN_LENGTH) {
+    // N34: password ที่ไม่ใช่ string (array/object จาก JSON) ทำ strlen ระเบิด TypeError 500 → ตอบ 400
+    if (!is_string($data['password']) || strlen($data['password']) < PASSWORD_MIN_LENGTH) {
         http_response_code(400);
         echo json_encode(['error' => 'รหัสผ่านต้องมีความยาวอย่างน้อย ' . PASSWORD_MIN_LENGTH . ' ตัวอักษร']);
         return;
@@ -299,9 +300,10 @@ function updateUser(PDO $pdo, int $id, array $auth, ?array $input = null): void
     }
 
     // Reset password — hash ใหม่ + บังคับเปลี่ยนครั้งถัดไป
+    // N34: password ที่ไม่ใช่ string ทำ strlen ระเบิด TypeError 500 → ตอบ 400
     $passwordReset = false;
     if (isset($data['password']) && $data['password'] !== '') {
-        if (strlen($data['password']) < PASSWORD_MIN_LENGTH) {
+        if (!is_string($data['password']) || strlen($data['password']) < PASSWORD_MIN_LENGTH) {
             http_response_code(400);
             echo json_encode(['error' => 'รหัสผ่านต้องมีความยาวอย่างน้อย ' . PASSWORD_MIN_LENGTH . ' ตัวอักษร']);
             return;

--- a/backend/tests/Unit/AuditJsonEncodeTest.php
+++ b/backend/tests/Unit/AuditJsonEncodeTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PDO;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../audit.php';
+
+/**
+ * N36 — logAudit ต้องไม่เขียน payload ว่างเงียบเมื่อ json_encode ล้ม (UTF-8 พัง)
+ * เดิม json_encode คืน false → bind เป็น empty → audit row มี after_value ว่างโดยไม่มี error
+ * ตอนนี้ JSON_THROW_ON_ERROR ทำให้เข้า catch → error_log + คืน false และไม่เขียน row
+ */
+final class AuditJsonEncodeTest extends TestCase
+{
+    #[Test]
+    public function invalid_utf8_payload_returns_false_and_writes_no_row(): void
+    {
+        if (!in_array('sqlite', PDO::getAvailableDrivers(), true)) {
+            self::markTestSkipped('pdo_sqlite not available');
+        }
+
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->exec(
+            'CREATE TABLE audit_log (
+                audit_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER,
+                action TEXT,
+                table_name TEXT,
+                record_id INTEGER,
+                before_value TEXT,
+                after_value TEXT,
+                ip_address TEXT,
+                user_agent TEXT
+            )'
+        );
+
+        // "\xC3\x28" เป็น invalid UTF-8 sequence — json_encode(THROW_ON_ERROR) ต้อง throw
+        $ok = logAudit($pdo, 1, 'CREATE', 'personnel', 7, null, ['name' => "\xC3\x28"]);
+
+        self::assertFalse($ok);
+        self::assertSame(0, (int) $pdo->query('SELECT COUNT(*) FROM audit_log')->fetchColumn());
+    }
+
+    #[Test]
+    public function valid_payload_still_writes_row(): void
+    {
+        if (!in_array('sqlite', PDO::getAvailableDrivers(), true)) {
+            self::markTestSkipped('pdo_sqlite not available');
+        }
+
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->exec(
+            'CREATE TABLE audit_log (
+                audit_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER,
+                action TEXT,
+                table_name TEXT,
+                record_id INTEGER,
+                before_value TEXT,
+                after_value TEXT,
+                ip_address TEXT,
+                user_agent TEXT
+            )'
+        );
+
+        $ok = logAudit($pdo, 1, 'CREATE', 'personnel', 7, null, ['name' => 'สมชาย']);
+
+        self::assertTrue($ok);
+        self::assertSame(1, (int) $pdo->query('SELECT COUNT(*) FROM audit_log')->fetchColumn());
+    }
+}

--- a/backend/tests/Unit/CreatePersonnelPrecheckTest.php
+++ b/backend/tests/Unit/CreatePersonnelPrecheckTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PDO;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../routes/supportive.php';
+require_once __DIR__ . '/../../routes/equivalence.php';
+require_once __DIR__ . '/../../routes/diverse.php';
+
+/**
+ * N39 — create ของ supportive/equivalence/diverse ต้อง pre-check personnelExists
+ * (pattern เดียวกับ probation/multiplier) — personnel ไม่มีจริงต้องตอบ 404 ไม่ใช่
+ * INSERT แล้ว FK ระเบิดเป็น 500
+ *
+ * 404 path เกิดก่อน INSERT เสมอ จึงต้องการแค่ตาราง personnel ว่าง ๆ
+ */
+final class CreatePersonnelPrecheckTest extends TestCase
+{
+    private function emptyPersonnelPdo(): ?PDO
+    {
+        if (!in_array('sqlite', PDO::getAvailableDrivers(), true)) {
+            return null;
+        }
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->exec('CREATE TABLE personnel (personnel_id INTEGER PRIMARY KEY)');
+        return $pdo;
+    }
+
+    #[Test]
+    public function create_supportive_returns_404_for_missing_personnel(): void
+    {
+        $pdo = $this->emptyPersonnelPdo();
+        if ($pdo === null) {
+            self::markTestSkipped('pdo_sqlite not available');
+        }
+
+        http_response_code(200);
+        ob_start();
+        createSupportive($pdo, ['user_id' => 1], [
+            'personnel_id' => 999,
+            'job_series_name' => 'ทรัพยากรบุคคล',
+            'start_date' => '2024-01-01',
+            'end_date' => '2024-12-31',
+        ]);
+        json_decode((string) ob_get_clean(), true);
+
+        self::assertSame(404, http_response_code());
+    }
+
+    #[Test]
+    public function create_equivalence_returns_404_for_missing_personnel(): void
+    {
+        $pdo = $this->emptyPersonnelPdo();
+        if ($pdo === null) {
+            self::markTestSkipped('pdo_sqlite not available');
+        }
+
+        http_response_code(200);
+        ob_start();
+        createEquivalence($pdo, ['user_id' => 1], [
+            'personnel_id' => 999,
+            'actual_position' => 'นักวิชาการ',
+            'equivalent_type' => 'ทางวิชาการ',
+        ]);
+        json_decode((string) ob_get_clean(), true);
+
+        self::assertSame(404, http_response_code());
+    }
+
+    #[Test]
+    public function create_diverse_returns_404_for_missing_personnel(): void
+    {
+        $pdo = $this->emptyPersonnelPdo();
+        if ($pdo === null) {
+            self::markTestSkipped('pdo_sqlite not available');
+        }
+
+        http_response_code(200);
+        ob_start();
+        createDiverse($pdo, ['user_id' => 1], ['personnel_id' => 999]);
+        json_decode((string) ob_get_clean(), true);
+
+        self::assertSame(404, http_response_code());
+    }
+}

--- a/backend/tests/Unit/UserManagementGuardTest.php
+++ b/backend/tests/Unit/UserManagementGuardTest.php
@@ -113,6 +113,29 @@ final class UserManagementGuardTest extends TestCase
         self::assertSame('admin', $pdo->query('SELECT role FROM users WHERE user_id = 2')->fetchColumn());
     }
 
+    #[Test]
+    public function non_string_password_returns_400_not_type_error(): void
+    {
+        $pdo = $this->sqliteUsers();
+        if ($pdo === null) {
+            self::markTestSkipped('pdo_sqlite not available');
+        }
+
+        $pdo->exec(
+            "INSERT INTO users (user_id, username, full_name, email, role, is_active, must_change_password)
+             VALUES (1, 'sa1', 'One', null, 'superadmin', 1, 0)"
+        );
+
+        http_response_code(200);
+        ob_start();
+        // N34: password เป็น array จาก JSON — เดิม strlen() ระเบิด TypeError 500
+        updateUser($pdo, 1, ['user_id' => 99, 'role' => 'superadmin'], ['password' => ['a', 'b']]);
+        $body = json_decode((string) ob_get_clean(), true);
+
+        self::assertSame(400, http_response_code());
+        self::assertStringContainsString('รหัสผ่าน', (string) ($body['error'] ?? ''));
+    }
+
     private function sqliteUsers(): ?PDO
     {
         if (!in_array('sqlite', PDO::getAvailableDrivers(), true)) {


### PR DESCRIPTION
## สรุป

แก้ findings Low 5 ข้อจาก codebase review 2026-09-08

### N34 — password type check
- `strlen($data['password'])` ไม่เช็ค `is_string` — password เป็น array จาก JSON ทำ TypeError 500
- เช็ค `is_string` ก่อนทั้ง `createUser` และ reset ใน `updateUser` → ตอบ 400

### N36 — audit json_encode
- `logAudit` ใช้ `json_encode` โดยไม่ `JSON_THROW_ON_ERROR` — UTF-8 พังทำ payload ว่างเงียบ
- เปลี่ยนเป็น throw → เข้า catch + `error_log` + คืน false โดยไม่เขียน row ว่าง

### N38 — REJECTED เคลียร์ approved_by
- `updateEquivalence` REJECTED เคลียร์ approved dates/days แต่ลืม `approved_by` → เพิ่ม `approved_by = NULL`

### N39 — pre-check personnelExists
- `createSupportive`/`createEquivalence`/`createDiverse` ไม่เช็ค personnel ก่อน INSERT (probation/multiplier มี)
- เพิ่ม pre-check → 404 แทน FK ระเบิด 500

### N40 — civil-servants DELETE audit integrity
- audit ถูกเขียนก่อน UPDATE แม้ row ไม่มีจริงหรือปิดใช้งานอยู่แล้ว (rowCount=0 ยัง success)
- 404 ก่อน audit เมื่อไม่พบ row · 409 เมื่อปิดใช้งานอยู่แล้ว → audit ไม่บันทึกการลบที่ไม่ได้เกิด

## Test plan
- [x] PHPUnit Unit suite 339 tests ผ่าน (fail เฉพาะ `MigrationDirectoryTest` ที่ล้มบน Windows เสมอ ไม่เกี่ยวกับ diff)
- [x] tests ใหม่: `AuditJsonEncodeTest` (2) · `CreatePersonnelPrecheckTest` (3) · non-string password case
- [x] `php -l` ผ่านทุกไฟล์
- [x] pre-push hook ผ่าน (full vitest suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)