### PR TITLE
fix: strict-date guards, probation optional-date checks, import equivalence validation, S2/110 golden (F1-F3, F6)

### DIFF
--- a/backend/ImportService.php
+++ b/backend/ImportService.php
@@ -173,8 +173,34 @@ class ImportService
         $this->validateChild($sheets['Diverse'], $citizenIds, 'Diverse', ['qualified_date' => true], $errors);
         $this->validateChild($sheets['Equivalence'], $citizenIds, 'Equivalence', ['approved_total_days' => 'int'], $errors);
         $this->validateChild($sheets['History'], $citizenIds, 'History', ['position_level' => true, 'effective_date' => 'date'], $errors);
+        // F3 (N35): ชีต Equivalence — whitelist approval_status + ตรวจวันอนุมัติ
+        // (status ขยะเดิมถูกกลืนเงียบเพราะ engine นับแค่ APPROVED; วันดิบเข้า DATE เสี่ยง 500 แบบ N17)
+        $this->validateEquivalence($sheets['Equivalence'], $errors);
 
         return $errors;
+    }
+
+    /**
+     * F3 — ตรวจชีต Equivalence เพิ่มจาก validateChild: approval_status ว่างได้
+     * (default APPROVED ใน persist — ไฟล์ import ตรงไม่ผ่าน transition ของ route)
+     * หรือต้องเป็น PENDING/APPROVED/REJECTED (ตรง routes/equivalence.php);
+     * วันอนุมัติว่างได้ แต่ถ้ามีต้องเป็น YYYY-MM-DD
+     *
+     * @param array<int, array<string,string|null>> $rows
+     * @param array<int,string> $errors
+     */
+    private function validateEquivalence(array $rows, array &$errors): void
+    {
+        $allowed = ['PENDING', 'APPROVED', 'REJECTED'];
+        foreach ($rows as $i => $r) {
+            $rowNo = $i + 2;
+            $status = $r['approval_status'] ?? null;
+            if ($status !== null && $status !== '' && !in_array($status, $allowed, true)) {
+                $errors[] = "Equivalence แถว {$rowNo}: approval_status ไม่ถูกต้อง (PENDING/APPROVED/REJECTED)";
+            }
+            $this->checkDate($r['approved_start_date'] ?? null, false, "Equivalence แถว {$rowNo}: approved_start_date", $errors);
+            $this->checkDate($r['approved_end_date'] ?? null, false, "Equivalence แถว {$rowNo}: approved_end_date", $errors);
+        }
     }
 
     /**

--- a/backend/routes/diverse.php
+++ b/backend/routes/diverse.php
@@ -19,9 +19,13 @@ include_once __DIR__ . '/../audit.php';
 /**
  * parse Y-m-d แบบเข้มงวด (ลอก pattern จาก MultiplierEngine.php:224 / supportiveStrictDate)
  * เพื่อไม่ต้อง include engine ทั้งไฟล์ — คืน null ถ้า format ผิดหรือมี overflow
+ * F1: preg guard ให้ตรง probationStrictDate/supportiveStrictDate (กัน '2026-1-15' หลุด)
  */
 function diverseStrictDate(string $value): ?DateTime
 {
+    if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $value)) {
+        return null;
+    }
     $date = DateTime::createFromFormat('Y-m-d|', $value);
     $errors = DateTime::getLastErrors();
     if (

--- a/backend/routes/probation.php
+++ b/backend/routes/probation.php
@@ -69,7 +69,51 @@ function probationUpdateValidationError(array $data, array $existing): ?string
         return 'end_date must be greater than or equal to start_date';
     }
 
+    // F2: final_result_date/extension_end_date อยู่ใน $allowed แต่ไม่เคยถูกตรวจ —
+    // วันที่พัง bind ดิบลง DB (500/ข้อมูลเสีย) จึงตรวจ format ตรงนี้ก่อน bind
+    foreach (['final_result_date', 'extension_end_date'] as $optField) {
+        $optError = probationUpdateOptionalDateError($data, $optField);
+        if ($optError !== null) {
+            return $optError;
+        }
+    }
+
+    // F2: extension ต้องยืดออกไป ไม่ใช่หดกลับ (เทียบกับ end ที่ merge แล้ว;
+    // ไม่มี end ให้เทียบ = ข้าม เหลือแค่ format check ด้านบน)
+    if ($end instanceof DateTime
+        && array_key_exists('extension_end_date', $data)
+        && is_string($data['extension_end_date'])
+        && $data['extension_end_date'] !== ''
+    ) {
+        $ext = probationStrictDate($data['extension_end_date']);
+        if ($ext !== null && $ext < $end) {
+            return 'extension_end_date must be greater than or equal to end_date';
+        }
+    }
+
     return null;
+}
+
+/**
+ * F2 — ตรวจวัน optional ของ PUT พ้นทดลอง (`final_result_date`, `extension_end_date`):
+ * ไม่ส่งมา/`''`/JSON null = ล้างเป็น NULL ได้ (คง contract แถว coerce ใน update);
+ * นอกนั้นต้องเป็น string ผ่าน `probationStrictDate` มิฉะนั้น 400
+ *
+ * @param array<string, mixed> $data
+ */
+function probationUpdateOptionalDateError(array $data, string $field): ?string
+{
+    if (!array_key_exists($field, $data)) {
+        return null;
+    }
+    $val = $data[$field];
+    if ($val === '' || $val === null) {
+        return null;
+    }
+    if (!is_string($val)) {
+        return 'Invalid date format';
+    }
+    return probationStrictDate($val) === null ? 'Invalid date format' : null;
 }
 
 /**

--- a/backend/routes/supportive.php
+++ b/backend/routes/supportive.php
@@ -204,6 +204,10 @@ function supportiveRatioPercent(int|float|string $raw): float
 
 function supportiveStrictDate(string $value): ?DateTime
 {
+    // F1: preg guard ให้ตรง probationStrictDate (กัน '2026-1-15' หลุด)
+    if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $value)) {
+        return null;
+    }
     $date = DateTime::createFromFormat('Y-m-d|', $value);
     $errors = DateTime::getLastErrors();
     if (

--- a/backend/tests/Integration/ImportServiceTest.php
+++ b/backend/tests/Integration/ImportServiceTest.php
@@ -141,6 +141,74 @@ final class ImportServiceTest extends TestCase
         self::assertStringContainsString('เลขบัตรประชาชนไม่ถูกต้อง', implode(' ', $errors));
     }
 
+    /**
+     * F3 — ชีต Equivalence: approval_status นอก whitelist / วันอนุมัติผิด format ต้อง fail
+     * พร้อมข้อความระบุแถว; ค่าว่างผ่าน (default APPROVED / nullable)
+     */
+    #[Test]
+    public function it_rejects_equivalence_with_bad_status_or_dates(): void
+    {
+        $errors = $this->validateSheets([[
+            'citizen_id' => '1100100299013',
+            'actual_position' => 'นักวิชาการ',
+            'equivalent_type' => 'TYPE_A',
+            'approved_total_days' => '400',
+            'approval_status' => 'HACKED',
+            'approved_start_date' => '2019-01-01',
+            'approved_end_date' => '2020-02-05',
+        ]]);
+        self::assertStringContainsString('approval_status', implode(' ', $errors));
+
+        $errors = $this->validateSheets([[
+            'citizen_id' => '1100100299013',
+            'actual_position' => 'นักวิชาการ',
+            'equivalent_type' => 'TYPE_A',
+            'approved_total_days' => '400',
+            'approval_status' => 'APPROVED',
+            'approved_start_date' => '2026-13-40',
+            'approved_end_date' => '',
+        ]]);
+        self::assertStringContainsString('approved_start_date', implode(' ', $errors));
+    }
+
+    #[Test]
+    public function it_accepts_equivalence_with_empty_status_and_dates(): void
+    {
+        $errors = $this->validateSheets([[
+            'citizen_id' => '1100100299013',
+            'actual_position' => 'นักวิชาการ',
+            'equivalent_type' => 'TYPE_A',
+            'approved_total_days' => '400',
+            'approval_status' => '',
+            'approved_start_date' => '',
+            'approved_end_date' => '',
+        ]]);
+        $text = implode(' ', $errors);
+        self::assertStringNotContainsString('approval_status', $text);
+        self::assertStringNotContainsString('approved_start_date', $text);
+        self::assertStringNotContainsString('approved_end_date', $text);
+    }
+
+    /**
+     * @param list<array<string,string>> $equivalenceRows
+     * @return list<string>
+     */
+    private function validateSheets(array $equivalenceRows): array
+    {
+        $svc = new ImportService(self::$pdo);
+        $ref = new \ReflectionMethod($svc, 'validate');
+        $ref->setAccessible(true);
+        return $ref->invoke($svc, [
+            'Personnel' => [[
+                'citizen_id' => '1100100299013', 'first_name' => 'ก', 'last_name' => 'ข',
+                'hire_date' => '2010-01-01', 'current_level_code' => 'K3',
+                'current_level_start_date' => '2020-01-01', 'education_level' => 'MASTER',
+                'org_name' => 'กอง', 'position_name' => 'นักทรัพยากร',
+            ]],
+            'Diverse' => [], 'Equivalence' => $equivalenceRows, 'History' => [],
+        ]);
+    }
+
     #[Test]
     public function it_returns_friendly_error_on_reimport(): void
     {

--- a/backend/tests/Integration/QualificationEngineTest.php
+++ b/backend/tests/Integration/QualificationEngineTest.php
@@ -102,7 +102,9 @@ final class QualificationEngineTest extends TestCase
 
             // --- S2 combination (Excel to-S2 backdate; today หักล้าง → deterministic) ---
             'S2 บต+เทียบ 900ว (AC3 backdate)'          => ['S2', 109, '2020-12-14'],
-            'S2 ทว(K5)+อต/อส 300ว+เทียบ 400ว (AK3)'   => ['S2', 110, '2022-02-01'],
+            // F6: golden เก่าคำนวณด้วย ms 300 แบบ exclusive; #168 เปลี่ยน $msTenure เป็น
+            // inclusive (+1) ตรง computeNetBreakdown → 400+301=701: 2021-01-01−701d=2019-01-31+3y
+            'S2 ทว(K5)+อต/อส 301ว(inclusive)+เทียบ 400ว (AK3)' => ['S2', 110, '2022-01-31'],
             'S2 S1 ไม่มีเทียบ → เฉพาะ W3 (+1ปี)'       => ['S2', 108, '2023-01-01'],
 
             // --- K/O linear (buildBaseQuery) — coverage ใหม่ ไม่เคยมี automated test ---

--- a/backend/tests/Unit/DiverseStrictDateTest.php
+++ b/backend/tests/Unit/DiverseStrictDateTest.php
@@ -28,6 +28,20 @@ final class DiverseStrictDateTest extends TestCase
     }
 
     #[Test]
+    public function unpadded_dates_are_null(): void
+    {
+        // F1: ต้องเข้มเท่า probationStrictDate — ไม่มี zero-pad = format ผิด
+        self::assertNull(diverseStrictDate('2026-1-15'));
+        self::assertNull(diverseStrictDate('2026-01-5'));
+    }
+
+    #[Test]
+    public function datetime_suffix_is_null(): void
+    {
+        self::assertNull(diverseStrictDate('2026-01-15 00:00:00'));
+    }
+
+    #[Test]
     public function create_and_update_do_not_use_loose_datetime(): void
     {
         $src = file_get_contents(__DIR__ . '/../../routes/diverse.php');

--- a/backend/tests/Unit/ProbationUpdateValidationTest.php
+++ b/backend/tests/Unit/ProbationUpdateValidationTest.php
@@ -181,6 +181,75 @@ final class ProbationUpdateValidationTest extends TestCase
     }
 
     #[Test]
+    public function malformed_optional_dates_are_rejected(): void
+    {
+        foreach (['final_result_date', 'extension_end_date'] as $field) {
+            self::assertSame(
+                'Invalid date format',
+                probationUpdateValidationError([$field => 'not-a-date'], self::existing()),
+                $field
+            );
+            self::assertSame(
+                'Invalid date format',
+                probationUpdateValidationError([$field => '2026-02-30'], self::existing()),
+                $field
+            );
+            self::assertSame(
+                'Invalid date format',
+                probationUpdateValidationError([$field => '2026-1-5'], self::existing()),
+                $field
+            );
+            self::assertSame(
+                'Invalid date format',
+                probationUpdateValidationError([$field => ['x']], self::existing()),
+                $field
+            );
+        }
+    }
+
+    #[Test]
+    public function empty_or_missing_optional_dates_are_allowed(): void
+    {
+        foreach (['final_result_date', 'extension_end_date'] as $field) {
+            self::assertNull(probationUpdateValidationError([$field => ''], self::existing()), $field);
+            self::assertNull(probationUpdateValidationError([$field => null], self::existing()), $field);
+        }
+        self::assertNull(probationUpdateValidationError(
+            ['final_result_date' => '2026-08-01', 'extension_end_date' => '2026-09-01'],
+            self::existing()
+        ));
+    }
+
+    #[Test]
+    public function extension_end_before_end_is_rejected(): void
+    {
+        self::assertSame(
+            'extension_end_date must be greater than or equal to end_date',
+            probationUpdateValidationError(['extension_end_date' => '2026-06-01'], self::existing())
+        );
+    }
+
+    #[Test]
+    public function extension_end_equal_to_end_is_allowed(): void
+    {
+        self::assertNull(probationUpdateValidationError(
+            ['extension_end_date' => '2026-07-01'],
+            self::existing()
+        ));
+    }
+
+    #[Test]
+    public function extension_without_resolvable_end_skips_range_check(): void
+    {
+        $existing = self::existing();
+        $existing['end_date'] = null;
+        self::assertNull(probationUpdateValidationError(
+            ['extension_end_date' => '2026-01-01'],
+            $existing
+        ));
+    }
+
+    #[Test]
     public function update_source_calls_validator(): void
     {
         $src = file_get_contents(__DIR__ . '/../../routes/probation.php');

--- a/backend/tests/Unit/SupportiveStrictDateTest.php
+++ b/backend/tests/Unit/SupportiveStrictDateTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use DateTime;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../routes/supportive.php';
+
+/**
+ * F1 — supportiveStrictDate ต้องเข้มเท่า probationStrictDate
+ * (preg guard กันวันที่ไม่ pad-zero หลุด, mirror DiverseStrictDateTest)
+ */
+final class SupportiveStrictDateTest extends TestCase
+{
+    #[Test]
+    public function malformed_and_overflow_are_null(): void
+    {
+        self::assertNull(supportiveStrictDate('abc'));
+        self::assertNull(supportiveStrictDate('2026-02-30'));
+    }
+
+    #[Test]
+    public function valid_date_is_datetime(): void
+    {
+        $d = supportiveStrictDate('2026-01-15');
+        self::assertInstanceOf(DateTime::class, $d);
+        self::assertSame('2026-01-15', $d->format('Y-m-d'));
+    }
+
+    #[Test]
+    public function unpadded_dates_are_null(): void
+    {
+        self::assertNull(supportiveStrictDate('2026-1-15'));
+        self::assertNull(supportiveStrictDate('2026-01-5'));
+    }
+
+    #[Test]
+    public function datetime_suffix_is_null(): void
+    {
+        self::assertNull(supportiveStrictDate('2026-01-15 00:00:00'));
+    }
+}


### PR DESCRIPTION
## สรุป (Summary)

ปิด follow-up findings ค้างจากรอบ 2026-09-08 ผ่าน workflow `codebase-review-fix`
(binding spec `.claude/PRPs/findings/codebase-review-fix-20260910-findings.md`,
PRD/PRP + gate `prp-validate-plan` READY 10/10 — รอบแรก NOT READY แล้ว revise 1 loop):

- **F1** — `preg_match` guard ใน `diverseStrictDate`/`supportiveStrictDate` ให้เข้มเท่า
  `probationStrictDate` (กัน `2026-1-15`/`... 00:00:00` หลุด)
- **F2** — probation PUT ตรวจ `final_result_date`/`extension_end_date` (format + กฎใหม่
  `extension>=end`); `''`/JSON null ยังล้างเป็น NULL ตาม contract เดิม
- **F3 (= N35)** — ImportService ชีต Equivalence: whitelist `approval_status`
  (PENDING/APPROVED/REJECTED, ว่างได้ = default APPROVED) + `checkDate` วันอนุมัติ
- **F6 (NEW)** — golden S2/110 `2022-02-01` -> `2022-01-31`: สืบจบแล้วว่า engine ถูก
  (#168 เปลี่ยน `$msTenure` เป็น inclusive แต่ลืมแก้ golden; 400+301=701 วัน);
  ไม่แตะ engine/seed

ไม่ทำรอบนี้ (ผู้ใช้ยืนยัน): N30 (quota นอก repo), N60 (migration เสี่ยง)

## API / Schema

- ไม่แตะ schema/migration/`tidb-init.sql` (parity gate ผ่าน)
- HTTP contract: input ที่เคยหลุดผ่านตอนนี้ได้ 400/fail-closed พร้อมข้อความเดิม/ไทยระบุแถว;
  ไม่เปลี่ยน business rule การนับวัน

## Verification

- เทสใหม่/ต่อเติม 13 เคส; full backend suite **517 เทส 0 fail** (fail S2/110 เดิมหายไป)
- `node scripts/validate-schema-parity.mjs` -> OK
- pre-push hook: frontend vitest 76 ไฟล์ / 593 เทส + backend Unit 354 เทส ผ่าน
- Step 10: code + security review ขนาน PASS/PASS (ไม่มีประเด็น block)
