### PR TITLE
fix!: rename stale servant_id columns to personnel_id (N60)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,6 +248,7 @@ jobs:
             -v "$PWD/database/29-ensure-probation-view-prefixes.sql:/docker-entrypoint-initdb.d/29-ensure-probation-view-prefixes.sql" \
             -v "$PWD/database/30-photo-blob-storage.sql:/docker-entrypoint-initdb.d/30-photo-blob-storage.sql" \
             -v "$PWD/database/31-csp-violation-daily.sql:/docker-entrypoint-initdb.d/31-csp-violation-daily.sql" \
+            -v "$PWD/database/32-rename-servant-id.sql:/docker-entrypoint-initdb.d/32-rename-servant-id.sql" \
             mysql:8.0
 
       - name: Wait for schema init to finish

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -279,7 +279,7 @@ Pure PHP REST API with no framework.
 - PHP variables: camelCase (e.g., `$method`, `$path`, `$token`, `$data`, `$email`, `$password`)
 - Not explicitly used in this codebase (Vue 3/PHP)
 - Props object keys: camelCase (e.g., `status`, `label`, `requiresAuth`)
-- Response payload keys: snake_case from backend, accessed via destructuring (e.g., `servant_id`, `file_name`, `is_active`)
+- Response payload keys: snake_case from backend, accessed via destructuring (e.g., `personnel_id`, `file_name`, `is_active`)
 ## Code Style
 - No explicit linter/formatter configured
 - Indentation: 2 spaces observed in Vue/JS files

--- a/backend/api.php
+++ b/backend/api.php
@@ -198,7 +198,7 @@ switch ($path[0]) {
         if ($id) {
             // GET /profile/{id} — ข้อมูลข้าราชการรายบุคคล
             $stmt = $pdo->prepare(
-                "SELECT p.personnel_id AS servant_id, p.employee_id, p.first_name, p.last_name,
+                "SELECT p.personnel_id, p.employee_id, p.first_name, p.last_name,
                         p.birth_date, p.appointment_date, p.retirement_date,
                         p.servant_status, p.is_active,
                         CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name,
@@ -206,7 +206,7 @@ switch ($path[0]) {
                  FROM personnel p
                  LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id
                  LEFT JOIN civil_servant_photos csp
-                     ON p.personnel_id = csp.servant_id AND csp.is_primary = 1
+                     ON p.personnel_id = csp.personnel_id AND csp.is_primary = 1
                  WHERE p.personnel_id = ?"
             );
             $stmt->execute([$id]);
@@ -307,19 +307,19 @@ switch ($path[0]) {
     case 'photos':
         if ($method == 'POST') {
             requirePermission('create', 'photos');
-            $servant_id = intval($_POST['servant_id'] ?? 0);
+            $personnelId = intval($_POST['personnel_id'] ?? 0);
             $file = $_FILES['photo'] ?? null;
 
-            if ($servant_id <= 0 || !is_array($file)) {
+            if ($personnelId <= 0 || !is_array($file)) {
                 http_response_code(400);
                 echo json_encode(['error' => 'Invalid upload request']);
                 break;
             }
 
             // N37: pre-check personnel ก่อนรับไฟล์ (pattern เดียวกับ probation) —
-            // servant_id ที่ไม่มีจริงเดิม INSERT แล้วโยน FK/PD ที่ทำ store ระเบิดเป็น 500
+            // personnel_id ที่ไม่มีจริงเดิม INSERT แล้วโยน FK/PD ที่ทำ store ระเบิดเป็น 500
             $pdo = getDB();
-            if (!personnelExists($pdo, $servant_id)) {
+            if (!personnelExists($pdo, $personnelId)) {
                 http_response_code(404);
                 echo json_encode(['error' => 'Personnel not found']);
                 break;
@@ -386,7 +386,7 @@ switch ($path[0]) {
 
             try {
                 include_once __DIR__ . '/routes/photos.php';
-                $stored = storePhotoRecord($pdo, $servant_id, $safeFileName, $web_path, $bytes, $mimeType);
+                $stored = storePhotoRecord($pdo, $personnelId, $safeFileName, $web_path, $bytes, $mimeType);
 
                 // N37: บันทึก audit — เดิม POST /photos ไม่เข้า audit log เลย
                 logAudit(
@@ -396,7 +396,7 @@ switch ($path[0]) {
                     'civil_servant_photos',
                     (int) $stored['photo_id'],
                     null,
-                    ['servant_id' => $servant_id, 'file_name' => $safeFileName, 'mime_type' => $mimeType]
+                    ['personnel_id' => $personnelId, 'file_name' => $safeFileName, 'mime_type' => $mimeType]
                 );
 
                 echo json_encode([
@@ -416,7 +416,7 @@ switch ($path[0]) {
 
     case 'civil-servants':
         $pdo = getDB();
-        $servantId = isset($path[1]) ? intval($path[1]) : 0;
+        $personnelId = isset($path[1]) ? intval($path[1]) : 0;
 
         if ($method == 'GET') {
             requirePermission('read', 'personnel');
@@ -428,7 +428,7 @@ switch ($path[0]) {
             $offset = intval($_GET['offset'] ?? 0);
 
             echo json_encode(legacyCivilServantsList($pdo, $role, $search, $limit, $offset));
-        } elseif ($method === 'DELETE' && $servantId > 0) {
+        } elseif ($method === 'DELETE' && $personnelId > 0) {
             // Soft-delete: ปิดใช้งานบุคลากร (ออกจากรายชื่อ candidates ที่กรอง is_active=1)
             requirePermission('delete', 'personnel');
             // ขั้น 10 S1: SELECT FOR UPDATE → UPDATE → audit ใน transaction เดียว (pattern N13)
@@ -440,7 +440,7 @@ switch ($path[0]) {
                      FROM personnel WHERE personnel_id = ?' .
                     ($pdo->getAttribute(PDO::ATTR_DRIVER_NAME) === 'mysql' ? ' FOR UPDATE' : '')
                 );
-                $beforeStmt->execute([$servantId]);
+                $beforeStmt->execute([$personnelId]);
                 $beforeRow = $beforeStmt->fetch(PDO::FETCH_ASSOC);
                 // F15/N40: ไม่พบ row → 404; ปิดใช้งานอยู่แล้ว → 409 — ไม่เขียน audit
                 // (citizen_id ไม่เข้า audit เพราะเป็น PII)
@@ -459,7 +459,7 @@ switch ($path[0]) {
                 $stmt = $pdo->prepare(
                     'UPDATE personnel SET is_active = 0 WHERE personnel_id = ? AND is_active = 1'
                 );
-                $stmt->execute([$servantId]);
+                $stmt->execute([$personnelId]);
                 if ($stmt->rowCount() === 0) {
                     // กันระดับ isolation ที่ SELECT FOR UPDATE ไม่พอ (แผน B) — rowCount=0 = ไม่มีการเปลี่ยน
                     $pdo->rollBack();
@@ -472,7 +472,7 @@ switch ($path[0]) {
                     (int) (getAuthenticatedUser()['user_id'] ?? 0),
                     'DELETE',
                     'personnel',
-                    $servantId,
+                    $personnelId,
                     $beforeRow,
                     array_merge($beforeRow, ['is_active' => 0])
                 );

--- a/backend/routes/awards.php
+++ b/backend/routes/awards.php
@@ -63,14 +63,14 @@ function handleAwards(PDO $pdo, string $method, array $path): void
     }
 }
 
-const AWARD_SELECT = "a.award_id, a.servant_id, a.award_name, a.award_type,
+const AWARD_SELECT = "a.award_id, a.personnel_id, a.award_name, a.award_type,
                       a.award_level, a.awarded_date, a.description, a.created_at,
-                      CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS servant_name";
+                      CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS personnel_name";
 
 function awardBaseQuery(): string
 {
     return "FROM awards a
-            LEFT JOIN personnel p ON a.servant_id = p.personnel_id
+            LEFT JOIN personnel p ON a.personnel_id = p.personnel_id
             LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id";
 }
 
@@ -130,7 +130,7 @@ function getAwardDetail(PDO $pdo, int $id): void
 function validateAwardPayload(array $data, bool $requireCore): array
 {
     if ($requireCore) {
-        foreach (['servant_id', 'award_name'] as $field) {
+        foreach (['personnel_id', 'award_name'] as $field) {
             if (!isset($data[$field]) || $data[$field] === '') {
                 return [null, "กรุณาระบุข้อมูล: {$field}"];
             }
@@ -171,19 +171,19 @@ function createAward(PDO $pdo, ?array $auth): void
         return;
     }
 
-    $servantId = intval($valid['servant_id']);
-    if (!personnelExists($pdo, $servantId)) {
+    $personnelId = intval($valid['personnel_id']);
+    if (!personnelExists($pdo, $personnelId)) {
         http_response_code(404);
         echo json_encode(['error' => 'ไม่พบบุคลากรตามรหัสที่ระบุ']);
         return;
     }
 
     $stmt = $pdo->prepare(
-        "INSERT INTO awards (servant_id, award_name, award_type, award_level, awarded_date, description)
+        "INSERT INTO awards (personnel_id, award_name, award_type, award_level, awarded_date, description)
          VALUES (?, ?, ?, ?, ?, ?)"
     );
     $stmt->execute([
-        $servantId,
+        $personnelId,
         trim($valid['award_name']),
         $valid['award_type'] ?? 'general',
         ($valid['award_level'] ?? '') !== '' ? $valid['award_level'] : null,
@@ -193,7 +193,7 @@ function createAward(PDO $pdo, ?array $auth): void
 
     $newId = intval($pdo->lastInsertId());
     logAudit($pdo, intval($auth['user_id']), 'CREATE', 'awards', $newId, null, [
-        'servant_id' => intval($valid['servant_id']),
+        'personnel_id' => intval($valid['personnel_id']),
         'award_name' => trim($valid['award_name']),
         'award_type' => $valid['award_type'] ?? 'general',
     ]);
@@ -224,7 +224,7 @@ function updateAward(PDO $pdo, int $id, ?array $auth): void
 
     $fields = [];
     $params = [];
-    $editable = ['servant_id', 'award_name', 'award_type', 'award_level', 'awarded_date', 'description'];
+    $editable = ['personnel_id', 'award_name', 'award_type', 'award_level', 'awarded_date', 'description'];
     foreach ($editable as $col) {
         if (array_key_exists($col, $valid)) {
             $fields[] = "{$col} = ?";
@@ -232,7 +232,7 @@ function updateAward(PDO $pdo, int $id, ?array $auth): void
             if (in_array($col, ['award_level', 'awarded_date'], true) && $value === '') {
                 $value = null;
             }
-            if ($col === 'servant_id') {
+            if ($col === 'personnel_id') {
                 $value = intval($value);
                 if (!personnelExists($pdo, $value)) {
                     http_response_code(404);

--- a/backend/routes/decorations.php
+++ b/backend/routes/decorations.php
@@ -60,14 +60,14 @@ function handleDecorations(PDO $pdo, string $method, array $path): void
     }
 }
 
-const DECORATION_SELECT = "d.decoration_id, d.servant_id, d.decoration_name, d.decoration_class,
+const DECORATION_SELECT = "d.decoration_id, d.personnel_id, d.decoration_name, d.decoration_class,
                            d.received_year, d.gazette_ref, d.description, d.created_at,
-                           CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS servant_name";
+                           CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS personnel_name";
 
 function decorationBaseQuery(): string
 {
     return "FROM royal_decorations d
-            LEFT JOIN personnel p ON d.servant_id = p.personnel_id
+            LEFT JOIN personnel p ON d.personnel_id = p.personnel_id
             LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id";
 }
 
@@ -124,7 +124,7 @@ function getDecorationDetail(PDO $pdo, int $id): void
 function validateDecorationPayload(array $data, bool $requireCore): array
 {
     if ($requireCore) {
-        foreach (['servant_id', 'decoration_name'] as $field) {
+        foreach (['personnel_id', 'decoration_name'] as $field) {
             if (!isset($data[$field]) || $data[$field] === '') {
                 return [null, "กรุณาระบุข้อมูล: {$field}"];
             }
@@ -152,19 +152,19 @@ function createDecoration(PDO $pdo, ?array $auth): void
         return;
     }
 
-    $servantId = intval($valid['servant_id']);
-    if (!personnelExists($pdo, $servantId)) {
+    $personnelId = intval($valid['personnel_id']);
+    if (!personnelExists($pdo, $personnelId)) {
         http_response_code(404);
         echo json_encode(['error' => 'ไม่พบบุคลากรตามรหัสที่ระบุ']);
         return;
     }
 
     $stmt = $pdo->prepare(
-        "INSERT INTO royal_decorations (servant_id, decoration_name, decoration_class, received_year, gazette_ref, description)
+        "INSERT INTO royal_decorations (personnel_id, decoration_name, decoration_class, received_year, gazette_ref, description)
          VALUES (?, ?, ?, ?, ?, ?)"
     );
     $stmt->execute([
-        $servantId,
+        $personnelId,
         trim($valid['decoration_name']),
         ($valid['decoration_class'] ?? '') !== '' ? $valid['decoration_class'] : null,
         ($valid['received_year'] ?? '') !== '' ? intval($valid['received_year']) : null,
@@ -174,7 +174,7 @@ function createDecoration(PDO $pdo, ?array $auth): void
 
     $newId = intval($pdo->lastInsertId());
     logAudit($pdo, intval($auth['user_id']), 'CREATE', 'royal_decorations', $newId, null, [
-        'servant_id' => intval($valid['servant_id']),
+        'personnel_id' => intval($valid['personnel_id']),
         'decoration_name' => trim($valid['decoration_name']),
     ]);
 
@@ -204,7 +204,7 @@ function updateDecoration(PDO $pdo, int $id, ?array $auth): void
 
     $fields = [];
     $params = [];
-    $editable = ['servant_id', 'decoration_name', 'decoration_class', 'received_year', 'gazette_ref', 'description'];
+    $editable = ['personnel_id', 'decoration_name', 'decoration_class', 'received_year', 'gazette_ref', 'description'];
     foreach ($editable as $col) {
         if (array_key_exists($col, $valid)) {
             $fields[] = "{$col} = ?";
@@ -212,7 +212,7 @@ function updateDecoration(PDO $pdo, int $id, ?array $auth): void
             if (in_array($col, ['decoration_class', 'received_year', 'gazette_ref'], true) && $value === '') {
                 $value = null;
             }
-            if ($col === 'servant_id') {
+            if ($col === 'personnel_id') {
                 $value = intval($value);
                 if (!personnelExists($pdo, $value)) {
                     http_response_code(404);

--- a/backend/routes/personnel.php
+++ b/backend/routes/personnel.php
@@ -215,7 +215,8 @@ function redactPersonnelCitizenIdForRole(array $row, string $role): array
 }
 
 /**
- * Legacy /civil-servants list (เรียกจาก api.php) — contract เดิม + pagination
+ * Legacy /civil-servants list (เรียกจาก api.php) — N60: ฟิลด์ servant_id เปลี่ยนเป็น
+ * personnel_id พร้อม backend ทั้งหมด (deploy พร้อม frontend ใหม่)
  * แต่ค้นหาด้วย citizen_id ได้โดย "ไม่ให้ค่าคืน" แก่ role ที่ไม่ใช่ admin/superadmin
  * (CONTEXT.md: operator/viewer ค้นหาด้วยเลขบัตรได้ แต่ต้องไม่เห็นค่าใน response)
  *
@@ -241,7 +242,7 @@ function legacyCivilServantsList(PDO $pdo, string $role, string $search, int $li
 
     $sql = "
         SELECT
-            p.personnel_id AS servant_id,
+            p.personnel_id,
             p.employee_id,
             p.citizen_id,
             CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) as full_name,
@@ -261,12 +262,12 @@ function legacyCivilServantsList(PDO $pdo, string $role, string $search, int $li
 
     $stmt = $pdo->prepare($sql);
     $stmt->execute($params);
-    $servants = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
     // PII gate: role ที่ไม่ใช่ admin/superadmin ต้องไม่ได้รับ citizen_id
-    $servants = array_map(
+    $rows = array_map(
         static fn (array $row): array => redactPersonnelCitizenIdForRole($row, $role),
-        $servants
+        $rows
     );
 
     // นับ total ให้ตรงกับ filter ของ list query (is_active = 1)
@@ -277,7 +278,7 @@ function legacyCivilServantsList(PDO $pdo, string $role, string $search, int $li
 
     return [
         'success' => true,
-        'data' => $servants,
+        'data' => $rows,
         'pagination' => [
             'total' => $total,
             'limit' => $limit,

--- a/backend/routes/photos.php
+++ b/backend/routes/photos.php
@@ -27,25 +27,25 @@ function isValidPhotoFileName(string $name): bool
  *
  * @return array{photo_id: int}
  */
-function storePhotoRecord(PDO $pdo, int $servantId, string $fileName, string $webPath, string $bytes, string $mime): array
+function storePhotoRecord(PDO $pdo, int $personnelId, string $fileName, string $webPath, string $bytes, string $mime): array
 {
     $pdo->beginTransaction();
     try {
         $stmt = $pdo->prepare(
-            'INSERT INTO civil_servant_photos (servant_id, file_name, file_path, file_data, mime_type, file_size)
+            'INSERT INTO civil_servant_photos (personnel_id, file_name, file_path, file_data, mime_type, file_size)
              VALUES (?, ?, ?, ?, ?, ?)'
         );
-        $stmt->execute([$servantId, $fileName, $webPath, $bytes, $mime, strlen($bytes)]);
+        $stmt->execute([$personnelId, $fileName, $webPath, $bytes, $mime, strlen($bytes)]);
         $photoId = (int) $pdo->lastInsertId();
 
-        // รูปล่าสุดต้องเป็น primary เสมอ — กวาด is_primary = 0 ทุกแถวเก่าของ servant นี้
+        // รูปล่าสุดต้องเป็น primary เสมอ — กวาด is_primary = 0 ทุกแถวเก่าของบุคลากรนี้
         // (รวมแถวที่ถูก soft-delete ด้วย) ก่อนตั้งแถวใหม่เป็น 1 ใน transaction เดียวกัน
         // เพราะ GET /profile/{id} JOIN ด้วย is_primary = 1 ถ้ามี primary ค้างหลายแถว
         // profile จะได้รูปไม่ตรงหรือได้ null
         $sweep = $pdo->prepare(
-            'UPDATE civil_servant_photos SET is_primary = 0 WHERE servant_id = ? AND photo_id != ?'
+            'UPDATE civil_servant_photos SET is_primary = 0 WHERE personnel_id = ? AND photo_id != ?'
         );
-        $sweep->execute([$servantId, $photoId]);
+        $sweep->execute([$personnelId, $photoId]);
 
         $setPrimary = $pdo->prepare('UPDATE civil_servant_photos SET is_primary = 1 WHERE photo_id = ?');
         $setPrimary->execute([$photoId]);

--- a/backend/routes/retirement.php
+++ b/backend/routes/retirement.php
@@ -44,7 +44,7 @@ function getRetirementList(PDO $pdo): void
     }
     $where = ' WHERE ' . implode(' AND ', $conditions);
 
-    $select = "p.personnel_id AS servant_id, p.employee_id, p.retirement_date, p.servant_status,
+    $select = "p.personnel_id, p.employee_id, p.retirement_date, p.servant_status,
                DATEDIFF(p.retirement_date, CURDATE()) AS remaining_days,
                CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name";
     $base = "FROM personnel p LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id";

--- a/backend/routes/work_results.php
+++ b/backend/routes/work_results.php
@@ -29,16 +29,16 @@ function handleWorkResults(PDO $pdo, string $method, array $path): void
     }
 }
 
-const WORK_RESULT_SELECT = "pp.proposal_id, pp.servant_id, pp.proposal_type, pp.title,
+const WORK_RESULT_SELECT = "pp.proposal_id, pp.personnel_id, pp.proposal_type, pp.title,
                             pp.description, pp.impact_description, pp.quantitative_result,
                             pp.result_unit, pp.submission_date, pp.evaluation_score,
                             pp.status, pp.approval_level, pp.created_at,
-                            CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS servant_name";
+                            CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS personnel_name";
 
 function workResultBaseQuery(): string
 {
     return "FROM performance_proposals pp
-            LEFT JOIN personnel p ON pp.servant_id = p.personnel_id
+            LEFT JOIN personnel p ON pp.personnel_id = p.personnel_id
             LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id";
 }
 

--- a/backend/sync/Transformers/DecorationTransformer.php
+++ b/backend/sync/Transformers/DecorationTransformer.php
@@ -8,7 +8,7 @@ require_once __DIR__ . '/../SourceAdapterInterface.php';
 
 /**
  * D6: per_decoratehis (+ per_decoration lookup) → royal_decorations
- * Natural key: servant_id + decoration_name + received_year
+ * Natural key: personnel_id + decoration_name + received_year
  * received_year stores Buddhist Era (validation 2400-2700) — NO CE conversion
  */
 class DecorationTransformer
@@ -34,12 +34,12 @@ class DecorationTransformer
 
         $checkStmt = $this->target->prepare(
             'SELECT decoration_id FROM royal_decorations
-             WHERE servant_id = ? AND decoration_name = ? AND received_year = ?
+             WHERE personnel_id = ? AND decoration_name = ? AND received_year = ?
              LIMIT 1'
         );
 
         $insertStmt = $this->target->prepare(
-            'INSERT INTO royal_decorations (servant_id, decoration_name, decoration_class, received_year, gazette_ref)
+            'INSERT INTO royal_decorations (personnel_id, decoration_name, decoration_class, received_year, gazette_ref)
              VALUES (?, ?, ?, ?, ?)'
         );
 

--- a/backend/tests/Integration/AwardsRouteTest.php
+++ b/backend/tests/Integration/AwardsRouteTest.php
@@ -71,7 +71,7 @@ final class AwardsRouteTest extends TestCase
     private function seedAward(string $name, string $type = 'general'): int
     {
         self::$pdo->prepare(
-            'INSERT INTO awards (servant_id, award_name, award_type, awarded_date) VALUES (?, ?, ?, ?)'
+            'INSERT INTO awards (personnel_id, award_name, award_type, awarded_date) VALUES (?, ?, ?, ?)'
         )->execute([$this->personnelId, $name, $type, '2024-06-01']);
         $id = (int) self::$pdo->lastInsertId();
         $this->awardIds[] = $id;
@@ -91,19 +91,19 @@ final class AwardsRouteTest extends TestCase
         [, $err1] = validateAwardPayload([], true);
         self::assertNotNull($err1);
 
-        [, $err2] = validateAwardPayload(['servant_id' => 1, 'award_name' => 'x', 'award_type' => 'bogus'], true);
+        [, $err2] = validateAwardPayload(['personnel_id' => 1, 'award_name' => 'x', 'award_type' => 'bogus'], true);
         self::assertNotNull($err2);
 
-        [, $err3] = validateAwardPayload(['servant_id' => 1, 'award_name' => 'x', 'award_level' => 'bogus'], true);
+        [, $err3] = validateAwardPayload(['personnel_id' => 1, 'award_name' => 'x', 'award_level' => 'bogus'], true);
         self::assertNotNull($err3);
 
-        [$valid, $err4] = validateAwardPayload(['servant_id' => 1, 'award_name' => 'x', 'award_type' => 'honor'], true);
+        [$valid, $err4] = validateAwardPayload(['personnel_id' => 1, 'award_name' => 'x', 'award_type' => 'honor'], true);
         self::assertNull($err4);
         self::assertSame('honor', $valid['award_type']);
     }
 
     #[Test]
-    public function list_returns_seeded_award_with_joined_servant_name(): void
+    public function list_returns_seeded_award_with_joined_personnel_name(): void
     {
         $name = 'รางวัลทดสอบ-' . bin2hex(random_bytes(3));
         $this->seedAward($name);
@@ -115,7 +115,7 @@ final class AwardsRouteTest extends TestCase
         self::assertArrayHasKey('pagination', $response);
         self::assertGreaterThanOrEqual(1, $response['pagination']['total']);
         self::assertSame($name, $response['data'][0]['award_name']);
-        self::assertStringContainsString('ทดสอบ', $response['data'][0]['servant_name']);
+        self::assertStringContainsString('ทดสอบ', $response['data'][0]['personnel_name']);
     }
 
     #[Test]

--- a/backend/tests/Integration/DecorationsRouteTest.php
+++ b/backend/tests/Integration/DecorationsRouteTest.php
@@ -71,7 +71,7 @@ final class DecorationsRouteTest extends TestCase
     private function seedDecoration(string $name, ?int $year = 2565): int
     {
         self::$pdo->prepare(
-            'INSERT INTO royal_decorations (servant_id, decoration_name, received_year) VALUES (?, ?, ?)'
+            'INSERT INTO royal_decorations (personnel_id, decoration_name, received_year) VALUES (?, ?, ?)'
         )->execute([$this->personnelId, $name, $year]);
         $id = (int) self::$pdo->lastInsertId();
         $this->decorationIds[] = $id;
@@ -91,19 +91,19 @@ final class DecorationsRouteTest extends TestCase
         [, $err1] = validateDecorationPayload([], true);
         self::assertNotNull($err1);
 
-        [, $err2] = validateDecorationPayload(['servant_id' => 1, 'decoration_name' => 'x', 'received_year' => 1900], true);
+        [, $err2] = validateDecorationPayload(['personnel_id' => 1, 'decoration_name' => 'x', 'received_year' => 1900], true);
         self::assertNotNull($err2);
 
-        [, $err3] = validateDecorationPayload(['servant_id' => 1, 'decoration_name' => 'x', 'received_year' => 9999], true);
+        [, $err3] = validateDecorationPayload(['personnel_id' => 1, 'decoration_name' => 'x', 'received_year' => 9999], true);
         self::assertNotNull($err3);
 
-        [$valid, $err4] = validateDecorationPayload(['servant_id' => 1, 'decoration_name' => 'x', 'received_year' => 2565], true);
+        [$valid, $err4] = validateDecorationPayload(['personnel_id' => 1, 'decoration_name' => 'x', 'received_year' => 2565], true);
         self::assertNull($err4);
         self::assertSame(2565, (int) $valid['received_year']);
     }
 
     #[Test]
-    public function list_returns_seeded_decoration_with_joined_servant_name(): void
+    public function list_returns_seeded_decoration_with_joined_personnel_name(): void
     {
         $name = 'เครื่องราชฯทดสอบ-' . bin2hex(random_bytes(3));
         $this->seedDecoration($name);
@@ -115,7 +115,7 @@ final class DecorationsRouteTest extends TestCase
         self::assertArrayHasKey('pagination', $response);
         self::assertGreaterThanOrEqual(1, $response['pagination']['total']);
         self::assertSame($name, $response['data'][0]['decoration_name']);
-        self::assertStringContainsString('ทดสอบ', $response['data'][0]['servant_name']);
+        self::assertStringContainsString('ทดสอบ', $response['data'][0]['personnel_name']);
     }
 
     #[Test]

--- a/backend/tests/Integration/LegacyCivilServantsListTest.php
+++ b/backend/tests/Integration/LegacyCivilServantsListTest.php
@@ -78,7 +78,7 @@ final class LegacyCivilServantsListTest extends TestCase
     private function seededRow(array $payload): ?array
     {
         foreach ($payload['data'] as $row) {
-            if ((int) ($row['servant_id'] ?? 0) === $this->personnelId) {
+            if ((int) ($row['personnel_id'] ?? 0) === $this->personnelId) {
                 return $row;
             }
         }

--- a/backend/tests/Integration/PhotoStorageTest.php
+++ b/backend/tests/Integration/PhotoStorageTest.php
@@ -84,7 +84,7 @@ final class PhotoStorageTest extends TestCase
         // แถวรุ่นเก่าที่ไฟล์สูญหายจาก ephemeral disk — file_data NULL ต้องเสิร์ฟ 404 (null)
         $name = self::NAME_PREFIX . 'legacy.jpg';
         self::$pdo->prepare(
-            'INSERT INTO civil_servant_photos (servant_id, file_name, file_path) VALUES (1, ?, ?)'
+            'INSERT INTO civil_servant_photos (personnel_id, file_name, file_path) VALUES (1, ?, ?)'
         )->execute([$name, 'uploads/' . $name]);
 
         $this->assertNull(fetchActivePhoto(self::$pdo, $name));

--- a/backend/tests/Integration/RetirementRouteTest.php
+++ b/backend/tests/Integration/RetirementRouteTest.php
@@ -73,7 +73,7 @@ final class RetirementRouteTest extends TestCase
 
         $match = null;
         foreach ($response['data'] as $row) {
-            if ((int) $row['servant_id'] === $this->personnelId) {
+            if ((int) $row['personnel_id'] === $this->personnelId) {
                 $match = $row;
                 break;
             }

--- a/backend/tests/Integration/SyncTransformServiceTest.php
+++ b/backend/tests/Integration/SyncTransformServiceTest.php
@@ -289,7 +289,7 @@ final class SyncTransformServiceTest extends TestCase
 
         self::assertSame(1, $result['created'], json_encode($result));
 
-        $stmt = self::$pdo->prepare('SELECT * FROM royal_decorations WHERE servant_id = ?');
+        $stmt = self::$pdo->prepare('SELECT * FROM royal_decorations WHERE personnel_id = ?');
         $stmt->execute([$personnelId]);
         $dec = $stmt->fetch(PDO::FETCH_ASSOC);
 
@@ -335,7 +335,7 @@ final class SyncTransformServiceTest extends TestCase
         try {
             self::$pdo->exec("DELETE FROM external_ref WHERE source_system = 'legacy-hr'");
             self::$pdo->exec("DELETE FROM personnel_position_history WHERE personnel_id IN (SELECT personnel_id FROM personnel WHERE citizen_id LIKE '19999%')");
-            self::$pdo->exec("DELETE FROM royal_decorations WHERE servant_id IN (SELECT personnel_id FROM personnel WHERE citizen_id LIKE '19999%')");
+            self::$pdo->exec("DELETE FROM royal_decorations WHERE personnel_id IN (SELECT personnel_id FROM personnel WHERE citizen_id LIKE '19999%')");
             self::$pdo->exec("DELETE FROM personnel WHERE citizen_id LIKE '19999%'");
             self::$pdo->exec("DELETE FROM organization WHERE org_code LIKE 'TEST%'");
             self::$pdo->exec("DELETE FROM `position` WHERE position_code LIKE 'TEST%'");

--- a/backend/tests/Unit/AwardDateValidationTest.php
+++ b/backend/tests/Unit/AwardDateValidationTest.php
@@ -16,7 +16,7 @@ final class AwardDateValidationTest extends TestCase
     public function malformed_awarded_date_is_rejected(): void
     {
         [, $err] = validateAwardPayload([
-            'servant_id' => 1,
+            'personnel_id' => 1,
             'award_name' => 'x',
             'awarded_date' => 'not-a-date',
         ], true);
@@ -27,7 +27,7 @@ final class AwardDateValidationTest extends TestCase
     public function overflow_awarded_date_is_rejected(): void
     {
         [, $err] = validateAwardPayload([
-            'servant_id' => 1,
+            'personnel_id' => 1,
             'award_name' => 'x',
             'awarded_date' => '2026-02-30',
         ], true);
@@ -38,7 +38,7 @@ final class AwardDateValidationTest extends TestCase
     public function blank_awarded_date_is_allowed(): void
     {
         [, $err] = validateAwardPayload([
-            'servant_id' => 1,
+            'personnel_id' => 1,
             'award_name' => 'x',
             'awarded_date' => '',
         ], true);
@@ -49,7 +49,7 @@ final class AwardDateValidationTest extends TestCase
     public function canonical_awarded_date_is_allowed(): void
     {
         [, $err] = validateAwardPayload([
-            'servant_id' => 1,
+            'personnel_id' => 1,
             'award_name' => 'x',
             'awarded_date' => '2024-06-01',
         ], true);

--- a/database/32-rename-servant-id.sql
+++ b/database/32-rename-servant-id.sql
@@ -1,0 +1,38 @@
+-- บังคับ client charset เป็น utf8mb4 กัน mojibake ตอน docker init (client default อาจเป็น latin1)
+SET NAMES utf8mb4;
+
+-- ============================================================================
+-- 32-rename-servant-id.sql
+-- N60: คอลัมน์ servant_id ค้างหลัง unify person identity (migration 22 remap ค่า
+-- เป็น personnel_id แล้วแต่ชื่อคอลัมน์ยังเป็นชื่อเก่า) + type INT ไม่ตรง personnel_id
+-- ที่เป็น BIGINT — rename เป็น personnel_id + ขยายเป็น BIGINT ให้ตรง PK
+--
+-- ขอบเขต 4 ตารางที่ยังมีคอลัมน์นี้ (ตาราง dead โดน 24 ลบไปแล้ว):
+--   civil_servant_photos, performance_proposals, awards, royal_decorations
+-- evaluator_id/assignee_id/assigner_id ชื่อถูกแล้ว — ไม่แตะ (follow-up ได้)
+--
+-- TiDB: RENAME COLUMN / MODIFY COLUMN / RENAME INDEX รองรับ (แยก statement ละ 1 op
+-- กันความต่างการ parse ALTER หลายข้อ) · ไม่มี FK ค้าง (22 ปลดหมดแล้ว)
+-- Full rename รวม API (ตัดสินใจแล้ว): backend SQL + request/response fields +
+-- frontend เปลี่ยนเป็น personnel_id พร้อมกันใน PR เดียวกัน (deploy พร้อมกัน ไม่มี client นอก)
+-- ============================================================================
+
+-- civil_servant_photos (KEY ชื่อ servant_id ตาม dump เดิม)
+ALTER TABLE civil_servant_photos RENAME COLUMN servant_id TO personnel_id;
+ALTER TABLE civil_servant_photos MODIFY COLUMN personnel_id BIGINT NOT NULL;
+ALTER TABLE civil_servant_photos RENAME INDEX `servant_id` TO `personnel_id`;
+
+-- performance_proposals
+ALTER TABLE performance_proposals RENAME COLUMN servant_id TO personnel_id;
+ALTER TABLE performance_proposals MODIFY COLUMN personnel_id BIGINT NOT NULL;
+ALTER TABLE performance_proposals RENAME INDEX idx_servant_type TO idx_personnel_type;
+
+-- awards (19-awards.sql)
+ALTER TABLE awards RENAME COLUMN servant_id TO personnel_id;
+ALTER TABLE awards MODIFY COLUMN personnel_id BIGINT NOT NULL;
+ALTER TABLE awards RENAME INDEX idx_awards_servant TO idx_awards_personnel;
+
+-- royal_decorations (20-royal-decorations.sql)
+ALTER TABLE royal_decorations RENAME COLUMN servant_id TO personnel_id;
+ALTER TABLE royal_decorations MODIFY COLUMN personnel_id BIGINT NOT NULL;
+ALTER TABLE royal_decorations RENAME INDEX idx_decorations_servant TO idx_decorations_personnel;

--- a/database/tidb-init.sql
+++ b/database/tidb-init.sql
@@ -39,7 +39,7 @@ CREATE TABLE prefixes (
 -- Uploaded photo records for each civil servant.
 CREATE TABLE civil_servant_photos (
     photo_id INT PRIMARY KEY AUTO_INCREMENT,
-    servant_id INT NOT NULL,
+    personnel_id BIGINT NOT NULL,
     photo_type VARCHAR(20) NOT NULL DEFAULT 'profile',
     file_name VARCHAR(255) NOT NULL,
     file_path VARCHAR(500) NOT NULL,
@@ -50,7 +50,8 @@ CREATE TABLE civil_servant_photos (
     is_primary TINYINT(1) NOT NULL DEFAULT 0,
     upload_date DATETIME DEFAULT CURRENT_TIMESTAMP,
     is_active TINYINT(1) NOT NULL DEFAULT 1
-    -- FK (servant_id) -> civil_servants ถูกปลดโดย migration 22 (unify person identity)
+    -- FK เดิม (servant_id) -> civil_servants ถูกปลดโดย migration 22 (unify person identity)
+    -- คอลัมน์ rename เป็น personnel_id โดย migration 32 (N60)
     -- parity gate เทียบ FK pairs — ห้ามใส่กลับ
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
@@ -74,7 +75,7 @@ INSERT INTO prefixes (prefix_code, prefix_name_th) VALUES ('MR', 'นาย');
 -- ตาราง performance_proposals (ผลงานและข้อเสนอ)
 CREATE TABLE performance_proposals (
     proposal_id INT PRIMARY KEY AUTO_INCREMENT,
-    servant_id INT NOT NULL,
+    personnel_id BIGINT NOT NULL,
     proposal_type VARCHAR(20) NOT NULL,
     title VARCHAR(255) NOT NULL,
     description TEXT,
@@ -90,9 +91,10 @@ CREATE TABLE performance_proposals (
     is_active TINYINT(1) NOT NULL DEFAULT 1,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    -- FK (servant_id)/(evaluator_id) -> civil_servants ถูกปลดโดย migration 22
+    -- FK เดิม (servant_id)/(evaluator_id) -> civil_servants ถูกปลดโดย migration 22
+    -- servant_id rename เป็น personnel_id โดย migration 32 (N60)
     -- (ตารางนี้ไม่ถูก drop — parity gate เทียบ FK pairs ห้ามใส่กลับ)
-    INDEX idx_servant_type (servant_id, proposal_type),
+    INDEX idx_personnel_type (personnel_id, proposal_type),
     INDEX idx_status (status),
     INDEX idx_submission_date (submission_date)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -1272,14 +1274,14 @@ CREATE TABLE refresh_tokens (
 -- ============================================
 CREATE TABLE awards (
     award_id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    servant_id INT NOT NULL,
+    personnel_id BIGINT NOT NULL,
     award_name VARCHAR(255) NOT NULL,
     award_type VARCHAR(50) NOT NULL DEFAULT 'general',
     award_level VARCHAR(50) NULL DEFAULT NULL,
     awarded_date DATE NULL DEFAULT NULL,
     description TEXT NULL,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    KEY idx_awards_servant (servant_id),
+    KEY idx_awards_personnel (personnel_id),
     KEY idx_awards_date (awarded_date)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
@@ -1289,14 +1291,14 @@ CREATE TABLE awards (
 -- received_year เก็บเป็นปี พ.ศ. (SMALLINT) — validate ช่วง 2400-2700 ฝั่ง PHP
 CREATE TABLE royal_decorations (
     decoration_id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    servant_id INT NOT NULL,
+    personnel_id BIGINT NOT NULL,
     decoration_name VARCHAR(255) NOT NULL,
     decoration_class VARCHAR(100) NULL DEFAULT NULL,
     received_year SMALLINT NULL DEFAULT NULL,
     gazette_ref VARCHAR(255) NULL DEFAULT NULL,
     description TEXT NULL,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    KEY idx_decorations_servant (servant_id)
+    KEY idx_decorations_personnel (personnel_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- ============================================

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -105,6 +105,7 @@ services:
       - ./database/29-ensure-probation-view-prefixes.sql:/docker-entrypoint-initdb.d/29-ensure-probation-view-prefixes.sql
       - ./database/30-photo-blob-storage.sql:/docker-entrypoint-initdb.d/30-photo-blob-storage.sql
       - ./database/31-csp-violation-daily.sql:/docker-entrypoint-initdb.d/31-csp-violation-daily.sql
+      - ./database/32-rename-servant-id.sql:/docker-entrypoint-initdb.d/32-rename-servant-id.sql
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "--silent"]
       interval: 10s

--- a/frontend/src/__tests__/composables/useAwards.test.js
+++ b/frontend/src/__tests__/composables/useAwards.test.js
@@ -30,7 +30,7 @@ describe('useAwards', () => {
     mockGet.mockResolvedValue({
       success: true,
       data: [{
-        award_id: 1, servant_id: 5, servant_name: 'สมชาย',
+        award_id: 1, personnel_id: 5, personnel_name: 'สมชาย',
         award_name: 'รางวัลดีเด่น', award_type: 'honor', award_level: 'national',
         awarded_date: '2024-01-01', description: 'x', created_at: '2024-01-02',
       }],
@@ -44,7 +44,7 @@ describe('useAwards', () => {
     expect(url).toContain('limit=5')
     expect(url).toContain('offset=10')
     expect(result.data[0]).toEqual({
-      awardId: 1, servantId: 5, servantName: 'สมชาย',
+      awardId: 1, personnelId: 5, personnelName: 'สมชาย',
       awardName: 'รางวัลดีเด่น', awardType: 'honor', awardLevel: 'national',
       awardedDate: '2024-01-01', description: 'x', createdAt: '2024-01-02',
     })
@@ -53,9 +53,9 @@ describe('useAwards', () => {
   it('create maps camelCase payload to snake_case', async () => {
     mockPost.mockResolvedValue({ success: true })
     const { create } = useAwards()
-    await create({ servantId: 3, awardName: 'A', awardType: 'general', awardLevel: 'ministry', awardedDate: '2024-05-05', description: 'd' })
+    await create({ personnelId: 3, awardName: 'A', awardType: 'general', awardLevel: 'ministry', awardedDate: '2024-05-05', description: 'd' })
     expect(mockPost).toHaveBeenCalledWith('/awards', {
-      servant_id: 3, award_name: 'A', award_type: 'general', award_level: 'ministry', awarded_date: '2024-05-05', description: 'd',
+      personnel_id: 3, award_name: 'A', award_type: 'general', award_level: 'ministry', awarded_date: '2024-05-05', description: 'd',
     })
   })
 

--- a/frontend/src/__tests__/composables/useDecorations.test.js
+++ b/frontend/src/__tests__/composables/useDecorations.test.js
@@ -30,7 +30,7 @@ describe('useDecorations', () => {
     mockGet.mockResolvedValue({
       success: true,
       data: [{
-        decoration_id: 2, servant_id: 4, servant_name: 'สมหญิง',
+        decoration_id: 2, personnel_id: 4, personnel_name: 'สมหญิง',
         decoration_name: 'ทวีติยาภรณ์', decoration_class: 'ชั้นที่ 1',
         received_year: 2566, gazette_ref: 'ล.123', description: 'y', created_at: '2024-02-02',
       }],
@@ -40,7 +40,7 @@ describe('useDecorations', () => {
     const result = await fetchList()
     expect(mockGet.mock.calls[0][0]).toContain('/royal-decorations')
     expect(result.data[0]).toEqual({
-      decorationId: 2, servantId: 4, servantName: 'สมหญิง',
+      decorationId: 2, personnelId: 4, personnelName: 'สมหญิง',
       decorationName: 'ทวีติยาภรณ์', decorationClass: 'ชั้นที่ 1',
       receivedYear: 2566, gazetteRef: 'ล.123', description: 'y', createdAt: '2024-02-02',
     })
@@ -49,9 +49,9 @@ describe('useDecorations', () => {
   it('create maps camelCase to snake_case', async () => {
     mockPost.mockResolvedValue({ success: true })
     const { create } = useDecorations()
-    await create({ servantId: 1, decorationName: 'D', decorationClass: 'c', receivedYear: 2565, gazetteRef: 'g', description: 'z' })
+    await create({ personnelId: 1, decorationName: 'D', decorationClass: 'c', receivedYear: 2565, gazetteRef: 'g', description: 'z' })
     expect(mockPost).toHaveBeenCalledWith('/royal-decorations', {
-      servant_id: 1, decoration_name: 'D', decoration_class: 'c', received_year: 2565, gazette_ref: 'g', description: 'z',
+      personnel_id: 1, decoration_name: 'D', decoration_class: 'c', received_year: 2565, gazette_ref: 'g', description: 'z',
     })
   })
 

--- a/frontend/src/__tests__/composables/useProfile.test.js
+++ b/frontend/src/__tests__/composables/useProfile.test.js
@@ -43,7 +43,7 @@ describe('useProfile', () => {
     mockGet.mockResolvedValue({
       success: true,
       data: {
-        servant_id: 5, employee_id: 'EMP005', first_name: 'สม', last_name: 'ชาย',
+        personnel_id: 5, employee_id: 'EMP005', first_name: 'สม', last_name: 'ชาย',
         full_name: 'นายสมชาย', birth_date: '1980-01-01', appointment_date: '2000-01-01',
         retirement_date: '2040-09-30', servant_status: 'active',
         photo_path: 'uploads/photo_abc.jpg',
@@ -52,7 +52,7 @@ describe('useProfile', () => {
     const { fetchById } = useProfile()
     const result = await fetchById(5)
     expect(mockGet).toHaveBeenCalledWith('/profile/5')
-    expect(result.data.servantId).toBe(5)
+    expect(result.data.personnelId).toBe(5)
     expect(result.data.fullName).toBe('นายสมชาย')
     // ต้องเป็น URL ที่ยิงผ่าน API base ไม่ใช่ path ดิบจาก DB
     expect(result.data.photoPath).toBe('/api/uploads/photo_abc.jpg')
@@ -61,7 +61,7 @@ describe('useProfile', () => {
   it('maps a missing photo to null instead of a broken image URL', async () => {
     mockGet.mockResolvedValue({
       success: true,
-      data: { servant_id: 6, full_name: 'นางสาวสมหญิง', photo_path: null },
+      data: { personnel_id: 6, full_name: 'นางสาวสมหญิง', photo_path: null },
     })
     const { fetchById } = useProfile()
     const result = await fetchById(6)

--- a/frontend/src/__tests__/composables/useRetirement.test.js
+++ b/frontend/src/__tests__/composables/useRetirement.test.js
@@ -20,7 +20,7 @@ describe('useRetirement', () => {
     mockGet.mockResolvedValue({
       success: true,
       data: [{
-        servant_id: 3, employee_id: 'EMP003', full_name: 'สมศักดิ์',
+        personnel_id: 3, employee_id: 'EMP003', full_name: 'สมศักดิ์',
         retirement_date: '2030-09-30', servant_status: 'active', remaining_days: 120,
       }],
       pagination: { total: 1 },
@@ -31,7 +31,7 @@ describe('useRetirement', () => {
     expect(url).toContain('/retirement')
     expect(url).toContain('within=12')
     expect(result.data[0]).toEqual({
-      servantId: 3, employeeId: 'EMP003', fullName: 'สมศักดิ์',
+      personnelId: 3, employeeId: 'EMP003', fullName: 'สมศักดิ์',
       retirementDate: '2030-09-30', servantStatus: 'active', remainingDays: 120,
     })
   })
@@ -39,7 +39,7 @@ describe('useRetirement', () => {
   it('keeps null remainingDays as null', async () => {
     mockGet.mockResolvedValue({
       success: true,
-      data: [{ servant_id: 1, remaining_days: null }],
+      data: [{ personnel_id: 1, remaining_days: null }],
       pagination: {},
     })
     const { fetchList } = useRetirement()

--- a/frontend/src/__tests__/composables/useWorkResults.test.js
+++ b/frontend/src/__tests__/composables/useWorkResults.test.js
@@ -23,7 +23,7 @@ describe('useWorkResults', () => {
     mockGet.mockResolvedValue({
       success: true,
       data: [{
-        proposal_id: 1, servant_id: 2, servant_name: 'ก', proposal_type: 'improvement',
+        proposal_id: 1, personnel_id: 2, personnel_name: 'ก', proposal_type: 'improvement',
         title: 'ผลงาน', description: 'd', impact_description: 'i', quantitative_result: '10',
         result_unit: 'ครั้ง', submission_date: '2024-01-01', evaluation_score: 88,
         status: 'approved', approval_level: 'department', created_at: '2024-01-02',

--- a/frontend/src/__tests__/pages/AwardsPage.test.js
+++ b/frontend/src/__tests__/pages/AwardsPage.test.js
@@ -21,8 +21,8 @@ const AwardsPage = (await import('@/pages/AwardsPage.vue')).default
 
 const sampleRow = {
   awardId: 1,
-  servantId: 5,
-  servantName: 'สมชาย ใจดี',
+  personnelId: 5,
+  personnelName: 'สมชาย ใจดี',
   awardName: 'รางวัลดีเด่น',
   awardType: 'honor',
   awardLevel: 'national',

--- a/frontend/src/__tests__/pages/ProfilePage.test.js
+++ b/frontend/src/__tests__/pages/ProfilePage.test.js
@@ -31,7 +31,7 @@ async function mountPage(role = 'admin') {
 
 function activeServant(overrides = {}) {
   return {
-    servantId: 5,
+    personnelId: 5,
     employeeId: 'EMP005',
     fullName: 'นายสมชาย ไทยแท้',
     birthDate: '1980-01-01',

--- a/frontend/src/__tests__/pages/RetirementReportPage.test.js
+++ b/frontend/src/__tests__/pages/RetirementReportPage.test.js
@@ -10,7 +10,7 @@ vi.mock('@/composables/useRetirement.js', () => ({
 const RetirementReportPage = (await import('@/pages/RetirementReportPage.vue')).default
 
 const sampleRow = {
-  servantId: 3,
+  personnelId: 3,
   employeeId: 'EMP003',
   fullName: 'สมศักดิ์ ตั้งใจ',
   retirementDate: '2030-09-30',

--- a/frontend/src/__tests__/pages/RoyalDecorationsPage.test.js
+++ b/frontend/src/__tests__/pages/RoyalDecorationsPage.test.js
@@ -21,8 +21,8 @@ const RoyalDecorationsPage = (await import('@/pages/RoyalDecorationsPage.vue')).
 
 const sampleRow = {
   decorationId: 1,
-  servantId: 4,
-  servantName: 'สมหญิง รักดี',
+  personnelId: 4,
+  personnelName: 'สมหญิง รักดี',
   decorationName: 'ทวีติยาภรณ์ช้างเผือก',
   decorationClass: 'ชั้นที่ 1',
   receivedYear: 2566,

--- a/frontend/src/__tests__/pages/WorkResultsPage.test.js
+++ b/frontend/src/__tests__/pages/WorkResultsPage.test.js
@@ -12,7 +12,7 @@ const WorkResultsPage = (await import('@/pages/WorkResultsPage.vue')).default
 const sampleRow = {
   proposalId: 1,
   title: 'ผลงานเด่น',
-  servantName: 'สมชาย ใจดี',
+  personnelName: 'สมชาย ใจดี',
   proposalType: 'improvement',
   submissionDate: '2024-01-01',
   status: 'approved',

--- a/frontend/src/composables/useAwards.js
+++ b/frontend/src/composables/useAwards.js
@@ -2,7 +2,7 @@ import { useResourceCrud } from '@/composables/useResourceCrud.js'
 
 function toPayload(data) {
   const payload = {}
-  if (data.servantId !== undefined) payload.servant_id = data.servantId
+  if (data.personnelId !== undefined) payload.personnel_id = data.personnelId
   if (data.awardName !== undefined) payload.award_name = data.awardName
   if (data.awardType !== undefined) payload.award_type = data.awardType
   if (data.awardLevel !== undefined) payload.award_level = data.awardLevel
@@ -14,8 +14,8 @@ function toPayload(data) {
 function mapRow(row) {
   return {
     awardId: row.award_id,
-    servantId: row.servant_id,
-    servantName: row.servant_name,
+    personnelId: row.personnel_id,
+    personnelName: row.personnel_name,
     awardName: row.award_name,
     awardType: row.award_type,
     awardLevel: row.award_level,

--- a/frontend/src/composables/useDecorations.js
+++ b/frontend/src/composables/useDecorations.js
@@ -2,7 +2,7 @@ import { useResourceCrud } from '@/composables/useResourceCrud.js'
 
 function toPayload(data) {
   const payload = {}
-  if (data.servantId !== undefined) payload.servant_id = data.servantId
+  if (data.personnelId !== undefined) payload.personnel_id = data.personnelId
   if (data.decorationName !== undefined) payload.decoration_name = data.decorationName
   if (data.decorationClass !== undefined) payload.decoration_class = data.decorationClass
   if (data.receivedYear !== undefined) payload.received_year = data.receivedYear
@@ -14,8 +14,8 @@ function toPayload(data) {
 function mapRow(row) {
   return {
     decorationId: row.decoration_id,
-    servantId: row.servant_id,
-    servantName: row.servant_name,
+    personnelId: row.personnel_id,
+    personnelName: row.personnel_name,
     decorationName: row.decoration_name,
     decorationClass: row.decoration_class,
     receivedYear: row.received_year,

--- a/frontend/src/composables/useProfile.js
+++ b/frontend/src/composables/useProfile.js
@@ -29,7 +29,7 @@ export function useProfile() {
 
   function mapServant(row) {
     return {
-      servantId: row.servant_id,
+      personnelId: row.personnel_id,
       employeeId: row.employee_id,
       firstName: row.first_name,
       lastName: row.last_name,

--- a/frontend/src/composables/useRetirement.js
+++ b/frontend/src/composables/useRetirement.js
@@ -20,7 +20,7 @@ export function useRetirement() {
 
   function mapRow(row) {
     return {
-      servantId: row.servant_id,
+      personnelId: row.personnel_id,
       employeeId: row.employee_id,
       fullName: row.full_name,
       retirementDate: row.retirement_date,

--- a/frontend/src/composables/useWorkResults.js
+++ b/frontend/src/composables/useWorkResults.js
@@ -26,8 +26,8 @@ export function useWorkResults() {
   function mapRow(row) {
     return {
       proposalId: row.proposal_id,
-      servantId: row.servant_id,
-      servantName: row.servant_name,
+      personnelId: row.personnel_id,
+      personnelName: row.personnel_name,
       proposalType: row.proposal_type,
       title: row.title,
       description: row.description,

--- a/frontend/src/pages/AwardsPage.vue
+++ b/frontend/src/pages/AwardsPage.vue
@@ -62,7 +62,7 @@
             >
               <td class="px-6 py-3 text-sm text-gray-700">{{ pagination.offset + index + 1 }}</td>
               <td class="px-6 py-3 text-sm text-gray-900 font-medium">{{ row.awardName }}</td>
-              <td class="px-6 py-3 text-sm text-gray-700">{{ row.servantName || '-' }}</td>
+              <td class="px-6 py-3 text-sm text-gray-700">{{ row.personnelName || '-' }}</td>
               <td class="px-6 py-3 text-sm">
                 <StatusBadge :status="row.awardType || 'general'" />
               </td>
@@ -103,8 +103,8 @@
 
         <div class="space-y-3">
           <div>
-            <label for="awards-servant-id" class="block text-sm font-medium text-gray-700 mb-1">รหัสข้าราชการ (servant_id) <span class="text-red-500">*</span></label>
-            <input id="awards-servant-id" v-model.number="form.servantId" type="number" min="1" class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+            <label for="awards-personnel-id" class="block text-sm font-medium text-gray-700 mb-1">รหัสข้าราชการ (personnel_id) <span class="text-red-500">*</span></label>
+            <input id="awards-personnel-id" v-model.number="form.personnelId" type="number" min="1" class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
           </div>
           <div>
             <label for="awards-award-name" class="block text-sm font-medium text-gray-700 mb-1">ชื่อรางวัล <span class="text-red-500">*</span></label>
@@ -193,7 +193,7 @@ const { run: scheduleSearch } = useDebouncedCallback(() => {
 const showFormModal = ref(false)
 const editing = ref(null)
 const saving = ref(false)
-const defaultForm = () => ({ servantId: null, awardName: '', awardType: 'general', awardLevel: '', awardedDate: '', description: '' })
+const defaultForm = () => ({ personnelId: null, awardName: '', awardType: 'general', awardLevel: '', awardedDate: '', description: '' })
 const form = ref(defaultForm())
 
 
@@ -238,7 +238,7 @@ function openCreate() {
 function openEdit(row) {
   editing.value = row
   form.value = {
-    servantId: row.servantId,
+    personnelId: row.personnelId,
     awardName: row.awardName,
     awardType: row.awardType || 'general',
     awardLevel: row.awardLevel || '',
@@ -254,7 +254,7 @@ function closeFormModal() {
 }
 
 function validate() {
-  if (!form.value.servantId) {
+  if (!form.value.personnelId) {
     ui.showToast('กรุณาระบุรหัสข้าราชการ', 'error')
     return false
   }
@@ -274,7 +274,7 @@ async function submitForm() {
   saving.value = true
   try {
     const payload = {
-      servantId: form.value.servantId,
+      personnelId: form.value.personnelId,
       awardName: form.value.awardName.trim(),
       awardType: form.value.awardType,
       awardLevel: form.value.awardLevel || null,

--- a/frontend/src/pages/ProfilePage.vue
+++ b/frontend/src/pages/ProfilePage.vue
@@ -170,7 +170,7 @@ function goCreateTimeEntry(path) {
     path,
     query: {
       create: '1',
-      personnel_id: String(servant.value.servantId),
+      personnel_id: String(servant.value.personnelId),
       full_name: servant.value.fullName || '',
     },
   })

--- a/frontend/src/pages/RetirementReportPage.vue
+++ b/frontend/src/pages/RetirementReportPage.vue
@@ -84,7 +84,7 @@
           <tbody>
             <tr
               v-for="(row, index) in rows"
-              :key="row.servantId"
+              :key="row.personnelId"
               class="border-b border-gray-100 hover:bg-gray-50"
             >
               <td class="px-6 py-3 text-sm text-gray-700">{{ pagination.offset + index + 1 }}</td>

--- a/frontend/src/pages/RoyalDecorationsPage.vue
+++ b/frontend/src/pages/RoyalDecorationsPage.vue
@@ -62,7 +62,7 @@
             >
               <td class="px-6 py-3 text-sm text-gray-700">{{ pagination.offset + index + 1 }}</td>
               <td class="px-6 py-3 text-sm text-gray-900 font-medium">{{ row.decorationName }}</td>
-              <td class="px-6 py-3 text-sm text-gray-700">{{ row.servantName || '-' }}</td>
+              <td class="px-6 py-3 text-sm text-gray-700">{{ row.personnelName || '-' }}</td>
               <td class="px-6 py-3 text-sm text-gray-700">{{ row.decorationClass || '-' }}</td>
               <td class="px-6 py-3 text-sm text-gray-700">{{ row.receivedYear || '-' }}</td>
               <td class="px-6 py-3 text-sm text-gray-700">{{ row.gazetteRef || '-' }}</td>
@@ -101,8 +101,8 @@
 
         <div class="space-y-3">
           <div>
-            <label for="royal-decorations-servant-id" class="block text-sm font-medium text-gray-700 mb-1">รหัสข้าราชการ (servant_id) <span class="text-red-500">*</span></label>
-            <input id="royal-decorations-servant-id" v-model.number="form.servantId" type="number" min="1" class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+            <label for="royal-decorations-personnel-id" class="block text-sm font-medium text-gray-700 mb-1">รหัสข้าราชการ (personnel_id) <span class="text-red-500">*</span></label>
+            <input id="royal-decorations-personnel-id" v-model.number="form.personnelId" type="number" min="1" class="block w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
           </div>
           <div>
             <label for="royal-decorations-name" class="block text-sm font-medium text-gray-700 mb-1">ชื่อเครื่องราชอิสริยาภรณ์ <span class="text-red-500">*</span></label>
@@ -177,7 +177,7 @@ const { run: scheduleSearch } = useDebouncedCallback(() => {
 const showFormModal = ref(false)
 const editing = ref(null)
 const saving = ref(false)
-const defaultForm = () => ({ servantId: null, decorationName: '', decorationClass: '', receivedYear: null, gazetteRef: '', description: '' })
+const defaultForm = () => ({ personnelId: null, decorationName: '', decorationClass: '', receivedYear: null, gazetteRef: '', description: '' })
 const form = ref(defaultForm())
 
 
@@ -215,7 +215,7 @@ function openCreate() {
 function openEdit(row) {
   editing.value = row
   form.value = {
-    servantId: row.servantId,
+    personnelId: row.personnelId,
     decorationName: row.decorationName,
     decorationClass: row.decorationClass || '',
     receivedYear: row.receivedYear || null,
@@ -231,7 +231,7 @@ function closeFormModal() {
 }
 
 function validate() {
-  if (!form.value.servantId) {
+  if (!form.value.personnelId) {
     ui.showToast('กรุณาระบุรหัสข้าราชการ', 'error')
     return false
   }
@@ -253,7 +253,7 @@ async function submitForm() {
   saving.value = true
   try {
     const payload = {
-      servantId: form.value.servantId,
+      personnelId: form.value.personnelId,
       decorationName: form.value.decorationName.trim(),
       decorationClass: form.value.decorationClass || null,
       receivedYear: form.value.receivedYear || null,

--- a/frontend/src/pages/WorkResultsPage.vue
+++ b/frontend/src/pages/WorkResultsPage.vue
@@ -67,7 +67,7 @@
             >
               <td class="px-6 py-3 text-sm text-gray-700">{{ pagination.offset + index + 1 }}</td>
               <td class="px-6 py-3 text-sm text-gray-900 font-medium">{{ row.title }}</td>
-              <td class="px-6 py-3 text-sm text-gray-700">{{ row.servantName || '-' }}</td>
+              <td class="px-6 py-3 text-sm text-gray-700">{{ row.personnelName || '-' }}</td>
               <td class="px-6 py-3 text-sm text-gray-700">{{ row.proposalType || '-' }}</td>
               <td class="px-6 py-3 text-sm text-gray-700">{{ row.submissionDate || '-' }}</td>
               <td class="px-6 py-3 text-sm">
@@ -116,7 +116,7 @@
             <div class="grid grid-cols-2 gap-4">
               <div>
                 <p class="text-xs text-gray-500">ข้าราชการ</p>
-                <p class="text-sm text-gray-900">{{ viewingRow?.servantName || '-' }}</p>
+                <p class="text-sm text-gray-900">{{ viewingRow?.personnelName || '-' }}</p>
               </div>
               <div>
                 <p class="text-xs text-gray-500">สถานะ</p>


### PR DESCRIPTION
## สรุป (Summary)

ปิด N60 (Low): คอลัมน์ `servant_id INT` ค้างหลัง unify person identity (migration 22 remap ค่า
เป็น personnel id แล้ว แต่ชื่อค้าง + type ไม่ตรง `personnel_id BIGINT`) — full rename ตามที่ยืนยัน:

- **DB:** migration `32-rename-servant-id.sql` rename 4 ตาราง
  (`civil_servant_photos`, `performance_proposals`, `awards`, `royal_decorations`)
  เป็น `personnel_id BIGINT` + rename index; sync `tidb-init.sql`; mount compose + ci
- **Backend:** SQL + API request/response fields (`servant_id`/`servant_name` →
  `personnel_id`/`personnel_name`) ใน awards/decorations/photos/work-results/transformer/api/profile/legacy/retirement
- **Frontend:** 5 composables + 5 pages + 9 ไฟล์เทส
- **ไม่แตะ:** `servant_status` (คอลัมน์จริง), `evaluator_id` (ชื่อถูกแล้ว, follow-up ได้),
  endpoint `/civil-servants`, ADR เก่า

## BREAKING + Prod rollout

- API wire fields `servant_id`/`servant_name` → `personnel_id`/`personnel_name` —
  deploy backend+frontend พร้อมกัน (ไม่มี client นอก)
- Prod image ตั้ง `RUN_MIGRATIONS=0` migration 32 ไม่รันเอง:
  รัน `php scripts/run-migrations.php` ใส่ TiDB ช่วง maintenance window
  (RENAME ล็อกสั้น ตารางเล็ก)

## Verification

- migration 32 รันจริงบน local DB แล้ว (ตรวจ INFORMATION_SCHEMA: 4 ตารางเป็น BIGINT, index ใหม่)
- backend suite **534 เทส 0 fail**; frontend ไฟล์ที่แตะ 49/49; parity exit 0
- pre-push hook: vitest 76 ไฟล์ / 593 เทส + backend Unit 371 เทส ผ่าน
