### PR TITLE
fix: close review conditions S1–S6 from step-10 review on #168–#177

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -7,6 +7,11 @@ ALLOWED_ORIGINS=https://smart-port.onrender.com,https://smartport-backend.onrend
 # Application Environment (development|production)
 APP_ENV=production
 
+# Trusted proxies (comma-separated IP/CIDR) — REMOTE_ADDR ที่เชื่อได้จริงหลัง proxy
+# ว่าง/ไม่ตั้ง = ไม่เชื่อ X-Forwarded-For ทุกกรณี (rate limit ใช้ REMOTE_ADDR ตรง)
+# บน Render: ตั้งเป็น IP ของ Render edge proxy / egress range (ดู render proxy docs)
+# TRUSTED_PROXIES=
+
 # Database Configuration (ใช้ใน config.php)
 # MYSQL_HOST=localhost
 # MYSQL_DATABASE=civil_service_mgmt

--- a/backend/api.php
+++ b/backend/api.php
@@ -431,39 +431,58 @@ switch ($path[0]) {
         } elseif ($method === 'DELETE' && $servantId > 0) {
             // Soft-delete: ปิดใช้งานบุคลากร (ออกจากรายชื่อ candidates ที่กรอง is_active=1)
             requirePermission('delete', 'personnel');
-            // F15: บันทึก audit ก่อน UPDATE — pattern เดียวกับ PUT ใน routes/personnel.php
-            // (snapshot เฉพาะฟิลด์เดียวกัน, citizen_id ไม่เข้า audit เพราะเป็น PII)
-            $beforeStmt = $pdo->prepare(
-                'SELECT first_name, last_name, prefix_id, employee_id, is_active
-                 FROM personnel WHERE personnel_id = ?'
-            );
-            $beforeStmt->execute([$servantId]);
-            $beforeRow = $beforeStmt->fetch(PDO::FETCH_ASSOC);
-            // N40: ไม่พบ row → 404 ก่อน audit; ปิดใช้งานอยู่แล้ว → 409 ไม่เขียน audit ซ้ำ
-            // (เดิม audit ถูกเขียนแม้ UPDATE จะ rowCount=0 ทำให้ log โกหกว่ามีการลบ)
-            if (!$beforeRow) {
-                http_response_code(404);
-                echo json_encode(['error' => 'Not found']);
-                break;
+            // ขั้น 10 S1: SELECT FOR UPDATE → UPDATE → audit ใน transaction เดียว (pattern N13)
+            // — ของเดิม logAudit รันก่อน UPDATE โดยไม่มี lock ทำ race ขนานได้ audit DELETE ปลอม
+            try {
+                $pdo->beginTransaction();
+                $beforeStmt = $pdo->prepare(
+                    'SELECT first_name, last_name, prefix_id, employee_id, is_active
+                     FROM personnel WHERE personnel_id = ?' .
+                    ($pdo->getAttribute(PDO::ATTR_DRIVER_NAME) === 'mysql' ? ' FOR UPDATE' : '')
+                );
+                $beforeStmt->execute([$servantId]);
+                $beforeRow = $beforeStmt->fetch(PDO::FETCH_ASSOC);
+                // F15/N40: ไม่พบ row → 404; ปิดใช้งานอยู่แล้ว → 409 — ไม่เขียน audit
+                // (citizen_id ไม่เข้า audit เพราะเป็น PII)
+                if (!$beforeRow) {
+                    $pdo->rollBack();
+                    http_response_code(404);
+                    echo json_encode(['error' => 'Not found']);
+                    break;
+                }
+                if ((int) $beforeRow['is_active'] !== 1) {
+                    $pdo->rollBack();
+                    http_response_code(409);
+                    echo json_encode(['error' => 'บุคลากรถูกปิดใช้งานอยู่แล้ว']);
+                    break;
+                }
+                $stmt = $pdo->prepare(
+                    'UPDATE personnel SET is_active = 0 WHERE personnel_id = ? AND is_active = 1'
+                );
+                $stmt->execute([$servantId]);
+                if ($stmt->rowCount() === 0) {
+                    // กันระดับ isolation ที่ SELECT FOR UPDATE ไม่พอ (แผน B) — rowCount=0 = ไม่มีการเปลี่ยน
+                    $pdo->rollBack();
+                    http_response_code(409);
+                    echo json_encode(['error' => 'บุคลากรถูกปิดใช้งานอยู่แล้ว']);
+                    break;
+                }
+                logAudit(
+                    $pdo,
+                    (int) (getAuthenticatedUser()['user_id'] ?? 0),
+                    'DELETE',
+                    'personnel',
+                    $servantId,
+                    $beforeRow,
+                    array_merge($beforeRow, ['is_active' => 0])
+                );
+                $pdo->commit();
+            } catch (Throwable $e) {
+                if ($pdo->inTransaction()) {
+                    $pdo->rollBack();
+                }
+                throw $e;
             }
-            if ((int) $beforeRow['is_active'] !== 1) {
-                http_response_code(409);
-                echo json_encode(['error' => 'บุคลากรถูกปิดใช้งานอยู่แล้ว']);
-                break;
-            }
-            logAudit(
-                $pdo,
-                (int) (getAuthenticatedUser()['user_id'] ?? 0),
-                'DELETE',
-                'personnel',
-                $servantId,
-                $beforeRow,
-                array_merge($beforeRow, ['is_active' => 0])
-            );
-            $stmt = $pdo->prepare(
-                'UPDATE personnel SET is_active = 0 WHERE personnel_id = ? AND is_active = 1'
-            );
-            $stmt->execute([$servantId]);
             echo json_encode(['success' => true]);
         } else {
             respondMethodNotAllowed();

--- a/backend/middleware/rate_limit.php
+++ b/backend/middleware/rate_limit.php
@@ -165,20 +165,32 @@ function rateLimitGlobal(): void
 // ============================================================================
 
 /**
- * IP ของ client — last hop ของ X-Forwarded-For
+ * IP ของ client — last hop ของ X-Forwarded-For เมื่อ REMOTE_ADDR ของ host ที่ใช้
+ * เป็น "trusted proxy" ตาม TRUSTED_PROXIES env
  *
- * Render proxy chain: client → Render edge proxy → Apache ใน container
- * ทุก proxy ผนวก IP ของผู้ส่งต่อท้าย XFF ดังนั้น hop ท้ายสุดคือ IP จากการเชื่อมต่อจริง
- * ที่ proxy เชื่อถือได้ ส่วน hop แรกมาจาก header ที่ client ตั้งเองได้ (ปลอมได้)
- * — เคยใช้ first hop แล้วผู้โจมตีสุ่ม XFF เพื่อเปลี่ยน IP หนี rate limit ได้ทุก request
- * จึงเปลี่ยนมาใช้ last hop
+ * ขั้น 10 S1 review: ใช้ XFF แบบไม่เช็ค REMOTE_ADDR = ใครเข้าถึง backend ตรง ๆ (dev,
+ * หลัง LB ที่ reverse ได้) สุ่ม XFF เพื่อหลบ rate limit ได้ทุก request → ต้อง whitelist
+ *
+ * โทพอลอจีที่ตั้งค่าเอาไว้: Render edge proxy → Apache (php:8.3-apache, ไม่มี mod_remoteip)
+ * REMOTE_ADDR ที่ PHP เห็น = IP ของ Render edge — ดังนั้น:
+ *  - TRUSTED_PROXIES set + REMOTE_ADDR อยู่ในรายการ → เชื่อ last hop ของ XFF
+ *    (Render append IP จริง client ท้าย XFF เสมอ — hop แรก/กลางใด ๆ เป็นค่าที่ client ปลอมได้)
+ *  - REMOTE_ADDR ไม่ trusted → ใช้ REMOTE_ADDR ตรง ๆ (dev localhost ต่อตรง: ไม่มี XFF
+ *    ถูกนำมาตีความ แม้ส่ง header ปลอมมาก็ไม่เปลี่ยน key ของ rate limit)
+ *
+ * env: TRUSTED_PROXIES = comma-separated IPs/CIDRs (เว้นว่าง = ไม่เชื่อ XFF ทุกกรณี)
  * (ห้าม end(explode(...)) ตรง ๆ — PHP 8.3 notice: Only variables should be passed by reference)
- *
- * กรณีเรียกตรงไม่ผ่าน proxy (dev) จะไม่มี XFF → fallback REMOTE_ADDR เดิม
- * sanitize ให้เหลือแค่รูปของ IPv4/IPv6
  */
 function publicClientIp(): string
 {
+    $remoteAddr = (string) ($_SERVER['REMOTE_ADDR'] ?? '');
+
+    // REMOTE_ADDR ที่ไม่ trusted → ใช้เลย (dev / ต่อตรง / whitelist ไม่ตั้ง)
+    if (!remoteAddrIsTrustedProxy($remoteAddr)) {
+        return $remoteAddr !== '' ? $remoteAddr : 'unknown';
+    }
+
+
     $forwarded = (string) ($_SERVER['HTTP_X_FORWARDED_FOR'] ?? '');
     if ($forwarded !== '') {
         $hops = array_map('trim', explode(',', $forwarded));
@@ -188,7 +200,70 @@ function publicClientIp(): string
         }
     }
 
-    return (string) ($_SERVER['REMOTE_ADDR'] ?? 'unknown');
+    // trusted proxy แต่ไม่มี XFF ใช้ได้ — ยอมรับ key ร่วมของ proxy กลุ่มเดียว
+    // (โทพอล Render: ทุก connection จริงมาจาก edge เสมอ จึงเหมือน shared bucket)
+    return $remoteAddr !== '' ? $remoteAddr : 'unknown';
+}
+
+/**
+ * เช็ค REMOTE_ADDR อยู่ใน TRUSTED_PROXIES (exact IP หรือ CIDR IPv4) หรือไม่
+ * parse เมื่อเรียกเท่านั้น — แคช static เพราะ header เดิมทั้ง request
+ */
+function remoteAddrIsTrustedProxy(string $remoteAddr): bool
+{
+    static $cachedFor = null;
+    static $cachedVal = false;
+
+    if ($cachedFor === $remoteAddr) {
+        return $cachedVal;
+    }
+
+    if ($remoteAddr === '' || !filter_var($remoteAddr, FILTER_VALIDATE_IP)) {
+        // ไม่ cache ค่า output ไว้เมื่อ REMOTE_ADDR ไม่ใช่ IP (เช่น '' จาก tearDown)
+        // เพื่อให้เทสที่ set/unset REMOTE_ADDR ไล่กันได้ — mark cache miss โดยเทียบกับค่าล้ำหน้า
+        return false;
+    }
+
+    $trusted = array_map('trim', explode(',', (string) getenv('TRUSTED_PROXIES') ?: ''));
+    $isTrusted = false;
+    foreach ($trusted as $entry) {
+        if ($entry === '') {
+            continue;
+        }
+        if ($entry === $remoteAddr) {
+            $isTrusted = true;
+            break;
+        }
+        // CIDR /24 /64 — ใช้ filter_var ธรรมดา ไม่พึ่ง extension เพิ่ม
+        if (str_contains($entry, '/') && ipInCidr($remoteAddr, $entry)) {
+            $isTrusted = true;
+            break;
+        }
+    }
+
+    // แคชเฉพาะกรณีที่ env เปลี่ยนไม่สไตล์ runtime — ค่า get ก่อนหน้าใช้ซ้ำได้
+    $cachedVal = $isTrusted;
+    return $isTrusted;
+}
+
+/** IPv4 CIDR เท่านั้น (IPv6 ไม่ใช้ใน render topology — ระบุ exact IP) */
+function ipInCidr(string $ip, string $cidr): bool
+{
+    [$subnet, $bits] = array_pad(explode('/', $cidr, 2), 2, null);
+    if ($bits === null || filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) === false) {
+        return false;
+    }
+    $bits = (int) $bits;
+    if ($bits < 0 || $bits > 32) {
+        return false;
+    }
+    $ipLong = ip2long($ip);
+    $subnetLong = ip2long($subnet);
+    if ($ipLong === false || $subnetLong === false) {
+        return false;
+    }
+    $mask = $bits === 0 ? 0 : (-1 << (32 - $bits)) & 0xFFFFFFFF;
+    return ($ipLong & $mask) === ($subnetLong & $mask);
 }
 
 /**

--- a/backend/routes/multiplier.php
+++ b/backend/routes/multiplier.php
@@ -25,11 +25,24 @@ const MULTIPLIER_OVERLAP_EXCLUDE_SQL = 'SELECT COUNT(*) FROM multiplier_experien
           AND eligible_start_date <= ?
           AND eligible_end_date >= ?';
 
-/** N10 — เขียน master พื้นที่พิเศษ = admin/superadmin (UI requiresAdmin) */
-function multiplierAreaWriteAllowed(?array $user): bool
+/**
+ * N10 — เขียน master พื้นที่พิเศษ = admin/superadmin (UI requiresAdmin)
+ *
+ * ขั้น 10 S2: เดิม hardcode role check ขัด comment ของ sync.php (ห้าม hardcode role เพราะ
+ * superadmin override ไม่ถูกนับ) — ใช้ `delete:multiplier` แทน: ใน default matrix
+ * operator delete = [] จึงเทียบเท่า admin/superadmin ที่ตั้งใจ และปุ่มลบแถว master
+ * (DELETE /multiplier/{id}) ก็ใช้ delete:multiplier เป็นตัวตั้ง — ผู้ลบข้อมูลทวีคูณ
+ * ย่อมเพียงพอจะแก้ master อ้างอิง แต่ยังผ่าน override ของ settings ตาม matrix
+ *
+ * @param PDO|null $pdo ส่งเมื่อใช้จริง (evaluate overrides) — null = default matrix เท่านั้น
+ */
+function multiplierAreaWriteAllowed(?array $user, ?PDO $pdo = null): bool
 {
+    if (!$user) {
+        return false;
+    }
     $role = (string) ($user['role'] ?? '');
-    return $role === 'admin' || $role === 'superadmin';
+    return checkPermission($role, 'delete', 'multiplier', $pdo);
 }
 
 function denyMultiplierAreaWrite(): void
@@ -38,7 +51,7 @@ function denyMultiplierAreaWrite(): void
     echo json_encode([
         'error' => 'Forbidden',
         'message' => 'คุณไม่มีสิทธิ์ในการดำเนินการนี้',
-        'required_permission' => 'admin',
+        'required_permission' => 'delete:multiplier',
     ]);
 }
 
@@ -75,7 +88,7 @@ function handleMultiplier(PDO $pdo, string $method, array $path): void
 
             case 'POST':
                 if (($path[1] ?? '') === 'areas') {
-                    if (!multiplierAreaWriteAllowed($user)) {
+                    if (!multiplierAreaWriteAllowed($user, $pdo)) {
                         denyMultiplierAreaWrite();
                         return;
                     }
@@ -92,7 +105,7 @@ function handleMultiplier(PDO $pdo, string $method, array $path): void
                     && ctype_digit($path[2] ?? '')
                     && ($path[3] ?? '') === 'status'
                 ) {
-                    if (!multiplierAreaWriteAllowed($user)) {
+                    if (!multiplierAreaWriteAllowed($user, $pdo)) {
                         denyMultiplierAreaWrite();
                         return;
                     }

--- a/backend/routes/probation.php
+++ b/backend/routes/probation.php
@@ -528,40 +528,57 @@ function updateProbationEnrollment(PDO $pdo, int $enrollmentId): void
  */
 function deleteProbationEnrollment(PDO $pdo, int $enrollmentId): void
 {
-    $beforeStmt = $pdo->prepare('SELECT * FROM probation_enrollment WHERE enrollment_id = ?');
-    $beforeStmt->execute([$enrollmentId]);
-    $existing = $beforeStmt->fetch(PDO::FETCH_ASSOC);
-    if (!$existing) {
-        http_response_code(404);
-        echo json_encode(['error' => 'Enrollment not found']);
-        return;
-    }
-    if ($existing['overall_status'] === 'CANCELLED') {
-        echo json_encode(['success' => true]);
-        return;
-    }
+    // ขั้น 10 S6: SELECT FOR UPDATE → UPDATE → audit ใน transaction เดียว (pattern N13)
+    // — ของเดิม SELECT/UPDATE แยก + audit เสมอ ทำ race ได้ audit DELETE ปลอม
+    try {
+        $pdo->beginTransaction();
+        $beforeStmt = $pdo->prepare(
+            'SELECT * FROM probation_enrollment WHERE enrollment_id = ?' .
+            ($pdo->getAttribute(PDO::ATTR_DRIVER_NAME) === 'mysql' ? ' FOR UPDATE' : '')
+        );
+        $beforeStmt->execute([$enrollmentId]);
+        $existing = $beforeStmt->fetch(PDO::FETCH_ASSOC);
+        if (!$existing) {
+            $pdo->rollBack();
+            http_response_code(404);
+            echo json_encode(['error' => 'Enrollment not found']);
+            return;
+        }
+        if ($existing['overall_status'] === 'CANCELLED') {
+            // idempotent — ปิดไปแล้ว ไม่เขียน audit ซ้ำ
+            $pdo->rollBack();
+            echo json_encode(['success' => true]);
+            return;
+        }
 
-    $stmt = $pdo->prepare(
-        "UPDATE probation_enrollment
-         SET overall_status = 'CANCELLED'
-         WHERE enrollment_id = ?
-           AND overall_status <> 'CANCELLED'"
-    );
-    $stmt->execute([$enrollmentId]);
+        $stmt = $pdo->prepare(
+            "UPDATE probation_enrollment
+             SET overall_status = 'CANCELLED'
+             WHERE enrollment_id = ?
+               AND overall_status <> 'CANCELLED'"
+        );
+        $stmt->execute([$enrollmentId]);
 
-    $afterStmt = $pdo->prepare('SELECT * FROM probation_enrollment WHERE enrollment_id = ?');
-    $afterStmt->execute([$enrollmentId]);
-    $after = $afterStmt->fetch(PDO::FETCH_ASSOC);
-    $auth = getAuthenticatedUser();
-    logAudit(
-        $pdo,
-        (int) $auth['user_id'],
-        'DELETE',
-        'probation_enrollment',
-        $enrollmentId,
-        $existing,
-        $after ?: null
-    );
+        $afterStmt = $pdo->prepare('SELECT * FROM probation_enrollment WHERE enrollment_id = ?');
+        $afterStmt->execute([$enrollmentId]);
+        $after = $afterStmt->fetch(PDO::FETCH_ASSOC);
+        $auth = getAuthenticatedUser();
+        logAudit(
+            $pdo,
+            (int) $auth['user_id'],
+            'DELETE',
+            'probation_enrollment',
+            $enrollmentId,
+            $existing,
+            $after ?: null
+        );
+        $pdo->commit();
+    } catch (Throwable $e) {
+        if ($pdo->inTransaction()) {
+            $pdo->rollBack();
+        }
+        throw $e;
+    }
 
     echo json_encode(['success' => true]);
 }

--- a/backend/tests/Unit/PublicRateLimitTest.php
+++ b/backend/tests/Unit/PublicRateLimitTest.php
@@ -18,6 +18,20 @@ final class PublicRateLimitTest extends TestCase
 {
     private const TEST_IP = '203.0.113.122';
     private const BUCKET = 't122_bucket';
+    /** REMOTE_ADDR ปลอมที่ใช้แทน "Render edge"—ต้องเป็น IP public ที่ไม่ collide กับ TEST_IP */
+    private const EDGE_IP = '198.51.100.1';
+
+    protected function setUp(): void
+    {
+        // publicClientIp อ่าน TRUSTED_PROXIES — เทส XFF ต้อง set REMOTE_ADDR trusted ก่อน
+        $this->setTrusted(self::EDGE_IP);
+    }
+
+    private function setTrusted(string $ip): void
+    {
+        putenv('TRUSTED_PROXIES=' . $ip);
+        $_SERVER['REMOTE_ADDR'] = $ip;
+    }
 
     private function fileFor(): string
     {
@@ -31,6 +45,14 @@ final class PublicRateLimitTest extends TestCase
             unlink($file);
         }
         unset($_SERVER['HTTP_X_FORWARDED_FOR'], $_SERVER['REMOTE_ADDR']);
+        // รีเซ็ต TRUSTED_PROXIES + แคช static ของ remoteAddrIsTrustedProxy (อยู่ท้ายเทสถัดไป)
+        putenv('TRUSTED_PROXIES');
+        $mirror = new \ReflectionFunction('remoteAddrIsTrustedProxy');
+        foreach ($mirror->getStaticVariables() as $name => $_) {
+        }
+        // ล้าง static cache ด้วยการเรียกเมื่อ REMOTE_ADDR ว่าง (ทางลัด: unset หลัง env ล้างแล้ว)
+        unset($_SERVER['REMOTE_ADDR']);
+        remoteAddrIsTrustedProxy('');
     }
 
     #[Test]
@@ -54,7 +76,7 @@ final class PublicRateLimitTest extends TestCase
     }
 
     #[Test]
-    public function it_uses_last_hop_of_forwarded_for(): void
+    public function it_uses_last_hop_of_forwarded_for_from_trusted_proxy(): void
     {
         // Render proxy chain append IP จริงต่อท้าย XFF — hop ท้ายสุดเชื่อถือได้
         // hop แรกคือค่าที่ client ตั้งเองได้ (ปลอมได้) จึงต้องไม่ถูกใช้
@@ -72,20 +94,33 @@ final class PublicRateLimitTest extends TestCase
     }
 
     #[Test]
+    public function it_ignores_forwarded_for_when_remote_addr_is_not_trusted(): void
+    {
+        // ขั้น 10 S1: client ต่อตรง (dev) — XFF ปลอมต้องไม่เปลี่ยน rate-limit key
+        putenv('TRUSTED_PROXIES=');
+        $_SERVER['REMOTE_ADDR'] = '10.1.2.3';
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '6.6.6.6, 7.7.7.7';
+
+        self::assertSame('10.1.2.3', publicClientIp());
+    }
+
+    #[Test]
     public function it_falls_back_to_remote_addr_on_garbage_forwarded_for(): void
     {
+        putenv('TRUSTED_PROXIES=' . self::EDGE_IP);
+        $_SERVER['REMOTE_ADDR'] = self::EDGE_IP;
         $_SERVER['HTTP_X_FORWARDED_FOR'] = "evil\r\nX-Injected: 1";
-        $_SERVER['REMOTE_ADDR'] = '192.0.2.9';
 
-        self::assertSame('192.0.2.9', publicClientIp());
+        self::assertSame(self::EDGE_IP, publicClientIp());
     }
 
     #[Test]
     public function it_falls_back_to_remote_addr_when_no_forwarded_for(): void
     {
-        $_SERVER['REMOTE_ADDR'] = '192.0.2.55';
+        $_SERVER['REMOTE_ADDR'] = self::EDGE_IP;
+        unset($_SERVER['HTTP_X_FORWARDED_FOR']);
 
-        self::assertSame('192.0.2.55', publicClientIp());
+        self::assertSame(self::EDGE_IP, publicClientIp());
     }
 
     #[Test]


### PR DESCRIPTION
## สรุป

ปิดเงื่อนไขจากขั้น 10 code/security review บน diff #168–#177 (ผ่านมีเงื่อนไข — ไม่มี CRITICAL/HIGH)

### S1+S6 — audit atomicity ใน DELETE paths
- `backend/api.php` (civil-servants DELETE) + `backend/routes/probation.php` (DELETE enrollment): ครอบ `SELECT FOR UPDATE` → `UPDATE` → `logAudit` ใน transaction เดียว (pattern N13)
- rowCount=0 → 409 โดยไม่เขียน audit — กัน race ขนานทำ audit DELETE ปลอม

### S1 — rate limit trusted proxy
- `publicClientIp()` ใช้ X-Forwarded-For เฉพาะเมื่อ `REMOTE_ADDR` อยู่ใน `TRUSTED_PROXIES` env (IP/CIDR)
- client ต่อตรง (dev) สุ่ม XFF ไม่เปลี่ยน rate-limit key — ปิดช่อง bypass bucket auth ที่ review ชี้
- `.env.example` เพิ่ม `TRUSTED_PROXIES` พร้อมคำอธิบาย topology ของ Render

### S2 — multiplier areas authz consistency
- `multiplierAreaWriteAllowed` ใช้ `delete:multiplier` ผ่าน authz matrix แทน hardcode role check
- operator delete=`[]` → ผลเทียบเท่าเดิมทุกเคส แต่รับ override จาก settings ตามข้อบังคับ repo (ไม่ขัด comment sync.php)

## Test plan
- [x] PHPUnit Unit suite 340 tests ผ่าน (fail เฉพาะ `MigrationDirectoryTest` Windows-only ไม่เกี่ยว diff)
- [x] `PublicRateLimitTest` 8/8 รวมเคส trusted/untrusted ใหม่
- [x] `MultiplierAreaWriteAuthzTest` + probation tests ผ่าน 29/29
- [x] `php -l` ผ่านทุกไฟล์
- [x] pre-push hook ผ่าน (full vitest suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)