### PR TITLE
fix: load Apache headers module via a2enmod instead of RHEL path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN composer install --no-dev --no-interaction --no-plugins --no-scripts --optim
 # =========================================================================
 FROM php:8.3-apache
 
-RUN a2enmod rewrite
+RUN a2enmod rewrite headers
 
 RUN apt-get update && apt-get install -y \
     libzip-dev \
@@ -60,7 +60,6 @@ RUN printf "AddDefaultCharset UTF-8\n" > /etc/apache2/conf-enabled/charset.conf 
 # Apache ไม่ผ่าน frontend ที่มี render.yaml headers — ชุดเดียวกับ frontend (ตัด CSP
 # เพราะ API เสิร์ฟ JSON/รูปไม่มี HTML จะ sniff ได้)
 RUN printf '%s\n' \
-    'LoadModule headers_module modules/mod_headers.so' \
     'Header always set X-Content-Type-Options "nosniff"' \
     'Header always set X-Frame-Options "DENY"' \
     'Header always set Referrer-Policy "strict-origin-when-cross-origin"' \


### PR DESCRIPTION
## Summary
Root Dockerfile เขียน LoadModule ด้วย path แบบ RHEL (modules/mod_headers.so) แต่ image php:8.3-apache เป็น Debian ทำให้ Apache หา mod_headers.so ไม่เจอ crash-loop backend ไม่ ready E2E gate แดง

## Change
- a2enmod rewrite -> rewrite headers
- ลบบรรทัด LoadModule ออกจาก security-headers.conf

## Verification
- docker build + backend container healthy, GET / = 200 OK
- security headers ครบทุุกตัว (nosniff/DENY/Referrer-Policy/HSTS)
- ci-local: schema/regressions/tidb/frontend(593)/CSP/E2E/PHPUnit/docker เขียวหมด