### PR TITLE
refactor: DRY personnel full-name SQL + servant->personnel rename follow-up (N60)

### DIFF
--- a/backend/routes/awards.php
+++ b/backend/routes/awards.php
@@ -63,9 +63,12 @@ function handleAwards(PDO $pdo, string $method, array $path): void
     }
 }
 
-const AWARD_SELECT = "a.award_id, a.personnel_id, a.award_name, a.award_type,
-                      a.award_level, a.awarded_date, a.description, a.created_at,
-                      CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS personnel_name";
+function awardSelectSql(): string
+{
+    return "a.award_id, a.personnel_id, a.award_name, a.award_type,
+            a.award_level, a.awarded_date, a.description, a.created_at, "
+            . sqlPersonnelFullName() . " AS personnel_name";
+}
 
 function awardBaseQuery(): string
 {
@@ -88,7 +91,7 @@ function getAwardList(PDO $pdo): void
         $params = [$term, $term, $term];
     }
 
-    $sql = "SELECT " . AWARD_SELECT . ' ' . awardBaseQuery() . $where
+    $sql = "SELECT " . awardSelectSql() . ' ' . awardBaseQuery() . $where
         . " ORDER BY a.awarded_date DESC, a.award_id DESC LIMIT {$limit} OFFSET {$offset}";
     $stmt = $pdo->prepare($sql);
     $stmt->execute($params);
@@ -112,7 +115,7 @@ function getAwardList(PDO $pdo): void
 
 function getAwardDetail(PDO $pdo, int $id): void
 {
-    $sql = "SELECT " . AWARD_SELECT . ' ' . awardBaseQuery() . " WHERE a.award_id = ?";
+    $sql = "SELECT " . awardSelectSql() . ' ' . awardBaseQuery() . " WHERE a.award_id = ?";
     $stmt = $pdo->prepare($sql);
     $stmt->execute([$id]);
     $row = $stmt->fetch(PDO::FETCH_ASSOC);

--- a/backend/routes/decorations.php
+++ b/backend/routes/decorations.php
@@ -60,9 +60,12 @@ function handleDecorations(PDO $pdo, string $method, array $path): void
     }
 }
 
-const DECORATION_SELECT = "d.decoration_id, d.personnel_id, d.decoration_name, d.decoration_class,
-                           d.received_year, d.gazette_ref, d.description, d.created_at,
-                           CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS personnel_name";
+function decorationSelectSql(): string
+{
+    return "d.decoration_id, d.personnel_id, d.decoration_name, d.decoration_class,
+            d.received_year, d.gazette_ref, d.description, d.created_at, "
+            . sqlPersonnelFullName() . " AS personnel_name";
+}
 
 function decorationBaseQuery(): string
 {
@@ -85,7 +88,7 @@ function getDecorationList(PDO $pdo): void
         $params = [$term, $term, $term];
     }
 
-    $sql = "SELECT " . DECORATION_SELECT . ' ' . decorationBaseQuery() . $where
+    $sql = "SELECT " . decorationSelectSql() . ' ' . decorationBaseQuery() . $where
         . " ORDER BY d.received_year DESC, d.decoration_id DESC LIMIT {$limit} OFFSET {$offset}";
     $stmt = $pdo->prepare($sql);
     $stmt->execute($params);
@@ -109,7 +112,7 @@ function getDecorationList(PDO $pdo): void
 
 function getDecorationDetail(PDO $pdo, int $id): void
 {
-    $sql = "SELECT " . DECORATION_SELECT . ' ' . decorationBaseQuery() . " WHERE d.decoration_id = ?";
+    $sql = "SELECT " . decorationSelectSql() . ' ' . decorationBaseQuery() . " WHERE d.decoration_id = ?";
     $stmt = $pdo->prepare($sql);
     $stmt->execute([$id]);
     $row = $stmt->fetch(PDO::FETCH_ASSOC);

--- a/backend/routes/personnel.php
+++ b/backend/routes/personnel.php
@@ -215,8 +215,7 @@ function redactPersonnelCitizenIdForRole(array $row, string $role): array
 }
 
 /**
- * Legacy /civil-servants list (เรียกจาก api.php) — N60: ฟิลด์ servant_id เปลี่ยนเป็น
- * personnel_id พร้อม backend ทั้งหมด (deploy พร้อม frontend ใหม่)
+ * Legacy /civil-servants list (เรียกจาก api.php) — contract เดิม + pagination
  * แต่ค้นหาด้วย citizen_id ได้โดย "ไม่ให้ค่าคืน" แก่ role ที่ไม่ใช่ admin/superadmin
  * (CONTEXT.md: operator/viewer ค้นหาด้วยเลขบัตรได้ แต่ต้องไม่เห็นค่าใน response)
  *

--- a/backend/routes/work_results.php
+++ b/backend/routes/work_results.php
@@ -29,11 +29,14 @@ function handleWorkResults(PDO $pdo, string $method, array $path): void
     }
 }
 
-const WORK_RESULT_SELECT = "pp.proposal_id, pp.personnel_id, pp.proposal_type, pp.title,
-                            pp.description, pp.impact_description, pp.quantitative_result,
-                            pp.result_unit, pp.submission_date, pp.evaluation_score,
-                            pp.status, pp.approval_level, pp.created_at,
-                            CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS personnel_name";
+function workResultSelectSql(): string
+{
+    return "pp.proposal_id, pp.personnel_id, pp.proposal_type, pp.title,
+            pp.description, pp.impact_description, pp.quantitative_result,
+            pp.result_unit, pp.submission_date, pp.evaluation_score,
+            pp.status, pp.approval_level, pp.created_at, "
+            . sqlPersonnelFullName() . " AS personnel_name";
+}
 
 function workResultBaseQuery(): string
 {
@@ -62,7 +65,7 @@ function getWorkResultList(PDO $pdo): void
     }
     $where = ' WHERE ' . implode(' AND ', $conditions);
 
-    $sql = "SELECT " . WORK_RESULT_SELECT . ' ' . workResultBaseQuery() . $where
+    $sql = "SELECT " . workResultSelectSql() . ' ' . workResultBaseQuery() . $where
         . " ORDER BY pp.submission_date DESC, pp.proposal_id DESC LIMIT {$limit} OFFSET {$offset}";
     $stmt = $pdo->prepare($sql);
     $stmt->execute($params);
@@ -86,7 +89,7 @@ function getWorkResultList(PDO $pdo): void
 
 function getWorkResultDetail(PDO $pdo, int $id): void
 {
-    $sql = "SELECT " . WORK_RESULT_SELECT . ' ' . workResultBaseQuery() . " WHERE pp.proposal_id = ?";
+    $sql = "SELECT " . workResultSelectSql() . ' ' . workResultBaseQuery() . " WHERE pp.proposal_id = ?";
     $stmt = $pdo->prepare($sql);
     $stmt->execute([$id]);
     $row = $stmt->fetch(PDO::FETCH_ASSOC);

--- a/frontend/src/__tests__/pages/ProfilePage.test.js
+++ b/frontend/src/__tests__/pages/ProfilePage.test.js
@@ -29,7 +29,7 @@ async function mountPage(role = 'admin') {
   return wrapper
 }
 
-function activeServant(overrides = {}) {
+function activePersonnel(overrides = {}) {
   return {
     personnelId: 5,
     employeeId: 'EMP005',
@@ -55,7 +55,7 @@ describe('ProfilePage', () => {
         lastLoginAt: '2024-01-01 10:00:00', createdAt: '2023-01-01',
       },
     })
-    mockFetchById.mockResolvedValue({ data: activeServant() })
+    mockFetchById.mockResolvedValue({ data: activePersonnel() })
   })
 
   afterEach(() => {
@@ -84,7 +84,7 @@ describe('ProfilePage', () => {
     expect(wrapper.text()).toContain('2569')
   })
 
-  it('renders servant detail when id param present', async () => {
+  it('renders personnel detail when id param present', async () => {
     routeParams.value = { id: '5' }
     const wrapper = await mountPage()
     await vi.waitFor(() => expect(mockFetchById).toHaveBeenCalledWith('5'))
@@ -112,7 +112,7 @@ describe('ProfilePage', () => {
 
   it('hides career time shortcuts when personnel is inactive', async () => {
     routeParams.value = { id: '5' }
-    mockFetchById.mockResolvedValue({ data: activeServant({ isActive: false }) })
+    mockFetchById.mockResolvedValue({ data: activePersonnel({ isActive: false }) })
     const wrapper = await mountPage('admin')
     await vi.waitFor(() => expect(mockFetchById).toHaveBeenCalledWith('5'))
     await wrapper.vm.$nextTick()

--- a/frontend/src/composables/useProfile.js
+++ b/frontend/src/composables/useProfile.js
@@ -10,7 +10,7 @@ export function useProfile() {
 
   async function fetchById(id) {
     const result = await api.get(`/profile/${id}`)
-    return { success: result.success, data: result.data ? mapServant(result.data) : null }
+    return { success: result.success, data: result.data ? mapPersonnel(result.data) : null }
   }
 
   function mapAccount(row) {
@@ -27,7 +27,7 @@ export function useProfile() {
     }
   }
 
-  function mapServant(row) {
+  function mapPersonnel(row) {
     return {
       personnelId: row.personnel_id,
       employeeId: row.employee_id,

--- a/frontend/src/pages/ProfilePage.vue
+++ b/frontend/src/pages/ProfilePage.vue
@@ -54,13 +54,13 @@
       </dl>
     </div>
 
-    <!-- Servant detail + career shortcuts -->
-    <template v-else-if="isDetail && servant">
+    <!-- Personnel detail + career shortcuts -->
+    <template v-else-if="isDetail && personnel">
       <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 max-w-2xl">
         <div class="flex items-center gap-4 mb-6">
           <img
-            v-if="servant.photoPath"
-            :src="servant.photoPath"
+            v-if="personnel.photoPath"
+            :src="personnel.photoPath"
             alt="รูปข้าราชการ"
             class="w-20 h-20 rounded-lg object-cover border border-gray-200"
           />
@@ -68,26 +68,26 @@
             <User class="w-10 h-10 text-gray-400" />
           </div>
           <div>
-            <p class="text-lg font-semibold text-gray-900">{{ servant.fullName }}</p>
-            <p class="text-sm text-gray-500">รหัสพนักงาน: {{ servant.employeeId }}</p>
+            <p class="text-lg font-semibold text-gray-900">{{ personnel.fullName }}</p>
+            <p class="text-sm text-gray-500">รหัสพนักงาน: {{ personnel.employeeId }}</p>
           </div>
         </div>
         <dl class="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <div>
             <dt class="text-xs text-gray-500">วันเกิด</dt>
-            <dd class="text-sm text-gray-900">{{ servant.birthDate || '-' }}</dd>
+            <dd class="text-sm text-gray-900">{{ personnel.birthDate || '-' }}</dd>
           </div>
           <div>
             <dt class="text-xs text-gray-500">วันบรรจุ</dt>
-            <dd class="text-sm text-gray-900">{{ servant.appointmentDate || '-' }}</dd>
+            <dd class="text-sm text-gray-900">{{ personnel.appointmentDate || '-' }}</dd>
           </div>
           <div>
             <dt class="text-xs text-gray-500">วันเกษียณ</dt>
-            <dd class="text-sm text-gray-900">{{ servant.retirementDate || '-' }}</dd>
+            <dd class="text-sm text-gray-900">{{ personnel.retirementDate || '-' }}</dd>
           </div>
           <div>
             <dt class="text-xs text-gray-500">สถานะ</dt>
-            <dd class="text-sm text-gray-900">{{ servant.servantStatus || '-' }}</dd>
+            <dd class="text-sm text-gray-900">{{ personnel.servantStatus || '-' }}</dd>
           </div>
         </dl>
       </div>
@@ -148,7 +148,7 @@ const { next: nextRequest } = useRequestSeq()
 const loading = ref(false)
 const error = ref(null)
 const account = ref(null)
-const servant = ref(null)
+const personnel = ref(null)
 
 const isDetail = computed(() => !!route.params.id)
 
@@ -160,18 +160,18 @@ function canCreateResource(resource) {
 }
 
 const careerShortcuts = computed(() => {
-  if (!servant.value?.isActive) return []
+  if (!personnel.value?.isActive) return []
   return TIME_SHORTCUTS.filter((item) => canCreateResource(item.resource))
 })
 
 function goCreateTimeEntry(path) {
-  if (!servant.value) return
+  if (!personnel.value) return
   router.push({
     path,
     query: {
       create: '1',
-      personnel_id: String(servant.value.personnelId),
-      full_name: servant.value.fullName || '',
+      personnel_id: String(personnel.value.personnelId),
+      full_name: personnel.value.fullName || '',
     },
   })
 }
@@ -181,12 +181,12 @@ async function fetchData() {
   loading.value = true
   error.value = null
   account.value = null
-  servant.value = null
+  personnel.value = null
   try {
     if (isDetail.value) {
       const result = await fetchById(route.params.id)
       if (!req.isCurrent()) return
-      servant.value = result.data
+      personnel.value = result.data
     } else {
       const result = await fetchMe()
       if (!req.isCurrent()) return


### PR DESCRIPTION
## สรุป

Follow-up cleanup จาก N60 (#185) — behavior-preserving ทั้งหมด ไม่มี logic เปลี่ยน

### Backend (DRY SQL full-name expression)
- `awards.php` / `decorations.php` / `work_results.php`: เปลี่ยน `const *_SELECT`
  (ที่ copy-paste สตริง `CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), ...)`)
  เป็น function `awardSelectSql()` / `decorationSelectSql()` / `workResultSelectSql()`
  ที่เรียก helper `sqlPersonnelFullName()` (helpers.php) — SQL string ที่ได้ตรงกับของเดิมทุกตัวอักษร
- `personnel.php`: ลบคอมเมนต์ N60 stale (deploy ครบทั้ง frontend/backend แล้วใน #185)

### Frontend (rename ตาม N60)
- `ProfilePage.vue`: ref `servant` -> `personnel` (template + script)
- `useProfile.js`: `mapServant()` -> `mapPersonnel()`
- `ProfilePage.test.js`: helper `activeServant()` -> `activePersonnel()`, แก้ชื่อเทส

## การตรวจสอบ (ยืนยันด้วยการรัน)

| ชุดเทส | ผล |
|---|---|
| `vitest run src/__tests__/pages/ProfilePage.test.js` | 9/9 passed |
| PHPUnit Integration `AwardsRouteTest\|DecorationsRouteTest\|PersonnelFullNamePrefixTest` | 9/9 passed (38 assertions) |
| PHPUnit `AnalyticsRouteTest` (ครอบ work_results ผ่าน analytics) | 3/3 passed (21 assertions) |
| pre-push hook (vitest ทั้งชุด + backend) | ผ่าน |

## Test plan

- [x] Frontend ProfilePage 9/9
- [x] Backend Integration awards/decorations/full-name-prefix 9/9
- [x] AnalyticsRoute (work_results path) 3/3
- [x] pre-push เขียว (push สำเร็จ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
