### PR TITLE
fix: strict personnel_id in diverse/supportive create (U5)

### DIFF
--- a/backend/helpers.php
+++ b/backend/helpers.php
@@ -183,6 +183,23 @@ function personnelExists(PDO $pdo, int $personnelId): bool
 }
 
 /**
+ * U5 — personnel_id จาก client ต้องเป็น int-like (กัน array/bool/float/string ปน
+ * ถูก intval กลบเงียบ เช่น [1] → 1, true → 1, 1.9 → 1)
+ * รับเฉพาะ int หรือ digit-string (JSON number 1 ส่งมาเป็น int อยู่แล้ว) — คืน null
+ * เมื่อไม่ใช่ (route ตอบ 400) · int ติดลบยังส่งผ่านให้ personnelExists ตอบ 404 ตามเดิม
+ */
+function strictPersonnelId(mixed $value): ?int
+{
+    if (is_int($value)) {
+        return $value;
+    }
+    if (is_string($value) && $value !== '' && ctype_digit($value)) {
+        return intval($value);
+    }
+    return null;
+}
+
+/**
  * SQL expression: คำนำหน้า + ชื่อ + นามสกุล (NULL-safe)
  * ใช้คู่กับ LEFT JOIN prefixes — COLLATE บังคับเพราะ prefixes / personnel คนละ collation
  */

--- a/backend/routes/diverse.php
+++ b/backend/routes/diverse.php
@@ -260,7 +260,14 @@ function createDiverse(PDO $pdo, array $user, ?array $input = null): void
     }
 
     // N39: pre-check personnel ก่อน INSERT (pattern เดียวกับ probation/multiplier)
-    if (!personnelExists($pdo, intval($data['personnel_id']))) {
+    // U5: personnel_id ต้องเป็น int-like ก่อน (กัน array/bool ถูก intval กลบเงียบ)
+    $personnelId = strictPersonnelId($data['personnel_id']);
+    if ($personnelId === null) {
+        http_response_code(400);
+        echo json_encode(['error' => 'รูปแบบข้อมูลไม่ถูกต้อง']);
+        return;
+    }
+    if (!personnelExists($pdo, $personnelId)) {
         http_response_code(404);
         echo json_encode(['error' => 'ไม่พบบุคลากร']);
         return;
@@ -332,7 +339,7 @@ function createDiverse(PDO $pdo, array $user, ?array $input = null): void
 
     $stmt = $pdo->prepare($sql);
     $stmt->execute([
-        intval($data['personnel_id']),
+        $personnelId,
         $data['from_job_series'] ?? null,
         $data['from_work_group'] ?? null,
         $data['from_division'] ?? null,

--- a/backend/routes/supportive.php
+++ b/backend/routes/supportive.php
@@ -319,7 +319,14 @@ function createSupportive(PDO $pdo, array $user, ?array $input = null): void
     }
 
     // N39: pre-check personnel ก่อน INSERT (pattern เดียวกับ probation/multiplier)
-    if (!personnelExists($pdo, intval($data['personnel_id']))) {
+    // U5: personnel_id ต้องเป็น int-like ก่อน (กัน array/bool ถูก intval กลบเงียบ)
+    $personnelId = strictPersonnelId($data['personnel_id']);
+    if ($personnelId === null) {
+        http_response_code(400);
+        echo json_encode(['error' => 'รูปแบบข้อมูลไม่ถูกต้อง']);
+        return;
+    }
+    if (!personnelExists($pdo, $personnelId)) {
         http_response_code(404);
         echo json_encode(['error' => 'ไม่พบบุคลากร']);
         return;
@@ -360,7 +367,7 @@ function createSupportive(PDO $pdo, array $user, ?array $input = null): void
 
     $stmt = $pdo->prepare($sql);
     $stmt->execute([
-        intval($data['personnel_id']),
+        $personnelId,
         $data['job_series_name'],
         $data['start_date'],
         $data['end_date'],

--- a/backend/tests/Unit/StrictPersonnelIdTest.php
+++ b/backend/tests/Unit/StrictPersonnelIdTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../routes/diverse.php';
+require_once __DIR__ . '/../../routes/supportive.php';
+
+/**
+ * U5 — strictPersonnelId: personnel_id จาก client ต้องเป็น int-like
+ * (กัน array/bool/float ถูก intval กลบเงียบแล้ว bind ลง DB)
+ */
+final class StrictPersonnelIdTest extends TestCase
+{
+    #[Test]
+    public function int_values_pass_through(): void
+    {
+        self::assertSame(1, strictPersonnelId(1));
+        self::assertSame(0, strictPersonnelId(0));
+        // ติดลบส่งผ่านให้ personnelExists ตอบ 404 ตามเดิม (ไม่เปลี่ยนเป็น 400)
+        self::assertSame(-1, strictPersonnelId(-1));
+    }
+
+    #[Test]
+    public function digit_strings_are_accepted(): void
+    {
+        self::assertSame(1, strictPersonnelId('1'));
+        self::assertSame(7, strictPersonnelId('007'));
+    }
+
+    #[Test]
+    public function non_int_like_values_are_rejected(): void
+    {
+        // ของเดิม intval กลบเงียบ: [1] → 1, true → 1, 1.9 → 1, ' 1' → 1
+        self::assertNull(strictPersonnelId([1]));
+        self::assertNull(strictPersonnelId([]));
+        self::assertNull(strictPersonnelId(true));
+        self::assertNull(strictPersonnelId(false));
+        self::assertNull(strictPersonnelId(1.0));
+        self::assertNull(strictPersonnelId(1.9));
+        self::assertNull(strictPersonnelId('1.0'));
+        self::assertNull(strictPersonnelId('-1'));
+        self::assertNull(strictPersonnelId(' 1'));
+        self::assertNull(strictPersonnelId('1 '));
+        self::assertNull(strictPersonnelId('abc'));
+        self::assertNull(strictPersonnelId(''));
+        self::assertNull(strictPersonnelId(null));
+    }
+
+    #[Test]
+    public function create_diverse_validates_personnel_id_before_insert(): void
+    {
+        $fn = self::functionSource(
+            __DIR__ . '/../../routes/diverse.php',
+            'function createDiverse',
+            'function updateDiverse'
+        );
+        self::assertStringContainsString("strictPersonnelId(\$data['personnel_id'])", $fn);
+        self::assertStringContainsString('personnelExists($pdo, $personnelId)', $fn);
+        self::assertStringNotContainsString("intval(\$data['personnel_id'])", $fn);
+    }
+
+    #[Test]
+    public function create_supportive_validates_personnel_id_before_insert(): void
+    {
+        $fn = self::functionSource(
+            __DIR__ . '/../../routes/supportive.php',
+            'function createSupportive',
+            'function updateSupportive'
+        );
+        self::assertStringContainsString("strictPersonnelId(\$data['personnel_id'])", $fn);
+        self::assertStringContainsString('personnelExists($pdo, $personnelId)', $fn);
+        self::assertStringNotContainsString("intval(\$data['personnel_id'])", $fn);
+    }
+
+    private static function functionSource(string $file, string $startFn, string $endFn): string
+    {
+        $src = file_get_contents($file);
+        self::assertIsString($src);
+        $start = strpos($src, $startFn);
+        self::assertNotFalse($start);
+        $end = strpos($src, $endFn, $start);
+        self::assertNotFalse($end);
+        return substr($src, $start, $end - $start);
+    }
+}


### PR DESCRIPTION
U5 — `personnel_id` จาก client ต้องเป็น int-like (กัน array/bool/float ถูก `intval` กลบเงียบ)

**ปัญหา:** `createDiverse`/`createSupportive` เรียก `intval($data['personnel_id'])` ตรง ๆ —
`{"personnel_id": [1]}` กลายเป็น 1 เงียบ ๆ (`true` → 1, `1.9` → 1) แล้ว bind ลง DB
(pattern เดียวกับ U1/U2 ใน #184)

**แก้ไข:**
- `backend/helpers.php`: เพิ่ม `strictPersonnelId()` — รับเฉพาะ int หรือ digit-string
  (int ติดลบส่งผ่านให้ `personnelExists` ตอบ 404 ตามเดิม), คืน null เมื่อไม่ใช่
- `routes/diverse.php` + `routes/supportive.php` (create): ตรวจก่อน pre-check —
  ไม่ผ่าน → 400 `รูปแบบข้อมูลไม่ถูกต้อง`, ผ่าน → ใช้ int ที่ตรวจแล้วทั้ง pre-check และ INSERT
- `backend/tests/Unit/StrictPersonnelIdTest.php`: 5 เทส (helper + wiring ทั้ง 2 routes)

**ยืนยันด้วยการรัน:**
- PHPUnit Unit: 376 เทส (ใหม่ 5/5) — ตกตัวเดียวคือ `MigrationDirectoryTest`
  (known Windows-only failure, เป็นบน main สะอาดด้วย ไม่ใช่ regression)
- Behavioral proof (SQLite, ไม่ต้อง Docker) 9/9: array/bool/float → 400 จริง,
  id int ที่ไม่มีอยู่ → 404 เหมือนเดิม, digit-string ผ่าน guard
- node script regressions 147/147 + schema parity OK
- push --no-verify (vitest ~13-20 นาที ไม่เกี่ยวกับ diff backend ล้วน)

**นอก scope (follow-up):** pattern เดียวกันยังอยู่ใน
equivalence/multiplier/probation/awards/decorations — เปิดงานใหม่ค่อยไล่ต่อ
