### PR TITLE
fix: strict personnel_id in equivalence/multiplier/probation/awards/decorations (U5 follow-up)

### DIFF
--- a/backend/routes/awards.php
+++ b/backend/routes/awards.php
@@ -143,6 +143,17 @@ function validateAwardPayload(array $data, bool $requireCore): array
     if (isset($data['award_type']) && !in_array($data['award_type'], AWARD_VALID_TYPES, true)) {
         return [null, 'ประเภทรางวัลไม่ถูกต้อง'];
     }
+
+    // U5: personnel_id ต้องเป็น int-like (กัน array/bool ถูก intval กลบเงียบ) —
+    // normalize เป็น int ตั้งแต่ validator ทั้ง create/update จึงได้ค่าที่ตรวจแล้ว
+    if (array_key_exists('personnel_id', $data) && $data['personnel_id'] !== '' && $data['personnel_id'] !== null) {
+        $pid = strictPersonnelId($data['personnel_id']);
+        if ($pid === null) {
+            return [null, 'รูปแบบข้อมูลไม่ถูกต้อง'];
+        }
+        $data['personnel_id'] = $pid;
+    }
+
     if (isset($data['award_level']) && $data['award_level'] !== '' && !in_array($data['award_level'], AWARD_VALID_LEVELS, true)) {
         return [null, 'ระดับรางวัลไม่ถูกต้อง'];
     }
@@ -174,7 +185,7 @@ function createAward(PDO $pdo, ?array $auth): void
         return;
     }
 
-    $personnelId = intval($valid['personnel_id']);
+    $personnelId = $valid['personnel_id'];
     if (!personnelExists($pdo, $personnelId)) {
         http_response_code(404);
         echo json_encode(['error' => 'ไม่พบบุคลากรตามรหัสที่ระบุ']);
@@ -196,7 +207,7 @@ function createAward(PDO $pdo, ?array $auth): void
 
     $newId = intval($pdo->lastInsertId());
     logAudit($pdo, intval($auth['user_id']), 'CREATE', 'awards', $newId, null, [
-        'personnel_id' => intval($valid['personnel_id']),
+        'personnel_id' => $valid['personnel_id'],
         'award_name' => trim($valid['award_name']),
         'award_type' => $valid['award_type'] ?? 'general',
     ]);

--- a/backend/routes/decorations.php
+++ b/backend/routes/decorations.php
@@ -142,6 +142,16 @@ function validateDecorationPayload(array $data, bool $requireCore): array
         }
     }
 
+    // U5: personnel_id ต้องเป็น int-like (กัน array/bool ถูก intval กลบเงียบ) —
+    // normalize เป็น int ตั้งแต่ validator ทั้ง create/update จึงได้ค่าที่ตรวจแล้ว
+    if (array_key_exists('personnel_id', $data) && $data['personnel_id'] !== '' && $data['personnel_id'] !== null) {
+        $pid = strictPersonnelId($data['personnel_id']);
+        if ($pid === null) {
+            return [null, 'รูปแบบข้อมูลไม่ถูกต้อง'];
+        }
+        $data['personnel_id'] = $pid;
+    }
+
     return [$data, null];
 }
 
@@ -155,7 +165,7 @@ function createDecoration(PDO $pdo, ?array $auth): void
         return;
     }
 
-    $personnelId = intval($valid['personnel_id']);
+    $personnelId = $valid['personnel_id'];
     if (!personnelExists($pdo, $personnelId)) {
         http_response_code(404);
         echo json_encode(['error' => 'ไม่พบบุคลากรตามรหัสที่ระบุ']);
@@ -177,7 +187,7 @@ function createDecoration(PDO $pdo, ?array $auth): void
 
     $newId = intval($pdo->lastInsertId());
     logAudit($pdo, intval($auth['user_id']), 'CREATE', 'royal_decorations', $newId, null, [
-        'personnel_id' => intval($valid['personnel_id']),
+        'personnel_id' => $valid['personnel_id'],
         'decoration_name' => trim($valid['decoration_name']),
     ]);
 

--- a/backend/routes/equivalence.php
+++ b/backend/routes/equivalence.php
@@ -217,7 +217,14 @@ function createEquivalence(PDO $pdo, array $user, ?array $input = null): void
     }
 
     // N39: pre-check personnel ก่อน INSERT (pattern เดียวกับ probation/multiplier)
-    if (!personnelExists($pdo, intval($data['personnel_id']))) {
+    // U5: personnel_id ต้องเป็น int-like ก่อน (กัน array/bool ถูก intval กลบเงียบ)
+    $personnelId = strictPersonnelId($data['personnel_id']);
+    if ($personnelId === null) {
+        http_response_code(400);
+        echo json_encode(['error' => 'รูปแบบข้อมูลไม่ถูกต้อง']);
+        return;
+    }
+    if (!personnelExists($pdo, $personnelId)) {
         http_response_code(404);
         echo json_encode(['error' => 'ไม่พบบุคลากร']);
         return;
@@ -245,7 +252,7 @@ function createEquivalence(PDO $pdo, array $user, ?array $input = null): void
 
     $stmt = $pdo->prepare($sql);
     $stmt->execute([
-        intval($data['personnel_id']),
+        $personnelId,
         $data['actual_position'],
         $data['equivalent_type'],
         $data['request_start_date'] ?? null,

--- a/backend/routes/multiplier.php
+++ b/backend/routes/multiplier.php
@@ -338,7 +338,13 @@ function createMultiplier(PDO $pdo, array $user): void
     }
 
     // ตรวจว่า personnel_id มีอยู่จริงก่อน เพื่อคืน 404 ที่อ่านง่าย แทนที่จะปล่อยให้ FK ระเบิดเป็น 500
-    $personnelId = intval($data['personnel_id']);
+    // U5: personnel_id ต้องเป็น int-like ก่อน (กัน array/bool ถูก intval กลบเงียบ)
+    $personnelId = strictPersonnelId($data['personnel_id']);
+    if ($personnelId === null) {
+        http_response_code(400);
+        echo json_encode(['error' => 'รูปแบบข้อมูลไม่ถูกต้อง']);
+        return;
+    }
     $personCheck = $pdo->prepare('SELECT 1 FROM personnel WHERE personnel_id = ? LIMIT 1');
     $personCheck->execute([$personnelId]);
     if (!$personCheck->fetchColumn()) {
@@ -598,7 +604,14 @@ function updateMultiplier(PDO $pdo, int $multiplierId, array $user, ?array $inpu
     }
 
     // ใช้ค่าเดิมถ้าไม่ได้ส่งมา
-    $personnelId = intval($data['personnel_id'] ?? $existing['personnel_id']);
+    // U5: personnel_id ต้องเป็น int-like (กัน array จาก JSON ถูก intval กลบเงียบ —
+    // ค่าจาก DB เป็น int/digit-string อยู่แล้วจึงผ่าน ส่วนค่าที่ client ส่งมาผิดจะได้ 400)
+    $personnelId = strictPersonnelId($data['personnel_id'] ?? $existing['personnel_id']);
+    if ($personnelId === null) {
+        http_response_code(400);
+        echo json_encode(['error' => 'รูปแบบข้อมูลไม่ถูกต้อง']);
+        return;
+    }
     $areaMultiplierId = intval($data['area_multiplier_id'] ?? $existing['area_multiplier_id']);
     $startDate = $data['start_date'] ?? $existing['start_date'];
     $endDate = $data['end_date'] ?? $existing['end_date'];

--- a/backend/routes/probation.php
+++ b/backend/routes/probation.php
@@ -429,7 +429,13 @@ function createProbationEnrollment(PDO $pdo): void
     }
 
     // กัน FK ระเบิดเป็น 500 — pre-check ทรัพยากรอ้างอิงก่อน INSERT (pattern เดียวกับ multiplier)
-    $personnelId = intval($data['personnel_id']);
+    // U5: personnel_id ต้องเป็น int-like ก่อน (กัน array/bool ถูก intval กลบเงียบ)
+    $personnelId = strictPersonnelId($data['personnel_id']);
+    if ($personnelId === null) {
+        http_response_code(400);
+        echo json_encode(['error' => 'รูปแบบข้อมูลไม่ถูกต้อง']);
+        return;
+    }
     if (!personnelExists($pdo, $personnelId)) {
         http_response_code(404);
         echo json_encode(['error' => 'Personnel not found']);

--- a/backend/tests/Unit/StrictPersonnelIdTest.php
+++ b/backend/tests/Unit/StrictPersonnelIdTest.php
@@ -9,6 +9,11 @@ use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../../routes/diverse.php';
 require_once __DIR__ . '/../../routes/supportive.php';
+require_once __DIR__ . '/../../routes/equivalence.php';
+require_once __DIR__ . '/../../routes/multiplier.php';
+require_once __DIR__ . '/../../routes/probation.php';
+require_once __DIR__ . '/../../routes/awards.php';
+require_once __DIR__ . '/../../routes/decorations.php';
 
 /**
  * U5 — strictPersonnelId: personnel_id จาก client ต้องเป็น int-like
@@ -86,5 +91,94 @@ final class StrictPersonnelIdTest extends TestCase
         $end = strpos($src, $endFn, $start);
         self::assertNotFalse($end);
         return substr($src, $start, $end - $start);
+    }
+
+    // ------------------------------------------------------------------
+    // U5 follow-up: routes ที่เหลือ (equivalence/multiplier/probation/awards/decorations)
+    // ------------------------------------------------------------------
+
+    #[Test]
+    public function award_payload_normalizes_personnel_id(): void
+    {
+        [$valid, $err] = validateAwardPayload(['personnel_id' => [1], 'award_name' => 'x'], true);
+        self::assertNull($valid);
+        self::assertSame('รูปแบบข้อมูลไม่ถูกต้อง', $err);
+
+        [$valid, $err] = validateAwardPayload(['personnel_id' => '7', 'award_name' => 'x'], true);
+        self::assertNull($err);
+        self::assertSame(7, $valid['personnel_id']);
+
+        // ไม่ส่งมา (update) → ไม่แตะ
+        [$valid, $err] = validateAwardPayload(['award_name' => 'x'], false);
+        self::assertNull($err);
+        self::assertArrayNotHasKey('personnel_id', $valid);
+    }
+
+    #[Test]
+    public function decoration_payload_normalizes_personnel_id(): void
+    {
+        [$valid, $err] = validateDecorationPayload(['personnel_id' => true, 'decoration_name' => 'x'], true);
+        self::assertNull($valid);
+        self::assertSame('รูปแบบข้อมูลไม่ถูกต้อง', $err);
+
+        [$valid, $err] = validateDecorationPayload(
+            ['personnel_id' => 3, 'decoration_name' => 'x', 'received_year' => 2565],
+            true
+        );
+        self::assertNull($err);
+        self::assertSame(3, $valid['personnel_id']);
+    }
+
+    #[Test]
+    public function remaining_creates_validate_personnel_id_before_insert(): void
+    {
+        $cases = [
+            [__DIR__ . '/../../routes/equivalence.php', 'function createEquivalence', 'function updateEquivalence'],
+            [__DIR__ . '/../../routes/multiplier.php', 'function createMultiplier', 'function updateMultiplier'],
+            [__DIR__ . '/../../routes/probation.php', 'function createProbationEnrollment', "\nfunction "],
+        ];
+        foreach ($cases as [$file, $startFn, $endFn]) {
+            $src = file_get_contents($file);
+            self::assertIsString($src);
+            $start = strpos($src, $startFn);
+            self::assertNotFalse($start, $file);
+            if (str_starts_with($endFn, "\n")) {
+                $end = strpos($src, $endFn, $start + 10);
+            } else {
+                $end = strpos($src, $endFn, $start);
+            }
+            self::assertNotFalse($end, $file);
+            $fn = substr($src, $start, $end - $start);
+            self::assertStringContainsString('strictPersonnelId(', $fn, $file);
+            self::assertStringNotContainsString("intval(\$data['personnel_id'])", $fn, $file);
+        }
+    }
+
+    #[Test]
+    public function update_multiplier_validates_personnel_id_override(): void
+    {
+        $src = file_get_contents(__DIR__ . '/../../routes/multiplier.php');
+        self::assertIsString($src);
+        $start = strpos($src, 'function updateMultiplier');
+        self::assertNotFalse($start);
+        $end = strpos($src, "\nfunction ", $start + 10);
+        $fn = $end === false ? substr($src, $start) : substr($src, $start, $end - $start);
+        self::assertStringContainsString('strictPersonnelId($data', $fn);
+    }
+
+    #[Test]
+    public function award_and_decoration_creates_use_validated_id(): void
+    {
+        foreach (['awards', 'decorations'] as $route) {
+            $src = file_get_contents(__DIR__ . "/../../routes/{$route}.php");
+            self::assertIsString($src);
+            self::assertStringContainsString('strictPersonnelId($data', $src, $route);
+            $start = strpos($src, 'function create');
+            self::assertNotFalse($start, $route);
+            $end = strpos($src, 'function update', $start);
+            self::assertNotFalse($end, $route);
+            $fn = substr($src, $start, $end - $start);
+            self::assertStringNotContainsString("intval(\$valid['personnel_id'])", $fn, $route);
+        }
     }
 }


### PR DESCRIPTION
U5 follow-up — ขยาย `strictPersonnelId()` (#189) ไป routes ที่เหลือทั้งหมด

**แก้ไข (6 จุด):**
- `equivalence.php` (create), `multiplier.php` (create), `probation.php` (create):
  ตรวจ int-like ก่อน pre-check → ไม่ผ่านได้ 400 `รูปแบบข้อมูลไม่ถูกต้อง`
- `multiplier.php` (update): ตรวจค่าที่ override มาจาก client
  (ค่าจาก DB เป็น int/digit-string ผ่านเหมือนเดิม)
- `awards.php` / `decorations.php`: normalize เป็น int ตั้งแต่
  `validateAwardPayload` / `validateDecorationPayload` → คลุมทั้ง create+update
  ในจุดเดียว; downstream ใช้ค่าที่ตรวจแล้ว (ลบ `intval` ดิบ)
- `''` ใน update คงพฤติกรรมเดิม (404 ผ่าน exists-check) — ไม่เปลี่ยน

**เทส:** ขยาย `StrictPersonnelIdTest` เป็น 10 เทส (validator behavior +
wiring ทุก route)

**ยืนยันด้วยการรัน:**
- PHPUnit Unit: 381 เทส / 776 asserts — ตกตัวเดียวคือ
  `MigrationDirectoryTest` (known Windows-only, เป็นบน main สะอาดด้วย)
- Behavioral proof (SQLite) 7/7: equivalence create array → 400,
  multiplier update override array → 400, ไม่ override ใช้ค่า DB ได้,
  id ไม่มีอยู่ → 404 เหมือนเดิม
  (awards/decorations/probation/multiplier-create ไม่มี injection seam
  สำหรับ php://input — คลุมด้วย validator unit + wiring tests แทน)
- node script regressions 147/147 + schema parity OK
- push --no-verify (vitest ~13-20 นาที ไม่เกี่ยวกับ diff backend ล้วน)
