### PR TITLE
feat(test): route-level integration suite for sync, candidates, users + import positive path (N23, N56)

### DIFF
--- a/backend/routes/candidates.php
+++ b/backend/routes/candidates.php
@@ -16,13 +16,30 @@ include_once __DIR__ . '/../QualificationEngine.php';
 include_once __DIR__ . '/personnel.php';
 
 /**
+ * N23: test hook — pattern เดียวกับ routes/settings.php (array_key_exists
+ * เพื่อให้ฉีด null = unauthenticated ได้ ไม่ตกทะลุ getAuthenticatedUser)
+ */
+function resolveCandidatesUser(): ?array
+{
+    if (array_key_exists('__auth_user', $GLOBALS)) {
+        $u = $GLOBALS['__auth_user'];
+        return is_array($u) ? $u : null;
+    }
+    return getAuthenticatedUser();
+}
+
+/**
  * จัดการ request สำหรับ candidate list endpoints
+ *
+ * N23: $authUser/$query สำหรับ integration test (null = resolve/อ่าน $_GET ตามเดิม)
  *
  * @param PDO $pdo Database connection
  * @param string $method HTTP method
  * @param array $path URL path segments
+ * @param array{user_id?:int|string, role?:string}|null $authUser
+ * @param array<string,mixed>|null $query
  */
-function handleCandidates(PDO $pdo, string $method, array $path): void
+function handleCandidates(PDO $pdo, string $method, array $path, ?array $authUser = null, ?array $query = null): void
 {
     // เฉพาะ GET เท่านั้น
     if ($method !== 'GET') {
@@ -31,7 +48,15 @@ function handleCandidates(PDO $pdo, string $method, array $path): void
         return;
     }
 
-    requirePermission('read', 'candidates');
+    $user = $authUser ?? resolveCandidatesUser();
+    // N23: เดิม requirePermission exit จะฆ่า PHPUnit — ใช้ evaluate + return
+    // contract เดิม (401/403/503 + body) คงไว้ทุกประการ
+    $denied = evaluatePermissionAccess('read', 'candidates', $user, $pdo);
+    if ($denied !== null) {
+        http_response_code($denied['status']);
+        echo json_encode($denied['body']);
+        return;
+    }
 
     // GET /candidates/overview — สรุปภาพรวมทุกระดับ (ต้องเช็คก่อน treat path[1] เป็น targetLevel)
     if (strtolower($path[1] ?? '') === 'overview') {
@@ -72,14 +97,15 @@ function handleCandidates(PDO $pdo, string $method, array $path): void
             echo json_encode(['error' => 'Personnel not found']);
             return;
         }
-        $role = (string) (getAuthenticatedUser()['role'] ?? '');
+        $role = (string) ($user['role'] ?? '');
         $result['data'] = redactPersonnelCitizenIdForRole($result['data'], $role);
         echo json_encode($result);
     } else {
         // รายชื่อทั้งหมด: GET /candidates/K2?search=&limit=20&offset=0
-        $search = $_GET['search'] ?? '';
-        $limit = intval($_GET['limit'] ?? 20);
-        $offset = intval($_GET['offset'] ?? 0);
+        $q = $query ?? $_GET;
+        $search = $q['search'] ?? '';
+        $limit = intval($q['limit'] ?? 20);
+        $offset = intval($q['offset'] ?? 0);
 
         $result = $engine->computeForLevel($targetLevel, $search, $limit, $offset);
         echo json_encode($result);

--- a/backend/routes/import.php
+++ b/backend/routes/import.php
@@ -16,10 +16,75 @@ const IMPORT_MAX_BYTES = 5 * 1024 * 1024;   // 5MB
 const IMPORT_RATE_MAX = 10;                  // จำนวนครั้งต่อหน้าต่าง
 const IMPORT_RATE_WINDOW_MIN = 15;           // นาที
 
+/**
+ * N23/N56: test hook — pattern เดียวกับ routes/settings.php (array_key_exists
+ * เพื่อให้ฉีด null = unauthenticated ได้)
+ */
+function resolveImportUser(): ?array
+{
+    if (array_key_exists('__auth_user', $GLOBALS)) {
+        $u = $GLOBALS['__auth_user'];
+        return is_array($u) ? $u : null;
+    }
+    return getAuthenticatedUser();
+}
+
+/**
+ * N56: แกนนำเข้าไฟล์ที่ผ่านการตรวจชั้น upload แล้ว — pre-log → ImportService
+ * → update import_log → audit → สรุปผล (ไม่แตะ $_FILES/is_uploaded_file จึงเรียก
+ * จาก integration test ได้ตรง ๆ ด้วย fixture .xlsx)
+ *
+ * @return array{http:int, body:array<string,mixed>} http = 200 (สำเร็จ) | 422 (ล้มเหลว)
+ */
+function processImportUpload(PDO $pdo, string $tmpPath, string $origName, int $userId): array
+{
+    // pre-log attempt ก่อน import — กัน rate-limit bypass (นับทันที) + audit ไว้แม้ import crash
+    $logStmt = $pdo->prepare('INSERT INTO import_log (user_id, filename) VALUES (?, ?)');
+    $logStmt->execute([$userId, mb_substr($origName, 0, 300)]);
+    $logId = (int) $pdo->lastInsertId();
+
+    $result = (new ImportService($pdo))->importFromFile($tmpPath);
+
+    // อัปเดตผลลง import_log (OWASP A09) — ไม่เก็บ citizen_id (PII)
+    $pdo->prepare(
+        'UPDATE import_log SET personnel_count = ?, is_success = ?, error_summary = ? WHERE log_id = ?'
+    )->execute([
+        (int) ($result['summary']['personnel'] ?? 0),
+        $result['success'] ? 1 : 0,
+        $result['success'] ? null : mb_substr(implode(' | ', $result['errors']), 0, 500),
+        $logId,
+    ]);
+
+    // Audit log: บันทึกสรุปผลนำเข้า — เฉพาะตัวเลข/สถานะ ไม่มี PII (citizen_id, ชื่อ-สกุล)
+    logAudit(
+        $pdo,
+        $userId,
+        'CREATE',
+        'import',
+        $logId,
+        null,
+        [
+            'filename' => mb_substr($origName, 0, 300),
+            'personnel_count' => (int) ($result['summary']['personnel'] ?? 0),
+            'success' => $result['success'],
+            'error_count' => count($result['errors'] ?? []),
+        ]
+    );
+
+    return ['http' => $result['success'] ? 200 : 422, 'body' => $result];
+}
+
 function handleImport(PDO $pdo, string $method, array $path): void
 {
-    requirePermission('create', 'import');
-    $user = getAuthenticatedUser();
+    $user = resolveImportUser();
+    // N23: เดิม requirePermission exit จะฆ่า PHPUnit — ใช้ evaluate + return
+    // contract เดิม (401/403/503 + body) คงไว้ทุกประการ
+    $denied = evaluatePermissionAccess('create', 'import', $user, $pdo);
+    if ($denied !== null) {
+        http_response_code($denied['status']);
+        echo json_encode($denied['body']);
+        return;
+    }
     $userId = (int) ($user['user_id'] ?? 0);
     if ($userId < 1) {
         http_response_code(401);
@@ -92,39 +157,8 @@ function handleImport(PDO $pdo, string $method, array $path): void
         return;
     }
 
-    // pre-log attempt ก่อน import — กัน rate-limit bypass (นับทันที) + audit ไว้แม้ import crash
-    $logStmt = $pdo->prepare('INSERT INTO import_log (user_id, filename) VALUES (?, ?)');
-    $logStmt->execute([$userId, mb_substr((string) ($file['name'] ?? ''), 0, 300)]);
-    $logId = (int) $pdo->lastInsertId();
+    $outcome = processImportUpload($pdo, (string) $file['tmp_name'], (string) ($file['name'] ?? ''), $userId);
 
-    $result = (new ImportService($pdo))->importFromFile((string) $file['tmp_name']);
-
-    // อัปเดตผลลง import_log (OWASP A09) — ไม่เก็บ citizen_id (PII)
-    $pdo->prepare(
-        'UPDATE import_log SET personnel_count = ?, is_success = ?, error_summary = ? WHERE log_id = ?'
-    )->execute([
-        (int) ($result['summary']['personnel'] ?? 0),
-        $result['success'] ? 1 : 0,
-        $result['success'] ? null : mb_substr(implode(' | ', $result['errors']), 0, 500),
-        $logId,
-    ]);
-
-    // Audit log: บันทึกสรุปผลนำเข้า — เฉพาะตัวเลข/สถานะ ไม่มี PII (citizen_id, ชื่อ-สกุล)
-    logAudit(
-        $pdo,
-        $userId,
-        'CREATE',
-        'import',
-        $logId,
-        null,
-        [
-            'filename' => mb_substr((string) ($file['name'] ?? ''), 0, 300),
-            'personnel_count' => (int) ($result['summary']['personnel'] ?? 0),
-            'success' => $result['success'],
-            'error_count' => count($result['errors'] ?? []),
-        ]
-    );
-
-    http_response_code($result['success'] ? 200 : 422);
-    echo json_encode($result, JSON_UNESCAPED_UNICODE);
+    http_response_code($outcome['http']);
+    echo json_encode($outcome['body'], JSON_UNESCAPED_UNICODE);
 }

--- a/backend/routes/sync.php
+++ b/backend/routes/sync.php
@@ -15,9 +15,39 @@ include_once __DIR__ . '/../SyncTransformService.php';
 include_once __DIR__ . '/../sync/StagingPdoAdapter.php';
 include_once __DIR__ . '/../sync/CsvFileAdapter.php';
 
+/**
+ * N23: test hook — integration test ฉีด identity ผ่าน $GLOBALS['__auth_user']
+ * แทน JWT+DB (pattern เดียวกับ routes/settings.php) ใช้ array_key_exists
+ * เพื่อให้ฉีด null (unauthenticated) ได้ต่างจาก ?? ที่ตกทะลุ getAuthenticatedUser
+ */
+function resolveSyncUser(): ?array
+{
+    if (array_key_exists('__auth_user', $GLOBALS)) {
+        $u = $GLOBALS['__auth_user'];
+        return is_array($u) ? $u : null;
+    }
+    return getAuthenticatedUser();
+}
+
+/**
+ * N23: ตรวจ permission แบบไม่ exit (requirePermission exit จะฆ่า PHPUnit)
+ * contract เดียวกัน — 401/403/503 พร้อม body เดิมจาก evaluatePermissionAccess
+ *
+ * @return array{status:int, body:array<string,mixed>}|null null = ผ่าน
+ */
+function denySyncIfForbidden(PDO $pdo, string $action, ?array $user): ?array
+{
+    $denied = evaluatePermissionAccess($action, 'sync', $user, $pdo);
+    if ($denied !== null) {
+        http_response_code($denied['status']);
+        echo json_encode($denied['body']);
+    }
+    return $denied;
+}
+
 function handleSync(PDO $pdo, string $method, array $path): void
 {
-    $user = getAuthenticatedUser();
+    $user = resolveSyncUser();
     if (!$user) {
         http_response_code(401);
         echo json_encode(['error' => 'Unauthorized']);
@@ -31,7 +61,9 @@ function handleSync(PDO $pdo, string $method, array $path): void
             case 'GET':
                 if ($sub === 'status') {
                     // N32: GET ใช้ read:sync ไม่ใช่ create:sync
-                    requirePermission('read', 'sync');
+                    if (denySyncIfForbidden($pdo, 'read', $user) !== null) {
+                        return;
+                    }
                     handleSyncStatus($pdo);
                 } else {
                     http_response_code(404);
@@ -42,8 +74,10 @@ function handleSync(PDO $pdo, string $method, array $path): void
             case 'POST':
                 // ใช้ authz matrix เป็นเส้นตัดสิน (fail-closed) — ห้าม hardcode role check
                 // เพราะ superadmin โดน 403 และ override จาก settings ไม่ถูกนับ
-                requirePermission('create', 'sync');
-                handleSyncTrigger($pdo, $sub);
+                if (denySyncIfForbidden($pdo, 'create', $user) !== null) {
+                    return;
+                }
+                handleSyncTrigger($pdo, $sub, null, $user);
                 break;
 
             default:
@@ -71,11 +105,19 @@ function handleSyncStatus(PDO $pdo): void
     echo json_encode(['success' => true, 'data' => $status], JSON_UNESCAPED_UNICODE);
 }
 
-function handleSyncTrigger(PDO $pdo, string $domain): void
+/**
+ * @param array<string,mixed>|null $input บอดี้ที่ฉีดจาก test (null = อ่าน php://input)
+ * @param array{user_id?:int|string}|null $authUser ผู้เรียก (null = resolve เอง)
+ */
+function handleSyncTrigger(PDO $pdo, string $domain, ?array $input = null, ?array $authUser = null): void
 {
-    $body = json_decode(file_get_contents('php://input'), true) ?? [];
+    $body = $input ?? (json_decode(file_get_contents('php://input'), true) ?? []);
     $sourceType = $body['source'] ?? 'staging';
     $full = (bool) ($body['full'] ?? false);
+    // N23: ของเดิมอ้าง $user ที่ไม่มีใน scope นี้ (ประกาศใน handleSync) —
+    // ส่งผู้เรียกเข้ามาตรง ๆ แทน (fallback resolve เองเพื่อคงพฤติกรรมเดิม)
+    $triggerUser = $authUser ?? resolveSyncUser();
+    $triggerUserId = (int) ($triggerUser['user_id'] ?? 0);
 
     if ($sourceType === 'staging') {
         $host = getenv('SYNC_STAGING_HOST') ?: '';
@@ -148,5 +190,5 @@ function handleSyncTrigger(PDO $pdo, string $domain): void
         echo json_encode(['success' => !$hasErrors, 'data' => $result], JSON_UNESCAPED_UNICODE);
     }
 
-    logAudit($pdo, (int) ($user['user_id'] ?? 0), 'sync', 'external_ref', null, null, ['domain' => $domain ?: 'all', 'source' => $sourceType, 'full' => $full]);
+    logAudit($pdo, $triggerUserId, 'sync', 'external_ref', null, null, ['domain' => $domain ?: 'all', 'source' => $sourceType, 'full' => $full]);
 }

--- a/backend/routes/users.php
+++ b/backend/routes/users.php
@@ -53,26 +53,51 @@ function countActiveSuperadmins(PDO $pdo, bool $forUpdate = false): int
 }
 
 /**
+ * N23: test hook — pattern เดียวกับ routes/settings.php + routes/sync.php
+ * ใช้ array_key_exists เพื่อให้ฉีด null (unauthenticated) ได้
+ */
+function resolveUsersAuthUser(): ?array
+{
+    if (array_key_exists('__auth_user', $GLOBALS)) {
+        $u = $GLOBALS['__auth_user'];
+        return is_array($u) ? $u : null;
+    }
+    return getAuthenticatedUser();
+}
+
+/**
  * จัดการ request สำหรับ user management endpoints
  * GET = read (admin+operator ดูได้), POST/PUT = create/update (admin เท่านั้น ตาม permission matrix)
+ *
+ * N23: $input/$query สำหรับฉีดบอดี้/query จาก integration test
+ * (null = อ่าน php://input/$_GET ตามเดิม) — contract HTTP ไม่เปลี่ยน
  *
  * @param PDO $pdo Database connection
  * @param string $method HTTP method
  * @param array $path URL path segments
+ * @param array<string,mixed>|null $input
+ * @param array<string,mixed>|null $query
  */
-function handleUsers(PDO $pdo, string $method, array $path): void
+function handleUsers(PDO $pdo, string $method, array $path, ?array $input = null, ?array $query = null): void
 {
     $actionMap = ['GET' => 'read', 'POST' => 'create', 'PUT' => 'update'];
-    requirePermission($actionMap[$method] ?? 'read', 'users');
-    $auth = getAuthenticatedUser();
+    $auth = resolveUsersAuthUser();
+    // N23: เดิม requirePermission exit จะฆ่า PHPUnit — ใช้ evaluate + return
+    // contract เดิม (401/403/503 + body) คงไว้ทุกประการ
+    $denied = evaluatePermissionAccess($actionMap[$method] ?? 'read', 'users', $auth, $pdo);
+    if ($denied !== null) {
+        http_response_code($denied['status']);
+        echo json_encode($denied['body']);
+        return;
+    }
 
     switch ($method) {
         case 'GET':
-            getUserList($pdo);
+            getUserList($pdo, $query);
             break;
 
         case 'POST':
-            createUser($pdo, $auth);
+            createUser($pdo, $auth, $input);
             break;
 
         case 'PUT':
@@ -82,7 +107,7 @@ function handleUsers(PDO $pdo, string $method, array $path): void
                 echo json_encode(['error' => 'กรุณาระบุ ID ของผู้ใช้']);
                 return;
             }
-            updateUser($pdo, intval($id), $auth);
+            updateUser($pdo, intval($id), $auth, $input);
             break;
 
         default:
@@ -93,13 +118,16 @@ function handleUsers(PDO $pdo, string $method, array $path): void
 
 /**
  * GET /users — รายชื่อผู้ใช้ พร้อม pagination และค้นหาจาก username/full_name
+ *
+ * @param array<string,mixed>|null $query ฉีด query จาก test (null = $_GET)
  */
-function getUserList(PDO $pdo): void
+function getUserList(PDO $pdo, ?array $query = null): void
 {
-    $search = $_GET['search'] ?? '';
+    $q = $query ?? $_GET;
+    $search = $q['search'] ?? '';
     // clamp กัน limit มหาศาล / offset ติดลบ
-    $limit = max(1, min(intval($_GET['limit'] ?? 20), 200));
-    $offset = max(0, intval($_GET['offset'] ?? 0));
+    $limit = max(1, min(intval($q['limit'] ?? 20), 200));
+    $offset = max(0, intval($q['offset'] ?? 0));
 
     $where = '';
     $params = [];
@@ -134,10 +162,12 @@ function getUserList(PDO $pdo): void
 
 /**
  * POST /users — สร้างผู้ใช้ใหม่ (must_change_password = 1 เสมอ)
+ *
+ * @param array<string,mixed>|null $input ฉีดบอดี้จาก test (null = อ่าน php://input)
  */
-function createUser(PDO $pdo, ?array $auth): void
+function createUser(PDO $pdo, ?array $auth, ?array $input = null): void
 {
-    $data = json_decode(file_get_contents('php://input'), true);
+    $data = $input ?? json_decode(file_get_contents('php://input'), true);
 
     $required = ['username', 'password', 'full_name', 'role'];
     foreach ($required as $field) {

--- a/backend/tests/Integration/CandidatesRouteTest.php
+++ b/backend/tests/Integration/CandidatesRouteTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration;
+
+use PDO;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Throwable;
+
+putenv('JWT_SECRET=integration-test-secret-0123456789abcdef');
+
+require_once __DIR__ . '/../../config.php';
+require_once __DIR__ . '/../../routes/candidates.php';
+
+/**
+ * N23 — integration suite ของ candidates route ต่อ DB จริง
+ *
+ * QualificationEngine มีเทสแล้ว (QualificationEngineTest) แต่ชั้น route
+ * (overview/list/detail, redaction ตาม role, 400/404/405/401) ไม่มีเทสเลย
+ * ใช้ $GLOBALS['__auth_user'] ฉีด identity (pattern เดียวกับ routes/settings.php)
+ */
+final class CandidatesRouteTest extends TestCase
+{
+    private static ?PDO $pdo = null;
+    private static bool $seedReady = false;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$pdo = testPdo();
+        if (self::$pdo === null) {
+            return;
+        }
+        try {
+            $count = (int) self::$pdo
+                ->query('SELECT COUNT(*) FROM personnel WHERE personnel_id BETWEEN 101 AND 111')
+                ->fetchColumn();
+            self::$seedReady = $count >= 11;
+        } catch (Throwable $e) {
+            self::$seedReady = false;
+        }
+    }
+
+    protected function setUp(): void
+    {
+        if (self::$pdo === null) {
+            self::markTestSkipped('ต่อ MySQL ไม่ได้ — รัน: docker compose up -d db แล้วใช้ tests/run.sh');
+        }
+        if (!self::$seedReady) {
+            self::markTestSkipped('seed executive (personnel 101-111) ไม่ครบ — re-seed DB ก่อน');
+        }
+        http_response_code(200);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['__auth_user']);
+        http_response_code(200);
+    }
+
+    #[Test]
+    public function overview_returns_by_level_shape(): void
+    {
+        $out = $this->call('GET', ['candidates', 'overview'], ['user_id' => 1, 'role' => 'admin']);
+
+        self::assertSame(200, $out['code']);
+        self::assertTrue($out['body']['success']);
+        foreach (['K2', 'K3', 'K4', 'O2', 'O3', 'M1', 'M2', 'S1', 'S2'] as $level) {
+            self::assertArrayHasKey($level, $out['body']['by_level'], "by_level ต้องมี {$level}");
+        }
+    }
+
+    #[Test]
+    public function list_returns_pagination_with_full_dataset_summary(): void
+    {
+        $out = $this->call('GET', ['candidates', 'M1'], ['user_id' => 1, 'role' => 'admin']);
+
+        self::assertSame(200, $out['code']);
+        self::assertTrue($out['body']['success']);
+        self::assertArrayHasKey('summary', $out['body']);
+        self::assertArrayHasKey('pagination', $out['body']);
+        $summary = $out['body']['summary'];
+        self::assertSame(
+            $summary['total'],
+            $summary['qualified'] + $summary['not_yet'] + $summary['check_data']
+        );
+        self::assertGreaterThan(0, $summary['total']);
+    }
+
+    #[Test]
+    public function detail_visible_citizen_id_for_admin(): void
+    {
+        $out = $this->call('GET', ['candidates', 'M1', '101'], ['user_id' => 1, 'role' => 'admin']);
+
+        self::assertSame(200, $out['code']);
+        self::assertArrayHasKey('data', $out['body']);
+        self::assertArrayHasKey('citizen_id', $out['body']['data'], 'admin ต้องเห็น citizen_id');
+    }
+
+    #[Test]
+    public function detail_redacts_citizen_id_for_viewer(): void
+    {
+        $out = $this->call('GET', ['candidates', 'M1', '101'], ['user_id' => 2, 'role' => 'viewer']);
+
+        self::assertSame(200, $out['code']);
+        self::assertArrayHasKey('data', $out['body']);
+        self::assertArrayNotHasKey('citizen_id', $out['body']['data'], 'viewer ต้องไม่เห็น citizen_id');
+    }
+
+    #[Test]
+    public function invalid_level_returns_400(): void
+    {
+        $out = $this->call('GET', ['candidates', 'K9'], ['user_id' => 1, 'role' => 'admin']);
+
+        self::assertSame(400, $out['code']);
+        self::assertStringContainsString('Invalid target level', (string) ($out['body']['error'] ?? ''));
+    }
+
+    #[Test]
+    public function unknown_personnel_returns_404(): void
+    {
+        $out = $this->call('GET', ['candidates', 'M1', '999999989'], ['user_id' => 1, 'role' => 'admin']);
+
+        self::assertSame(404, $out['code']);
+        self::assertSame('Personnel not found', $out['body']['error'] ?? null);
+    }
+
+    #[Test]
+    public function non_get_returns_405(): void
+    {
+        $out = $this->call('POST', ['candidates', 'M1'], ['user_id' => 1, 'role' => 'admin']);
+
+        self::assertSame(405, $out['code']);
+    }
+
+    #[Test]
+    public function unauthenticated_returns_401(): void
+    {
+        $GLOBALS['__auth_user'] = null;
+        http_response_code(200);
+        ob_start();
+        handleCandidates(self::$pdo, 'GET', ['candidates', 'M1']);
+        $raw = (string) ob_get_clean();
+
+        self::assertSame(401, http_response_code());
+        self::assertSame('Unauthorized', json_decode($raw, true)['error'] ?? null);
+    }
+
+    /**
+     * @param list<string> $path
+     * @param array{user_id?:int|string, role?:string} $auth
+     * @return array{code:int, body:array<string,mixed>}
+     */
+    private function call(string $method, array $path, array $auth): array
+    {
+        $GLOBALS['__auth_user'] = $auth;
+        http_response_code(200);
+        ob_start();
+        handleCandidates(self::$pdo, $method, $path, $auth, []);
+        $raw = (string) ob_get_clean();
+        return ['code' => http_response_code(), 'body' => json_decode($raw, true) ?? []];
+    }
+}

--- a/backend/tests/Integration/ImportRouteTest.php
+++ b/backend/tests/Integration/ImportRouteTest.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration;
+
+use PDO;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use QualificationEngine;
+use Throwable;
+
+putenv('JWT_SECRET=integration-test-secret-0123456789abcdef');
+
+require_once __DIR__ . '/../../config.php';
+require_once __DIR__ . '/../../routes/import.php';
+
+/**
+ * N56 — import e2e positive path ต่อ DB จริง
+ *
+ * เดิม ImportServiceTest มี positive ระดับ service แต่ชั้น route (handleImport +
+ * processImportUpload: pre-log → service → import_log/audit → HTTP 200/422)
+ * มีแค่ negative path (formula/OLE) — ไฟล์นี้ปิด positive loop แบบ end-to-end:
+ * fixture .xlsx → personnel จริง → engine คำนวณได้ → import_log + audit ครบ
+ */
+final class ImportRouteTest extends TestCase
+{
+    private const SAMPLE = __DIR__ . '/../fixtures/import-sample.xlsx';
+
+    private static ?PDO $pdo = null;
+
+    private int $actorId = 0;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$pdo = testPdo();
+    }
+
+    protected function setUp(): void
+    {
+        if (self::$pdo === null) {
+            self::markTestSkipped('ต่อ MySQL ไม่ได้ — รัน: docker compose up -d db แล้วใช้ tests/run.sh');
+        }
+        if (!is_file(self::SAMPLE)) {
+            self::markTestSkipped('ไม่พบ fixture import-sample.xlsx');
+        }
+        foreach (['personnel', 'import_log', 'audit_log'] as $table) {
+            if (!self::$pdo->query("SHOW TABLES LIKE '{$table}'")->fetchColumn()) {
+                self::markTestSkipped("ไม่พบตาราง {$table}");
+            }
+        }
+        http_response_code(200);
+        $this->cleanup();
+
+        $actorName = 'n56actor' . bin2hex(random_bytes(3));
+        self::$pdo->prepare(
+            "INSERT INTO users (username, password_hash, full_name, role, is_active, must_change_password)
+             VALUES (?, ?, 'N56 Actor', 'admin', 1, 0)"
+        )->execute([$actorName, password_hash('ActorPass123', PASSWORD_BCRYPT)]);
+        $this->actorId = (int) self::$pdo->lastInsertId();
+        $GLOBALS['__auth_user'] = ['user_id' => $this->actorId, 'role' => 'admin'];
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['__auth_user']);
+        if (self::$pdo !== null) {
+            $this->cleanup();
+            try {
+                if ($this->actorId > 0) {
+                    self::$pdo->prepare('DELETE FROM users WHERE user_id = ?')->execute([$this->actorId]);
+                }
+            } catch (Throwable $e) {
+                // cleanup ล้มเหลว — อย่าทำให้ผลเทสเสีย
+            }
+        }
+        $this->actorId = 0;
+        http_response_code(200);
+    }
+
+    #[Test]
+    public function positive_upload_persists_personnel_and_logs(): void
+    {
+        $logBefore = $this->importLogCount();
+        $auditBefore = $this->importAuditCount();
+
+        $outcome = processImportUpload(self::$pdo, self::SAMPLE, 'import-sample.xlsx', $this->actorId);
+
+        self::assertSame(200, $outcome['http'], json_encode($outcome['body']));
+        self::assertTrue($outcome['body']['success']);
+        self::assertSame(2, $outcome['body']['summary']['personnel']);
+        self::assertSame(1, $outcome['body']['summary']['diverse']);
+
+        // personnel จริงถูก insert
+        $count = (int) self::$pdo->query(
+            "SELECT COUNT(*) FROM personnel WHERE citizen_id LIKE '11001002990%'"
+        )->fetchColumn();
+        self::assertSame(2, $count);
+
+        // import_log: สำเร็จ 1 แถว บันทึกจำนวนคน ไม่มี PII
+        self::assertSame($logBefore + 1, $this->importLogCount());
+        $log = self::$pdo->query(
+            'SELECT personnel_count, is_success, error_summary, filename FROM import_log ORDER BY log_id DESC LIMIT 1'
+        )->fetch(PDO::FETCH_ASSOC);
+        self::assertSame(2, (int) $log['personnel_count']);
+        self::assertSame(1, (int) $log['is_success']);
+        self::assertNull($log['error_summary']);
+
+        // audit_log: CREATE import 1 แถว
+        self::assertSame($auditBefore + 1, $this->importAuditCount());
+
+        // engine คำนวณได้หลังนำเข้า — ปิด loop e2e (ค่าตรงกับ ImportServiceTest)
+        $engine = new QualificationEngine(self::$pdo);
+        $m1 = $engine->computeDetail('M1', $this->personnelId('1100100299005'));
+        self::assertNotNull($m1);
+        self::assertSame('2023-01-01', $m1['data']['qualification_date']);
+    }
+
+    #[Test]
+    public function reimport_returns_friendly_duplicate_error(): void
+    {
+        $first = processImportUpload(self::$pdo, self::SAMPLE, 'import-sample.xlsx', $this->actorId);
+        self::assertSame(200, $first['http'], json_encode($first['body']));
+
+        $logBefore = $this->importLogCount();
+        $second = processImportUpload(self::$pdo, self::SAMPLE, 'import-sample.xlsx', $this->actorId);
+
+        self::assertSame(422, $second['http']);
+        self::assertFalse($second['body']['success']);
+        $errors = implode(' ', $second['body']['errors']);
+        self::assertStringContainsString('เลขบัตรประชาชนซ้ำ', $errors);
+        self::assertStringNotContainsString('SQLSTATE', $errors);
+
+        // import ซ้ำก็ถูกบันทึกเป็น attempt ที่ล้มเหลว
+        self::assertSame($logBefore + 1, $this->importLogCount());
+        $isSuccess = (int) self::$pdo->query(
+            'SELECT is_success FROM import_log ORDER BY log_id DESC LIMIT 1'
+        )->fetchColumn();
+        self::assertSame(0, $isSuccess);
+    }
+
+    #[Test]
+    public function missing_file_returns_422_and_logs_attempt(): void
+    {
+        $outcome = processImportUpload(self::$pdo, __DIR__ . '/nonexistent-n56.xlsx', 'missing.xlsx', $this->actorId);
+
+        self::assertSame(422, $outcome['http']);
+        self::assertFalse($outcome['body']['success']);
+        self::assertNotEmpty($outcome['body']['errors']);
+    }
+
+    #[Test]
+    public function handle_import_validates_method_path_and_auth(): void
+    {
+        // ผิด method → 405
+        $out = $this->callHandle('GET', ['import', 'executive']);
+        self::assertSame(405, $out['code']);
+
+        // ผิด path → 404
+        $out = $this->callHandle('POST', ['import', 'wrong']);
+        self::assertSame(404, $out['code']);
+
+        // unauthenticated → 401
+        $GLOBALS['__auth_user'] = null;
+        $out = $this->callHandle('POST', ['import', 'executive']);
+        self::assertSame(401, $out['code']);
+
+        // viewer ไม่มี create:import → 403
+        $GLOBALS['__auth_user'] = ['user_id' => $this->actorId, 'role' => 'viewer'];
+        $out = $this->callHandle('POST', ['import', 'executive']);
+        self::assertSame(403, $out['code']);
+    }
+
+    /**
+     * @param list<string> $path
+     * @return array{code:int, body:array<string,mixed>}
+     */
+    private function callHandle(string $method, array $path): array
+    {
+        http_response_code(200);
+        ob_start();
+        handleImport(self::$pdo, $method, $path);
+        $raw = (string) ob_get_clean();
+        return ['code' => http_response_code(), 'body' => json_decode($raw, true) ?? []];
+    }
+
+    private function importLogCount(): int
+    {
+        return (int) self::$pdo->query('SELECT COUNT(*) FROM import_log')->fetchColumn();
+    }
+
+    private function importAuditCount(): int
+    {
+        return (int) self::$pdo->query(
+            "SELECT COUNT(*) FROM audit_log WHERE action = 'CREATE' AND table_name = 'import'"
+        )->fetchColumn();
+    }
+
+    private function personnelId(string $citizenId): int
+    {
+        $stmt = self::$pdo->prepare('SELECT personnel_id FROM personnel WHERE citizen_id = ?');
+        $stmt->execute([$citizenId]);
+        return (int) $stmt->fetchColumn();
+    }
+
+    private function cleanup(): void
+    {
+        $ids = "SELECT personnel_id FROM personnel WHERE citizen_id LIKE '11001002990%'";
+        try {
+            self::$pdo->exec("DELETE FROM diverse_experience WHERE personnel_id IN ({$ids})");
+            self::$pdo->exec("DELETE FROM position_equivalence WHERE personnel_id IN ({$ids})");
+            self::$pdo->exec("DELETE FROM personnel_position_history WHERE personnel_id IN ({$ids})");
+            self::$pdo->exec("DELETE FROM personnel WHERE citizen_id LIKE '11001002990%'");
+            self::$pdo->exec("DELETE FROM organization WHERE org_name = 'กองบริหารทรัพยากรบุคคล'");
+            self::$pdo->exec("DELETE FROM `position` WHERE position_name IN ('นักทรัพยากรบุคคลชำนาญการ', 'ผู้อำนวยการกอง')");
+            self::$pdo->exec('DELETE FROM import_log WHERE filename IN (\'import-sample.xlsx\', \'missing.xlsx\')');
+            self::$pdo->exec("DELETE FROM audit_log WHERE action = 'CREATE' AND table_name = 'import'");
+        } catch (Throwable $e) {
+            // ตารางอาจยังไม่มีในบาง schema — ปล่อยให้ test จริงจับ
+        }
+    }
+}

--- a/backend/tests/Integration/SyncRouteTest.php
+++ b/backend/tests/Integration/SyncRouteTest.php
@@ -1,0 +1,300 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration;
+
+use PDO;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Throwable;
+
+putenv('JWT_SECRET=integration-test-secret-0123456789abcdef');
+
+require_once __DIR__ . '/../../config.php';
+require_once __DIR__ . '/../../routes/sync.php';
+
+/**
+ * N23 — integration suite ของชั้น route sync (handleSync, status, trigger) ต่อ DB จริง
+ *
+ * เดิมมีแค่ SyncTransformService ระดับ service (SyncTransformServiceTest) ไม่มีเทส
+ * ชั้น route: auth/permission branching, validation (domain/source), audit log
+ * ใช้ $GLOBALS['__auth_user'] ฉีด identity (pattern เดียวกับ routes/settings.php)
+ */
+final class SyncRouteTest extends TestCase
+{
+    private static ?PDO $pdo = null;
+
+    /** @var list<string> temp dirs ที่ต้องลบ */
+    private array $tmpDirs = [];
+
+    /** @var array<string,string|false> env ที่ backup ไว้ */
+    private array $envBackup = [];
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$pdo = testPdo();
+    }
+
+    protected function setUp(): void
+    {
+        if (self::$pdo === null) {
+            self::markTestSkipped('ต่อ MySQL ไม่ได้ — รัน: docker compose up -d db แล้วใช้ tests/run.sh');
+        }
+        foreach (['external_ref', 'prefixes', 'audit_log'] as $table) {
+            if (!self::$pdo->query("SHOW TABLES LIKE '{$table}'")->fetchColumn()) {
+                self::markTestSkipped("ไม่พบตาราง {$table}");
+            }
+        }
+        http_response_code(200);
+        $GLOBALS['__auth_user'] = ['user_id' => 1, 'role' => 'admin'];
+        $this->cleanup();
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['__auth_user']);
+        foreach (['SYNC_STAGING_HOST', 'SYNC_STAGING_DATABASE', 'SYNC_STAGING_USER', 'SYNC_CSV_DIR'] as $k) {
+            $this->restoreEnv($k);
+        }
+        foreach ($this->tmpDirs as $dir) {
+            $this->removeDir($dir);
+        }
+        $this->tmpDirs = [];
+        if (self::$pdo !== null) {
+            $this->cleanup();
+        }
+        http_response_code(200);
+    }
+
+    #[Test]
+    public function status_returns_all_domains_with_source_tables(): void
+    {
+        http_response_code(200);
+        ob_start();
+        handleSyncStatus(self::$pdo);
+        $body = json_decode((string) ob_get_clean(), true);
+
+        self::assertSame(200, http_response_code());
+        self::assertTrue($body['success']);
+        foreach (['D1', 'D2', 'D3', 'D4', 'D5', 'D6', 'D7'] as $d) {
+            self::assertArrayHasKey($d, $body['data'], "status ต้องมี {$d}");
+            self::assertArrayHasKey('source_table', $body['data'][$d]);
+        }
+        self::assertSame('per_personal', $body['data']['D1']['source_table']);
+    }
+
+    #[Test]
+    public function route_get_status_returns_200_for_admin(): void
+    {
+        $out = $this->callSync('GET', ['sync', 'status']);
+
+        self::assertSame(200, $out['code']);
+        self::assertTrue($out['body']['success']);
+        self::assertArrayHasKey('D4', $out['body']['data']);
+    }
+
+    #[Test]
+    public function route_get_status_returns_401_when_unauthenticated(): void
+    {
+        $GLOBALS['__auth_user'] = null;
+        $out = $this->callSync('GET', ['sync', 'status']);
+
+        self::assertSame(401, $out['code']);
+        self::assertSame('Unauthorized', $out['body']['error'] ?? null);
+    }
+
+    #[Test]
+    public function route_post_is_forbidden_for_operator_by_default(): void
+    {
+        // POST /sync คือ create:sync — operator ไม่มีตาม default matrix
+        $GLOBALS['__auth_user'] = ['user_id' => 2, 'role' => 'operator'];
+        $out = $this->callSync('POST', ['sync', 'D4']);
+
+        self::assertSame(403, $out['code']);
+        self::assertSame('create:sync', $out['body']['required_permission'] ?? null);
+    }
+
+    #[Test]
+    public function trigger_rejects_invalid_domain(): void
+    {
+        // domain ตรวจหลัง source resolve — ต้องมี csv dir ใช้ได้ก่อนจึงจะถึงเช็ค domain
+        $this->setEnv('SYNC_CSV_DIR', $this->makeCsvDir([]));
+        http_response_code(200);
+        ob_start();
+        handleSyncTrigger(self::$pdo, 'DX', ['source' => 'csv', 'full' => true], ['user_id' => 1, 'role' => 'admin']);
+        $body = json_decode((string) ob_get_clean(), true);
+
+        self::assertSame(400, http_response_code());
+        self::assertStringContainsString('domain ไม่ถูกต้อง', (string) ($body['error'] ?? ''));
+    }
+
+    #[Test]
+    public function trigger_rejects_unknown_source(): void
+    {
+        http_response_code(200);
+        ob_start();
+        handleSyncTrigger(self::$pdo, 'D4', ['source' => 'carrier-pigeon'], ['user_id' => 1, 'role' => 'admin']);
+        $body = json_decode((string) ob_get_clean(), true);
+
+        self::assertSame(400, http_response_code());
+        self::assertStringContainsString('staging หรือ csv', (string) ($body['error'] ?? ''));
+    }
+
+    #[Test]
+    public function trigger_returns_503_when_staging_not_configured(): void
+    {
+        $this->clearEnv('SYNC_STAGING_HOST');
+        $this->clearEnv('SYNC_STAGING_DATABASE');
+        $this->clearEnv('SYNC_STAGING_USER');
+
+        http_response_code(200);
+        ob_start();
+        handleSyncTrigger(self::$pdo, 'D4', ['source' => 'staging'], ['user_id' => 1, 'role' => 'admin']);
+        $body = json_decode((string) ob_get_clean(), true);
+
+        self::assertSame(503, http_response_code());
+        self::assertStringContainsString('SYNC_STAGING_', (string) ($body['error'] ?? ''));
+    }
+
+    #[Test]
+    public function trigger_returns_503_when_csv_dir_missing(): void
+    {
+        $this->setEnv('SYNC_CSV_DIR', '/nonexistent-sync-csv-dir-n23');
+
+        http_response_code(200);
+        ob_start();
+        handleSyncTrigger(self::$pdo, 'D4', ['source' => 'csv', 'full' => true], ['user_id' => 1, 'role' => 'admin']);
+        $body = json_decode((string) ob_get_clean(), true);
+
+        self::assertSame(503, http_response_code());
+        self::assertStringContainsString('SYNC_CSV_DIR', (string) ($body['error'] ?? ''));
+    }
+
+    #[Test]
+    public function trigger_syncs_d4_from_csv_and_writes_audit(): void
+    {
+        $dir = $this->makeCsvDir([
+            'per_prename.csv' => "pn_code,pn_name,pn_eng_name,pn_shortname,pn_active\n"
+                . "SYN001,นายทดสอบซิงก์,Mr.,นทซ,1\n"
+                . "SYN002,นางทดสอบซิงก์,Mrs.,นทซญ,1\n"
+                . "SYN003,นางสาวทดสอบซิงก์,Miss,น.ส.ทซ,1\n",
+        ]);
+        $this->setEnv('SYNC_CSV_DIR', $dir);
+
+        $auditBefore = $this->syncAuditCount();
+
+        http_response_code(200);
+        ob_start();
+        handleSyncTrigger(self::$pdo, 'D4', ['source' => 'csv', 'full' => true], ['user_id' => 1, 'role' => 'admin']);
+        $body = json_decode((string) ob_get_clean(), true);
+
+        self::assertSame(200, http_response_code(), json_encode($body));
+        self::assertTrue($body['success']);
+        self::assertSame(3, $body['data']['created'] ?? null, json_encode($body));
+
+        $count = (int) self::$pdo->query(
+            "SELECT COUNT(*) FROM prefixes WHERE prefix_code IN ('SYN001','SYN002','SYN003')"
+        )->fetchColumn();
+        self::assertSame(3, $count);
+
+        $refCount = (int) self::$pdo->query(
+            "SELECT COUNT(*) FROM external_ref WHERE source_table = 'per_prename'"
+            . " AND source_system = 'legacy-hr'"
+            . " AND source_id IN ('SYN001','SYN002','SYN003')"
+        )->fetchColumn();
+        self::assertSame(3, $refCount);
+
+        self::assertSame($auditBefore + 1, $this->syncAuditCount(), 'trigger ต้องเขียน audit_log 1 แถว');
+    }
+
+    /**
+     * @param list<string> $path
+     * @return array{code:int, body:array<string,mixed>}
+     */
+    private function callSync(string $method, array $path): array
+    {
+        http_response_code(200);
+        ob_start();
+        handleSync(self::$pdo, $method, $path);
+        $raw = (string) ob_get_clean();
+        return ['code' => http_response_code(), 'body' => json_decode($raw, true) ?? []];
+    }
+
+    private function syncAuditCount(): int
+    {
+        return (int) self::$pdo->query(
+            "SELECT COUNT(*) FROM audit_log WHERE action = 'sync' AND table_name = 'external_ref'"
+        )->fetchColumn();
+    }
+
+    /** @param array<string,string> $files */
+    private function makeCsvDir(array $files): string
+    {
+        $dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'syncn23_' . bin2hex(random_bytes(6));
+        mkdir($dir, 0777, true);
+        foreach ($files as $name => $content) {
+            file_put_contents($dir . DIRECTORY_SEPARATOR . $name, $content);
+        }
+        $this->tmpDirs[] = $dir;
+        return $dir;
+    }
+
+    private function removeDir(string $dir): void
+    {
+        foreach (glob($dir . DIRECTORY_SEPARATOR . '*') ?: [] as $f) {
+            if (is_file($f)) {
+                @unlink($f);
+            }
+        }
+        @rmdir($dir);
+    }
+
+    private function setEnv(string $key, string $value): void
+    {
+        if (!array_key_exists($key, $this->envBackup)) {
+            $this->envBackup[$key] = getenv($key);
+        }
+        putenv("{$key}={$value}");
+        $_ENV[$key] = $value;
+    }
+
+    private function clearEnv(string $key): void
+    {
+        if (!array_key_exists($key, $this->envBackup)) {
+            $this->envBackup[$key] = getenv($key);
+        }
+        putenv($key);
+        unset($_ENV[$key]);
+    }
+
+    private function restoreEnv(string $key): void
+    {
+        if (!array_key_exists($key, $this->envBackup)) {
+            return;
+        }
+        $old = $this->envBackup[$key];
+        if ($old === false) {
+            putenv($key);
+            unset($_ENV[$key]);
+        } else {
+            putenv("{$key}={$old}");
+            $_ENV[$key] = $old;
+        }
+        unset($this->envBackup[$key]);
+    }
+
+    private function cleanup(): void
+    {
+        try {
+            self::$pdo->exec(
+                "DELETE FROM external_ref WHERE source_system = 'legacy-hr'"
+                . " AND source_id IN ('SYN001','SYN002','SYN003')"
+            );
+            self::$pdo->exec("DELETE FROM prefixes WHERE prefix_code LIKE 'SYN%'");
+            self::$pdo->exec("DELETE FROM audit_log WHERE action = 'sync' AND table_name = 'external_ref'");
+        } catch (Throwable $e) {
+            // ตารางอาจยังไม่มีในบาง schema — ปล่อยให้ test จริงจับ
+        }
+    }
+}

--- a/backend/tests/Integration/UsersCrudTest.php
+++ b/backend/tests/Integration/UsersCrudTest.php
@@ -1,0 +1,333 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration;
+
+use PDO;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Throwable;
+
+putenv('JWT_SECRET=integration-test-secret-0123456789abcdef');
+
+require_once __DIR__ . '/../../config.php';
+require_once __DIR__ . '/../../routes/users.php';
+
+/**
+ * N23 — integration suite ของ users CRUD ต่อ DB จริง
+ *
+ * เดิมมีแค่ guard ระดับ sqlite (UserManagementGuardTest) ไม่มีเทสต่อ MySQL:
+ * create/get/update roundtrip, duplicate 409, password reset revoke refresh,
+ * self-guard, last-superadmin guard, routing ผ่าน handleUsers
+ */
+final class UsersCrudTest extends TestCase
+{
+    private static ?PDO $pdo = null;
+
+    /** @var list<int> user ที่สร้างในแต่ละเทส */
+    private array $userIds = [];
+
+    private int $actorId = 0;
+
+    /** @var array{user_id:int, role:string} */
+    private array $actor = ['user_id' => 0, 'role' => 'admin'];
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$pdo = testPdo();
+    }
+
+    protected function setUp(): void
+    {
+        if (self::$pdo === null) {
+            self::markTestSkipped('ต่อ MySQL ไม่ได้ — รัน: docker compose up -d db แล้วใช้ tests/run.sh');
+        }
+        if (!self::$pdo->query("SHOW TABLES LIKE 'users'")->fetchColumn()) {
+            self::markTestSkipped('ไม่พบตาราง users');
+        }
+        http_response_code(200);
+
+        // actor แอดมินจริงใน DB (logAudit มี FK ไป users — ใช้ id จริงกัน violation)
+        $actorName = 'n23actor' . bin2hex(random_bytes(3));
+        self::$pdo->prepare(
+            "INSERT INTO users (username, password_hash, full_name, role, is_active, must_change_password)
+             VALUES (?, ?, 'N23 Actor', 'admin', 1, 0)"
+        )->execute([$actorName, password_hash('ActorPass123', PASSWORD_BCRYPT)]);
+        $this->actorId = (int) self::$pdo->lastInsertId();
+        $this->actor = ['user_id' => $this->actorId, 'role' => 'admin'];
+        $GLOBALS['__auth_user'] = $this->actor;
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['__auth_user']);
+        if (self::$pdo !== null) {
+            try {
+                if ($this->userIds !== []) {
+                    $placeholders = implode(',', array_fill(0, count($this->userIds), '?'));
+                    self::$pdo->prepare("DELETE FROM refresh_tokens WHERE user_id IN ({$placeholders})")
+                        ->execute($this->userIds);
+                    self::$pdo->prepare("DELETE FROM users WHERE user_id IN ({$placeholders})")
+                        ->execute($this->userIds);
+                }
+                if ($this->actorId > 0) {
+                    self::$pdo->prepare('DELETE FROM refresh_tokens WHERE user_id = ?')->execute([$this->actorId]);
+                    self::$pdo->prepare('DELETE FROM users WHERE user_id = ?')->execute([$this->actorId]);
+                }
+            } catch (Throwable $e) {
+                // cleanup ล้มเหลว — อย่าทำให้ผลเทสเสีย
+            }
+        }
+        $this->userIds = [];
+        $this->actorId = 0;
+        http_response_code(200);
+    }
+
+    #[Test]
+    public function create_list_update_roundtrip(): void
+    {
+        $username = $this->uniqueUsername();
+
+        http_response_code(200);
+        ob_start();
+        createUser(self::$pdo, $this->actor, [
+            'username' => $username,
+            'password' => 'TestPass123',
+            'full_name' => 'ทดสอบ ครัด',
+            'role' => 'viewer',
+        ]);
+        $raw = (string) ob_get_clean();
+        $created = json_decode($raw, true);
+
+        self::assertSame(201, http_response_code(), $raw);
+        self::assertTrue($created['success']);
+        $newId = (int) $created['user_id'];
+        self::assertGreaterThan(0, $newId);
+        $this->userIds[] = $newId;
+
+        // list เจอ + ไม่มี password_hash หลุด
+        http_response_code(200);
+        ob_start();
+        getUserList(self::$pdo, ['search' => $username, 'limit' => 20, 'offset' => 0]);
+        $list = json_decode((string) ob_get_clean(), true);
+
+        self::assertSame(200, http_response_code());
+        self::assertTrue($list['success']);
+        self::assertGreaterThanOrEqual(1, $list['pagination']['total']);
+        $found = null;
+        foreach ($list['data'] as $row) {
+            if ((int) $row['user_id'] === $newId) {
+                $found = $row;
+            }
+        }
+        self::assertNotNull($found, 'ต้องเจอ user ที่สร้างใน list');
+        self::assertArrayNotHasKey('password_hash', $found);
+        self::assertSame($username, $found['username']);
+
+        // update full_name
+        http_response_code(200);
+        ob_start();
+        updateUser(self::$pdo, $newId, $this->actor, ['full_name' => 'ทดสอบ เปลี่ยนชื่อ']);
+        $updated = json_decode((string) ob_get_clean(), true);
+
+        self::assertSame(200, http_response_code());
+        self::assertTrue($updated['success']);
+        $name = self::$pdo->query("SELECT full_name FROM users WHERE user_id = {$newId}")->fetchColumn();
+        self::assertSame('ทดสอบ เปลี่ยนชื่อ', $name);
+    }
+
+    #[Test]
+    public function create_duplicate_username_returns_409(): void
+    {
+        $username = $this->uniqueUsername();
+        $this->createDirect($username);
+
+        http_response_code(200);
+        ob_start();
+        createUser(self::$pdo, $this->actor, [
+            'username' => $username,
+            'password' => 'TestPass123',
+            'full_name' => 'ซ้ำ',
+            'role' => 'viewer',
+        ]);
+        $raw = (string) ob_get_clean();
+        $body = json_decode($raw, true);
+
+        self::assertSame(409, http_response_code(), $raw);
+        self::assertSame('ชื่อผู้ใช้นี้ถูกใช้งานแล้ว', $body['error'] ?? null);
+    }
+
+    #[Test]
+    public function create_rejects_bad_input(): void
+    {
+        // role ผิด
+        $out = $this->tryCreate(['role' => 'nobody']);
+        self::assertSame(400, $out['code']);
+        self::assertSame('role ไม่ถูกต้อง', $out['body']['error'] ?? null);
+
+        // รหัสผ่านสั้น
+        $out = $this->tryCreate(['password' => 'short']);
+        self::assertSame(400, $out['code']);
+        self::assertStringContainsString('รหัสผ่าน', (string) ($out['body']['error'] ?? ''));
+
+        // N34: password ไม่ใช่ string → 400 ไม่ใช่ TypeError 500
+        $out = $this->tryCreate(['password' => ['a', 'b']]);
+        self::assertSame(400, $out['code']);
+
+        // username ผิด pattern
+        $out = $this->tryCreate(['username' => 'bad name!']);
+        self::assertSame(400, $out['code']);
+    }
+
+    #[Test]
+    public function admin_cannot_create_superadmin(): void
+    {
+        $out = $this->tryCreate(['role' => 'superadmin']);
+
+        self::assertSame(403, $out['code']);
+        self::assertSame('คุณไม่มีสิทธิ์กำหนดบทบาทนี้', $out['body']['error'] ?? null);
+    }
+
+    #[Test]
+    public function password_reset_revokes_refresh_tokens(): void
+    {
+        if (!self::$pdo->query("SHOW TABLES LIKE 'refresh_tokens'")->fetchColumn()) {
+            self::markTestSkipped('ไม่พบตาราง refresh_tokens');
+        }
+        $id = $this->createDirect($this->uniqueUsername());
+
+        self::$pdo->prepare(
+            'INSERT INTO refresh_tokens (user_id, token_hash, expires_at) VALUES (?, ?, DATE_ADD(NOW(), INTERVAL 1 DAY))'
+        )->execute([$id, hash('sha256', 'n23-refresh-' . $id)]);
+
+        http_response_code(200);
+        ob_start();
+        updateUser(self::$pdo, $id, $this->actor, ['password' => 'NewPass456']);
+        $raw = (string) ob_get_clean();
+
+        self::assertSame(200, http_response_code(), $raw);
+        $active = (int) self::$pdo->query(
+            "SELECT COUNT(*) FROM refresh_tokens WHERE user_id = {$id} AND revoked_at IS NULL"
+        )->fetchColumn();
+        self::assertSame(0, $active, 'reset แล้ว refresh token ต้องถูก revoke หมด');
+        $flag = (int) self::$pdo->query("SELECT must_change_password FROM users WHERE user_id = {$id}")->fetchColumn();
+        self::assertSame(1, $flag);
+    }
+
+    #[Test]
+    public function self_demote_and_deactivate_are_blocked(): void
+    {
+        $self = ['user_id' => $this->actorId, 'role' => 'admin'];
+
+        http_response_code(200);
+        ob_start();
+        updateUser(self::$pdo, $this->actorId, $self, ['role' => 'viewer']);
+        $raw = (string) ob_get_clean();
+        self::assertSame(400, http_response_code(), $raw);
+
+        http_response_code(200);
+        ob_start();
+        updateUser(self::$pdo, $this->actorId, $self, ['is_active' => 0]);
+        $raw2 = (string) ob_get_clean();
+        self::assertSame(400, http_response_code(), $raw2);
+
+        $row = self::$pdo->query(
+            "SELECT role, is_active FROM users WHERE user_id = {$this->actorId}"
+        )->fetch(PDO::FETCH_ASSOC);
+        self::assertSame('admin', $row['role']);
+        self::assertSame(1, (int) $row['is_active']);
+    }
+
+    #[Test]
+    public function update_unknown_user_returns_404(): void
+    {
+        http_response_code(200);
+        ob_start();
+        updateUser(self::$pdo, 999999989, $this->actor, ['full_name' => 'ผี']);
+        $raw = (string) ob_get_clean();
+
+        self::assertSame(404, http_response_code(), $raw);
+    }
+
+    #[Test]
+    public function handle_users_routing(): void
+    {
+        // GET ด้วย operator (read:users ผ่าน default) → 200
+        $GLOBALS['__auth_user'] = ['user_id' => $this->actorId, 'role' => 'operator'];
+        $out = $this->callHandle('GET', ['users']);
+        self::assertSame(200, $out['code']);
+        self::assertTrue($out['body']['success']);
+
+        // POST ด้วย viewer (ไม่มี create:users) → 403
+        $GLOBALS['__auth_user'] = ['user_id' => $this->actorId, 'role' => 'viewer'];
+        $out = $this->callHandle('POST', ['users'], ['username' => 'x', 'password' => 'TestPass123', 'full_name' => 'x', 'role' => 'viewer']);
+        self::assertSame(403, $out['code']);
+
+        // PUT ไม่ระบุ id → 400
+        $GLOBALS['__auth_user'] = $this->actor;
+        $out = $this->callHandle('PUT', ['users']);
+        self::assertSame(400, $out['code']);
+
+        // unauthenticated → 401
+        $GLOBALS['__auth_user'] = null;
+        $out = $this->callHandle('GET', ['users']);
+        self::assertSame(401, $out['code']);
+    }
+
+    /** @return array{code:int, body:array<string,mixed>} */
+    private function tryCreate(array $overrides): array
+    {
+        $input = array_merge([
+            'username' => $this->uniqueUsername(),
+            'password' => 'TestPass123',
+            'full_name' => 'ทดสอบ',
+            'role' => 'viewer',
+        ], $overrides);
+        http_response_code(200);
+        ob_start();
+        createUser(self::$pdo, $this->actor, $input);
+        $raw = (string) ob_get_clean();
+        $body = json_decode($raw, true) ?? [];
+        if (($body['success'] ?? false) && isset($body['user_id'])) {
+            $this->userIds[] = (int) $body['user_id'];
+        }
+        return ['code' => http_response_code(), 'body' => $body];
+    }
+
+    private function createDirect(string $username): int
+    {
+        http_response_code(200);
+        ob_start();
+        createUser(self::$pdo, $this->actor, [
+            'username' => $username,
+            'password' => 'TestPass123',
+            'full_name' => 'ทดสอบ ตรง',
+            'role' => 'viewer',
+        ]);
+        $raw = (string) ob_get_clean();
+        $body = json_decode($raw, true);
+        self::assertSame(201, http_response_code(), $raw);
+        $id = (int) $body['user_id'];
+        $this->userIds[] = $id;
+        return $id;
+    }
+
+    /**
+     * @param list<string> $path
+     * @return array{code:int, body:array<string,mixed>}
+     */
+    private function callHandle(string $method, array $path, ?array $input = null): array
+    {
+        http_response_code(200);
+        ob_start();
+        handleUsers(self::$pdo, $method, $path, $input, []);
+        $raw = (string) ob_get_clean();
+        return ['code' => http_response_code(), 'body' => json_decode($raw, true) ?? []];
+    }
+
+    private function uniqueUsername(): string
+    {
+        return 'n23user' . bin2hex(random_bytes(3));
+    }
+}


### PR DESCRIPTION
## สรุป (Summary)

ปิด findings N23 + N56 จาก binding spec `.claude/PRPs/findings/codebase-review-fix-20260908-findings.md`:
- **N23** — เพิ่ม PHPUnit integration ของ `handleSync`/status/trigger, candidates route (overview/list/detail + redaction), users CRUD ต่อ MySQL จริง
- **N56** — import e2e positive path ระดับ route: fixture `.xlsx` -> personnel จริง -> engine คำนวณได้ -> `import_log` + audit ครบ

## API / Schema

- ไม่แตะ schema/migration ใด ๆ (parity gate ผ่าน)
- Route handlers คง HTTP contract เดิมทุกประการ (status/body เดิม) — เพิ่มแค่ optional params (`$input`/`$query`/`$authUser`) + test hook `GLOBALS[__auth_user]` ตาม pattern `routes/settings.php`; `requirePermission` (exit) -> `evaluate+return` เฉพาะใน handler เพื่อไม่ฆ่า PHPUnit
- แก้บั๊กแถม: `handleSyncTrigger` อ้าง `$user` ที่ไม่มีใน scope (ประกาศใน `handleSync`) ทำให้ audit `user_id` เป็น 0 เสมอ — ส่งผู้เรียกเข้าตรง ๆ

## ไฟล์

- `backend/routes/sync.php`, `users.php`, `candidates.php`, `import.php` (refactor เพื่อ testability)
- ใหม่: `SyncRouteTest` (9), `CandidatesRouteTest` (8), `UsersCrudTest` (8), `ImportRouteTest` (4)

## Verification

- เทสใหม่ 29/29 ผ่านบน MySQL (Docker, `backend/tests/run.sh --filter ...` ทีละคลาส)
- Full backend suite: 504 เทส ตก 1 ที่ `QualificationEngineTest S2/110` (คาด 2022-02-01 ได้ 2022-01-31) — พิสูจน์ด้วย `git stash` แล้วว่าเป็นของเดิมบน `main` สะอาด ไม่เกี่ยวกับ PR นี้
- Frontend vitest ผ่าน pre-push hook: 76 ไฟล์ / 593 เทส
- `node scripts/validate-schema-parity.mjs` -> OK
