### PR TITLE
fix: review diff #184-190 findings R1-R6 (U6, strict ids, baseline to 32)

### DIFF
--- a/backend/api.php
+++ b/backend/api.php
@@ -307,7 +307,12 @@ switch ($path[0]) {
     case 'photos':
         if ($method == 'POST') {
             requirePermission('create', 'photos');
-            $personnelId = intval($_POST['personnel_id'] ?? 0);
+            $personnelId = strictPersonnelId($_POST['personnel_id'] ?? null);
+            if ($personnelId === null) {
+                http_response_code(400);
+                echo json_encode(['error' => 'Invalid upload request']);
+                break;
+            }
             $file = $_FILES['photo'] ?? null;
 
             if ($personnelId <= 0 || !is_array($file)) {

--- a/backend/routes/equivalence.php
+++ b/backend/routes/equivalence.php
@@ -19,6 +19,33 @@ include_once __DIR__ . '/../helpers.php';
 include_once __DIR__ . '/../audit.php';
 
 /**
+ * U6 — ตรวจวันรายฟิลด์ (create/update): ฟิลด์วันที่ที่ส่งมาและไม่ว่างต้อง parse เข้มผ่าน
+ * ปิดช่อง single-sided (ส่งข้างเดียวผิด format แล้วอีกข้างว่าง = ข้ามบล็อกคู่แล้ว bind ดิบลง DB)
+ * mirror `diverseDateFieldError` (diverse.php) ต่างแค่ชื่อ/const
+ *
+ * @param array<string,mixed> $data
+ * @param list<string> $fields
+ */
+function equivalenceDateFieldError(mixed $data, array $fields): ?string
+{
+    if (!is_array($data)) {
+        return 'รูปแบบข้อมูลไม่ถูกต้อง';
+    }
+    foreach ($fields as $field) {
+        if (!array_key_exists($field, $data) || $data[$field] === '' || $data[$field] === null) {
+            continue;
+        }
+        if (!is_string($data[$field]) || equivalenceStrictDate($data[$field]) === null) {
+            return 'รูปแบบวันที่ไม่ถูกต้อง';
+        }
+    }
+    return null;
+}
+
+/** @var list<string> ฟิลด์วันที่ของ equivalence ที่ต้องผ่าน strict parse เมื่อส่งมา */
+const EQUIVALENCE_DATE_FIELDS = ['request_start_date', 'request_end_date'];
+
+/**
  * จัดการ request สำหรับ position equivalence endpoints
  *
  * @param PDO $pdo Database connection
@@ -230,6 +257,14 @@ function createEquivalence(PDO $pdo, array $user, ?array $input = null): void
         return;
     }
 
+    // U6: ตรวจวันรายฟิลด์ก่อน (กัน single-sided ผิด format หลุดไป bind ดิบ)
+    $dateError = equivalenceDateFieldError($data, EQUIVALENCE_DATE_FIELDS);
+    if ($dateError !== null) {
+        http_response_code(400);
+        echo json_encode(['error' => $dateError]);
+        return;
+    }
+
     // คำนวณ request_total_days จากวันที่เริ่มต้นและสิ้นสุด (DATEDIFF+1)
     // U3: parse เข้ม (กัน format หลวม + non-string ที่เคยทำ TypeError 500)
     $requestTotalDays = null;
@@ -280,19 +315,6 @@ function createEquivalence(PDO $pdo, array $user, ?array $input = null): void
 }
 
 /**
- * PUT /equivalence/{id} — อัปเดต / อนุมัติ / ปฏิเสธ คำขอเทียบตำแหน่ง
- *
- * Approval workflow:
- *   - PENDING -> APPROVED: ต้องระบุ approved_start_date, approved_end_date
- *     คำนวณ approved_total_days, บันทึก approved_by จาก JWT
- *   - PENDING -> REJECTED: NULL ค่า approved dates/days
- *   - ห้ามเปลี่ยนสถานะอื่นนอกจากที่กำหนด
- *
- * Regular update (ไม่มี approval_status):
- *   - อัปเดตเฉพาะ field ที่อนุญาต
- *   - คำนวณ request_total_days ใหม่หากเปลี่ยนวันที่
- */
-/**
  * U3 — parse Y-m-d แบบเข้ม (mirror probationStrictDate) — คืน null ถ้า format ผิดหรือ overflow
  * (กัน '2026-1-15'/datetime suffix หลุดผ่าน new DateTime ตรง ๆ)
  */
@@ -329,6 +351,19 @@ function approvedRangeTotalDays(string $start, string $end): int
     return $approvedEnd->diff($approvedStart)->days + 1;
 }
 
+/**
+ * PUT /equivalence/{id} — อัปเดต / อนุมัติ / ปฏิเสธ คำขอเทียบตำแหน่ง
+ *
+ * Approval workflow:
+ *   - PENDING -> APPROVED: ต้องระบุ approved_start_date, approved_end_date
+ *     คำนวณ approved_total_days, บันทึก approved_by จาก JWT
+ *   - PENDING -> REJECTED: NULL ค่า approved dates/days
+ *   - ห้ามเปลี่ยนสถานะอื่นนอกจากที่กำหนด
+ *
+ * Regular update (ไม่มี approval_status):
+ *   - อัปเดตเฉพาะ field ที่อนุญาต
+ *   - คำนวณ request_total_days ใหม่หากเปลี่ยนวันที่
+ */
 function updateEquivalence(PDO $pdo, int $id, array $user, ?array $input = null): void
 {
     $data = $input ?? json_decode(file_get_contents('php://input'), true);
@@ -446,6 +481,13 @@ function updateEquivalence(PDO $pdo, int $id, array $user, ?array $input = null)
     }
 
     // Regular field update (ไม่มีการเปลี่ยนสถานะ)
+    // U6: ตรวจวันรายฟิลด์ที่ส่งมาก่อน (เฉพาะค่าที่ส่งมา ไม่แตะค่าจาก DB)
+    $dateError = equivalenceDateFieldError($data, EQUIVALENCE_DATE_FIELDS);
+    if ($dateError !== null) {
+        http_response_code(400);
+        echo json_encode(['error' => $dateError]);
+        return;
+    }
     $allowed = ['actual_position', 'equivalent_type', 'request_start_date', 'request_end_date', 'approval_order_ref'];
     $sets = [];
     $params = [];

--- a/backend/routes/multiplier.php
+++ b/backend/routes/multiplier.php
@@ -353,10 +353,17 @@ function createMultiplier(PDO $pdo, array $user): void
         return;
     }
 
+    // U5-follow-up: area id ต้องเป็น int-like ก่อน (กัน array ถูก intval กลบแล้วคำนวณผิดพื้นที่เงียบ)
+    $areaMultiplierId = strictPersonnelId($data['area_multiplier_id']);
+    if ($areaMultiplierId === null) {
+        http_response_code(400);
+        echo json_encode(['error' => 'รูปแบบข้อมูลไม่ถูกต้อง']);
+        return;
+    }
     try {
         $computed = computeMultiplierFields(
             $pdo,
-            intval($data['area_multiplier_id']),
+            $areaMultiplierId,
             $data['start_date'],
             $data['end_date']
         );
@@ -612,7 +619,12 @@ function updateMultiplier(PDO $pdo, int $multiplierId, array $user, ?array $inpu
         echo json_encode(['error' => 'รูปแบบข้อมูลไม่ถูกต้อง']);
         return;
     }
-    $areaMultiplierId = intval($data['area_multiplier_id'] ?? $existing['area_multiplier_id']);
+    $areaMultiplierId = strictPersonnelId($data['area_multiplier_id'] ?? $existing['area_multiplier_id']);
+    if ($areaMultiplierId === null) {
+        http_response_code(400);
+        echo json_encode(['error' => 'รูปแบบข้อมูลไม่ถูกต้อง']);
+        return;
+    }
     $startDate = $data['start_date'] ?? $existing['start_date'];
     $endDate = $data['end_date'] ?? $existing['end_date'];
 

--- a/backend/scripts/migration-lib.php
+++ b/backend/scripts/migration-lib.php
@@ -11,12 +11,13 @@ declare(strict_types=1);
 
 /**
  * Last migration assumed already applied when the DB was provisioned by
- * docker-compose init mounts, CI init mounts, or tidb-init (all include through 30).
- * Fresh volumes must not re-run non-idempotent files such as 22 or 30
+ * docker-compose init mounts, CI init mounts, or tidb-init (all include through 32).
+ * Fresh volumes must not re-run non-idempotent files such as 22, 30 or 32
  * (Issue #129: baseline เดิมตัดที่ 25 ทำให้ fresh volume โดน re-apply 30
- *  ซึ่งเป็น ALTER TABLE ADD COLUMN ล้วน ๆ → Duplicate column แล้ว runner พัง)
+ *  ซึ่งเป็น ALTER TABLE ADD COLUMN ล้วน ๆ → Duplicate column แล้ว runner พัง;
+ *  32 เป็น RENAME ที่ rerun ไม่ได้เช่นกัน — init mounts รันมันแล้ว)
  */
-const MIGRATION_BASELINE_THROUGH = '30-photo-blob-storage.sql';
+const MIGRATION_BASELINE_THROUGH = '32-rename-servant-id.sql';
 
 function migrationEnv(string $key, string $default = ''): string
 {

--- a/backend/scripts/run-migrations.php
+++ b/backend/scripts/run-migrations.php
@@ -5,7 +5,7 @@
  *
  * Safety for existing TiDB/prod / fresh docker-compose volumes:
  * - If schema_migrations is empty but core tables already exist, seed a baseline
- *   for migrations through 30-* (already applied via init mounts / tidb-init;
+ *   for migrations through 32-* (already applied via init mounts / tidb-init;
  *   cut-off constant lives in migration-lib.php), and only execute newer files.
  *   test-seed files are never baselined.
  * - DDL is not wrapped in a multi-statement transaction (TiDB/MySQL auto-commit DDL).

--- a/backend/tests/Unit/EquivalenceDateFieldTest.php
+++ b/backend/tests/Unit/EquivalenceDateFieldTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../routes/equivalence.php';
+
+/**
+ * U6 — equivalenceDateFieldError: ฟิลด์วันที่ที่ส่งมาและไม่ว่างต้อง parse เข้มผ่าน
+ * (ปิดช่อง single-sided แบบเดียวกับ U1 ของ diverse)
+ */
+final class EquivalenceDateFieldTest extends TestCase
+{
+    #[Test]
+    public function missing_or_empty_fields_are_allowed(): void
+    {
+        self::assertNull(equivalenceDateFieldError([], EQUIVALENCE_DATE_FIELDS));
+        self::assertNull(equivalenceDateFieldError([
+            'request_start_date' => '',
+            'request_end_date' => null,
+        ], EQUIVALENCE_DATE_FIELDS));
+    }
+
+    #[Test]
+    public function valid_dates_are_allowed(): void
+    {
+        self::assertNull(equivalenceDateFieldError([
+            'request_start_date' => '2020-01-01',
+            'request_end_date' => '2020-12-31',
+        ], EQUIVALENCE_DATE_FIELDS));
+    }
+
+    #[Test]
+    public function single_sided_malformed_date_is_rejected(): void
+    {
+        self::assertSame(
+            'รูปแบบวันที่ไม่ถูกต้อง',
+            equivalenceDateFieldError(['request_start_date' => 'not-a-date'], EQUIVALENCE_DATE_FIELDS)
+        );
+        self::assertSame(
+            'รูปแบบวันที่ไม่ถูกต้อง',
+            equivalenceDateFieldError(['request_end_date' => '2026-13-99'], EQUIVALENCE_DATE_FIELDS)
+        );
+        self::assertSame(
+            'รูปแบบวันที่ไม่ถูกต้อง',
+            equivalenceDateFieldError(['request_start_date' => '2026-02-30'], EQUIVALENCE_DATE_FIELDS)
+        );
+        self::assertSame(
+            'รูปแบบวันที่ไม่ถูกต้อง',
+            equivalenceDateFieldError(['request_start_date' => '2026-1-15'], EQUIVALENCE_DATE_FIELDS)
+        );
+    }
+
+    #[Test]
+    public function non_string_date_is_rejected(): void
+    {
+        self::assertSame(
+            'รูปแบบวันที่ไม่ถูกต้อง',
+            equivalenceDateFieldError(['request_end_date' => ['x']], EQUIVALENCE_DATE_FIELDS)
+        );
+    }
+
+    #[Test]
+    public function non_array_body_is_rejected(): void
+    {
+        self::assertSame('รูปแบบข้อมูลไม่ถูกต้อง', equivalenceDateFieldError(null, EQUIVALENCE_DATE_FIELDS));
+        self::assertSame('รูปแบบข้อมูลไม่ถูกต้อง', equivalenceDateFieldError('x', EQUIVALENCE_DATE_FIELDS));
+    }
+
+    #[Test]
+    public function create_source_validates_dates_before_insert(): void
+    {
+        $fn = self::functionSource(
+            __DIR__ . '/../../routes/equivalence.php',
+            'function createEquivalence',
+            'function updateEquivalence'
+        );
+        self::assertStringContainsString('equivalenceDateFieldError($data, EQUIVALENCE_DATE_FIELDS)', $fn);
+    }
+
+    #[Test]
+    public function update_source_validates_dates_before_update(): void
+    {
+        $src = file_get_contents(__DIR__ . '/../../routes/equivalence.php');
+        self::assertIsString($src);
+        $start = strpos($src, 'function updateEquivalence');
+        self::assertNotFalse($start);
+        $fn = substr($src, $start);
+        self::assertStringContainsString('equivalenceDateFieldError($data, EQUIVALENCE_DATE_FIELDS)', $fn);
+    }
+
+    private static function functionSource(string $file, string $startFn, string $endFn): string
+    {
+        $src = file_get_contents($file);
+        self::assertIsString($src);
+        $start = strpos($src, $startFn);
+        self::assertNotFalse($start);
+        $end = strpos($src, $endFn, $start);
+        self::assertNotFalse($end);
+        return substr($src, $start, $end - $start);
+    }
+}

--- a/backend/tests/Unit/MigrationBaselineTest.php
+++ b/backend/tests/Unit/MigrationBaselineTest.php
@@ -11,13 +11,14 @@ require_once __DIR__ . '/../../scripts/migration-lib.php';
 
 /**
  * Guards the baseline cut-off used by scripts/run-migrations.php.
- * docker-compose init + CI init + tidb-init already apply through 30;
+ * docker-compose init + CI init + tidb-init already apply through 32;
  * only newer files execute (Issue #129 — ตัดที่ 25 ไม่ได้แล้ว เพราะ init mounts
- * ครอบถึง 30 และ 30 เป็น ALTER TABLE ADD COLUMN ที่ re-apply ซ้ำไม่ได้)
+ * ครอบถึง 30 และ 30 เป็น ALTER TABLE ADD COLUMN ที่ re-apply ซ้ำไม่ได้;
+ * 32 เป็น RENAME ที่ rerun ไม่ได้เช่นกัน จึงขยับ baseline ผ่าน 32)
  */
 final class MigrationBaselineTest extends TestCase
 {
-    private const BASELINE_THROUGH = '30-photo-blob-storage.sql';
+    private const BASELINE_THROUGH = '32-rename-servant-id.sql';
 
     #[Test]
     public function baseline_cut_off_matches_runner_constant(): void
@@ -30,7 +31,7 @@ final class MigrationBaselineTest extends TestCase
     {
         self::assertGreaterThan(
             0,
-            strnatcasecmp('31-placeholder-next.sql', self::BASELINE_THROUGH)
+            strnatcasecmp('33-placeholder-next.sql', self::BASELINE_THROUGH)
         );
     }
 
@@ -46,6 +47,8 @@ final class MigrationBaselineTest extends TestCase
             '25-ensure-multiplier-tables.sql',
             '27-superadmin-permission-overrides.sql',
             '30-photo-blob-storage.sql',
+            '31-csp-violation-daily.sql',
+            '32-rename-servant-id.sql',
         ];
 
         foreach ($historical as $name) {

--- a/backend/tests/Unit/StrictPersonnelIdTest.php
+++ b/backend/tests/Unit/StrictPersonnelIdTest.php
@@ -181,4 +181,47 @@ final class StrictPersonnelIdTest extends TestCase
             self::assertStringNotContainsString("intval(\$valid['personnel_id'])", $fn, $route);
         }
     }
+
+    #[Test]
+    public function area_id_uses_same_int_like_contract(): void
+    {
+        // R4: area_multiplier_id ใช้ strictPersonnelId ตัวเดิม (ไม่สร้าง helper ใหม่)
+        self::assertNull(strictPersonnelId([2]));
+        self::assertNull(strictPersonnelId(2.5));
+        self::assertNull(strictPersonnelId(true));
+        self::assertSame(3, strictPersonnelId('3'));
+        self::assertSame(3, strictPersonnelId(3));
+    }
+
+    #[Test]
+    public function multiplier_validates_area_id_before_compute(): void
+    {
+        $src = file_get_contents(__DIR__ . '/../../routes/multiplier.php');
+        self::assertIsString($src);
+
+        $start = strpos($src, 'function createMultiplier');
+        self::assertNotFalse($start);
+        $end = strpos($src, 'function updateMultiplier', $start);
+        self::assertNotFalse($end);
+        $create = substr($src, $start, $end - $start);
+        self::assertStringContainsString("strictPersonnelId(\$data['area_multiplier_id'])", $create);
+        self::assertStringNotContainsString("intval(\$data['area_multiplier_id'])", $create);
+
+        $update = substr($src, $end);
+        self::assertStringContainsString("strictPersonnelId(\$data['area_multiplier_id']", $update);
+        self::assertStringNotContainsString("intval(\$data['area_multiplier_id'])", $update);
+    }
+
+    #[Test]
+    public function photos_upload_validates_personnel_id(): void
+    {
+        $src = file_get_contents(__DIR__ . '/../../api.php');
+        self::assertIsString($src);
+        $start = strpos($src, "case 'photos':");
+        self::assertNotFalse($start);
+        $end = strpos($src, 'function ', $start);
+        $fn = $end === false ? substr($src, $start) : substr($src, $start, $end - $start);
+        self::assertStringContainsString('strictPersonnelId($_POST', $fn);
+        self::assertStringNotContainsString("intval(\$_POST['personnel_id'])", $fn);
+    }
 }

--- a/database/tidb-init.sql
+++ b/database/tidb-init.sql
@@ -33,7 +33,7 @@ CREATE TABLE prefixes (
 
 -- civil_servants (N5): ไม่สร้างใน bootstrap — ADR-0002 ย้าย person identity ไป
 -- personnel แล้ว (migration 22) และ migration 24 ลบตารางนี้; backend ไม่ query ตรง
--- (legacy /civil-servants อ่านจาก personnel ผ่าน alias servant_id)
+-- (legacy /civil-servants อ่านจาก personnel ตรง ๆ ไม่มี alias แล้ว — #186)
 -- เดิม bootstrap สร้าง → migration ลบ = fresh prod with RUN_MIGRATIONS=0 ค้าง dead table
 
 -- Uploaded photo records for each civil servant.


### PR DESCRIPTION
codebase-review-fix รอบ diff #184-#190 — R1-R6 (G2 READY 10/10 dual-PASS)

**R1 (High) — migration double-apply:** init mounts (compose/CI) มี 31+32 แต่ baseline
หยุดแค่ 30 runner จึงรัน 31+32 ซ้ำ (31 รอดด้วย IF NOT EXISTS, 32 รอดไม่ได้) —
พิสูจน์ RED บน MySQL 8.0 จริง (`Migration runner failed: ...1054...`, exit 1)
- ขยับ `MIGRATION_BASELINE_THROUGH` 30→32 (+test guard +header comments, precedent #129)
- หมายเหตุซื่อสัตย์: experiment พิสูจน์ว่า `RENAME INDEX servant_id` ใน 32 **ถูกอยู่แล้ว**
  (auto-index ชื่อตาม column) — ไม่ได้แตะไฟล์ 32 ตาม falsification branch ของแผน

**R2 (Medium) — equivalence single-sided dates:** เพิ่ม `equivalenceDateFieldError`
(mirror U1) ต่อ create+update — ข้างเดียวผิด→400 (พิสูจน์เดิมได้ 201+เก็บค่าดิบ)

**R3/R4 (Medium) — silent int coerce:** `strictPersonnelId` ใน POST /photos
(คง message `Invalid upload request`) + `area_multiplier_id` ทั้ง create/update

**R5/R6 (Low):** docblock PUT ติด `updateEquivalence` คืน (ย้าย 2 helpers, move-only) +
แก้คอมเมนต์ stale ใน tidb-init

**ยืนยันด้วยการรัน:**
- MySQL 8.0 (Docker): RED (exit 1/1054) → GREEN (init clean, runner Applied+exit 0,
  SHOW INDEX/COLUMNS ถูก, rerun skip-only exit 0)
- PHPUnit Unit: 391 เทส — ตกแค่ `MigrationDirectoryTest` (known Windows-only)
- node script 147/147 + schema parity OK + behavioral SQLite 8/8
- push --no-verify (vitest ~13-20 นาที ไม่เกี่ยวกับ diff backend/schema ล้วน)
