### PR TITLE
feat: permission-aware UI gates from effective matrix (N4)

### DIFF
--- a/backend/routes/settings.php
+++ b/backend/routes/settings.php
@@ -22,6 +22,12 @@ function handleSettings(PDO $pdo, string $method, array $path): void
     $section = $path[1] ?? '';
 
     if ($section === 'permissions') {
+        // N4: GET .../permissions/self — effective matrix ของ role ตัวเอง (login ใด ๆ)
+        // ให้ FE คำนวณปุ่มจาก matrix จริงรวม override แทน hardcode role เทียบ
+        if (($path[2] ?? '') === 'self' && $method === 'GET') {
+            getOwnPermissionMatrix($pdo);
+            return;
+        }
         $auth = requireSuperAdmin();
         if ($method === 'GET') {
             getPermissionSettings($pdo);
@@ -38,6 +44,54 @@ function handleSettings(PDO $pdo, string $method, array $path): void
 
     http_response_code(404);
     echo json_encode(['error' => 'ไม่พบ endpoint การตั้งค่า']);
+}
+
+/**
+ * N4 — GET /settings/permissions/self
+ * Effective permission matrix ของ role ผู้เรียกเอง (รวม role_permission_overrides)
+ * ให้ FE render ปุ่ม/เมนูจากสิทธิ์จริง ไม่ใช่เทียบ role แข็ง — superadmin bypass
+ * จึงคืน 'all' เป็นสัญญาณ; 503 fail-closed ตาม authz.php เมื่อ override store unreachable
+ */
+function getOwnPermissionMatrix(PDO $pdo): void
+{
+    // test hook: getAuthenticatedUser อ่าน JWT+DB — unit test ฉีด identity ผ่าน global แทน
+    $user = $GLOBALS['__auth_user'] ?? getAuthenticatedUser();
+    if (!$user) {
+        http_response_code(401);
+        echo json_encode(['error' => 'Unauthorized']);
+        return;
+    }
+    $role = (string) ($user['role'] ?? 'viewer');
+
+    if ($role === 'superadmin') {
+        http_response_code(200);
+        echo json_encode(['success' => true, 'data' => ['role' => $role, 'all' => true]]);
+        return;
+    }
+
+    clearPermissionOverrideCache();
+    try {
+        $grants = [];
+        foreach (AUTHZ_ACTIONS as $action) {
+            $allowed = [];
+            foreach (authzResources() as $resource) {
+                if (checkPermission($role, $action, $resource, $pdo)) {
+                    $allowed[] = $resource;
+                }
+            }
+            $grants[$action] = $allowed;
+        }
+    } catch (RuntimeException $e) {
+        http_response_code(503);
+        echo json_encode([
+            'error' => 'Service Unavailable',
+            'message' => 'ไม่สามารถตรวจสอบสิทธิ์ระบบได้ในขณะนี้',
+        ]);
+        return;
+    }
+
+    http_response_code(200);
+    echo json_encode(['success' => true, 'data' => ['role' => $role, 'grants' => $grants]]);
 }
 
 function getPermissionSettings(PDO $pdo): void

--- a/backend/tests/Unit/OwnPermissionMatrixTest.php
+++ b/backend/tests/Unit/OwnPermissionMatrixTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PDO;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../routes/settings.php';
+require_once __DIR__ . '/../../authz.php';
+
+/**
+ * N4 — GET /settings/permissions/self คืน effective grants ของ role ตัวเอง
+ * (รวม role_permission_overrides) — ตรวจ response shape + กัน unauthenticated
+ * + superadmin คืน all=true — Authorization guard ของ requireSuperAdmin เดิม
+ * ไม่ถูกแตะ (PUT/Edit ยัง superadmin เท่านั้น)
+ */
+final class OwnPermissionMatrixTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        // เทสอื่นอาจพึ่ง $GLOBALS['__auth_user'] override — ล้างเสมอ
+        $GLOBALS['__auth_user'] = null;
+    }
+
+    /** @return array{status:int, body:array} */
+    private function call(string $role, ?PDO $pdo = null): array
+    {
+        $GLOBALS['__auth_user'] = ['user_id' => 1, 'role' => $role];
+        http_response_code(418);
+        ob_start();
+        getOwnPermissionMatrix($pdo ?? new PDO('sqlite::memory:'));
+        $body = json_decode((string) ob_get_clean(), true) ?? [];
+        return ['status' => http_response_code(), 'body' => $body];
+    }
+
+    private function emptyOverridesPdo(): ?PDO
+    {
+        if (!in_array('sqlite', PDO::getAvailableDrivers(), true)) {
+            return null;
+        }
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->exec(
+            'CREATE TABLE role_permission_overrides (
+                role TEXT NOT NULL, action TEXT NOT NULL, resource TEXT NOT NULL,
+                allowed INTEGER NOT NULL)'
+        );
+        return $pdo;
+    }
+
+    #[Test]
+    public function superadmin_gets_all_flag(): void
+    {
+        $result = $this->call('superadmin');
+        self::assertSame(200, $result['status']);
+        self::assertTrue($result['body']['data']['all']);
+    }
+
+    #[Test]
+    public function operator_grants_exclude_delete(): void
+    {
+        $pdo = $this->emptyOverridesPdo();
+        if ($pdo === null) {
+            self::markTestSkipped('pdo_sqlite not available');
+        }
+        $result = $this->call('operator', $pdo);
+        self::assertSame(200, $result['status']);
+        $grants = $result['body']['data']['grants'];
+        self::assertSame('operator', $result['body']['data']['role']);
+        self::assertSame([], $grants['delete']);
+        // operator read = ['*'] → ควรมี resource หลากหลาย
+        self::assertContains('multiplier', $grants['read']);
+        self::assertContains('audit', $grants['read']);
+    }
+
+    #[Test]
+    public function viewer_grants_are_narrow(): void
+    {
+        $pdo = $this->emptyOverridesPdo();
+        if ($pdo === null) {
+            self::markTestSkipped('pdo_sqlite not available');
+        }
+        $result = $this->call('viewer', $pdo);
+        self::assertSame(200, $result['status']);
+        $grants = $result['body']['data']['grants'];
+        self::assertNotContains('audit', $grants['read']);
+        self::assertContains('dashboard', $grants['read']);
+        self::assertSame([], $grants['create']);
+    }
+}

--- a/frontend/src/__tests__/router/guards.test.js
+++ b/frontend/src/__tests__/router/guards.test.js
@@ -4,6 +4,8 @@ const mockAuth = {
   isAuthenticated: false,
   mustChangePassword: false,
   user: null,
+  permissionGrants: null,
+  fetchPermissionGrants: vi.fn(async () => {}),
   get isAdmin() {
     return this.user?.role === 'admin' || this.user?.role === 'superadmin'
   },

--- a/frontend/src/__tests__/stores/auth.test.js
+++ b/frontend/src/__tests__/stores/auth.test.js
@@ -37,6 +37,44 @@ describe('auth store', () => {
     expect(auth.isAdmin).toBe(false)
   })
 
+  // N4 — can() อ่าน effective grants (รวม role_permission_overrides)
+  describe('N4 permission grants', () => {
+    it('can() returns null-grants fallback to role intents', () => {
+      const auth = useAuthStore()
+      auth.setAuth(authData()) // role = admin
+      expect(auth.can('delete', 'multiplier')).toBe(true) // fallback: admin ทุกอย่าง
+
+      const opAuth = useAuthStore()
+      opAuth.setAuth({ ...authData(), user: { ...authData().user, role: 'operator' } })
+      expect(opAuth.can('delete', 'multiplier')).toBe(false)
+      expect(opAuth.can('create', 'multiplier')).toBe(true)
+      expect(opAuth.can('create', 'photos')).toBe(true)
+    })
+
+    it('can() uses loaded grants instead of role', () => {
+      const auth = useAuthStore()
+      auth.setAuth(authData())
+      // override ปิด delete:multiplier ของ admin — can() ต้องตาม grants
+      auth.permissionGrants = { read: ['*'], create: [], update: [], delete: [] }
+      expect(auth.can('delete', 'multiplier')).toBe(false)
+      expect(auth.isAdmin).toBe(false) // no delete grants = not admin-like
+    })
+
+    it('setAuth clears stale grants on session change', () => {
+      const auth = useAuthStore()
+      auth.setAuth(authData())
+      auth.permissionGrants = { read: ['multiplier'], create: [], update: [], delete: [] }
+      auth.setAuth(authData())
+      expect(auth.permissionGrants).toBeNull()
+    })
+
+    it('isAdmin stays role-based before grants load (fallback)', () => {
+      const auth = useAuthStore()
+      auth.setAuth(authData()) // admin, grants = null
+      expect(auth.isAdmin).toBe(true)
+    })
+  })
+
   it('setAuth persists token/user/csrf and authenticates', () => {
     const auth = useAuthStore()
     auth.setAuth(authData())

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -182,6 +182,12 @@ router.beforeEach(async (to) => {
     return '/login'
   }
 
+  // N4: โหลด effective grants ของ role ตัวเองครั้งเดียวต่อ session (grants=null หลัง
+  // login/refresh เสมอ) — ล้มเงียบได้เพราะ can() fallback เทียบ role ตาม intents เดิม
+  if (auth.isAuthenticated && !auth.permissionGrants && !auth.isSuperAdmin) {
+    auth.fetchPermissionGrants().catch(() => {})
+  }
+
   if (auth.isAuthenticated && auth.mustChangePassword && to.path !== '/change-password') {
     return '/change-password'
   }

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -65,10 +65,40 @@ export const useAuthStore = defineStore('auth', () => {
   const csrfToken = ref(readStoredString('csrf_token'))
   const user = ref(readStoredJson('user'))
 
+  // N4: effective permission grants ของ role ตัวเอง (จาก GET /settings/permissions/self)
+  // — FE คำนวณปุ่มจาก matrix จริงรวม role_permission_overrides แทน hardcode role เทียบ
+  // null = ยังไม่โหลด → fallback เทียบ role ขา intents เดิม (กันล็อก UI ตอน endpoint มีปัญหา)
+  const permissionGrants = ref(null)
+
   const isAuthenticated = computed(() => !!token.value && isTokenValid())
   const isSuperAdmin = computed(() => user.value?.role === 'superadmin')
-  const isAdmin = computed(() => user.value?.role === 'admin' || user.value?.role === 'superadmin')
+  // N4: "admin" = สิทธิ์ delete อะไรได้ก็ได้ตาม matrix จริง (รวม override) —
+  // grants ยังไม่โหลด → fallback เทียบ role ตาม intents เดิม (admin/superadmin)
+  const isAdmin = computed(() => {
+    if (isSuperAdmin.value) return true
+    if (permissionGrants.value) {
+      return (permissionGrants.value.delete || []).length > 0
+    }
+    return user.value?.role === 'admin' || user.value?.role === 'superadmin'
+  })
   const mustChangePassword = computed(() => Boolean(user.value?.must_change_password))
+
+  /**
+   * ตรวจสิทธิ์จาก matrix จริง (รวม override) — fallback ไป intents เดิมเมื่อ grants ยังไม่โหลด
+   * @param {string} action 'read'|'create'|'update'|'delete'
+   * @param {string} resource resource key ตาม authzResources()
+   */
+  const can = computed(() => (action, resource) => {
+    if (isSuperAdmin.value) return true
+    if (permissionGrants.value) {
+      return (permissionGrants.value[action] || []).includes(resource)
+    }
+    // fallback: intents เดิม — admin ได้ทุก action, operator อ่าน/สร้าง/แก้ไข
+    if (isAdmin.value) return true
+    if (action === 'read') return true
+    if (action === 'delete') return false
+    return user.value?.role === 'operator'
+  })
 
   function isTokenValid() {
     if (!token.value) return false
@@ -124,7 +154,26 @@ export const useAuthStore = defineStore('auth', () => {
     csrfToken.value = data.csrf_token || ''
     user.value = data.user
     refreshToken.value = data.refresh_token || ''
+    // N4: grants ผูกกับ token — ล้างค่าเก่ากัน role ค้าง (โหลดใหม่โดย router guard)
+    // ไม่ยิง fetch ตรงนี้: setAuth ถูกเรียกใน contexts มากกว่า login (เช่น hydrate test)
+    permissionGrants.value = null
     persistAuthStorage(options.remember)
+  }
+
+  // N4 — ดึง effective matrix ของตัวเอง (GET /settings/permissions/self)
+  // ล้มเงียบได้: can() ยัง fallback เทียบ role ตาม intents เดิม
+  async function fetchPermissionGrants() {
+    if (!token.value || isSuperAdmin.value) return
+    const { useApi } = await import('@/composables/useApi.js')
+    const api = useApi()
+    try {
+      const result = await api.get('/settings/permissions/self')
+      if (result?.data?.grants) {
+        permissionGrants.value = result.data.grants
+      }
+    } catch {
+      // ปล่อย null — fallback ทำงานแทน ไม่ล็อกผู้ใช้ออกจากหน้า
+    }
   }
 
   // N44: default remember=false — refresh token เก็บ sessionStorage ไม่ localStorage
@@ -260,6 +309,9 @@ export const useAuthStore = defineStore('auth', () => {
     isAdmin,
     isSuperAdmin,
     mustChangePassword,
+    can,
+    permissionGrants,
+    fetchPermissionGrants,
     isTokenValid,
     setAuth,
     setMustChangePassword,


### PR DESCRIPTION
## สรุป

ปิด finding N4 (Medium) — superadmin เปิด/ปิดสิทธิ์ในเมทริกซ์ `role_permission_overrides` แล้ว UI ยังซ่อน/แสดงปุ่มจากเทียบ role แข็ง

### Backend — `GET /settings/permissions/self`
- login ใด ๆ อ่าน effective grants ของ role ตัวเอง (ผ่าน `checkPermission` = รวม overrides)
- superadmin → `{ all: true }` · role อื่น → `{ grants: { read|create|update|delete: [resources] } }`
- 503 fail-closed เมื่อ override store unreachable (ปรัชญาเดียวกับ authz.php)
- PUT/Edit permissions ยัง `requireSuperAdmin` ครบ

### Frontend — auth store
- `can(action, resource)` — ตัดสินจาก grants จริง · fallback เทียบ role ตาม intents เดิมเมื่อ grants ยังไม่โหลด (กันล็อก UI เมื่อ endpoint มีปัญหา)
- `isAdmin` คำนวณจาก `delete` grants — admin ที่ถูก override ปิด `delete:*` ทั้งหมดไม่ถือเป็น admin แล้ว (ปุ่มลบ/เมนูแอดมินตามสิทธิ์จริง)
- `setAuth` ล้าง grants เก่าทุกครั้งที่ session เปลี่ยน (กันสิทธิ์ค้างข้าม token)
- โหลด 1 ครั้งต่อ session ที่ router guard — ล้มเงียบได้
- 39 call sites `isAdmin` ทั่วระบบได้พฤติกรรมใหม่โดยไม่ต้องแก้ · gate ระดับ action ละเอียดกว่านั้นใช้ `can()` เมื่อต้องการ

### Tests
- `OwnPermissionMatrixTest` (3) — superadmin all / operator delete=[] / viewer narrow (sqlite overrides)
- auth store +4 N4 cases (can fallback, can จาก grants, setAuth ล้าง grants, isAdmin role fallback)
- guards.test เติม mock fields

## Test plan
- [x] PHPUnit Unit 343 ผ่าน (fail เฉพาะ MigrationDirectoryTest Windows-only)
- [x] vitest auth store 21/21 + router guards 15/15
- [x] `php -l` ผ่าน
- [x] pre-push hook ผ่าน (full vitest suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)