### PR TITLE
fix: per-field date validation (diverse), string-input guards (supportive), strict dates (equivalence) (U1-U4)

### DIFF
--- a/backend/routes/diverse.php
+++ b/backend/routes/diverse.php
@@ -38,6 +38,32 @@ function diverseStrictDate(string $value): ?DateTime
 }
 
 /**
+ * U1 — ตรวจวันรายฟิลด์ (create/update): ฟิลด์วันที่ที่ส่งมาและไม่ว่างต้อง parse เข้มผ่าน
+ * ปิดช่อง single-sided (ส่งข้างเดียวผิด format แล้วอีกข้างว่าง = ข้ามบล็อกคู่แล้ว bind ดิบลง DB)
+ *
+ * @param array<string,mixed> $data
+ * @param list<string> $fields
+ */
+function diverseDateFieldError(mixed $data, array $fields): ?string
+{
+    if (!is_array($data)) {
+        return 'รูปแบบข้อมูลไม่ถูกต้อง';
+    }
+    foreach ($fields as $field) {
+        if (!array_key_exists($field, $data) || $data[$field] === '' || $data[$field] === null) {
+            continue;
+        }
+        if (!is_string($data[$field]) || diverseStrictDate($data[$field]) === null) {
+            return 'รูปแบบวันที่ไม่ถูกต้อง';
+        }
+    }
+    return null;
+}
+
+/** @var list<string> ฟิลด์วันที่ของ diverse ที่ต้องผ่าน strict parse เมื่อส่งมา */
+const DIVERSE_DATE_FIELDS = ['from_start_date', 'from_end_date', 'to_start_date', 'to_end_date'];
+
+/**
  * จัดการ request สำหรับ diverse experience endpoints
  *
  * @param PDO $pdo Database connection
@@ -240,6 +266,14 @@ function createDiverse(PDO $pdo, array $user, ?array $input = null): void
         return;
     }
 
+    // U1: ตรวจวันรายฟิลด์ก่อน (กัน single-sided ผิด format หลุดไป bind ดิบ)
+    $dateError = diverseDateFieldError($data, DIVERSE_DATE_FIELDS);
+    if ($dateError !== null) {
+        http_response_code(400);
+        echo json_encode(['error' => $dateError]);
+        return;
+    }
+
     $fromTotalDays = null;
     if (!empty($data['from_start_date']) && !empty($data['from_end_date'])) {
         $fromStart = diverseStrictDate((string) $data['from_start_date']);
@@ -360,6 +394,14 @@ function updateDiverse(PDO $pdo, int $id, array $user, ?array $input = null): vo
     }
 
     $data = $input ?? json_decode(file_get_contents('php://input'), true);
+
+    // U1: ตรวจวันรายฟิลด์ที่ส่งมาก่อน (เฉพาะค่าที่ส่งมา ไม่แตะค่าจาก DB)
+    $dateError = diverseDateFieldError($data, DIVERSE_DATE_FIELDS);
+    if ($dateError !== null) {
+        http_response_code(400);
+        echo json_encode(['error' => $dateError]);
+        return;
+    }
 
     // Allowed fields — ไม่รวม diff_count (GENERATED column)
     $allowed = [

--- a/backend/routes/equivalence.php
+++ b/backend/routes/equivalence.php
@@ -224,12 +224,14 @@ function createEquivalence(PDO $pdo, array $user, ?array $input = null): void
     }
 
     // คำนวณ request_total_days จากวันที่เริ่มต้นและสิ้นสุด (DATEDIFF+1)
+    // U3: parse เข้ม (กัน format หลวม + non-string ที่เคยทำ TypeError 500)
     $requestTotalDays = null;
     if (!empty($data['request_start_date']) && !empty($data['request_end_date'])) {
-        try {
-            $startDate = new DateTime($data['request_start_date']);
-            $endDate = new DateTime($data['request_end_date']);
-        } catch (Exception $e) {
+        $startDate = is_string($data['request_start_date'])
+            ? equivalenceStrictDate($data['request_start_date']) : null;
+        $endDate = is_string($data['request_end_date'])
+            ? equivalenceStrictDate($data['request_end_date']) : null;
+        if ($startDate === null || $endDate === null) {
             http_response_code(400);
             echo json_encode(['error' => 'รูปแบบวันที่ไม่ถูกต้อง']);
             return;
@@ -284,13 +286,36 @@ function createEquivalence(PDO $pdo, array $user, ?array $input = null): void
  *   - คำนวณ request_total_days ใหม่หากเปลี่ยนวันที่
  */
 /**
+ * U3 — parse Y-m-d แบบเข้ม (mirror probationStrictDate) — คืน null ถ้า format ผิดหรือ overflow
+ * (กัน '2026-1-15'/datetime suffix หลุดผ่าน new DateTime ตรง ๆ)
+ */
+function equivalenceStrictDate(string $value): ?DateTime
+{
+    if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $value)) {
+        return null;
+    }
+    $date = DateTime::createFromFormat('Y-m-d|', $value);
+    $errors = DateTime::getLastErrors();
+    if (
+        $date === false
+        || ($errors !== false && ($errors['warning_count'] > 0 || $errors['error_count'] > 0))
+    ) {
+        return null;
+    }
+    return $date;
+}
+
+/**
  * Inclusive day count for an approved date range.
  * Throws InvalidArgumentException when end < start (message matches MultiplierEngine.php:20).
  */
 function approvedRangeTotalDays(string $start, string $end): int
 {
-    $approvedStart = new DateTime($start);
-    $approvedEnd = new DateTime($end);
+    $approvedStart = equivalenceStrictDate($start);
+    $approvedEnd = equivalenceStrictDate($end);
+    if ($approvedStart === null || $approvedEnd === null) {
+        throw new InvalidArgumentException('รูปแบบวันที่ไม่ถูกต้อง');
+    }
     if ($approvedEnd < $approvedStart) {
         throw new InvalidArgumentException('วันสิ้นสุดต้องไม่น้อยกว่าวันเริ่มต้น');
     }
@@ -429,10 +454,10 @@ function updateEquivalence(PDO $pdo, int $id, array $user, ?array $input = null)
     $startDate = $data['request_start_date'] ?? $current['request_start_date'];
     $endDate = $data['request_end_date'] ?? $current['request_end_date'];
     if ((isset($data['request_start_date']) || isset($data['request_end_date'])) && !empty($startDate) && !empty($endDate)) {
-        try {
-            $start = new DateTime($startDate);
-            $end = new DateTime($endDate);
-        } catch (Exception $e) {
+        // U3: parse เข้ม (กัน format หลวม + non-string ที่เคยทำ TypeError 500)
+        $start = is_string($startDate) ? equivalenceStrictDate($startDate) : null;
+        $end = is_string($endDate) ? equivalenceStrictDate($endDate) : null;
+        if ($start === null || $end === null) {
             http_response_code(400);
             echo json_encode(['error' => 'รูปแบบวันที่ไม่ถูกต้อง']);
             return;

--- a/backend/routes/supportive.php
+++ b/backend/routes/supportive.php
@@ -202,6 +202,23 @@ function supportiveRatioPercent(int|float|string $raw): float
     return (float) $raw;
 }
 
+/**
+ * U2 — ฟิลด์ string ที่ส่งมาต้องเป็น string จริง (กัน array จาก JSON ทำ TypeError 500
+ * ใน computeSupportiveFields ที่รับ string) — ข้ามค่าที่ไม่ส่งมา/null
+ *
+ * @param array<string,mixed> $data
+ * @param list<string> $fields
+ */
+function supportiveStringFieldError(array $data, array $fields): ?string
+{
+    foreach ($fields as $field) {
+        if (array_key_exists($field, $data) && $data[$field] !== null && !is_string($data[$field])) {
+            return 'รูปแบบข้อมูลไม่ถูกต้อง';
+        }
+    }
+    return null;
+}
+
 function supportiveStrictDate(string $value): ?DateTime
 {
     // F1: preg guard ให้ตรง probationStrictDate (กัน '2026-1-15' หลุด)
@@ -308,6 +325,17 @@ function createSupportive(PDO $pdo, array $user, ?array $input = null): void
         return;
     }
 
+    // U2: string fields ต้องเป็น string จริง (กัน array จาก JSON ทำ TypeError 500)
+    $typeError = supportiveStringFieldError(
+        $data,
+        ['start_date', 'end_date', 'job_series_name', 'primary_series_name']
+    );
+    if ($typeError !== null) {
+        http_response_code(400);
+        echo json_encode(['error' => $typeError], JSON_UNESCAPED_UNICODE);
+        return;
+    }
+
     // Server-side computation (D-05, D-06, D-07, SE-04)
     // วันที่ malformed หรือ end < start → 400 (message มาจาก InvalidArgumentException)
     try {
@@ -407,6 +435,18 @@ function updateSupportive(PDO $pdo, int $id, array $user, ?array $input = null):
                       || isset($data['job_series_name']) || isset($data['primary_series_name']);
 
     if ($needsRecompute) {
+        // U2: กัน array จาก JSON ทำ TypeError 500 (ตรวจเฉพาะค่าที่ส่งมา; null = ไม่ส่งมา)
+        if (is_array($data)) {
+            $typeError = supportiveStringFieldError(
+                $data,
+                ['start_date', 'end_date', 'job_series_name', 'primary_series_name']
+            );
+            if ($typeError !== null) {
+                http_response_code(400);
+                echo json_encode(['error' => $typeError], JSON_UNESCAPED_UNICODE);
+                return;
+            }
+        }
         $startDate = $data['start_date'] ?? $existing['start_date'];
         $endDate = $data['end_date'] ?? $existing['end_date'];
         $jobSeriesName = $data['job_series_name'] ?? $existing['job_series_name'];

--- a/backend/tests/Integration/ImportServiceTest.php
+++ b/backend/tests/Integration/ImportServiceTest.php
@@ -183,10 +183,8 @@ final class ImportServiceTest extends TestCase
             'approved_start_date' => '',
             'approved_end_date' => '',
         ]]);
-        $text = implode(' ', $errors);
-        self::assertStringNotContainsString('approval_status', $text);
-        self::assertStringNotContainsString('approved_start_date', $text);
-        self::assertStringNotContainsString('approved_end_date', $text);
+        // U4: assert ให้แน่น — fixture นี้ต้องไม่มี error ใด ๆ เลย ไม่ใช่แค่ไม่มี 3 กลุ่มนี้
+        self::assertEmpty($errors, 'unexpected errors: ' . implode(' | ', $errors));
     }
 
     /**

--- a/backend/tests/Unit/DiverseDateFieldTest.php
+++ b/backend/tests/Unit/DiverseDateFieldTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../routes/diverse.php';
+
+/**
+ * U1 — diverseDateFieldError: ฟิลด์วันที่ที่ส่งมาและไม่ว่างต้อง parse เข้มผ่าน
+ * (ปิดช่อง single-sided ที่ข้ามบล็อกคู่แล้ว bind ดิบ)
+ */
+final class DiverseDateFieldTest extends TestCase
+{
+    #[Test]
+    public function missing_or_empty_fields_are_allowed(): void
+    {
+        self::assertNull(diverseDateFieldError([], DIVERSE_DATE_FIELDS));
+        self::assertNull(diverseDateFieldError([
+            'from_start_date' => '',
+            'to_end_date' => null,
+        ], DIVERSE_DATE_FIELDS));
+    }
+
+    #[Test]
+    public function valid_dates_are_allowed(): void
+    {
+        self::assertNull(diverseDateFieldError([
+            'from_start_date' => '2020-01-01',
+            'from_end_date' => '2020-12-31',
+            'to_start_date' => '2021-01-01',
+            'to_end_date' => '2021-06-30',
+        ], DIVERSE_DATE_FIELDS));
+    }
+
+    #[Test]
+    public function single_sided_malformed_date_is_rejected(): void
+    {
+        // ช่องโหว่เดิม: ส่งข้างเดียว อีกข้างว่าง = ข้ามบล็อกคู่แล้ว bind ดิบ
+        self::assertSame(
+            'รูปแบบวันที่ไม่ถูกต้อง',
+            diverseDateFieldError(['from_start_date' => 'not-a-date'], DIVERSE_DATE_FIELDS)
+        );
+        self::assertSame(
+            'รูปแบบวันที่ไม่ถูกต้อง',
+            diverseDateFieldError(['to_end_date' => '2026-02-30'], DIVERSE_DATE_FIELDS)
+        );
+        self::assertSame(
+            'รูปแบบวันที่ไม่ถูกต้อง',
+            diverseDateFieldError(['from_start_date' => '2026-1-15'], DIVERSE_DATE_FIELDS)
+        );
+    }
+
+    #[Test]
+    public function non_string_date_is_rejected(): void
+    {
+        self::assertSame(
+            'รูปแบบวันที่ไม่ถูกต้อง',
+            diverseDateFieldError(['from_start_date' => ['x']], DIVERSE_DATE_FIELDS)
+        );
+    }
+
+    #[Test]
+    public function non_array_body_is_rejected(): void
+    {
+        self::assertSame('รูปแบบข้อมูลไม่ถูกต้อง', diverseDateFieldError(null, DIVERSE_DATE_FIELDS));
+        self::assertSame('รูปแบบข้อมูลไม่ถูกต้อง', diverseDateFieldError('x', DIVERSE_DATE_FIELDS));
+    }
+
+    #[Test]
+    public function create_source_validates_dates_before_insert(): void
+    {
+        $src = file_get_contents(__DIR__ . '/../../routes/diverse.php');
+        self::assertIsString($src);
+        $start = strpos($src, 'function createDiverse');
+        self::assertNotFalse($start);
+        $end = strpos($src, 'function updateDiverse', $start);
+        $fn = substr($src, $start, $end - $start);
+        self::assertStringContainsString('diverseDateFieldError($data, DIVERSE_DATE_FIELDS)', $fn);
+    }
+
+    #[Test]
+    public function update_source_validates_dates_before_update(): void
+    {
+        $src = file_get_contents(__DIR__ . '/../../routes/diverse.php');
+        self::assertIsString($src);
+        $start = strpos($src, 'function updateDiverse');
+        self::assertNotFalse($start);
+        $end = strpos($src, 'function deleteDiverse', $start);
+        $fn = substr($src, $start, $end - $start);
+        self::assertStringContainsString('diverseDateFieldError($data, DIVERSE_DATE_FIELDS)', $fn);
+    }
+}

--- a/backend/tests/Unit/EquivalenceApprovedRangeTest.php
+++ b/backend/tests/Unit/EquivalenceApprovedRangeTest.php
@@ -25,4 +25,13 @@ final class EquivalenceApprovedRangeTest extends TestCase
     {
         self::assertSame(31, approvedRangeTotalDays('2026-01-01', '2026-01-31'));
     }
+
+    #[Test]
+    public function malformed_date_throws_invalid_format(): void
+    {
+        // U3: strict parse — วันที่หลวมต้อง 400 (InvalidArgumentException) ไม่ใช่ TypeError 500
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('รูปแบบวันที่ไม่ถูกต้อง');
+        approvedRangeTotalDays('2026-1-15', '2026-01-31');
+    }
 }

--- a/backend/tests/Unit/EquivalenceStrictDateTest.php
+++ b/backend/tests/Unit/EquivalenceStrictDateTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use DateTime;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../routes/equivalence.php';
+
+/**
+ * U3 — equivalenceStrictDate ต้องเข้มเท่า probationStrictDate
+ * (mirror DiverseStrictDateTest/SupportiveStrictDateTest)
+ */
+final class EquivalenceStrictDateTest extends TestCase
+{
+    #[Test]
+    public function malformed_and_overflow_are_null(): void
+    {
+        self::assertNull(equivalenceStrictDate('abc'));
+        self::assertNull(equivalenceStrictDate('2026-02-30'));
+    }
+
+    #[Test]
+    public function valid_date_is_datetime(): void
+    {
+        $d = equivalenceStrictDate('2026-01-15');
+        self::assertInstanceOf(DateTime::class, $d);
+        self::assertSame('2026-01-15', $d->format('Y-m-d'));
+    }
+
+    #[Test]
+    public function unpadded_dates_are_null(): void
+    {
+        self::assertNull(equivalenceStrictDate('2026-1-15'));
+        self::assertNull(equivalenceStrictDate('2026-01-5'));
+    }
+
+    #[Test]
+    public function datetime_suffix_is_null(): void
+    {
+        self::assertNull(equivalenceStrictDate('2026-01-15 00:00:00'));
+    }
+}

--- a/backend/tests/Unit/SupportiveStringFieldTest.php
+++ b/backend/tests/Unit/SupportiveStringFieldTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../routes/supportive.php';
+
+/**
+ * U2 — supportiveStringFieldError: ฟิลด์ string ที่ส่งมาต้องเป็น string จริง
+ * (กัน array จาก JSON ทำ TypeError 500 ใน computeSupportiveFields)
+ */
+final class SupportiveStringFieldTest extends TestCase
+{
+    private const FIELDS = ['start_date', 'end_date', 'job_series_name', 'primary_series_name'];
+
+    #[Test]
+    public function missing_or_null_fields_are_allowed(): void
+    {
+        self::assertNull(supportiveStringFieldError([], self::FIELDS));
+        self::assertNull(supportiveStringFieldError(['primary_series_name' => null], self::FIELDS));
+    }
+
+    #[Test]
+    public function valid_strings_are_allowed(): void
+    {
+        self::assertNull(supportiveStringFieldError([
+            'start_date' => '2020-01-01',
+            'end_date' => '2020-12-31',
+            'job_series_name' => 'วิชาการ',
+            'primary_series_name' => 'อำนวยการ',
+        ], self::FIELDS));
+    }
+
+    #[Test]
+    public function array_values_are_rejected(): void
+    {
+        self::assertSame(
+            'รูปแบบข้อมูลไม่ถูกต้อง',
+            supportiveStringFieldError(['start_date' => ['2020-01-01']], self::FIELDS)
+        );
+        self::assertSame(
+            'รูปแบบข้อมูลไม่ถูกต้อง',
+            supportiveStringFieldError(['job_series_name' => ['x']], self::FIELDS)
+        );
+    }
+
+    #[Test]
+    public function int_values_are_rejected(): void
+    {
+        self::assertSame(
+            'รูปแบบข้อมูลไม่ถูกต้อง',
+            supportiveStringFieldError(['end_date' => 20200101], self::FIELDS)
+        );
+    }
+
+    #[Test]
+    public function create_and_update_call_the_guard(): void
+    {
+        $src = file_get_contents(__DIR__ . '/../../routes/supportive.php');
+        self::assertIsString($src);
+
+        $start = strpos($src, 'function createSupportive');
+        self::assertNotFalse($start);
+        $end = strpos($src, 'function updateSupportive', $start);
+        self::assertNotFalse($end);
+        self::assertStringContainsString(
+            'supportiveStringFieldError(',
+            substr($src, $start, $end - $start)
+        );
+
+        $start = $end;
+        $end = strpos($src, "\nfunction ", $start + 10);
+        $fn = $end === false ? substr($src, $start) : substr($src, $start, $end - $start);
+        self::assertStringContainsString('supportiveStringFieldError(', $fn);
+    }
+}


### PR DESCRIPTION
## สรุป (Summary)

เก็บ follow-up ไม่ block 4 ข้อจาก Step-10 review ของรอบ F1-F3/F6 (ทั้งหมด fail-closed 400):

- **U1** — `diverseDateFieldError()` helper ใหม่ ตรวจวันรายฟิลด์ใน create/update
  ปิดช่อง single-sided (ส่งข้างเดียวผิด format แล้วอีกข้างว่าง = ข้ามบล็อกคู่แล้ว bind ดิบ)
- **U2** — `supportiveStringFieldError()` กัน array จาก JSON ทำ TypeError 500
  ใน `computeSupportiveFields` ทั้ง create/update → 400
- **U3** — `equivalenceStrictDate()` (mirror probationStrictDate) แทน `new DateTime`
  3 จุด: create/update request dates + `approvedRangeTotalDays`
- **U4** — `assertEmpty` แทน 3x not-contains ใน ImportServiceTest

## API / Schema

- ไม่แตะ schema/migration (parity gate ผ่าน)
- HTTP contract: input ผิดที่เคยหลุด/500 ตอนนี้ได้ 400 พร้อมข้อความเดิม;
  ไม่เปลี่ยน business rule ใด ๆ (create diverse ไม่เช็ค end น้อยกว่า start — คงพฤติกรรมเดิม)

## Verification

- เทสใหม่ 17 เคส (DiverseDateField 7, SupportiveStringField 5, EquivalenceStrictDate 4, range +1);
  full backend suite **534 เทส 0 fail**; parity exit 0
- pre-push hook: frontend vitest 76 ไฟล์ / 593 เทส + backend Unit 371 เทส ผ่าน
