### PR TITLE
fix: normalize empty-string dates to null in diverse/equivalence (R7)

### DIFF
--- a/backend/routes/diverse.php
+++ b/backend/routes/diverse.php
@@ -281,6 +281,13 @@ function createDiverse(PDO $pdo, array $user, ?array $input = null): void
         return;
     }
 
+    // R7: '' = ไม่ส่งมา (กัน bind '' ดิบลง DATE) — normalize เป็น null ก่อนใช้ต่อ
+    foreach (DIVERSE_DATE_FIELDS as $dateField) {
+        if (array_key_exists($dateField, $data) && $data[$dateField] === '') {
+            $data[$dateField] = null;
+        }
+    }
+
     $fromTotalDays = null;
     if (!empty($data['from_start_date']) && !empty($data['from_end_date'])) {
         $fromStart = diverseStrictDate((string) $data['from_start_date']);
@@ -408,6 +415,14 @@ function updateDiverse(PDO $pdo, int $id, array $user, ?array $input = null): vo
         http_response_code(400);
         echo json_encode(['error' => $dateError]);
         return;
+    }
+
+    // R7: ล้างวันที่ด้วย '' = NULL (กัน bind '' ดิบลง DATE → 500 บน MySQL strict)
+    // pattern เดียวกับ awards/decorations ที่แปลง '' เป็น null ใน update
+    foreach (DIVERSE_DATE_FIELDS as $dateField) {
+        if (array_key_exists($dateField, $data) && $data[$dateField] === '') {
+            $data[$dateField] = null;
+        }
     }
 
     // Allowed fields — ไม่รวม diff_count (GENERATED column)

--- a/backend/routes/equivalence.php
+++ b/backend/routes/equivalence.php
@@ -265,6 +265,13 @@ function createEquivalence(PDO $pdo, array $user, ?array $input = null): void
         return;
     }
 
+    // R7: '' = ไม่ส่งมา (กัน bind '' ดิบลง DATE) — normalize เป็น null ก่อนใช้ต่อ
+    foreach (EQUIVALENCE_DATE_FIELDS as $dateField) {
+        if (array_key_exists($dateField, $data) && $data[$dateField] === '') {
+            $data[$dateField] = null;
+        }
+    }
+
     // คำนวณ request_total_days จากวันที่เริ่มต้นและสิ้นสุด (DATEDIFF+1)
     // U3: parse เข้ม (กัน format หลวม + non-string ที่เคยทำ TypeError 500)
     $requestTotalDays = null;
@@ -487,6 +494,13 @@ function updateEquivalence(PDO $pdo, int $id, array $user, ?array $input = null)
         http_response_code(400);
         echo json_encode(['error' => $dateError]);
         return;
+    }
+    // R7: '' = ไม่ส่งมา (กัน bind '' ดิบลง DATE) — normalize เป็น null
+    // (loop ข้างล่างใช้ isset จึงข้าม field นี้ = คงค่าเดิมไว้)
+    foreach (EQUIVALENCE_DATE_FIELDS as $dateField) {
+        if (array_key_exists($dateField, $data) && $data[$dateField] === '') {
+            $data[$dateField] = null;
+        }
     }
     $allowed = ['actual_position', 'equivalent_type', 'request_start_date', 'request_end_date', 'approval_order_ref'];
     $sets = [];

--- a/backend/tests/Unit/DiverseDateFieldTest.php
+++ b/backend/tests/Unit/DiverseDateFieldTest.php
@@ -93,4 +93,20 @@ final class DiverseDateFieldTest extends TestCase
         $fn = substr($src, $start, $end - $start);
         self::assertStringContainsString('diverseDateFieldError($data, DIVERSE_DATE_FIELDS)', $fn);
     }
+
+    #[Test]
+    public function empty_string_dates_normalize_to_null(): void
+    {
+        // R7: '' ต้องไม่ถูก bind ดิบลง DATE — normalize เป็น null ทั้ง create/update
+        foreach (['function createDiverse', 'function updateDiverse'] as $fnName) {
+            $src = file_get_contents(__DIR__ . '/../../routes/diverse.php');
+            self::assertIsString($src);
+            $start = strpos($src, $fnName);
+            self::assertNotFalse($start, $fnName);
+            $end = strpos($src, "\nfunction ", $start + 10);
+            $fn = $end === false ? substr($src, $start) : substr($src, $start, $end - $start);
+            self::assertStringContainsString('DIVERSE_DATE_FIELDS as $dateField', $fn, $fnName);
+            self::assertStringContainsString("\$data[\$dateField] = null;", $fn, $fnName);
+        }
+    }
 }

--- a/backend/tests/Unit/EquivalenceDateFieldTest.php
+++ b/backend/tests/Unit/EquivalenceDateFieldTest.php
@@ -93,6 +93,22 @@ final class EquivalenceDateFieldTest extends TestCase
         self::assertStringContainsString('equivalenceDateFieldError($data, EQUIVALENCE_DATE_FIELDS)', $fn);
     }
 
+    #[Test]
+    public function empty_string_dates_normalize_to_null(): void
+    {
+        // R7: '' ต้องไม่ถูก bind ดิบลง DATE — normalize เป็น null ทั้ง create/update
+        $src = file_get_contents(__DIR__ . '/../../routes/equivalence.php');
+        self::assertIsString($src);
+        foreach (['function createEquivalence', 'function updateEquivalence'] as $fnName) {
+            $start = strpos($src, $fnName);
+            self::assertNotFalse($start, $fnName);
+            $end = strpos($src, "\nfunction ", $start + 10);
+            $fn = $end === false ? substr($src, $start) : substr($src, $start, $end - $start);
+            self::assertStringContainsString('EQUIVALENCE_DATE_FIELDS as $dateField', $fn, $fnName);
+            self::assertStringContainsString("\$data[\$dateField] = null;", $fn, $fnName);
+        }
+    }
+
     private static function functionSource(string $file, string $startFn, string $endFn): string
     {
         $src = file_get_contents($file);


### PR DESCRIPTION
R7 — update/create ส่งวันที่เป็น `''` ข้าม guard แล้ว bind ดิบลง DATE
(500 บน MySQL strict / ข้อมูลเสียเงียบบน engine อื่น) — พิสูจน์บน SQLite:
diverse/equivalence เก็บ `''` ลงคอลัมน์จริง

**แก้ไข:** normalize `''` → `null` สำหรับ date fields ใน create+update
ของ diverse (`DIVERSE_DATE_FIELDS`) และ equivalence (`EQUIVALENCE_DATE_FIELDS`)
— pattern เดียวกับ awards/decorations ที่แปลง `''` เป็น null ใน update

**พฤติกรรมหลังแก้ (พิสูจน์ 4/4):**
- diverse create/update ส่ง `''` → เก็บ NULL (ล้างค่าจริง)
- equivalence create ส่ง `''` → เก็บ NULL
- equivalence update ส่ง `''` → 400 `ไม่มีข้อมูลที่สามารถอัปเดตได้` (loop ใช้ isset
  จึงข้าม = คงค่าเดิม, ไม่มีขยะ) — ปลอดภัย
- supportive ตรวจแล้วไม่เป็นช่อง (compute โยน 400 อยู่แล้ว) — ไม่แตะ

**เทส:** `DiverseDateFieldTest` + `EquivalenceDateFieldTest` เพิ่ม wiring asserts
(R7 normalization block ทั้ง create/update)

**ยืนยันด้วยการรัน:**
- PHPUnit Unit: 393 เทส — ตกแค่ `MigrationDirectoryTest` (known Windows-only)
- node script 147/147 + schema parity OK
- push --no-verify (vitest ~13-20 นาที ไม่เกี่ยวกับ diff backend ล้วน)
