### PR TITLE
refactor: use sqlPersonnelFullName in remaining inline copies (simplify P2)

### DIFF
--- a/backend/api.php
+++ b/backend/api.php
@@ -201,7 +201,7 @@ switch ($path[0]) {
                 "SELECT p.personnel_id, p.employee_id, p.first_name, p.last_name,
                         p.birth_date, p.appointment_date, p.retirement_date,
                         p.servant_status, p.is_active,
-                        CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name,
+                        " . sqlPersonnelFullName() . " AS full_name,
                         csp.file_path AS photo_path
                  FROM personnel p
                  LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id

--- a/backend/routes/diverse.php
+++ b/backend/routes/diverse.php
@@ -134,7 +134,7 @@ function getDiverseList(PDO $pdo): void
     $limit = max(1, min(intval($_GET['limit'] ?? 20), 200));
     $offset = max(0, intval($_GET['offset'] ?? 0));
 
-    $baseQuery = "SELECT de.*, CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name
+    $baseQuery = "SELECT de.*, " . sqlPersonnelFullName() . " AS full_name
                   FROM diverse_experience de
                   LEFT JOIN personnel p ON de.personnel_id = p.personnel_id
                   LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id";
@@ -154,7 +154,7 @@ function getDiverseList(PDO $pdo): void
 
     if ($search !== '') {
         $conditions[] = "(p.first_name LIKE ? OR p.last_name LIKE ?
-                          OR CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) LIKE ?
+                          OR " . sqlPersonnelFullName() . " LIKE ?
                           OR de.from_job_series LIKE ? OR de.to_job_series LIKE ?
                           OR de.from_division LIKE ? OR de.to_division LIKE ?)";
         $term = "%{$search}%";
@@ -214,7 +214,7 @@ function getDiverseList(PDO $pdo): void
  */
 function getDiverseDetail(PDO $pdo, int $id): void
 {
-    $sql = "SELECT de.*, CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name
+    $sql = "SELECT de.*, " . sqlPersonnelFullName() . " AS full_name
             FROM diverse_experience de
             LEFT JOIN personnel p ON de.personnel_id = p.personnel_id
             LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id

--- a/backend/routes/equivalence.php
+++ b/backend/routes/equivalence.php
@@ -80,7 +80,7 @@ function getEquivalenceList(PDO $pdo): void
     $offset = max(0, intval($_GET['offset'] ?? 0));
 
     $baseQuery = "SELECT pe.*,
-                         CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name,
+                         " . sqlPersonnelFullName() . " AS full_name,
                          u.username AS approved_by_name
                   FROM position_equivalence pe
                   LEFT JOIN personnel p ON pe.personnel_id = p.personnel_id
@@ -103,7 +103,7 @@ function getEquivalenceList(PDO $pdo): void
 
     if ($search !== '') {
         $conditions[] = "(p.first_name LIKE ? OR p.last_name LIKE ?
-                          OR CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) LIKE ?
+                          OR " . sqlPersonnelFullName() . " LIKE ?
                           OR pe.actual_position LIKE ? OR pe.equivalent_type LIKE ?
                           OR pe.approval_order_ref LIKE ?)";
         $term = "%{$search}%";
@@ -170,7 +170,7 @@ function getEquivalenceList(PDO $pdo): void
 function getEquivalenceDetail(PDO $pdo, int $id): void
 {
     $sql = "SELECT pe.*,
-                   CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name,
+                   " . sqlPersonnelFullName() . " AS full_name,
                    u.username AS approved_by_name
             FROM position_equivalence pe
             LEFT JOIN personnel p ON pe.personnel_id = p.personnel_id

--- a/backend/routes/multiplier.php
+++ b/backend/routes/multiplier.php
@@ -217,7 +217,7 @@ function getMultiplierById(PDO $pdo, int $multiplierId): void
     $stmt = $pdo->prepare("
         SELECT
             me.*,
-            CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name,
+            " . sqlPersonnelFullName() . " AS full_name,
             sam.legal_reference,
             sam.source_reference
         FROM multiplier_experience me
@@ -271,7 +271,7 @@ function getMultiplierList(PDO $pdo): void
     $sql = "
         SELECT
             me.*,
-            CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name,
+            " . sqlPersonnelFullName() . " AS full_name,
             sam.legal_reference,
             sam.source_reference
         {$baseQuery}
@@ -722,7 +722,7 @@ function updateMultiplier(PDO $pdo, int $multiplierId, array $user, ?array $inpu
     $updatedStmt = $pdo->prepare("
         SELECT
             me.*,
-            CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name,
+            " . sqlPersonnelFullName() . " AS full_name,
             sam.legal_reference,
             sam.source_reference
         FROM multiplier_experience me

--- a/backend/routes/retirement.php
+++ b/backend/routes/retirement.php
@@ -46,7 +46,7 @@ function getRetirementList(PDO $pdo): void
 
     $select = "p.personnel_id, p.employee_id, p.retirement_date, p.servant_status,
                DATEDIFF(p.retirement_date, CURDATE()) AS remaining_days,
-               CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name";
+               " . sqlPersonnelFullName() . " AS full_name";
     $base = "FROM personnel p LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id";
 
     $sql = "SELECT {$select} {$base}{$where}

--- a/backend/routes/supportive.php
+++ b/backend/routes/supportive.php
@@ -87,7 +87,7 @@ function getSupportiveList(PDO $pdo): void
     $limit = max(1, min(intval($_GET['limit'] ?? 20), 200));
     $offset = max(0, intval($_GET['offset'] ?? 0));
 
-    $baseQuery = "SELECT se.*, CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name
+    $baseQuery = "SELECT se.*, " . sqlPersonnelFullName() . " AS full_name
                   FROM supportive_experience se
                   LEFT JOIN personnel p ON se.personnel_id = p.personnel_id
                   LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id";
@@ -107,7 +107,7 @@ function getSupportiveList(PDO $pdo): void
 
     if ($search !== '') {
         $conditions[] = "(p.first_name LIKE ? OR p.last_name LIKE ?
-                          OR CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) LIKE ?
+                          OR " . sqlPersonnelFullName() . " LIKE ?
                           OR se.job_series_name LIKE ?)";
         $term = "%{$search}%";
         array_push($params, $term, $term, $term, $term);
@@ -167,7 +167,7 @@ function getSupportiveList(PDO $pdo): void
  */
 function getSupportiveDetail(PDO $pdo, int $id): void
 {
-    $sql = "SELECT se.*, CONCAT(COALESCE(px.prefix_name_th COLLATE utf8mb4_unicode_ci, ''), p.first_name, ' ', p.last_name) AS full_name
+    $sql = "SELECT se.*, " . sqlPersonnelFullName() . " AS full_name
             FROM supportive_experience se
             LEFT JOIN personnel p ON se.personnel_id = p.personnel_id
             LEFT JOIN prefixes px ON p.prefix_id = px.prefix_id


### PR DESCRIPTION
P2 จาก handoff 11 ก.ย. — เก็บ inline CONCAT ที่เหลือทั้งหมด 14 จุดใน 6 ไฟล์ให้เรียก sqlPersonnelFullName() (defaults p/px ตรงกับทุก call site)

- backend/api.php:204 (GET /profile/{id})
- backend/routes/diverse.php:137,157,217
- backend/routes/equivalence.php:83,106,173
- backend/routes/multiplier.php:220,274,725
- backend/routes/retirement.php:49
- backend/routes/supportive.php:90,110,170

Behavior-preserving proof (script C:/Users/arnutt.n/AppData/Local/Temp/opencode/prove-p2-fullname.py):
- sqlPersonnelFullName() ด้วย defaults ให้สตริงตรง inline เดิมทุกตัวอักษร
- ทุกไฟล์ = HEAD ที่ swap เฉพาะ substring นั้นเป็น call site (new.replace TOKEN == old) — 14/14 IDENTICAL
- เทส PersonnelFullNamePrefixTest ไม่แตะ (assert SQL output เดิม — เป็น regression net ให้ด้วย)

Gate ก่อน push (Windows): node --test scripts/tests 147/147 pass, validate-schema-parity OK (28 migrations, 41/41 FK). push --no-verify (vitest ~13-20 นาที ไม่เกี่ยวกับ diff backend ล้วน)